### PR TITLE
Per-axis motion, roll-tilt navigation, and the TapQ-1 encoder backend (0.2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ build/
 DerivedData/
 *.xcodeproj/xcuserdata/
 .DS_Store
+__pycache__/
+ml/.venv/
+ml/data/
+ml/checkpoints/
+ml/models/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 - `TiltCommand` cases are now `tiltLeft`/`tiltRight`; the pitch-based
   `tiltUp`/`tiltDown` tilt and its displacement analyzer are retired.
+- The TapQ-1 encoder backend now requires two shake atoms to deny, matching the
+  heuristic pipeline's double-shake pairing. Both backends therefore turn the same
+  physical motion into the same command, and replay label segments for `shake` span
+  the complete double shake.
 
 ## [0.1.0] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ All notable changes to TapQ will be recorded in this file. The project uses
   earbud or ear from per-axis acceleration, with gravity-referenced up/down direction.
   Disabled by default (`MotionGesturePipeline.swipeDetectionEnabled`) pending capture
   study validation on real AirPods streams.
+- TapQ-1 stage-1 encoder infrastructure: a versioned feature contract
+  (`EncoderFeatureLayout`, 9 channels × 32 samples at 25 Hz), a window builder, a
+  `MotionWindowScoring` backend protocol, and an `EncoderMotionPipeline` decision layer
+  that converts per-window class scores into the same doubled commands as the heuristic
+  pipeline. `CoreMLMotionScorer` runs exported models on Core ML and refuses any model
+  whose embedded contract metadata disagrees with the runtime. The deterministic
+  heuristics always keep running as the offline fallback.
+- `tapq replay`: stream a recorded capture through the detection backends offline.
+  With a JSONL label file it reports per-gesture precision/recall and false positives
+  per minute, and `--encoder-model` adds a side-by-side TapQ-1 encoder run — the
+  evaluation yardstick for the capture study and for backend comparison.
+- `tapq serve --encoder-model PATH [--encoder-mode shadow|primary]`: attach a TapQ-1
+  model in shadow mode (detections recorded as diagnostics while heuristics keep
+  driving events) or promote it to primary (heuristic detections logged for
+  comparison). A model that fails to load degrades to heuristics and says so.
+- `ml/`: the TapQ-1 training pipeline — LIMU-BERT-style masked-reconstruction
+  pretraining, supervised joint-head training with time-warp/rotation/noise
+  augmentation, Core ML export that embeds the contract metadata, and a synthetic
+  smoke test covering train → export → load with no captured data.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
+### Added
+
+- Per-axis headphone motion throughout the portable pipeline: `HeadMotionSample` now
+  carries roll attitude and signed 3-axis user acceleration, rotation rate, and gravity
+  alongside the existing magnitudes. `tapq capture` writes the new fields in both JSONL
+  and CSV; the original five CSV columns keep their positions, and records captured
+  before this change still decode.
+- Double roll-tilt navigation: two quick same-direction lateral tilts (ear toward
+  shoulder) select the next (right) or previous (left) option. Tilt detection is
+  roll-dominant with pitch/yaw crosstalk gates and double-tilt pairing, so nods, shakes,
+  and single leans never navigate — the structural collisions that forced the original
+  pitch-based tilt out of the runtime.
+- An experimental motion-swipe analyzer that recognizes sustained gentle drags on the
+  earbud or ear from per-axis acceleration, with gravity-referenced up/down direction.
+  Disabled by default (`MotionGesturePipeline.swipeDetectionEnabled`) pending capture
+  study validation on real AirPods streams.
+
+### Changed
+
+- `TiltCommand` cases are now `tiltLeft`/`tiltRight`; the pitch-based
+  `tiltUp`/`tiltDown` tilt and its displacement analyzer are retired.
+
 ## [0.1.0] - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-27
+
 ### Added
 
 - Per-axis headphone motion throughout the portable pipeline: `HeadMotionSample` now
@@ -107,5 +109,6 @@ All notable changes to TapQ will be recorded in this file. The project uses
 The Codex slice does not yet provide strict `PreToolUse`, structured
 `request_user_input`, `UserPromptSubmit` steering, or generic notification-hook parity.
 
-[Unreleased]: https://github.com/spaceamoeba-t/tapq/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/spaceamoeba-t/tapq/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/spaceamoeba-t/tapq/releases/tag/v0.2.0
 [0.1.0]: https://github.com/spaceamoeba-t/tapq/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,32 @@ All notable changes to TapQ will be recorded in this file. The project uses
   pretraining, supervised joint-head training with time-warp/rotation/noise
   augmentation, Core ML export that embeds the contract metadata, and a synthetic
   smoke test covering train → export → load with no captured data.
+- `tapq serve --question-classifier auto|apple|anthropic|openai|local`: choose which
+  backend classifies questions in a final agent response. Apple Foundation Models and
+  OpenAI GPT-5.6 Luna join the existing Claude Haiku option. `auto` never enables cloud
+  processing — it uses the on-device Apple model when available and otherwise the
+  deterministic local heuristic. Cloud providers require their API key in the runtime
+  environment and fall back to the local heuristic when a request fails.
 
 ### Changed
 
+- Denying an approval now requires a double shake, so a single head turn can no longer
+  deny a request. `HeadGestureConfig` gains `doubleShakeWindowSeconds` and
+  `minDoubleShakeGap`; profiles saved before this change still decode and take the
+  defaults.
+- Response windows are considerably longer: the interaction budget total moved from 105
+  to 245 seconds, and the `tapq serve --timeout` default and maximum from 100 to 240,
+  keeping the interaction total inside the shim socket and hook timeouts.
 - `TiltCommand` cases are now `tiltLeft`/`tiltRight`; the pitch-based
-  `tiltUp`/`tiltDown` tilt and its displacement analyzer are retired.
-- The TapQ-1 encoder backend now requires two shake atoms to deny, matching the
-  heuristic pipeline's double-shake pairing. Both backends therefore turn the same
-  physical motion into the same command, and replay label segments for `shake` span
-  the complete double shake.
+  `tiltUp`/`tiltDown` tilt and its displacement analyzer are retired. Together with the
+  new roll-based `TiltAnalyzer.detect` signature, this is a source-breaking change for
+  code consuming `TapQContracts` or `TapQDetectionBaseline` as libraries.
+- The TapQ-1 encoder backend pairs shake detections the same way the heuristics do, so
+  both backends turn the same physical motion into the same command. Replay label
+  segments span the complete doubled gesture accordingly: a `shake` segment covers the
+  full double shake, as a `nod` segment covers the full double nod.
+- The broker wire protocol is unchanged at version 3. Hooks and brokers built against
+  the previous release remain compatible with this runtime.
 
 ## [0.1.0] - Unreleased
 

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -79,11 +79,13 @@ import Darwin
         let volumeSwipe = VolumeSwipeDetector(diagnosticSink: diagnostics)
         let selectionArbiter = SelectionArbiter(
             voice: voice,
-            // A tilt and the first half of a nod/tap come from the same motion stream.
-            // Letting tilt resolve immediately tears down the gesture pairing state
-            // before the confirming nod/tap can arrive. Volume/voice own navigation;
-            // head gestures and taps own confirmation/defer.
-            tilts: nil,
+            // Tilt navigation is the roll-axis double tilt: roll is orthogonal to nod
+            // (pitch) and shake (yaw), the analyzer requires roll dominance, and a
+            // command needs two same-direction tilts — so the first half of a nod/tap
+            // can no longer be misread as navigation, which is what forced the retired
+            // pitch tilt off. Volume swipes remain the premium navigation channel on
+            // hardware that has them.
+            tilts: gestures,
             swipes: volumeSwipe,
             taps: gestures,
             gestures: gestures,

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -52,6 +52,25 @@ import Darwin
             tapConfig: tapProfile?.config ?? TapConfig(),
             diagnosticSink: diagnostics
         )
+
+        var encoderStatus: String?
+        if let modelURL = configuration.encoderModelURL, configuration.encoderMode != .off {
+            do {
+                let scorer = try await CoreMLMotionScorer.load(modelURL: modelURL)
+                gestures.configureEncoder(scorer: scorer, mode: configuration.encoderMode)
+                encoderStatus = configuration.encoderMode.rawValue
+            } catch {
+                // A broken model must never take down hands-free serving; the
+                // deterministic heuristics are the documented offline fallback.
+                diagnostics.record(.init(
+                    category: "GestureAdapter",
+                    name: "encoder.load_failed",
+                    level: .error,
+                    fields: ["error": String(describing: error)]
+                ))
+                encoderStatus = "unavailable, heuristic fallback (\(error.localizedDescription))"
+            }
+        }
         let rawVoice = VoiceListener(diagnosticSink: diagnostics)
         let voiceAuthorized = configuration.voiceEnabled
             ? await VoiceListener.requestAuthorization()
@@ -174,7 +193,8 @@ import Darwin
             gestureProfileLoaded: gestureProfile != nil,
             tapProfileLoaded: tapProfile != nil,
             motionAvailable: HeadGestureDetector.isAvailable,
-            voiceAvailable: voiceAuthorized
+            voiceAvailable: voiceAuthorized,
+            encoderStatus: encoderStatus
         ))
 
         defer {

--- a/Executables/tapq/Info.plist
+++ b/Executables/tapq/Info.plist
@@ -13,9 +13,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.2.0</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>LSUIElement</key>

--- a/Executables/tapq/TapQMain.swift
+++ b/Executables/tapq/TapQMain.swift
@@ -28,14 +28,19 @@ struct TapQMain {
         #if canImport(TapQAppleAdapters)
         let capture: (any TapQMotionCapturing)? = AppleHeadphoneMotionCapture()
         let runtime: (any TapQRuntimeServing)? = AppleTapQRuntimeService()
+        let scorerLoader: ((URL) async throws -> any MotionWindowScoring)? = { url in
+            try await CoreMLMotionScorer.load(modelURL: url)
+        }
         #else
         let capture: (any TapQMotionCapturing)? = nil
         let runtime: (any TapQRuntimeServing)? = nil
+        let scorerLoader: ((URL) async throws -> any MotionWindowScoring)? = nil
         #endif
 
         let application = TapQCLIApplication(
             motionCapture: capture,
             runtimeService: runtime,
+            motionScorerLoader: scorerLoader,
             executableURL: executableURL,
             currentDirectory: currentDirectory
         )

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ live commands that need macOS privacy permissions.
 | `tapq calibration run` | Calibrate gesture and tap profiles together or separately | macOS |
 | `tapq calibration show/reset` | Inspect or remove saved profiles | macOS, Linux |
 | `tapq capture` | Stream raw headphone motion as JSONL or CSV | macOS |
+| `tapq replay` | Replay a capture through detection backends offline, with accuracy reporting against labels | macOS, Linux |
 | `tapq integration claude` | Install, inspect, or remove Claude Code hooks | macOS, Linux |
 | `tapq integration codex` | Install, inspect, or remove stable Codex hooks | macOS, Linux |
 | `tapq version` | Print the CLI and wire protocol version | macOS, Linux |
@@ -197,6 +198,7 @@ Examples:
 
 ```bash
 tapq capture --duration 10 --format csv --output capture.csv
+tapq replay --input capture.jsonl --labels capture.labels.jsonl
 tapq calibration show --json
 tapq integration claude status
 tapq integration codex status
@@ -205,8 +207,12 @@ tapq version --json
 
 Capture output records timestamp, full attitude (pitch, yaw, roll), acceleration and
 rotation magnitudes, and signed per-axis user acceleration, rotation rate, and gravity;
-it does not classify samples. See the [CLI reference](docs/CLI.md) for every command,
-option, location, environment variable, and troubleshooting path.
+it does not classify samples. Replay streams a recorded capture back through the
+detection pipelines offline — with a label file it reports per-gesture precision,
+recall, and false positives per minute, and `--encoder-model` compares a trained
+TapQ-1 encoder (see [ml/README.md](ml/README.md)) against the deterministic baseline
+on the same data. See the [CLI reference](docs/CLI.md) for every command, option,
+location, environment variable, and troubleshooting path.
 
 ## Claude Code permission policies
 
@@ -365,11 +371,13 @@ exposed by each platform and manufacturer.
   destructive, external, or security-sensitive actions.
 - [ ] **Personalization and accessibility** — configurable gesture mappings, per-device
   profiles, one-sided controls, and voice-only or haptic-only modes.
-- [ ] **Local simulator and evaluation tools** — replay synthetic or user-authorized
-  sensor streams to test adapters and recognition changes without requiring every
-  supported device.
-- [ ] **Pluggable local intelligence** — support interchangeable recognition and
-  question-classification backends while preserving an offline, deterministic fallback.
+- [x] **Local replay and evaluation tools** — `tapq replay` streams user-authorized
+  motion captures through the detection backends offline with per-gesture accuracy
+  reporting; broader adapter simulation remains open under the device-adapter SDK.
+- [x] **Pluggable local intelligence** — the TapQ-1 encoder backend: a window-scorer
+  protocol with a Core ML adapter, shadow/primary serve modes, a training pipeline in
+  `ml/`, and the deterministic heuristics preserved as the always-available offline
+  fallback. Training a production model awaits the capture study.
 
 Contributions and design discussion are welcome; see
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -54,10 +54,15 @@ more agent adapters planned.
 |---|---|---|
 | Approve / yes | Double nod or double tap | `yes`, `approve`, `go ahead` |
 | Deny / no | Shake | `no`, `deny`, `cancel` |
-| Next option | Stem swipe down (volume down) | `next`, `move on` |
-| Previous option | Stem swipe up (volume up) | `previous`, `go back` |
+| Next option | Stem swipe down (volume down) or double tilt right | `next`, `move on` |
+| Previous option | Stem swipe up (volume up) or double tilt left | `previous`, `go back` |
 | Confirm option | Double nod or double tap | `select`, `this one`, `one`–`four` |
 | Return to on-screen prompt | Shake | `skip`, `later`, `not sure` |
+
+A tilt is a lateral ear-toward-shoulder lean; two quick tilts to the same side
+navigate, so a single lean never moves the selection. Tilt navigation works on
+every AirPods model that exposes headphone motion, including models without
+stem volume swipes.
 
 Stem navigation requires an AirPods model that exposes volume swipes. Voice recognition
 currently uses an English (`en-US`) command grammar.
@@ -198,9 +203,10 @@ tapq integration codex status
 tapq version --json
 ```
 
-Capture output records timestamp, pitch, yaw, acceleration magnitude, and rotation
-magnitude; it does not classify samples. See the [CLI reference](docs/CLI.md) for every
-command, option, location, environment variable, and troubleshooting path.
+Capture output records timestamp, full attitude (pitch, yaw, roll), acceleration and
+rotation magnitudes, and signed per-axis user acceleration, rotation rate, and gravity;
+it does not classify samples. See the [CLI reference](docs/CLI.md) for every command,
+option, location, environment variable, and troubleshooting path.
 
 ## Claude Code permission policies
 

--- a/Sources/TapQAppleAdapters/CoreMLMotionScorer.swift
+++ b/Sources/TapQAppleAdapters/CoreMLMotionScorer.swift
@@ -1,0 +1,149 @@
+import Foundation
+import TapQDetectionBaseline
+#if canImport(CoreML)
+import CoreML
+
+public enum CoreMLMotionScorerError: Error, LocalizedError, Equatable {
+    case metadataMissing(String)
+    case layoutMismatch(expected: String, found: String)
+    case classesMismatch(expected: String, found: String)
+    case windowLengthMismatch(expected: Int, found: String)
+    case unsupportedModel(String)
+    case windowShapeMismatch(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .metadataMissing(let key):
+            return "The model does not declare \(key); it was not exported by ml/tapq1/export.py or predates the current contract."
+        case .layoutMismatch(let expected, let found):
+            return "The model was trained for feature layout '\(found)' but this runtime speaks '\(expected)'. Re-export the model against the current layout."
+        case .classesMismatch(let expected, let found):
+            return "The model declares classes '\(found)' but this runtime expects '\(expected)'."
+        case .windowLengthMismatch(let expected, let found):
+            return "The model declares window length \(found) but this runtime expects \(expected)."
+        case .unsupportedModel(let reason):
+            return "Unsupported TapQ-1 model: \(reason)"
+        case .windowShapeMismatch(let reason):
+            return "Encoder window does not match the model input: \(reason)"
+        }
+    }
+}
+
+/// Core ML backend for the TapQ-1 stage-1 encoder. Loads a model exported by
+/// `ml/tapq1/export.py`, refuses any model whose embedded contract (feature-layout
+/// version, class order, window length) disagrees with this runtime, and scores
+/// windows on whatever compute units Core ML selects (ANE-eligible).
+public final class CoreMLMotionScorer: MotionWindowScoring {
+    private let model: MLModel
+    private let inputName: String
+    private let outputName: String
+    public let windowLength: Int
+
+    /// Loads from a `.mlpackage`/`.mlmodel` (compiled on the fly) or a pre-compiled
+    /// `.mlmodelc` directory.
+    public static func load(
+        modelURL: URL,
+        configuration: MLModelConfiguration = MLModelConfiguration()
+    ) async throws -> CoreMLMotionScorer {
+        let compiledURL = modelURL.pathExtension == "mlmodelc"
+            ? modelURL
+            : try await MLModel.compileModel(at: modelURL)
+        return try CoreMLMotionScorer(
+            model: MLModel(contentsOf: compiledURL, configuration: configuration)
+        )
+    }
+
+    init(model: MLModel) throws {
+        self.model = model
+        let description = model.modelDescription
+
+        let metadata = description.metadata[.creatorDefinedKey] as? [String: String] ?? [:]
+        guard let layout = metadata[TapQ1ModelMetadata.featureLayoutKey] else {
+            throw CoreMLMotionScorerError.metadataMissing(TapQ1ModelMetadata.featureLayoutKey)
+        }
+        guard layout == EncoderFeatureLayout.version else {
+            throw CoreMLMotionScorerError.layoutMismatch(
+                expected: EncoderFeatureLayout.version, found: layout)
+        }
+        guard let classes = metadata[TapQ1ModelMetadata.classesKey] else {
+            throw CoreMLMotionScorerError.metadataMissing(TapQ1ModelMetadata.classesKey)
+        }
+        guard classes == TapQ1ModelMetadata.expectedClasses else {
+            throw CoreMLMotionScorerError.classesMismatch(
+                expected: TapQ1ModelMetadata.expectedClasses, found: classes)
+        }
+        guard let declaredWindow = metadata[TapQ1ModelMetadata.windowLengthKey] else {
+            throw CoreMLMotionScorerError.metadataMissing(TapQ1ModelMetadata.windowLengthKey)
+        }
+        guard Int(declaredWindow) == EncoderFeatureLayout.windowLength else {
+            throw CoreMLMotionScorerError.windowLengthMismatch(
+                expected: EncoderFeatureLayout.windowLength, found: declaredWindow)
+        }
+        windowLength = EncoderFeatureLayout.windowLength
+
+        guard description.inputDescriptionsByName.count == 1,
+              let input = description.inputDescriptionsByName.first,
+              let inputConstraint = input.value.multiArrayConstraint else {
+            throw CoreMLMotionScorerError.unsupportedModel(
+                "expected exactly one multi-array input")
+        }
+        let expectedInput = [1, EncoderFeatureLayout.windowLength,
+                             EncoderFeatureLayout.channelCount]
+        guard inputConstraint.shape.map(\.intValue) == expectedInput else {
+            throw CoreMLMotionScorerError.unsupportedModel(
+                "input shape \(inputConstraint.shape) != \(expectedInput)")
+        }
+        inputName = input.key
+
+        guard description.outputDescriptionsByName.count == 1,
+              let output = description.outputDescriptionsByName.first,
+              let outputConstraint = output.value.multiArrayConstraint else {
+            throw CoreMLMotionScorerError.unsupportedModel(
+                "expected exactly one multi-array output")
+        }
+        let classCount = GestureClass.allCases.count
+        guard outputConstraint.shape.map(\.intValue) == [1, classCount] else {
+            throw CoreMLMotionScorerError.unsupportedModel(
+                "output shape \(outputConstraint.shape) != [1, \(classCount)]")
+        }
+        outputName = output.key
+    }
+
+    public func score(_ window: EncoderInputWindow) throws -> GestureScores {
+        guard window.features.count == windowLength else {
+            throw CoreMLMotionScorerError.windowShapeMismatch(
+                "\(window.features.count) rows, expected \(windowLength)")
+        }
+        let channelCount = EncoderFeatureLayout.channelCount
+        let array = try MLMultiArray(
+            shape: [1, NSNumber(value: windowLength), NSNumber(value: channelCount)],
+            dataType: .float32
+        )
+        var index = 0
+        for row in window.features {
+            guard row.count == channelCount else {
+                throw CoreMLMotionScorerError.windowShapeMismatch(
+                    "\(row.count) channels, expected \(channelCount)")
+            }
+            for value in row {
+                array[index] = NSNumber(value: value)
+                index += 1
+            }
+        }
+
+        let prediction = try model.prediction(
+            from: MLDictionaryFeatureProvider(dictionary: [inputName: array])
+        )
+        guard let scores = prediction.featureValue(for: outputName)?.multiArrayValue,
+              scores.count == GestureClass.allCases.count else {
+            throw CoreMLMotionScorerError.unsupportedModel(
+                "prediction did not produce \(GestureClass.allCases.count) class scores")
+        }
+        var values: [GestureClass: Float] = [:]
+        for (offset, gestureClass) in GestureClass.allCases.enumerated() {
+            values[gestureClass] = scores[offset].floatValue
+        }
+        return GestureScores(values: values)
+    }
+}
+#endif

--- a/Sources/TapQAppleAdapters/HeadGestureDetector.swift
+++ b/Sources/TapQAppleAdapters/HeadGestureDetector.swift
@@ -46,7 +46,13 @@ import TapQDetectionBaseline
     /// so a genuinely new outage is reported as well.
     public var onMotionLost: (@MainActor () -> Void)?
 
+    /// How a configured TapQ-1 encoder backend participates. `.off` until
+    /// `configureEncoder` succeeds; the heuristic pipeline always keeps running so a
+    /// backend failure can never leave the detector silent.
+    public private(set) var encoderMode: EncoderMode = .off
+
     private var pipeline: MotionGesturePipeline
+    private var encoderPipeline: EncoderMotionPipeline?
     private var onGesture: (@MainActor (HeadGesture) -> Void)?
     private var onTap: (@MainActor (TapCommand) -> Void)?
     private var onTilt: (@MainActor (TiltCommand) -> Void)?
@@ -73,6 +79,7 @@ import TapQDetectionBaseline
     private let maximumStartupRestarts: Int
     private let source: HeadphoneMotionSource
     private let diagnostics: TapQDiagnosticEmitter
+    private let diagnosticSink: any TapQDiagnosticSink
 
     /// Test seam: inject a fake source so tests can exercise adapter lifecycle without
     /// touching CoreMotion.
@@ -95,7 +102,23 @@ import TapQDetectionBaseline
             max(0, startupRestartBackoff) * 1_000_000_000)
         self.maximumStartupRestarts = max(0, maximumStartupRestarts)
         self.diagnostics = TapQDiagnosticEmitter(category: "GestureAdapter", sink: diagnosticSink)
+        self.diagnosticSink = diagnosticSink
         super.init()
+    }
+
+    /// Attaches a TapQ-1 encoder backend. In `.shadow` mode the encoder's detections
+    /// are recorded as diagnostics while heuristics keep driving events; in `.primary`
+    /// mode the encoder drives events and heuristic detections are recorded for
+    /// comparison. Passing `.off` detaches the backend.
+    public func configureEncoder(
+        scorer: any MotionWindowScoring,
+        config: EncoderConfig = .init(),
+        mode: EncoderMode
+    ) {
+        encoderMode = mode
+        encoderPipeline = mode == .off ? nil : EncoderMotionPipeline(
+            scorer: scorer, config: config, diagnosticSink: diagnosticSink)
+        diagnostics.record("encoder.configured", fields: ["mode": mode.rawValue])
     }
 
     public convenience init(config: HeadGestureConfig = .init(),
@@ -298,6 +321,7 @@ import TapQDetectionBaseline
         onMotionSwipe = nil
         onSample = nil
         pipeline.reset()
+        encoderPipeline?.reset()
     }
 
     private func resetSession() {
@@ -309,6 +333,7 @@ import TapQDetectionBaseline
         awaitingFirstSampleEpoch = nil
         firstSampleStartedAt = nil
         pipeline.reset()
+        encoderPipeline?.reset()
         motionLossSignaled = false
     }
 
@@ -323,11 +348,36 @@ import TapQDetectionBaseline
 
     private func ingest(_ sample: HeadMotionSample) {
         handleMotionRecoveryIfNeeded()
-        let result = pipeline.ingest(sample)
-        if let gesture = result.gesture { onGesture?(gesture) }
-        if let tap = result.tap { onTap?(tap) }
-        if let tilt = result.tilt { onTilt?(tilt) }
-        if let swipe = result.swipe { onMotionSwipe?(swipe) }
+        // Heuristics run in every mode: they are the fallback and, in primary mode,
+        // the comparison shadow — the cost is trivial next to a model inference.
+        let heuristic = pipeline.ingest(sample)
+        let delivered: MotionDetectionResult
+        switch encoderMode {
+        case .off:
+            delivered = heuristic
+        case .shadow:
+            if let shadow = encoderPipeline?.ingest(sample) {
+                recordShadowDetections(shadow, backend: "encoder")
+            }
+            delivered = heuristic
+        case .primary:
+            delivered = encoderPipeline?.ingest(sample) ?? heuristic
+            recordShadowDetections(heuristic, backend: "heuristic")
+        }
+        if let gesture = delivered.gesture { onGesture?(gesture) }
+        if let tap = delivered.tap { onTap?(tap) }
+        if let tilt = delivered.tilt { onTilt?(tilt) }
+        if let swipe = delivered.swipe { onMotionSwipe?(swipe) }
+    }
+
+    private func recordShadowDetections(_ result: MotionDetectionResult, backend: String) {
+        guard result != MotionDetectionResult() else { return }
+        var fields = ["backend": backend]
+        if let gesture = result.gesture { fields["gesture"] = "\(gesture)" }
+        if let tap = result.tap { fields["tap"] = "\(tap)" }
+        if let tilt = result.tilt { fields["tilt"] = "\(tilt)" }
+        if let swipe = result.swipe { fields["swipe"] = "\(swipe)" }
+        diagnostics.record("detection.shadow", fields: fields)
     }
 
     /// `startUpdates` returning only means CoreMotion accepted the request. A stream is

--- a/Sources/TapQAppleAdapters/HeadGestureDetector.swift
+++ b/Sources/TapQAppleAdapters/HeadGestureDetector.swift
@@ -23,6 +23,25 @@ import TapQDetectionBaseline
         set { pipeline.tapDetectionEnabled = newValue }
     }
 
+    public var tiltConfig: TiltConfig {
+        get { pipeline.tiltConfig }
+        set { pipeline.tiltConfig = newValue }
+    }
+
+    public var swipeConfig: SwipeConfig {
+        get { pipeline.swipeConfig }
+        set { pipeline.swipeConfig = newValue }
+    }
+
+    /// Experimental; see `MotionGesturePipeline.swipeDetectionEnabled`.
+    public var swipeDetectionEnabled: Bool {
+        get { pipeline.swipeDetectionEnabled }
+        set { pipeline.swipeDetectionEnabled = newValue }
+    }
+
+    /// Experimental motion-swipe events; delivered only while swipe detection is enabled.
+    public var onMotionSwipe: (@MainActor (MotionSwipeCommand) -> Void)?
+
     /// Fired once per contiguous motion outage. A later valid sample rearms the callback
     /// so a genuinely new outage is reported as well.
     public var onMotionLost: (@MainActor () -> Void)?
@@ -251,6 +270,7 @@ import TapQDetectionBaseline
             onGesture = nil
             onTap = nil
             onTilt = nil
+            onMotionSwipe = nil
             return
         }
         diagnostics.record("motion.stopped")
@@ -275,6 +295,7 @@ import TapQDetectionBaseline
         onGesture = nil
         onTap = nil
         onTilt = nil
+        onMotionSwipe = nil
         onSample = nil
         pipeline.reset()
     }
@@ -306,6 +327,7 @@ import TapQDetectionBaseline
         if let gesture = result.gesture { onGesture?(gesture) }
         if let tap = result.tap { onTap?(tap) }
         if let tilt = result.tilt { onTilt?(tilt) }
+        if let swipe = result.swipe { onMotionSwipe?(swipe) }
     }
 
     /// `startUpdates` returning only means CoreMotion accepted the request. A stream is
@@ -457,8 +479,8 @@ import TapQDetectionBaseline
         }
     }
 
-    func ingestTilt(pitch: Double, time: TimeInterval) {
-        if let tilt = pipeline.ingestTilt(pitch: pitch, time: time) {
+    func ingestTilt(roll: Double, pitch: Double, yaw: Double, time: TimeInterval) {
+        if let tilt = pipeline.ingestTilt(roll: roll, pitch: pitch, yaw: yaw, time: time) {
             onTilt?(tilt)
         }
     }

--- a/Sources/TapQAppleAdapters/HeadphoneMotionSource.swift
+++ b/Sources/TapQAppleAdapters/HeadphoneMotionSource.swift
@@ -85,8 +85,10 @@ enum HeadphoneMotionSourceError: LocalizedError {
                 handler(HeadMotionSample(timestamp: motion.timestamp,
                                          pitch: motion.attitude.pitch,
                                          yaw: motion.attitude.yaw,
-                                         accelerationMagnitude: Self.magnitude(motion.userAcceleration),
-                                         rotationMagnitude: Self.magnitude(motion.rotationRate)),
+                                         roll: motion.attitude.roll,
+                                         userAcceleration: Self.vector(motion.userAcceleration),
+                                         rotationRate: Self.vector(motion.rotationRate),
+                                         gravity: Self.vector(motion.gravity)),
                         nil)
             }
         }
@@ -119,12 +121,12 @@ enum HeadphoneMotionSourceError: LocalizedError {
         handler(nil, HeadphoneMotionSourceError.disconnected)
     }
 
-    private static func magnitude(_ v: CMAcceleration) -> Double {
-        (v.x * v.x + v.y * v.y + v.z * v.z).squareRoot()
+    private static func vector(_ v: CMAcceleration) -> MotionVector {
+        MotionVector(x: v.x, y: v.y, z: v.z)
     }
 
-    private static func magnitude(_ v: CMRotationRate) -> Double {
-        (v.x * v.x + v.y * v.y + v.z * v.z).squareRoot()
+    private static func vector(_ v: CMRotationRate) -> MotionVector {
+        MotionVector(x: v.x, y: v.y, z: v.z)
     }
 }
 

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -1,10 +1,12 @@
 import Foundation
 import TapQClaudeAdapter
+import TapQDetectionBaseline
 
 enum CLIHelpTopic: Equatable {
     case root
     case serve
     case capture
+    case replay
     case calibration
     case integration
 }
@@ -29,6 +31,21 @@ struct ServeOptions: Equatable {
     var voiceEnabled = true
     var announcementsEnabled = true
     var steeringEnabled = false
+    var encoderModelPath: String?
+    /// Meaningful only alongside `encoderModelPath`; shadow is the safe default —
+    /// the encoder is observed, never trusted, until promoted explicitly.
+    var encoderMode: EncoderMode = .shadow
+}
+
+struct ReplayOptions: Equatable {
+    var inputPath = ""
+    var labelsPath: String?
+    var format: CaptureFormat?
+    var tolerance: TimeInterval = 1.0
+    var json = false
+    var encoderModelPath: String?
+    var gestureProfilePath: String?
+    var tapProfilePath: String?
 }
 
 enum CalibrationTarget: String, Equatable {
@@ -105,6 +122,7 @@ enum CLICommand: Equatable {
     case version(json: Bool)
     case serve(ServeOptions)
     case capture(CaptureOptions)
+    case replay(ReplayOptions)
     case calibration(CalibrationCommand)
     case integration(IntegrationOptions)
 }
@@ -130,6 +148,9 @@ enum CLICommandParser {
         case "capture":
             if isHelp(rest) { return .help(.capture) }
             return .capture(try parseCapture(rest))
+        case "replay":
+            if isHelp(rest) { return .help(.replay) }
+            return .replay(try parseReplay(rest))
         case "calibrate":
             if isHelp(rest) { return .help(.calibration) }
             return .calibration(.run(try parseCalibrationRun(rest)))
@@ -150,6 +171,7 @@ enum CLICommandParser {
         switch topic {
         case "serve": return .serve
         case "capture": return .capture
+        case "replay": return .replay
         case "calibrate", "calibration": return .calibration
         case "integration": return .integration
         default: throw CLIUsageError(message: "Unknown help topic '\(topic)'.")
@@ -191,6 +213,7 @@ enum CLICommandParser {
 
     private static func parseServe(_ arguments: [String]) throws -> ServeOptions {
         var options = ServeOptions()
+        var encoderModeSpecified = false
         var cursor = ArgumentCursor(arguments)
         while let argument = cursor.pop() {
             switch argument {
@@ -209,9 +232,57 @@ enum CLICommandParser {
                 options.announcementsEnabled = false
             case "--steering":
                 options.steeringEnabled = true
+            case "--encoder-model":
+                options.encoderModelPath = try cursor.requireValue(for: argument)
+            case "--encoder-mode":
+                let value = try cursor.requireValue(for: argument)
+                guard let mode = EncoderMode(rawValue: value), mode != .off else {
+                    throw CLIUsageError(message: "--encoder-mode must be 'shadow' or 'primary'.")
+                }
+                options.encoderMode = mode
+                encoderModeSpecified = true
             default:
                 throw CLIUsageError(message: "Unknown serve option '\(argument)'.")
             }
+        }
+        if encoderModeSpecified, options.encoderModelPath == nil {
+            throw CLIUsageError(message: "--encoder-mode requires --encoder-model.")
+        }
+        return options
+    }
+
+    private static func parseReplay(_ arguments: [String]) throws -> ReplayOptions {
+        var options = ReplayOptions()
+        var cursor = ArgumentCursor(arguments)
+        while let argument = cursor.pop() {
+            switch argument {
+            case "--input", "-i":
+                options.inputPath = try cursor.requireValue(for: argument)
+            case "--labels":
+                options.labelsPath = try cursor.requireValue(for: argument)
+            case "--format":
+                let value = try cursor.requireValue(for: argument)
+                guard let format = CaptureFormat(rawValue: value) else {
+                    throw CLIUsageError(message: "--format must be 'jsonl' or 'csv'.")
+                }
+                options.format = format
+            case "--tolerance":
+                options.tolerance = try duration(
+                    cursor.requireValue(for: argument), flag: argument)
+            case "--json":
+                options.json = true
+            case "--encoder-model":
+                options.encoderModelPath = try cursor.requireValue(for: argument)
+            case "--gesture-profile":
+                options.gestureProfilePath = try cursor.requireValue(for: argument)
+            case "--tap-profile":
+                options.tapProfilePath = try cursor.requireValue(for: argument)
+            default:
+                throw CLIUsageError(message: "Unknown replay option '\(argument)'.")
+            }
+        }
+        guard !options.inputPath.isEmpty else {
+            throw CLIUsageError(message: "replay requires --input PATH.")
         }
         return options
     }

--- a/Sources/TapQCLI/CaptureReplay.swift
+++ b/Sources/TapQCLI/CaptureReplay.swift
@@ -1,0 +1,400 @@
+import Foundation
+import TapQContracts
+import TapQDetectionBaseline
+
+/// Event vocabulary of replay evaluation: the user-visible commands a backend can emit.
+/// Labels mark command-level expectations — a `nod` segment contains the full double
+/// nod, a `tap` segment the full double tap — because that is what a wearer actually
+/// performs and what a backend is expected to turn into exactly one event.
+enum ReplayEventLabel: String, Codable, CaseIterable, Equatable {
+    case nod
+    case shake
+    case tiltLeft = "tilt_left"
+    case tiltRight = "tilt_right"
+    case tap
+    case swipeUp = "swipe_up"
+    case swipeDown = "swipe_down"
+}
+
+struct ReplayEvent: Equatable {
+    let time: TimeInterval
+    let label: ReplayEventLabel
+}
+
+extension MotionDetectionResult {
+    var replayLabels: [ReplayEventLabel] {
+        var labels: [ReplayEventLabel] = []
+        switch gesture {
+        case .nod: labels.append(.nod)
+        case .shake: labels.append(.shake)
+        case nil: break
+        }
+        if tap != nil { labels.append(.tap) }
+        switch tilt {
+        case .tiltLeft: labels.append(.tiltLeft)
+        case .tiltRight: labels.append(.tiltRight)
+        case nil: break
+        }
+        switch swipe {
+        case .swipeUp: labels.append(.swipeUp)
+        case .swipeDown: labels.append(.swipeDown)
+        case nil: break
+        }
+        return labels
+    }
+}
+
+enum CaptureReadError: Error, LocalizedError, Equatable {
+    case unreadable(String)
+    case unrecognizedFormat(String)
+    case missingColumns(String)
+    case badLine(Int, String)
+    case badLabelLine(Int, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unreadable(let path):
+            return "Could not read capture input at \(path)."
+        case .unrecognizedFormat(let path):
+            return "Could not recognize the capture format of \(path). Pass --format jsonl or --format csv."
+        case .missingColumns(let details):
+            return "The CSV header is missing required columns: \(details)."
+        case .badLine(let line, let details):
+            return "Could not parse capture line \(line): \(details)"
+        case .badLabelLine(let line, let details):
+            return "Could not parse label line \(line): \(details)"
+        }
+    }
+}
+
+/// Reads `tapq capture` output — JSONL or CSV, per-axis or the magnitude-only layout
+/// that predates per-axis capture — back into portable samples.
+enum MotionCaptureReader {
+    static func samples(
+        fromFileAt url: URL, formatHint: CaptureFormat?
+    ) throws -> [HeadMotionSample] {
+        guard let data = FileManager.default.contents(atPath: url.path),
+              let text = String(data: data, encoding: .utf8) else {
+            throw CaptureReadError.unreadable(url.path)
+        }
+        let format = formatHint
+            ?? inferFormat(text: text, pathExtension: url.pathExtension)
+        guard let format else { throw CaptureReadError.unrecognizedFormat(url.path) }
+        return try samples(fromText: text, format: format)
+    }
+
+    static func inferFormat(text: String, pathExtension: String) -> CaptureFormat? {
+        switch pathExtension.lowercased() {
+        case "jsonl", "json": return .jsonl
+        case "csv": return .csv
+        default: break
+        }
+        guard let first = text.split(separator: "\n", omittingEmptySubsequences: true).first
+        else { return nil }
+        if first.hasPrefix("{") { return .jsonl }
+        if first.hasPrefix("timestamp,") { return .csv }
+        return nil
+    }
+
+    static func samples(fromText text: String, format: CaptureFormat) throws -> [HeadMotionSample] {
+        switch format {
+        case .jsonl: return try jsonlSamples(text)
+        case .csv: return try csvSamples(text)
+        }
+    }
+
+    private static func jsonlSamples(_ text: String) throws -> [HeadMotionSample] {
+        let decoder = JSONDecoder()
+        var samples: [HeadMotionSample] = []
+        for (index, line) in text.split(separator: "\n").enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            do {
+                let record = try decoder.decode(
+                    ReplayCaptureRecord.self, from: Data(trimmed.utf8))
+                samples.append(record.sample)
+            } catch {
+                throw CaptureReadError.badLine(index + 1, String(describing: error))
+            }
+        }
+        return samples
+    }
+
+    private static func csvSamples(_ text: String) throws -> [HeadMotionSample] {
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        guard !lines.isEmpty else { return [] }
+        let header = lines.removeFirst().split(separator: ",").map(String.init)
+        var column: [String: Int] = [:]
+        for (index, name) in header.enumerated() { column[name] = index }
+
+        let required = ["timestamp", "pitch", "yaw",
+                        "acceleration_magnitude", "rotation_magnitude"]
+        let missing = required.filter { column[$0] == nil }
+        guard missing.isEmpty else {
+            throw CaptureReadError.missingColumns(missing.joined(separator: ", "))
+        }
+        let axisColumns = ["roll",
+                           "user_acceleration_x", "user_acceleration_y", "user_acceleration_z",
+                           "rotation_rate_x", "rotation_rate_y", "rotation_rate_z",
+                           "gravity_x", "gravity_y", "gravity_z"]
+        let hasAxisData = axisColumns.allSatisfy { column[$0] != nil }
+
+        var samples: [HeadMotionSample] = []
+        for (offset, line) in lines.enumerated() {
+            let fields = line.split(separator: ",", omittingEmptySubsequences: false)
+                .map(String.init)
+            func value(_ name: String) throws -> Double {
+                guard let index = column[name], index < fields.count,
+                      let parsed = Double(fields[index]) else {
+                    throw CaptureReadError.badLine(offset + 2, "column '\(name)'")
+                }
+                return parsed
+            }
+            if hasAxisData {
+                samples.append(HeadMotionSample(
+                    timestamp: try value("timestamp"),
+                    pitch: try value("pitch"),
+                    yaw: try value("yaw"),
+                    roll: try value("roll"),
+                    userAcceleration: MotionVector(
+                        x: try value("user_acceleration_x"),
+                        y: try value("user_acceleration_y"),
+                        z: try value("user_acceleration_z")),
+                    rotationRate: MotionVector(
+                        x: try value("rotation_rate_x"),
+                        y: try value("rotation_rate_y"),
+                        z: try value("rotation_rate_z")),
+                    gravity: MotionVector(
+                        x: try value("gravity_x"),
+                        y: try value("gravity_y"),
+                        z: try value("gravity_z"))
+                ))
+            } else {
+                samples.append(HeadMotionSample(
+                    timestamp: try value("timestamp"),
+                    pitch: try value("pitch"),
+                    yaw: try value("yaw"),
+                    accelerationMagnitude: try value("acceleration_magnitude"),
+                    rotationMagnitude: try value("rotation_magnitude")
+                ))
+            }
+        }
+        return samples
+    }
+
+    /// Decoding mirror of `MotionSampleFormatter.CaptureRecord`; per-axis keys are
+    /// optional so magnitude-only captures from before per-axis capture still replay.
+    private struct ReplayCaptureRecord: Decodable {
+        let timestamp: TimeInterval
+        let pitch: Double
+        let yaw: Double
+        let roll: Double?
+        let accelerationMagnitude: Double
+        let rotationMagnitude: Double
+        let userAccelerationX: Double?
+        let userAccelerationY: Double?
+        let userAccelerationZ: Double?
+        let rotationRateX: Double?
+        let rotationRateY: Double?
+        let rotationRateZ: Double?
+        let gravityX: Double?
+        let gravityY: Double?
+        let gravityZ: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case timestamp, pitch, yaw, roll
+            case accelerationMagnitude = "acceleration_magnitude"
+            case rotationMagnitude = "rotation_magnitude"
+            case userAccelerationX = "user_acceleration_x"
+            case userAccelerationY = "user_acceleration_y"
+            case userAccelerationZ = "user_acceleration_z"
+            case rotationRateX = "rotation_rate_x"
+            case rotationRateY = "rotation_rate_y"
+            case rotationRateZ = "rotation_rate_z"
+            case gravityX = "gravity_x"
+            case gravityY = "gravity_y"
+            case gravityZ = "gravity_z"
+        }
+
+        var sample: HeadMotionSample {
+            if let roll,
+               let uax = userAccelerationX, let uay = userAccelerationY,
+               let uaz = userAccelerationZ,
+               let rrx = rotationRateX, let rry = rotationRateY, let rrz = rotationRateZ,
+               let gx = gravityX, let gy = gravityY, let gz = gravityZ {
+                return HeadMotionSample(
+                    timestamp: timestamp, pitch: pitch, yaw: yaw, roll: roll,
+                    userAcceleration: MotionVector(x: uax, y: uay, z: uaz),
+                    rotationRate: MotionVector(x: rrx, y: rry, z: rrz),
+                    gravity: MotionVector(x: gx, y: gy, z: gz)
+                )
+            }
+            return HeadMotionSample(
+                timestamp: timestamp, pitch: pitch, yaw: yaw,
+                accelerationMagnitude: accelerationMagnitude,
+                rotationMagnitude: rotationMagnitude
+            )
+        }
+    }
+}
+
+/// One expected command in a labeled capture: the wearer performed `label` between
+/// `start` and `end`, in the capture's own timestamp clock.
+struct ReplayLabelSegment: Decodable, Equatable {
+    let start: TimeInterval
+    let end: TimeInterval
+    let label: ReplayEventLabel
+}
+
+enum ReplayLabelReader {
+    static func segments(fromFileAt url: URL) throws -> [ReplayLabelSegment] {
+        guard let data = FileManager.default.contents(atPath: url.path),
+              let text = String(data: data, encoding: .utf8) else {
+            throw CaptureReadError.unreadable(url.path)
+        }
+        return try segments(fromText: text)
+    }
+
+    static func segments(fromText text: String) throws -> [ReplayLabelSegment] {
+        let decoder = JSONDecoder()
+        var segments: [ReplayLabelSegment] = []
+        for (index, line) in text.split(separator: "\n").enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            do {
+                let segment = try decoder.decode(
+                    ReplayLabelSegment.self, from: Data(trimmed.utf8))
+                guard segment.start <= segment.end else {
+                    throw CaptureReadError.badLabelLine(index + 1, "start is after end")
+                }
+                segments.append(segment)
+            } catch let error as CaptureReadError {
+                throw error
+            } catch {
+                throw CaptureReadError.badLabelLine(index + 1, String(describing: error))
+            }
+        }
+        return segments.sorted { $0.start < $1.start }
+    }
+}
+
+struct ReplayLabelMetrics: Equatable {
+    let label: ReplayEventLabel
+    let truePositives: Int
+    let falseNegatives: Int
+    let falsePositives: Int
+
+    var precision: Double? {
+        let emitted = truePositives + falsePositives
+        return emitted == 0 ? nil : Double(truePositives) / Double(emitted)
+    }
+
+    var recall: Double? {
+        let expected = truePositives + falseNegatives
+        return expected == 0 ? nil : Double(truePositives) / Double(expected)
+    }
+}
+
+struct ReplayReport: Equatable {
+    let metrics: [ReplayLabelMetrics]
+    let durationSeconds: TimeInterval
+
+    var falsePositives: Int { metrics.reduce(0) { $0 + $1.falsePositives } }
+    var falsePositivesPerMinute: Double? {
+        durationSeconds > 0 ? Double(falsePositives) / (durationSeconds / 60) : nil
+    }
+}
+
+enum ReplayEvaluator {
+    /// A segment is satisfied by the first same-label event inside
+    /// [start, end + tolerance] — commands complete (and therefore emit) after the
+    /// motion ends. Extra same-segment events are double fires and count as false
+    /// positives, as does any event no segment claims.
+    static func evaluate(
+        events: [ReplayEvent],
+        segments: [ReplayLabelSegment],
+        tolerance: TimeInterval,
+        duration: TimeInterval
+    ) -> ReplayReport {
+        let ordered = events.sorted { $0.time < $1.time }
+        var consumed = Array(repeating: false, count: ordered.count)
+        var truePositives: [ReplayEventLabel: Int] = [:]
+        var falseNegatives: [ReplayEventLabel: Int] = [:]
+
+        for segment in segments.sorted(by: { $0.start < $1.start }) {
+            let match = ordered.indices.first { index in
+                !consumed[index]
+                    && ordered[index].label == segment.label
+                    && ordered[index].time >= segment.start
+                    && ordered[index].time <= segment.end + tolerance
+            }
+            if let match {
+                consumed[match] = true
+                truePositives[segment.label, default: 0] += 1
+            } else {
+                falseNegatives[segment.label, default: 0] += 1
+            }
+        }
+
+        var falsePositives: [ReplayEventLabel: Int] = [:]
+        for (index, event) in ordered.enumerated() where !consumed[index] {
+            falsePositives[event.label, default: 0] += 1
+        }
+
+        let metrics = ReplayEventLabel.allCases.compactMap { label -> ReplayLabelMetrics? in
+            let tp = truePositives[label] ?? 0
+            let fn = falseNegatives[label] ?? 0
+            let fp = falsePositives[label] ?? 0
+            guard tp + fn + fp > 0 else { return nil }
+            return ReplayLabelMetrics(
+                label: label, truePositives: tp, falseNegatives: fn, falsePositives: fp)
+        }
+        return ReplayReport(metrics: metrics, durationSeconds: duration)
+    }
+}
+
+/// Streams a capture through a detection backend and collects emitted events, stamped
+/// with the producing sample's capture timestamp.
+enum ReplayBackendRunner {
+    /// Heuristic backend. Swipe detection is force-enabled: replay exists to evaluate
+    /// channels offline, including experimental ones that ship disabled.
+    static func heuristicEvents(
+        samples: [HeadMotionSample],
+        gestureConfig: HeadGestureConfig,
+        tapConfig: TapConfig,
+        tiltConfig: TiltConfig = .init(),
+        swipeConfig: SwipeConfig = .init()
+    ) -> [ReplayEvent] {
+        var pipeline = MotionGesturePipeline(
+            config: gestureConfig,
+            tapConfig: tapConfig,
+            tiltConfig: tiltConfig,
+            swipeConfig: swipeConfig,
+            swipeDetectionEnabled: true
+        )
+        return run(samples: samples) { pipeline.ingest($0) }
+    }
+
+    static func encoderEvents(
+        samples: [HeadMotionSample],
+        scorer: any MotionWindowScoring,
+        config: EncoderConfig = .init()
+    ) -> [ReplayEvent] {
+        var pipeline = EncoderMotionPipeline(scorer: scorer, config: config)
+        return run(samples: samples) { pipeline.ingest($0) }
+    }
+
+    private static func run(
+        samples: [HeadMotionSample],
+        ingest: (HeadMotionSample) -> MotionDetectionResult
+    ) -> [ReplayEvent] {
+        var events: [ReplayEvent] = []
+        for sample in samples {
+            for label in ingest(sample).replayLabels {
+                events.append(ReplayEvent(time: sample.timestamp, label: label))
+            }
+        }
+        return events
+    }
+}

--- a/Sources/TapQCLI/CaptureReplay.swift
+++ b/Sources/TapQCLI/CaptureReplay.swift
@@ -4,8 +4,9 @@ import TapQDetectionBaseline
 
 /// Event vocabulary of replay evaluation: the user-visible commands a backend can emit.
 /// Labels mark command-level expectations — a `nod` segment contains the full double
-/// nod, a `tap` segment the full double tap — because that is what a wearer actually
-/// performs and what a backend is expected to turn into exactly one event.
+/// nod, a `shake` segment the full double shake, a `tap` segment the full double tap —
+/// because that is what a wearer actually performs and what a backend is expected to
+/// turn into exactly one event.
 enum ReplayEventLabel: String, Codable, CaseIterable, Equatable {
     case nod
     case shake

--- a/Sources/TapQCLI/MotionCapture.swift
+++ b/Sources/TapQCLI/MotionCapture.swift
@@ -51,7 +51,11 @@ public struct MotionCaptureHealth: Equatable {
 }
 
 enum MotionSampleFormatter {
-    static let csvHeader = "timestamp,pitch,yaw,acceleration_magnitude,rotation_magnitude"
+    /// The original five columns keep their positions so existing capture tooling keeps
+    /// working; per-axis columns are appended.
+    static let csvHeader = "timestamp,pitch,yaw,acceleration_magnitude,rotation_magnitude,"
+        + "roll,user_acceleration_x,user_acceleration_y,user_acceleration_z,"
+        + "rotation_rate_x,rotation_rate_y,rotation_rate_z,gravity_x,gravity_y,gravity_z"
 
     static func line(for sample: HeadMotionSample, format: CaptureFormat) -> String {
         switch format {
@@ -71,6 +75,16 @@ enum MotionSampleFormatter {
                 decimal(sample.yaw),
                 decimal(sample.accelerationMagnitude),
                 decimal(sample.rotationMagnitude),
+                decimal(sample.roll),
+                decimal(sample.userAcceleration.x),
+                decimal(sample.userAcceleration.y),
+                decimal(sample.userAcceleration.z),
+                decimal(sample.rotationRate.x),
+                decimal(sample.rotationRate.y),
+                decimal(sample.rotationRate.z),
+                decimal(sample.gravity.x),
+                decimal(sample.gravity.y),
+                decimal(sample.gravity.z),
             ].joined(separator: ",")
         }
     }
@@ -83,21 +97,50 @@ enum MotionSampleFormatter {
         let timestamp: TimeInterval
         let pitch: Double
         let yaw: Double
+        let roll: Double
         let accelerationMagnitude: Double
         let rotationMagnitude: Double
+        let userAccelerationX: Double
+        let userAccelerationY: Double
+        let userAccelerationZ: Double
+        let rotationRateX: Double
+        let rotationRateY: Double
+        let rotationRateZ: Double
+        let gravityX: Double
+        let gravityY: Double
+        let gravityZ: Double
 
         enum CodingKeys: String, CodingKey {
-            case timestamp, pitch, yaw
+            case timestamp, pitch, yaw, roll
             case accelerationMagnitude = "acceleration_magnitude"
             case rotationMagnitude = "rotation_magnitude"
+            case userAccelerationX = "user_acceleration_x"
+            case userAccelerationY = "user_acceleration_y"
+            case userAccelerationZ = "user_acceleration_z"
+            case rotationRateX = "rotation_rate_x"
+            case rotationRateY = "rotation_rate_y"
+            case rotationRateZ = "rotation_rate_z"
+            case gravityX = "gravity_x"
+            case gravityY = "gravity_y"
+            case gravityZ = "gravity_z"
         }
 
         init(sample: HeadMotionSample) {
             timestamp = sample.timestamp
             pitch = sample.pitch
             yaw = sample.yaw
+            roll = sample.roll
             accelerationMagnitude = sample.accelerationMagnitude
             rotationMagnitude = sample.rotationMagnitude
+            userAccelerationX = sample.userAcceleration.x
+            userAccelerationY = sample.userAcceleration.y
+            userAccelerationZ = sample.userAcceleration.z
+            rotationRateX = sample.rotationRate.x
+            rotationRateY = sample.rotationRate.y
+            rotationRateZ = sample.rotationRate.z
+            gravityX = sample.gravity.x
+            gravityY = sample.gravity.y
+            gravityZ = sample.gravity.z
         }
     }
 }

--- a/Sources/TapQCLI/RuntimeService.swift
+++ b/Sources/TapQCLI/RuntimeService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TapQDetectionBaseline
 
 /// Platform-neutral configuration passed from CLI parsing to an injected runtime host.
 /// The macOS executable supplies the AirPods/voice host; Linux can supply another host later.
@@ -10,6 +11,10 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
     public let voiceEnabled: Bool
     public let announcementsEnabled: Bool
     public let steeringEnabled: Bool
+    /// TapQ-1 encoder model to load, if any. A load failure must degrade to the
+    /// heuristic backend, never abort serving.
+    public let encoderModelURL: URL?
+    public let encoderMode: EncoderMode
 
     public init(
         brokerDirectory: URL? = nil,
@@ -18,7 +23,9 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         interactionTimeout: TimeInterval = 100,
         voiceEnabled: Bool = true,
         announcementsEnabled: Bool = true,
-        steeringEnabled: Bool = false
+        steeringEnabled: Bool = false,
+        encoderModelURL: URL? = nil,
+        encoderMode: EncoderMode = .off
     ) {
         self.brokerDirectory = brokerDirectory
         self.gestureProfileURL = gestureProfileURL
@@ -27,6 +34,8 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         self.voiceEnabled = voiceEnabled
         self.announcementsEnabled = announcementsEnabled
         self.steeringEnabled = steeringEnabled
+        self.encoderModelURL = encoderModelURL
+        self.encoderMode = encoderMode
     }
 }
 
@@ -37,6 +46,8 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
     public let tapProfileLoaded: Bool
     public let motionAvailable: Bool
     public let voiceAvailable: Bool
+    /// Human-readable TapQ-1 encoder state; nil when no encoder was requested.
+    public let encoderStatus: String?
 
     public init(
         socketPath: String,
@@ -44,7 +55,8 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         gestureProfileLoaded: Bool,
         tapProfileLoaded: Bool,
         motionAvailable: Bool,
-        voiceAvailable: Bool
+        voiceAvailable: Bool,
+        encoderStatus: String? = nil
     ) {
         self.socketPath = socketPath
         self.discoveryPath = discoveryPath
@@ -52,6 +64,7 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         self.tapProfileLoaded = tapProfileLoaded
         self.motionAvailable = motionAvailable
         self.voiceAvailable = voiceAvailable
+        self.encoderStatus = encoderStatus
     }
 }
 

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -35,6 +35,9 @@ public struct TapQCLIIO {
     private let io: TapQCLIIO
     private let motionCapture: (any TapQMotionCapturing)?
     private let runtimeService: (any TapQRuntimeServing)?
+    /// Loads a TapQ-1 model into a window scorer for `tapq replay --encoder-model`.
+    /// nil on platforms without a Core ML host (the flag then reports unavailability).
+    private let motionScorerLoader: ((URL) async throws -> any MotionWindowScoring)?
     private let environment: [String: String]
     private let homeDirectory: URL
     private let executableURL: URL
@@ -45,6 +48,7 @@ public struct TapQCLIIO {
         io: TapQCLIIO = .live,
         motionCapture: (any TapQMotionCapturing)? = nil,
         runtimeService: (any TapQRuntimeServing)? = nil,
+        motionScorerLoader: ((URL) async throws -> any MotionWindowScoring)? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         executableURL: URL,
@@ -59,6 +63,7 @@ public struct TapQCLIIO {
         self.io = io
         self.motionCapture = motionCapture
         self.runtimeService = runtimeService
+        self.motionScorerLoader = motionScorerLoader
         self.environment = environment
         self.homeDirectory = homeDirectory
         self.executableURL = executableURL
@@ -102,6 +107,8 @@ public struct TapQCLIIO {
             try await runServe(options)
         case .capture(let options):
             try await runCapture(options)
+        case .replay(let options):
+            try await runReplay(options)
         case .calibration(let command):
             try await runCalibration(command)
         case .integration(let options):
@@ -128,7 +135,9 @@ public struct TapQCLIIO {
             ),
             voiceEnabled: options.voiceEnabled,
             announcementsEnabled: options.announcementsEnabled,
-            steeringEnabled: options.steeringEnabled
+            steeringEnabled: options.steeringEnabled,
+            encoderModelURL: options.encoderModelPath.map(resolvedURL(for:)),
+            encoderMode: options.encoderModelPath == nil ? .off : options.encoderMode
         )
         try await runtimeService.serve(configuration: configuration) { [io] endpoint in
             io.writeOutput("TapQ runtime is ready. Press Control-C to stop.\n")
@@ -138,6 +147,9 @@ public struct TapQCLIIO {
             io.writeOutput("Tap profile: \(endpoint.tapProfileLoaded ? "loaded" : "default")\n")
             io.writeOutput("AirPods motion: \(endpoint.motionAvailable ? "available" : "unavailable")\n")
             io.writeOutput("Voice input: \(endpoint.voiceAvailable ? "available" : "unavailable")\n")
+            if let encoderStatus = endpoint.encoderStatus {
+                io.writeOutput("TapQ-1 encoder: \(encoderStatus)\n")
+            }
         }
     }
 
@@ -169,6 +181,179 @@ public struct TapQCLIIO {
             sampleCount += 1
         }
         errorLine("Captured \(sampleCount) samples.")
+    }
+
+    private func runReplay(_ options: ReplayOptions) async throws {
+        let inputURL = resolvedURL(for: options.inputPath)
+        let samples = try MotionCaptureReader.samples(
+            fromFileAt: inputURL, formatHint: options.format)
+        guard let first = samples.first, let last = samples.last else {
+            throw CLIExecutionError("The capture at \(inputURL.path) contains no samples.")
+        }
+        let duration = last.timestamp - first.timestamp
+
+        let store = calibrationStore(
+            gesturePath: options.gestureProfilePath,
+            tapPath: options.tapProfilePath
+        )
+        let gestureConfig = store.exists(.gesture)
+            ? (try? store.loadGesture().config) ?? HeadGestureConfig()
+            : HeadGestureConfig()
+        let tapConfig = store.exists(.tap)
+            ? (try? store.loadTap().config) ?? TapConfig()
+            : TapConfig()
+
+        var backends: [(name: String, events: [ReplayEvent])] = [(
+            "heuristic",
+            ReplayBackendRunner.heuristicEvents(
+                samples: samples, gestureConfig: gestureConfig, tapConfig: tapConfig)
+        )]
+        if let modelPath = options.encoderModelPath {
+            guard let motionScorerLoader else {
+                throw CLIExecutionError("Encoder replay requires the macOS build of tapq (Core ML is unavailable on this platform).")
+            }
+            let scorer = try await motionScorerLoader(resolvedURL(for: modelPath))
+            backends.append((
+                "encoder",
+                ReplayBackendRunner.encoderEvents(samples: samples, scorer: scorer)
+            ))
+        }
+        let segments = try options.labelsPath.map {
+            try ReplayLabelReader.segments(fromFileAt: resolvedURL(for: $0))
+        }
+
+        if options.json {
+            try outputReplayJSON(
+                input: inputURL.path, sampleCount: samples.count, duration: duration,
+                backends: backends, segments: segments, tolerance: options.tolerance)
+            return
+        }
+
+        let rate = duration > 0 ? Double(samples.count - 1) / duration : 0
+        outputLine("Replayed \(samples.count) samples over \(display(duration)) s (\(display(rate)) Hz) from \(inputURL.path).")
+        for backend in backends {
+            outputLine("")
+            outputLine("Backend \(backend.name): \(backend.events.count) event\(backend.events.count == 1 ? "" : "s")")
+            for event in backend.events {
+                let offset = String(format: "%8.2f", event.time - first.timestamp)
+                outputLine("  +\(offset)s  \(event.label.rawValue)")
+            }
+            if let segments {
+                let report = ReplayEvaluator.evaluate(
+                    events: backend.events, segments: segments,
+                    tolerance: options.tolerance, duration: duration)
+                outputLine("  " + pad("label", 12) + lpad("TP", 4) + lpad("FN", 4)
+                    + lpad("FP", 4) + "  " + pad("precision", 9) + "  recall")
+                for metric in report.metrics {
+                    outputLine("  " + pad(metric.label.rawValue, 12)
+                        + lpad("\(metric.truePositives)", 4)
+                        + lpad("\(metric.falseNegatives)", 4)
+                        + lpad("\(metric.falsePositives)", 4)
+                        + "  " + pad(displayRatio(metric.precision), 9)
+                        + "  " + displayRatio(metric.recall))
+                }
+                if let perMinute = report.falsePositivesPerMinute {
+                    outputLine("  false positives: \(report.falsePositives) (\(display(perMinute))/min)")
+                }
+            }
+        }
+    }
+
+    private func outputReplayJSON(
+        input: String, sampleCount: Int, duration: TimeInterval,
+        backends: [(name: String, events: [ReplayEvent])],
+        segments: [ReplayLabelSegment]?, tolerance: TimeInterval
+    ) throws {
+        struct EventJSON: Encodable {
+            let time: Double
+            let label: String
+        }
+        struct MetricJSON: Encodable {
+            let label: String
+            let truePositives: Int
+            let falseNegatives: Int
+            let falsePositives: Int
+            let precision: Double?
+            let recall: Double?
+            enum CodingKeys: String, CodingKey {
+                case label
+                case truePositives = "true_positives"
+                case falseNegatives = "false_negatives"
+                case falsePositives = "false_positives"
+                case precision, recall
+            }
+        }
+        struct BackendJSON: Encodable {
+            let name: String
+            let events: [EventJSON]
+            let metrics: [MetricJSON]?
+            let falsePositivesPerMinute: Double?
+            enum CodingKeys: String, CodingKey {
+                case name, events, metrics
+                case falsePositivesPerMinute = "false_positives_per_minute"
+            }
+        }
+        struct ReportJSON: Encodable {
+            let input: String
+            let samples: Int
+            let durationSeconds: Double
+            let backends: [BackendJSON]
+            enum CodingKeys: String, CodingKey {
+                case input, samples, backends
+                case durationSeconds = "duration_seconds"
+            }
+        }
+
+        let report = ReportJSON(
+            input: input, samples: sampleCount, durationSeconds: duration,
+            backends: backends.map { backend in
+                let evaluation = segments.map {
+                    ReplayEvaluator.evaluate(
+                        events: backend.events, segments: $0,
+                        tolerance: tolerance, duration: duration)
+                }
+                return BackendJSON(
+                    name: backend.name,
+                    events: backend.events.map {
+                        EventJSON(time: $0.time, label: $0.label.rawValue)
+                    },
+                    metrics: evaluation.map { report in
+                        report.metrics.map {
+                            MetricJSON(
+                                label: $0.label.rawValue,
+                                truePositives: $0.truePositives,
+                                falseNegatives: $0.falseNegatives,
+                                falsePositives: $0.falsePositives,
+                                precision: $0.precision,
+                                recall: $0.recall)
+                        }
+                    },
+                    falsePositivesPerMinute: evaluation?.falsePositivesPerMinute)
+            }
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(report)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw CLIExecutionError("Could not encode the replay report.")
+        }
+        outputLine(text)
+    }
+
+    private func displayRatio(_ value: Double?) -> String {
+        value.map { String(format: "%.2f", $0) } ?? "n/a"
+    }
+
+    private func pad(_ text: String, _ width: Int) -> String {
+        text.count >= width
+            ? text
+            : text + String(repeating: " ", count: width - text.count)
+    }
+
+    private func lpad(_ text: String, _ width: Int) -> String {
+        text.count >= width
+            ? text
+            : String(repeating: " ", count: width - text.count) + text
     }
 
     private func runCalibration(_ command: CalibrationCommand) async throws {
@@ -552,6 +737,7 @@ public struct TapQCLIIO {
         case .root: return rootHelp
         case .serve: return serveHelp
         case .capture: return captureHelp
+        case .replay: return replayHelp
         case .calibration: return calibrationHelp
         case .integration: return integrationHelp
         }
@@ -567,6 +753,7 @@ public struct TapQCLIIO {
       calibration   Run, inspect, or reset AirPods calibration
       calibrate     Shortcut for `tapq calibration run`
       capture       Capture raw headphone motion as JSONL or CSV
+      replay        Replay a motion capture through detection backends offline
       serve         Run the local agent-agnostic TapQ broker
       integration   Manage agent integrations
       version       Print the TapQ CLI version
@@ -588,6 +775,11 @@ public struct TapQCLIIO {
       --no-voice               Disable microphone speech recognition
       --no-announcements       Disable non-blocking agent status announcements
       --steering               Ask supported adapters to prefer structured questions
+      --encoder-model PATH     Load a TapQ-1 encoder model (.mlpackage or .mlmodelc)
+      --encoder-mode MODE      shadow (default) records encoder detections as
+                               diagnostics only; primary lets the encoder drive events.
+                               If the model fails to load, serving continues on the
+                               deterministic heuristics.
 
     The broker is agent-neutral. Install each agent's adapter separately with
     `tapq integration claude install` or `tapq integration codex install`.
@@ -604,6 +796,33 @@ public struct TapQCLIIO {
       --format FORMAT      jsonl (default) or csv
       --output, -o PATH    Output file, or - for stdout (default: -)
       --force, -f          Replace an existing output file
+    """
+
+    private static let replayHelp = """
+    Replay a recorded motion capture through TapQ's detection backends, entirely
+    offline. With a label file, reports per-gesture precision/recall and false
+    positives per minute — the yardstick for tuning and for comparing the heuristic
+    baseline against a TapQ-1 encoder model.
+
+    USAGE
+      tapq replay --input PATH [options]
+
+    OPTIONS
+      --input, -i PATH         Capture file from `tapq capture` (jsonl or csv)
+      --labels PATH            JSONL label segments: {"start": s, "end": s, "label": l}
+                               using the capture's own timestamps. Labels mark the full
+                               command (a `nod` segment spans the complete double nod):
+                               nod, shake, tilt_left, tilt_right, tap, swipe_up, swipe_down
+      --format jsonl|csv       Override capture format auto-detection
+      --tolerance SECONDS      Grace period after a segment's end in which its event may
+                               still fire (default: 1.0)
+      --encoder-model PATH     Also replay through a TapQ-1 encoder model (macOS only)
+      --gesture-profile PATH   Use a calibrated gesture profile instead of defaults
+      --tap-profile PATH       Use a calibrated tap profile instead of defaults
+      --json                   Emit the report as JSON
+
+    Swipe detection is enabled during replay even though it ships disabled live, so
+    experimental channels can be evaluated from the same recordings.
     """
 
     private static let calibrationHelp = """

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -813,8 +813,9 @@ public struct TapQCLIIO {
       --input, -i PATH         Capture file from `tapq capture` (jsonl or csv)
       --labels PATH            JSONL label segments: {"start": s, "end": s, "label": l}
                                using the capture's own timestamps. Labels mark the full
-                               command (a `nod` segment spans the complete double nod):
-                               nod, shake, tilt_left, tilt_right, tap, swipe_up, swipe_down
+                               command (a `nod` segment spans the complete double nod,
+                               `shake` the complete double shake): nod, shake, tilt_left,
+                               tilt_right, tap, swipe_up, swipe_down
       --format jsonl|csv       Override capture format auto-detection
       --tolerance SECONDS      Grace period after a segment's end in which its event may
                                still fire (default: 1.0)

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -6,7 +6,7 @@ import TapQDetectionBaseline
 import TapQWireProtocol
 
 public enum TapQVersion {
-    public static let current = "0.1.0"
+    public static let current = "0.2.0"
 }
 
 public struct TapQCLIIO {

--- a/Sources/TapQContracts/Inputs.swift
+++ b/Sources/TapQContracts/Inputs.swift
@@ -139,9 +139,21 @@ public extension TapCommand {
     var onSpeakingChange: (@MainActor (Bool) -> Void)? { get set }
 }
 
+/// A doubled lateral head tilt (ear toward shoulder, roll axis). Replaces the retired
+/// pitch-based tilt: a single pitch excursion is indistinguishable from glancing at the
+/// keyboard and shares its axis with nod pairing, whereas a repeated roll excursion is
+/// rare in natural desk motion and orthogonal to both nod (pitch) and shake (yaw).
 public enum TiltCommand: Sendable, Equatable {
-    case tiltUp
-    case tiltDown
+    case tiltLeft
+    case tiltRight
+}
+
+/// A sustained finger drag on the earbud or ear detected from motion alone.
+/// Experimental: disabled by default until capture-study validation confirms direction
+/// separability at the ~25 Hz headphone motion rate.
+public enum MotionSwipeCommand: Sendable, Equatable {
+    case swipeUp
+    case swipeDown
 }
 
 public enum VolumeSwipeCommand: Sendable, Equatable {

--- a/Sources/TapQDetectionBaseline/EncoderConfig.swift
+++ b/Sources/TapQDetectionBaseline/EncoderConfig.swift
@@ -43,6 +43,10 @@ public struct EncoderConfig: Sendable, Codable, Equatable {
     /// atom is already the complete double-tap pattern (see `GestureClass`).
     public var nodPairWindowSeconds: Double
     public var minNodPairGap: Double
+    /// Shake pairing, mirroring `HeadGestureConfig`. Deny is the most consequential
+    /// command, so it carries the same doubling requirement as the heuristics.
+    public var shakePairWindowSeconds: Double
+    public var minShakePairGap: Double
     /// Tilt pairing, mirroring `TiltConfig`.
     public var tiltPairWindowSeconds: Double
     public var minTiltPairGap: Double
@@ -58,6 +62,8 @@ public struct EncoderConfig: Sendable, Codable, Equatable {
         eventDebounceSeconds: Double = 1.0,
         nodPairWindowSeconds: Double = 1.5,
         minNodPairGap: Double = 0.3,
+        shakePairWindowSeconds: Double = 1.5,
+        minShakePairGap: Double = 0.3,
         tiltPairWindowSeconds: Double = 1.6,
         minTiltPairGap: Double = 0.25
     ) {
@@ -71,6 +77,8 @@ public struct EncoderConfig: Sendable, Codable, Equatable {
         self.eventDebounceSeconds = eventDebounceSeconds
         self.nodPairWindowSeconds = nodPairWindowSeconds
         self.minNodPairGap = minNodPairGap
+        self.shakePairWindowSeconds = shakePairWindowSeconds
+        self.minShakePairGap = minShakePairGap
         self.tiltPairWindowSeconds = tiltPairWindowSeconds
         self.minTiltPairGap = minTiltPairGap
     }

--- a/Sources/TapQDetectionBaseline/EncoderConfig.swift
+++ b/Sources/TapQDetectionBaseline/EncoderConfig.swift
@@ -1,0 +1,77 @@
+import Foundation
+import TapQContracts
+
+/// How an encoder backend participates in detection at composition time.
+public enum EncoderMode: String, Sendable, Codable, Equatable {
+    /// Encoder not consulted.
+    case off
+    /// Encoder runs on every sample and records detections as diagnostics, but the
+    /// deterministic heuristics keep driving events. The validation posture: compare
+    /// backends on live motion with zero behavior risk.
+    case shadow
+    /// Encoder detections drive events; heuristics run silently for comparison
+    /// diagnostics and remain the automatic fallback when no model loads.
+    case primary
+}
+
+/// Tunable thresholds for the encoder decision layer. Windowing values are runtime
+/// knobs except `windowLength`, which is part of the model contract
+/// (`EncoderFeatureLayout`) and validated at model load. Pairing values deliberately
+/// mirror the heuristic configs so a backend swap never changes command timing.
+public struct EncoderConfig: Sendable, Codable, Equatable {
+    /// Samples per scored window; must equal the loaded model's window length.
+    public var windowLength: Int
+    /// Samples between consecutive scored windows (~0.32 s at 25 Hz).
+    public var hopSamples: Int
+    /// A gap between samples longer than this resets the window buffer.
+    public var gapResetSeconds: Double
+    /// Minimum top-class probability for a window to count as a detection.
+    public var classThreshold: Double
+    /// The top class must beat the runner-up by at least this much — near-ties are
+    /// ambiguity, not detections.
+    public var minMargin: Double
+    /// Consecutive agreeing windows required before an atom is emitted. Two windows at
+    /// the default hop ≈ 0.64 s of sustained agreement.
+    public var agreementWindows: Int
+    /// Minimum interval between emitted atoms — one physical motion spans several
+    /// hops and must not emit twice.
+    public var atomDebounceSeconds: Double
+    /// Ignore further atoms for this long after a command fires (mirrors the
+    /// heuristic pipelines' post-emission debounce).
+    public var eventDebounceSeconds: Double
+    /// Nod pairing, mirroring `HeadGestureConfig`. Tap has no pairing knobs: a `tap`
+    /// atom is already the complete double-tap pattern (see `GestureClass`).
+    public var nodPairWindowSeconds: Double
+    public var minNodPairGap: Double
+    /// Tilt pairing, mirroring `TiltConfig`.
+    public var tiltPairWindowSeconds: Double
+    public var minTiltPairGap: Double
+
+    public init(
+        windowLength: Int = EncoderFeatureLayout.windowLength,
+        hopSamples: Int = 8,
+        gapResetSeconds: Double = 0.5,
+        classThreshold: Double = 0.7,
+        minMargin: Double = 0.2,
+        agreementWindows: Int = 2,
+        atomDebounceSeconds: Double = 0.6,
+        eventDebounceSeconds: Double = 1.0,
+        nodPairWindowSeconds: Double = 1.5,
+        minNodPairGap: Double = 0.3,
+        tiltPairWindowSeconds: Double = 1.6,
+        minTiltPairGap: Double = 0.25
+    ) {
+        self.windowLength = windowLength
+        self.hopSamples = hopSamples
+        self.gapResetSeconds = gapResetSeconds
+        self.classThreshold = classThreshold
+        self.minMargin = minMargin
+        self.agreementWindows = agreementWindows
+        self.atomDebounceSeconds = atomDebounceSeconds
+        self.eventDebounceSeconds = eventDebounceSeconds
+        self.nodPairWindowSeconds = nodPairWindowSeconds
+        self.minNodPairGap = minNodPairGap
+        self.tiltPairWindowSeconds = tiltPairWindowSeconds
+        self.minTiltPairGap = minTiltPairGap
+    }
+}

--- a/Sources/TapQDetectionBaseline/EncoderContract.swift
+++ b/Sources/TapQDetectionBaseline/EncoderContract.swift
@@ -4,12 +4,12 @@ import Foundation
 /// output-vector order.
 ///
 /// Classes are gesture *atoms at window time-scale*. For motions longer than a window
-/// (nod, tilt) an atom is one excursion and `EncoderMotionPipeline` pairs two atoms
-/// deterministically, keeping the doubling false-positive filter structural. `tap` is
-/// the exception: both transients of a double tap fit inside one window (≤0.5 s apart
-/// vs a 1.28 s window), so `tap` means the complete double-tap pattern and training
-/// labels must mark full double taps — lone bumps belong to `quiet`. `shake` is
-/// inherently oscillatory and `swipe*` is a single sustained drag; both emit directly.
+/// (nod, shake, tilt) an atom is one excursion and `EncoderMotionPipeline` pairs two
+/// atoms deterministically, keeping the doubling false-positive filter structural.
+/// `tap` is the exception: both transients of a double tap fit inside one window
+/// (≤0.5 s apart vs a 1.28 s window), so `tap` means the complete double-tap pattern
+/// and training labels must mark full double taps — lone bumps belong to `quiet`.
+/// `swipe*` is a single sustained drag and emits directly.
 public enum GestureClass: String, CaseIterable, Sendable, Codable, Equatable {
     case quiet
     case nod

--- a/Sources/TapQDetectionBaseline/EncoderContract.swift
+++ b/Sources/TapQDetectionBaseline/EncoderContract.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// The closed label set of the TapQ-1 stage-1 encoder. `allCases` order is the model's
+/// output-vector order.
+///
+/// Classes are gesture *atoms at window time-scale*. For motions longer than a window
+/// (nod, tilt) an atom is one excursion and `EncoderMotionPipeline` pairs two atoms
+/// deterministically, keeping the doubling false-positive filter structural. `tap` is
+/// the exception: both transients of a double tap fit inside one window (≤0.5 s apart
+/// vs a 1.28 s window), so `tap` means the complete double-tap pattern and training
+/// labels must mark full double taps — lone bumps belong to `quiet`. `shake` is
+/// inherently oscillatory and `swipe*` is a single sustained drag; both emit directly.
+public enum GestureClass: String, CaseIterable, Sendable, Codable, Equatable {
+    case quiet
+    case nod
+    case shake
+    case tiltLeft = "tilt_left"
+    case tiltRight = "tilt_right"
+    case tap
+    case swipeUp = "swipe_up"
+    case swipeDown = "swipe_down"
+}
+
+/// The versioned feature contract between the Swift runtime and the Python training
+/// pipeline (`ml/tapq1/layout.py` mirrors these values). A trained model embeds the
+/// version in its metadata and `CoreMLMotionScorer` refuses to load a mismatch, so the
+/// two sides can never drift silently. Any change to channels, order, scaling, or
+/// window length is a new version.
+public enum EncoderFeatureLayout {
+    public static let version = "tapq1-features-v1"
+
+    /// Per-sample channels, in input order. Signed per-axis data only — attitude is
+    /// deliberately absent (yaw drifts with body heading; gravity plus rotation rate
+    /// carries the same orientation information without the drift).
+    public static let channelNames = [
+        "user_acceleration_x", "user_acceleration_y", "user_acceleration_z",
+        "rotation_rate_x", "rotation_rate_y", "rotation_rate_z",
+        "gravity_x", "gravity_y", "gravity_z",
+    ]
+    public static var channelCount: Int { channelNames.count }
+
+    /// Samples per window: 1.28 s at the ~25 Hz headphone motion rate — long enough
+    /// for one gesture atom, short enough that double-gesture pairing stays responsive.
+    public static let windowLength = 32
+
+    /// Fixed physical full-scale values used to normalize each channel into [-1, 1].
+    /// Fixed rather than dataset statistics so training and runtime cannot skew.
+    public static let accelerationFullScale = 2.0
+    public static let rotationFullScale = 8.0
+
+    /// One scaled, clipped feature row for a sample, in `channelNames` order.
+    public static func featureRow(for sample: HeadMotionSample) -> [Float] {
+        [
+            scaled(sample.userAcceleration.x, fullScale: accelerationFullScale),
+            scaled(sample.userAcceleration.y, fullScale: accelerationFullScale),
+            scaled(sample.userAcceleration.z, fullScale: accelerationFullScale),
+            scaled(sample.rotationRate.x, fullScale: rotationFullScale),
+            scaled(sample.rotationRate.y, fullScale: rotationFullScale),
+            scaled(sample.rotationRate.z, fullScale: rotationFullScale),
+            scaled(sample.gravity.x, fullScale: 1.0),
+            scaled(sample.gravity.y, fullScale: 1.0),
+            scaled(sample.gravity.z, fullScale: 1.0),
+        ]
+    }
+
+    private static func scaled(_ value: Double, fullScale: Double) -> Float {
+        Float(min(1.0, max(-1.0, value / fullScale)))
+    }
+}
+
+/// Creator-defined metadata keys a TapQ-1 model must carry so the runtime can verify
+/// it speaks the same contract. Written by `ml/tapq1/export.py`.
+public enum TapQ1ModelMetadata {
+    public static let featureLayoutKey = "com.tapq.tapq1.feature_layout"
+    public static let classesKey = "com.tapq.tapq1.classes"
+    public static let windowLengthKey = "com.tapq.tapq1.window_length"
+
+    /// The exact class list a conforming model must declare.
+    public static var expectedClasses: String {
+        GestureClass.allCases.map(\.rawValue).joined(separator: ",")
+    }
+}
+
+/// One fixed-size encoder input: `features` is time-major, oldest sample first, each
+/// row in `EncoderFeatureLayout.channelNames` order.
+public struct EncoderInputWindow: Sendable, Equatable {
+    public let features: [[Float]]
+    public let startTime: TimeInterval
+    public let endTime: TimeInterval
+
+    public init(features: [[Float]], startTime: TimeInterval, endTime: TimeInterval) {
+        self.features = features
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+}
+
+/// Per-class probabilities for one window. Probabilities are expected to come from an
+/// in-model softmax; absent classes read as zero.
+public struct GestureScores: Sendable, Equatable {
+    public let values: [GestureClass: Float]
+
+    public init(values: [GestureClass: Float]) {
+        self.values = values
+    }
+
+    public func probability(of gestureClass: GestureClass) -> Float {
+        values[gestureClass] ?? 0
+    }
+
+    /// Classes ranked by descending probability; ties broken by `allCases` order so
+    /// ranking is deterministic.
+    public var ranked: [(gestureClass: GestureClass, probability: Float)] {
+        GestureClass.allCases
+            .map { ($0, probability(of: $0)) }
+            .enumerated()
+            .sorted { lhs, rhs in
+                lhs.element.1 != rhs.element.1
+                    ? lhs.element.1 > rhs.element.1
+                    : lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+}
+
+/// A model backend that scores one encoder window. Production is Core ML in
+/// `TapQAppleAdapters`; tests use scripted scorers. Throwing signals a backend
+/// failure — the pipeline records it and skips the window.
+public protocol MotionWindowScoring {
+    func score(_ window: EncoderInputWindow) throws -> GestureScores
+}
+
+/// Accumulates per-axis samples into fixed-size encoder windows with a hop, resetting
+/// across stream gaps so a window never spans a disconnect.
+public struct EncoderWindowBuilder {
+    public let windowLength: Int
+    public let hopSamples: Int
+    public let gapResetSeconds: TimeInterval
+
+    private var rows: [[Float]] = []
+    private var timestamps: [TimeInterval] = []
+    private var samplesSinceEmit = 0
+    private var hasEmitted = false
+
+    public init(
+        windowLength: Int = EncoderFeatureLayout.windowLength,
+        hopSamples: Int = 8,
+        gapResetSeconds: TimeInterval = 0.5
+    ) {
+        self.windowLength = max(1, windowLength)
+        self.hopSamples = max(1, hopSamples)
+        self.gapResetSeconds = gapResetSeconds
+    }
+
+    /// Ingests one sample; returns a window when one becomes due. Samples without
+    /// per-axis data are ignored — a zero-filled row would look like fabricated
+    /// stillness to the model, which is worse than a shorter buffer.
+    public mutating func push(_ sample: HeadMotionSample) -> EncoderInputWindow? {
+        guard sample.hasPerAxisData else { return nil }
+        if let last = timestamps.last,
+           sample.timestamp < last || sample.timestamp - last > gapResetSeconds {
+            reset()
+        }
+
+        rows.append(EncoderFeatureLayout.featureRow(for: sample))
+        timestamps.append(sample.timestamp)
+        if rows.count > windowLength {
+            rows.removeFirst(rows.count - windowLength)
+            timestamps.removeFirst(timestamps.count - windowLength)
+        }
+        samplesSinceEmit += 1
+
+        guard rows.count == windowLength,
+              !hasEmitted || samplesSinceEmit >= hopSamples else { return nil }
+        samplesSinceEmit = 0
+        hasEmitted = true
+        return EncoderInputWindow(
+            features: rows,
+            startTime: timestamps.first ?? sample.timestamp,
+            endTime: sample.timestamp
+        )
+    }
+
+    public mutating func reset() {
+        rows.removeAll()
+        timestamps.removeAll()
+        samplesSinceEmit = 0
+        hasEmitted = false
+    }
+}

--- a/Sources/TapQDetectionBaseline/EncoderMotionPipeline.swift
+++ b/Sources/TapQDetectionBaseline/EncoderMotionPipeline.swift
@@ -1,0 +1,224 @@
+import Foundation
+import TapQContracts
+
+/// Stateful decision layer over a TapQ-1 window scorer. It owns windowing, per-window
+/// acceptance (threshold + margin), consecutive-window agreement, atom debounce, and
+/// the same double-nod/double-tilt pairing semantics as the heuristic
+/// `MotionGesturePipeline` — so swapping backends never changes command timing, and the
+/// doubling false-positive filter for window-spanning gestures stays deterministic
+/// rather than learned. `tap` atoms carry the whole double-tap pattern (both transients
+/// fit in one window) and therefore emit directly, like `shake` and swipes.
+public struct EncoderMotionPipeline {
+    public var config: EncoderConfig {
+        didSet {
+            windowBuilder = EncoderWindowBuilder(
+                windowLength: config.windowLength,
+                hopSamples: config.hopSamples,
+                gapResetSeconds: config.gapResetSeconds
+            )
+        }
+    }
+
+    private let scorer: any MotionWindowScoring
+    private var windowBuilder: EncoderWindowBuilder
+    private var streakClass: GestureClass?
+    private var streakCount = 0
+    private var lastAtomTime: TimeInterval = -.greatestFiniteMagnitude
+    private var lastEventTime: TimeInterval = -.greatestFiniteMagnitude
+    private var pendingFirstNod: TimeInterval?
+    private var pendingFirstTilt: (time: TimeInterval, direction: TiltCommand)?
+    private var scoringFailureCount = 0
+    private var missingPerAxisLogged = false
+    private let diagnostics: TapQDiagnosticEmitter
+
+    public init(
+        scorer: any MotionWindowScoring,
+        config: EncoderConfig = .init(),
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.scorer = scorer
+        self.config = config
+        self.windowBuilder = EncoderWindowBuilder(
+            windowLength: config.windowLength,
+            hopSamples: config.hopSamples,
+            gapResetSeconds: config.gapResetSeconds
+        )
+        self.diagnostics = TapQDiagnosticEmitter(category: "EncoderPipeline", sink: diagnosticSink)
+    }
+
+    /// Clears all temporal state while retaining configuration, scorer, and sink.
+    public mutating func reset() {
+        windowBuilder.reset()
+        streakClass = nil
+        streakCount = 0
+        lastAtomTime = -.greatestFiniteMagnitude
+        lastEventTime = -.greatestFiniteMagnitude
+        pendingFirstNod = nil
+        pendingFirstTilt = nil
+        missingPerAxisLogged = false
+    }
+
+    public mutating func ingest(_ sample: HeadMotionSample) -> MotionDetectionResult {
+        guard sample.hasPerAxisData else {
+            if !missingPerAxisLogged {
+                diagnostics.record("encoder.per_axis_missing", level: .warning)
+                missingPerAxisLogged = true
+            }
+            return MotionDetectionResult()
+        }
+
+        expirePendings(at: sample.timestamp)
+
+        guard let window = windowBuilder.push(sample) else {
+            return MotionDetectionResult()
+        }
+        guard let atom = classify(window) else { return MotionDetectionResult() }
+        return route(atom: atom, at: window.endTime)
+    }
+
+    /// Scores one window and applies acceptance plus agreement; returns an atom the
+    /// moment the streak requirement is met.
+    private mutating func classify(_ window: EncoderInputWindow) -> GestureClass? {
+        let scores: GestureScores
+        do {
+            scores = try scorer.score(window)
+        } catch {
+            scoringFailureCount += 1
+            if scoringFailureCount == 1 || scoringFailureCount % 100 == 0 {
+                diagnostics.record("encoder.scoring_failed", level: .error, fields: [
+                    "error": String(describing: error),
+                    "failures": "\(scoringFailureCount)",
+                ])
+            }
+            return nil
+        }
+
+        let ranked = scores.ranked
+        guard let top = ranked.first, top.gestureClass != .quiet,
+              Double(top.probability) >= config.classThreshold,
+              ranked.count < 2 || Double(top.probability - ranked[1].probability)
+                >= config.minMargin else {
+            streakClass = nil
+            streakCount = 0
+            return nil
+        }
+
+        if streakClass == top.gestureClass {
+            streakCount += 1
+        } else {
+            streakClass = top.gestureClass
+            streakCount = 1
+        }
+        guard streakCount >= config.agreementWindows else { return nil }
+
+        // Re-arming requires a fresh streak: a sustained motion must not emit again on
+        // every following hop.
+        streakClass = nil
+        streakCount = 0
+        diagnostics.record("encoder.atom", fields: [
+            "class": top.gestureClass.rawValue,
+            "probability": String(format: "%.3f", top.probability),
+        ])
+        return top.gestureClass
+    }
+
+    private mutating func route(atom: GestureClass, at time: TimeInterval) -> MotionDetectionResult {
+        guard time - lastEventTime > config.eventDebounceSeconds,
+              time - lastAtomTime > config.atomDebounceSeconds else {
+            return MotionDetectionResult()
+        }
+        lastAtomTime = time
+
+        switch atom {
+        case .quiet:
+            return MotionDetectionResult()
+        case .nod:
+            guard let paired = pairNod(at: time) else { return MotionDetectionResult() }
+            return emit(.init(gesture: .nod), channel: "nod", gap: paired, at: time)
+        case .shake:
+            return emit(.init(gesture: .shake), channel: "shake", gap: nil, at: time)
+        case .tiltLeft, .tiltRight:
+            let direction: TiltCommand = atom == .tiltLeft ? .tiltLeft : .tiltRight
+            guard let gap = pairTilt(direction: direction, at: time) else {
+                return MotionDetectionResult()
+            }
+            return emit(.init(tilt: direction), channel: "tilt", gap: gap, at: time)
+        case .tap:
+            // A tap atom is the full double-tap pattern; nothing further to pair.
+            return emit(.init(tap: .tap), channel: "tap", gap: nil, at: time)
+        case .swipeUp:
+            return emit(.init(swipe: .swipeUp), channel: "swipe", gap: nil, at: time)
+        case .swipeDown:
+            return emit(.init(swipe: .swipeDown), channel: "swipe", gap: nil, at: time)
+        }
+    }
+
+    /// First atom arms the pending state; a second inside the pair window (but past the
+    /// echo gap) completes it. Echoes are dropped with the pending kept, mirroring the
+    /// heuristic pipeline.
+    private mutating func pairNod(at time: TimeInterval) -> TimeInterval? {
+        if let first = pendingFirstNod {
+            let gap = time - first
+            guard gap >= config.minNodPairGap else {
+                diagnostics.record("encoder.rejected", fields: [
+                    "channel": "nod", "reason": "pair_echo",
+                ])
+                return nil
+            }
+            pendingFirstNod = nil
+            return gap
+        }
+        diagnostics.record("encoder.pending", fields: ["channel": "nod"])
+        pendingFirstNod = time
+        return nil
+    }
+
+    private mutating func pairTilt(direction: TiltCommand, at time: TimeInterval) -> TimeInterval? {
+        if let first = pendingFirstTilt {
+            guard first.direction == direction else {
+                diagnostics.record("encoder.pending_replaced", fields: [
+                    "channel": "tilt", "was": "\(first.direction)", "now": "\(direction)",
+                ])
+                pendingFirstTilt = (time, direction)
+                return nil
+            }
+            let gap = time - first.time
+            guard gap >= config.minTiltPairGap else {
+                diagnostics.record("encoder.rejected", fields: [
+                    "channel": "tilt", "reason": "pair_echo",
+                ])
+                return nil
+            }
+            pendingFirstTilt = nil
+            return gap
+        }
+        diagnostics.record("encoder.pending", fields: [
+            "channel": "tilt", "direction": "\(direction)",
+        ])
+        pendingFirstTilt = (time, direction)
+        return nil
+    }
+
+    private mutating func emit(
+        _ result: MotionDetectionResult, channel: String,
+        gap: TimeInterval?, at time: TimeInterval
+    ) -> MotionDetectionResult {
+        lastEventTime = time
+        var fields = ["channel": channel]
+        if let gap { fields["gap"] = String(format: "%.3f", gap) }
+        diagnostics.record("encoder.detected", fields: fields)
+        return result
+    }
+
+    private mutating func expirePendings(at time: TimeInterval) {
+        if let first = pendingFirstNod, time - first > config.nodPairWindowSeconds {
+            diagnostics.record("encoder.pending_expired", fields: ["channel": "nod"])
+            pendingFirstNod = nil
+        }
+        if let pending = pendingFirstTilt,
+           time - pending.time > config.tiltPairWindowSeconds {
+            diagnostics.record("encoder.pending_expired", fields: ["channel": "tilt"])
+            pendingFirstTilt = nil
+        }
+    }
+}

--- a/Sources/TapQDetectionBaseline/EncoderMotionPipeline.swift
+++ b/Sources/TapQDetectionBaseline/EncoderMotionPipeline.swift
@@ -3,11 +3,11 @@ import TapQContracts
 
 /// Stateful decision layer over a TapQ-1 window scorer. It owns windowing, per-window
 /// acceptance (threshold + margin), consecutive-window agreement, atom debounce, and
-/// the same double-nod/double-tilt pairing semantics as the heuristic
+/// the same double-nod/double-shake/double-tilt pairing semantics as the heuristic
 /// `MotionGesturePipeline` — so swapping backends never changes command timing, and the
 /// doubling false-positive filter for window-spanning gestures stays deterministic
 /// rather than learned. `tap` atoms carry the whole double-tap pattern (both transients
-/// fit in one window) and therefore emit directly, like `shake` and swipes.
+/// fit in one window) and therefore emit directly, as do swipes.
 public struct EncoderMotionPipeline {
     public var config: EncoderConfig {
         didSet {
@@ -26,6 +26,7 @@ public struct EncoderMotionPipeline {
     private var lastAtomTime: TimeInterval = -.greatestFiniteMagnitude
     private var lastEventTime: TimeInterval = -.greatestFiniteMagnitude
     private var pendingFirstNod: TimeInterval?
+    private var pendingFirstShake: TimeInterval?
     private var pendingFirstTilt: (time: TimeInterval, direction: TiltCommand)?
     private var scoringFailureCount = 0
     private var missingPerAxisLogged = false
@@ -54,6 +55,7 @@ public struct EncoderMotionPipeline {
         lastAtomTime = -.greatestFiniteMagnitude
         lastEventTime = -.greatestFiniteMagnitude
         pendingFirstNod = nil
+        pendingFirstShake = nil
         pendingFirstTilt = nil
         missingPerAxisLogged = false
     }
@@ -133,10 +135,15 @@ public struct EncoderMotionPipeline {
         case .quiet:
             return MotionDetectionResult()
         case .nod:
+            // A nod atom is one excursion; the heuristics require two, so the encoder
+            // must as well or the same motion would mean different things per backend.
+            pendingFirstShake = nil
             guard let paired = pairNod(at: time) else { return MotionDetectionResult() }
             return emit(.init(gesture: .nod), channel: "nod", gap: paired, at: time)
         case .shake:
-            return emit(.init(gesture: .shake), channel: "shake", gap: nil, at: time)
+            pendingFirstNod = nil
+            guard let paired = pairShake(at: time) else { return MotionDetectionResult() }
+            return emit(.init(gesture: .shake), channel: "shake", gap: paired, at: time)
         case .tiltLeft, .tiltRight:
             let direction: TiltCommand = atom == .tiltLeft ? .tiltLeft : .tiltRight
             guard let gap = pairTilt(direction: direction, at: time) else {
@@ -170,6 +177,23 @@ public struct EncoderMotionPipeline {
         }
         diagnostics.record("encoder.pending", fields: ["channel": "nod"])
         pendingFirstNod = time
+        return nil
+    }
+
+    private mutating func pairShake(at time: TimeInterval) -> TimeInterval? {
+        if let first = pendingFirstShake {
+            let gap = time - first
+            guard gap >= config.minShakePairGap else {
+                diagnostics.record("encoder.rejected", fields: [
+                    "channel": "shake", "reason": "pair_echo",
+                ])
+                return nil
+            }
+            pendingFirstShake = nil
+            return gap
+        }
+        diagnostics.record("encoder.pending", fields: ["channel": "shake"])
+        pendingFirstShake = time
         return nil
     }
 
@@ -214,6 +238,10 @@ public struct EncoderMotionPipeline {
         if let first = pendingFirstNod, time - first > config.nodPairWindowSeconds {
             diagnostics.record("encoder.pending_expired", fields: ["channel": "nod"])
             pendingFirstNod = nil
+        }
+        if let first = pendingFirstShake, time - first > config.shakePairWindowSeconds {
+            diagnostics.record("encoder.pending_expired", fields: ["channel": "shake"])
+            pendingFirstShake = nil
         }
         if let pending = pendingFirstTilt,
            time - pending.time > config.tiltPairWindowSeconds {

--- a/Sources/TapQDetectionBaseline/HeadMotionSample.swift
+++ b/Sources/TapQDetectionBaseline/HeadMotionSample.swift
@@ -1,20 +1,99 @@
 import Foundation
 
+/// A signed 3-axis motion quantity in the earbud's device frame (acceleration and
+/// gravity in g, rotation rate in rad/s). Platform-neutral so the baseline pipeline
+/// and capture tooling never depend on CoreMotion types.
+public struct MotionVector: Sendable, Codable, Equatable {
+    public let x: Double
+    public let y: Double
+    public let z: Double
+
+    public static let zero = MotionVector(x: 0, y: 0, z: 0)
+
+    public init(x: Double, y: Double, z: Double) {
+        self.x = x
+        self.y = y
+        self.z = z
+    }
+
+    public var magnitude: Double {
+        (x * x + y * y + z * z).squareRoot()
+    }
+}
+
 /// One IMU sample reduced to the platform-neutral values consumed by TapQ's baseline
 /// motion pipeline. Hardware adapters are responsible for producing these values.
+///
+/// Magnitude fields remain authoritative for the magnitude-based analyzers; the signed
+/// per-axis vectors and roll exist for direction-aware detection (lateral tilts, swipe
+/// direction) and for capture studies. Adapters that cannot supply per-axis data leave
+/// the vectors at `.zero` and roll at 0, which every consumer must treat as "absent".
 public struct HeadMotionSample: Sendable, Codable, Equatable {
     public let timestamp: TimeInterval
     public let pitch: Double
     public let yaw: Double
+    /// Attitude roll in radians (lateral ear-toward-shoulder lean). 0 when the producing
+    /// adapter predates per-axis capture.
+    public let roll: Double
     public let accelerationMagnitude: Double
     public let rotationMagnitude: Double
+    /// Signed user acceleration (gravity removed) in the earbud frame. `.zero` when absent.
+    public let userAcceleration: MotionVector
+    /// Signed rotation rate in the earbud frame. `.zero` when absent.
+    public let rotationRate: MotionVector
+    /// Gravity direction in the earbud frame; the reference for "up" in direction-aware
+    /// analysis regardless of ear fit. `.zero` when absent.
+    public let gravity: MotionVector
 
+    /// Magnitude-only sample. Kept for adapters, calibration hosts, and recorded data
+    /// that predate per-axis capture.
     public init(timestamp: TimeInterval, pitch: Double, yaw: Double,
                 accelerationMagnitude: Double, rotationMagnitude: Double) {
         self.timestamp = timestamp
         self.pitch = pitch
         self.yaw = yaw
+        self.roll = 0
         self.accelerationMagnitude = accelerationMagnitude
         self.rotationMagnitude = rotationMagnitude
+        self.userAcceleration = .zero
+        self.rotationRate = .zero
+        self.gravity = .zero
+    }
+
+    /// Full per-axis sample. Magnitudes are derived from the vectors so they can never
+    /// disagree with the signed data.
+    public init(timestamp: TimeInterval, pitch: Double, yaw: Double, roll: Double,
+                userAcceleration: MotionVector, rotationRate: MotionVector,
+                gravity: MotionVector) {
+        self.timestamp = timestamp
+        self.pitch = pitch
+        self.yaw = yaw
+        self.roll = roll
+        self.accelerationMagnitude = userAcceleration.magnitude
+        self.rotationMagnitude = rotationRate.magnitude
+        self.userAcceleration = userAcceleration
+        self.rotationRate = rotationRate
+        self.gravity = gravity
+    }
+
+    /// Tolerant decoding: samples recorded before per-axis capture existed must still
+    /// decode (mirrors `HeadGestureConfig`'s policy for persisted calibrations).
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        timestamp = try c.decode(TimeInterval.self, forKey: .timestamp)
+        pitch = try c.decode(Double.self, forKey: .pitch)
+        yaw = try c.decode(Double.self, forKey: .yaw)
+        roll = try c.decodeIfPresent(Double.self, forKey: .roll) ?? 0
+        accelerationMagnitude = try c.decode(Double.self, forKey: .accelerationMagnitude)
+        rotationMagnitude = try c.decode(Double.self, forKey: .rotationMagnitude)
+        userAcceleration = try c.decodeIfPresent(MotionVector.self, forKey: .userAcceleration) ?? .zero
+        rotationRate = try c.decodeIfPresent(MotionVector.self, forKey: .rotationRate) ?? .zero
+        gravity = try c.decodeIfPresent(MotionVector.self, forKey: .gravity) ?? .zero
+    }
+
+    /// True when the producing adapter supplied signed per-axis data, i.e. the sample can
+    /// feed direction-aware analysis rather than only the magnitude-based analyzers.
+    public var hasPerAxisData: Bool {
+        gravity != .zero || userAcceleration != .zero || rotationRate != .zero
     }
 }

--- a/Sources/TapQDetectionBaseline/MotionGesturePipeline.swift
+++ b/Sources/TapQDetectionBaseline/MotionGesturePipeline.swift
@@ -6,17 +6,20 @@ public struct MotionDetectionResult: Sendable, Equatable {
     public let gesture: HeadGesture?
     public let tap: TapCommand?
     public let tilt: TiltCommand?
+    public let swipe: MotionSwipeCommand?
 
     public init(gesture: HeadGesture? = nil, tap: TapCommand? = nil,
-                tilt: TiltCommand? = nil) {
+                tilt: TiltCommand? = nil, swipe: MotionSwipeCommand? = nil) {
         self.gesture = gesture
         self.tap = tap
         self.tilt = tilt
+        self.swipe = swipe
     }
 }
 
 /// Stateful, hardware-independent motion pipeline. It owns sliding windows, debounce,
-/// double-nod/double-tap pairing, and tilt detection; CoreMotion is only an input adapter.
+/// double-nod/double-tap/double-tilt pairing, and swipe detection; CoreMotion is only an
+/// input adapter.
 public struct MotionGesturePipeline {
     public var config: HeadGestureConfig {
         didSet { gestureAnalyzer = GestureAnalyzer(config: config) }
@@ -24,47 +27,64 @@ public struct MotionGesturePipeline {
     public var tapConfig: TapConfig {
         didSet { tapAnalyzer = TapAnalyzer(config: tapConfig) }
     }
+    public var tiltConfig: TiltConfig {
+        didSet { tiltAnalyzer = TiltAnalyzer(config: tiltConfig) }
+    }
+    public var swipeConfig: SwipeConfig {
+        didSet { swipeAnalyzer = SwipeAnalyzer(config: swipeConfig) }
+    }
     public var tapDetectionEnabled: Bool
+    /// Swipe detection is experimental and stays off until capture-study validation;
+    /// when off, no per-axis swipe windows are even accumulated.
+    public var swipeDetectionEnabled: Bool
 
     private var gestureAnalyzer: GestureAnalyzer
     private var tapAnalyzer: TapAnalyzer
     private var tiltAnalyzer: TiltAnalyzer
+    private var swipeAnalyzer: SwipeAnalyzer
     private var pitch: [(time: TimeInterval, value: Double)] = []
     private var yaw: [(time: TimeInterval, value: Double)] = []
     private var acceleration: [(time: TimeInterval, value: Double)] = []
     private var rotation: [(time: TimeInterval, value: Double)] = []
+    private var tiltRoll: [(time: TimeInterval, value: Double)] = []
     private var tiltPitch: [(time: TimeInterval, value: Double)] = []
+    private var tiltYaw: [(time: TimeInterval, value: Double)] = []
+    private var swipeAcceleration: [(time: TimeInterval, value: MotionVector)] = []
+    private var swipeGravity: [(time: TimeInterval, value: MotionVector)] = []
+    private var swipeRotation: [(time: TimeInterval, value: Double)] = []
     private var lastGestureEmit: TimeInterval = -.greatestFiniteMagnitude
     private var lastTapEmit: TimeInterval = -.greatestFiniteMagnitude
     private var lastTiltEmit: TimeInterval = -.greatestFiniteMagnitude
+    private var lastSwipeEmit: TimeInterval = -.greatestFiniteMagnitude
     private var pendingFirstTap: TimeInterval?
     private var pendingFirstNod: TimeInterval?
+    private var pendingFirstTilt: (time: TimeInterval, direction: TiltCommand)?
     private var tapDiagnosticCandidateStartedAt: TimeInterval?
     private var tapDiagnosticBaselineWaitLogged = false
     private var tapSampleTraceStartedAt: TimeInterval?
     private var tapSampleTraceSampleCount = 0
-    private let tiltWindowSeconds: TimeInterval
-    private let tiltDebounceSeconds: TimeInterval
     private let diagnostics: TapQDiagnosticEmitter
     private static let tapSampleTraceDurationSeconds: TimeInterval = 0.6
 
     public init(
         config: HeadGestureConfig = .init(),
         tapConfig: TapConfig = .init(),
-        tiltAnalyzer: TiltAnalyzer = .init(),
+        tiltConfig: TiltConfig = .init(),
+        swipeConfig: SwipeConfig = .init(),
         tapDetectionEnabled: Bool = true,
-        tiltWindowSeconds: TimeInterval = 0.6,
-        tiltDebounceSeconds: TimeInterval = 0.8,
+        swipeDetectionEnabled: Bool = false,
         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
     ) {
         self.config = config
         self.tapConfig = tapConfig
+        self.tiltConfig = tiltConfig
+        self.swipeConfig = swipeConfig
         self.gestureAnalyzer = GestureAnalyzer(config: config)
         self.tapAnalyzer = TapAnalyzer(config: tapConfig)
-        self.tiltAnalyzer = tiltAnalyzer
+        self.tiltAnalyzer = TiltAnalyzer(config: tiltConfig)
+        self.swipeAnalyzer = SwipeAnalyzer(config: swipeConfig)
         self.tapDetectionEnabled = tapDetectionEnabled
-        self.tiltWindowSeconds = tiltWindowSeconds
-        self.tiltDebounceSeconds = tiltDebounceSeconds
+        self.swipeDetectionEnabled = swipeDetectionEnabled
         self.diagnostics = TapQDiagnosticEmitter(category: "MotionPipeline", sink: diagnosticSink)
     }
 
@@ -86,12 +106,19 @@ public struct MotionGesturePipeline {
         yaw.removeAll()
         acceleration.removeAll()
         rotation.removeAll()
+        tiltRoll.removeAll()
         tiltPitch.removeAll()
+        tiltYaw.removeAll()
+        swipeAcceleration.removeAll()
+        swipeGravity.removeAll()
+        swipeRotation.removeAll()
         lastGestureEmit = -.greatestFiniteMagnitude
         lastTapEmit = -.greatestFiniteMagnitude
         lastTiltEmit = -.greatestFiniteMagnitude
+        lastSwipeEmit = -.greatestFiniteMagnitude
         pendingFirstTap = nil
         pendingFirstNod = nil
+        pendingFirstTilt = nil
         tapDiagnosticCandidateStartedAt = nil
         tapDiagnosticBaselineWaitLogged = false
         tapSampleTraceStartedAt = nil
@@ -105,7 +132,9 @@ public struct MotionGesturePipeline {
             tap: ingestTap(acceleration: sample.accelerationMagnitude,
                            rotation: sample.rotationMagnitude,
                            time: sample.timestamp),
-            tilt: ingestTilt(pitch: sample.pitch, time: sample.timestamp)
+            tilt: ingestTilt(roll: sample.roll, pitch: sample.pitch, yaw: sample.yaw,
+                             time: sample.timestamp),
+            swipe: ingestSwipe(sample)
         )
     }
 
@@ -289,17 +318,97 @@ public struct MotionGesturePipeline {
         return nil
     }
 
-    public mutating func ingestTilt(pitch newPitch: Double,
+    /// Lateral (roll-axis) tilt with double-tilt pairing. Mirrors the double-nod flow:
+    /// a first tilt arms a pending state, and only a second same-direction tilt within
+    /// the pair window emits a command — a lone lateral lean never navigates.
+    public mutating func ingestTilt(roll newRoll: Double, pitch newPitch: Double,
+                                    yaw newYaw: Double,
                                     time: TimeInterval) -> TiltCommand? {
+        tiltRoll.append((time, newRoll))
         tiltPitch.append((time, newPitch))
-        let cutoff = time - tiltWindowSeconds
+        tiltYaw.append((time, newYaw))
+        let cutoff = time - tiltConfig.windowSeconds
+        tiltRoll.removeAll { $0.time < cutoff }
         tiltPitch.removeAll { $0.time < cutoff }
-        guard time - lastTiltEmit > tiltDebounceSeconds else { return nil }
-        guard let tilt = tiltAnalyzer.detect(pitch: tiltPitch.map(\.value)) else { return nil }
-        lastTiltEmit = time
+        tiltYaw.removeAll { $0.time < cutoff }
+
+        guard time - lastTiltEmit > tiltConfig.debounceSeconds else { return nil }
+
+        if let pending = pendingFirstTilt,
+           time - pending.time > tiltConfig.doubleTiltWindowSeconds {
+            diagnostics.record("tilt.pending_expired", fields: [
+                "direction": "\(pending.direction)",
+            ])
+            pendingFirstTilt = nil
+        }
+
+        guard let tilt = tiltAnalyzer.detect(
+            roll: tiltRoll.map(\.value),
+            pitch: tiltPitch.map(\.value),
+            yaw: tiltYaw.map(\.value)
+        ) else { return nil }
+
+        // Consume the window so this excursion cannot re-trigger on later samples; the
+        // confirming tilt must be a fresh motion.
+        tiltRoll.removeAll()
         tiltPitch.removeAll()
-        diagnostics.record("tilt.detected", fields: ["tilt": "\(tilt)"])
-        return tilt
+        tiltYaw.removeAll()
+
+        if let pending = pendingFirstTilt {
+            guard pending.direction == tilt else {
+                // Opposite direction restarts the pair rather than emitting a garbled
+                // command — a left-right wobble is ambiguity, not navigation.
+                diagnostics.record("tilt.pending_replaced", fields: [
+                    "was": "\(pending.direction)", "now": "\(tilt)",
+                ])
+                pendingFirstTilt = (time, tilt)
+                return nil
+            }
+            let gap = time - pending.time
+            guard gap >= tiltConfig.minDoubleTiltGap else {
+                diagnostics.record("tilt.rejected", fields: ["reason": "double_tilt_echo"])
+                return nil
+            }
+            pendingFirstTilt = nil
+            lastTiltEmit = time
+            diagnostics.record("tilt.detected", fields: [
+                "tilt": "\(tilt)", "gap": "\(gap)",
+            ])
+            return tilt
+        }
+
+        diagnostics.record("tilt.pending", fields: ["direction": "\(tilt)"])
+        pendingFirstTilt = (time, tilt)
+        return nil
+    }
+
+    /// Experimental motion-swipe channel; inert unless `swipeDetectionEnabled` and the
+    /// samples carry per-axis data (magnitude-only adapters leave vectors at `.zero`).
+    public mutating func ingestSwipe(_ sample: HeadMotionSample) -> MotionSwipeCommand? {
+        guard swipeDetectionEnabled, sample.hasPerAxisData else { return nil }
+        let time = sample.timestamp
+        swipeAcceleration.append((time, sample.userAcceleration))
+        swipeGravity.append((time, sample.gravity))
+        swipeRotation.append((time, sample.rotationMagnitude))
+        let cutoff = time - swipeConfig.windowSeconds
+        swipeAcceleration.removeAll { $0.time < cutoff }
+        swipeGravity.removeAll { $0.time < cutoff }
+        swipeRotation.removeAll { $0.time < cutoff }
+
+        guard time - lastSwipeEmit > swipeConfig.debounceSeconds else { return nil }
+        guard let swipe = swipeAnalyzer.detect(
+            acceleration: swipeAcceleration.map(\.value),
+            gravity: swipeGravity.map(\.value),
+            rotation: swipeRotation.map(\.value)
+        ) else { return nil }
+
+        // Consume the window: one drag, one command.
+        swipeAcceleration.removeAll()
+        swipeGravity.removeAll()
+        swipeRotation.removeAll()
+        lastSwipeEmit = time
+        diagnostics.record("swipe.detected", fields: ["swipe": "\(swipe)"])
+        return swipe
     }
 
     private func recordGesture(_ gesture: HeadGesture, pitch: [Double], yaw: [Double],

--- a/Sources/TapQDetectionBaseline/SwipeAnalyzer.swift
+++ b/Sources/TapQDetectionBaseline/SwipeAnalyzer.swift
@@ -1,0 +1,143 @@
+import Foundation
+import TapQContracts
+
+/// Tunable thresholds for motion-based ear/earbud swipe detection. A swipe is the shape
+/// `TapAnalyzer` rejects as `spike_too_wide`: a sustained, gentle acceleration plateau
+/// with a still head, rather than a tap's brief sharp spike. Experimental — defaults are
+/// placeholders pending a per-axis capture study; the channel ships disabled.
+public struct SwipeConfig: Sendable, Codable, Equatable {
+    /// Minimum `|userAcceleration|` (g) for a sample to count as part of the drag. Drags
+    /// are gentler than taps, so this sits well below `TapConfig.amplitudeThreshold`.
+    public var elevatedLevel: Double
+    /// Peak `|userAcceleration|` (g) above which the transient is tap-class, not a drag.
+    public var peakCeiling: Double
+    /// The window's max `|rotationRate|` (rad/s) must stay below this — the head was
+    /// still, separating a drag from head-gesture motion (same gate as taps).
+    public var rotationQuiet: Double
+    /// Contiguous elevated run length, in samples, that reads as a drag (~160–560 ms at
+    /// 25 Hz). Shorter is tap territory; longer is an adjustment or sustained motion.
+    public var minElevatedSamples: Int
+    public var maxElevatedSamples: Int
+    /// Trailing window over which the drag and its rotation are judged.
+    public var windowSeconds: Double
+    /// Minimum samples in the window before attempting detection.
+    public var minSamples: Int
+    /// Ignore further swipes for this long after one fires.
+    public var debounceSeconds: Double
+    /// The gravity-aligned component of the drag's mean acceleration must exceed the
+    /// residual (non-vertical) component by this ratio for a direction to be reported.
+    public var directionDominance: Double
+
+    public init(
+        elevatedLevel: Double = 0.12,
+        peakCeiling: Double = 0.45,
+        rotationQuiet: Double = 0.6,
+        minElevatedSamples: Int = 4,
+        maxElevatedSamples: Int = 14,
+        windowSeconds: Double = 0.8,
+        minSamples: Int = 8,
+        debounceSeconds: Double = 0.8,
+        directionDominance: Double = 1.4
+    ) {
+        self.elevatedLevel = elevatedLevel
+        self.peakCeiling = peakCeiling
+        self.rotationQuiet = rotationQuiet
+        self.minElevatedSamples = minElevatedSamples
+        self.maxElevatedSamples = maxElevatedSamples
+        self.windowSeconds = windowSeconds
+        self.minSamples = minSamples
+        self.debounceSeconds = debounceSeconds
+        self.directionDominance = directionDominance
+    }
+}
+
+/// Pure swipe detector over a trailing window of per-axis samples. Separated from
+/// CoreMotion so the logic is unit-testable with synthetic data, mirroring
+/// `GestureAnalyzer` and `TapAnalyzer`.
+///
+/// A swipe fires when, within the window:
+///   1. `|accel|` holds a contiguous elevated run of drag length (not a tap's brief
+///      spike, not a long adjustment),
+///   2. the peak stays below tap amplitude and rotation stays quiet (head still),
+///   3. `|accel|` has returned below the elevated level at the window's end, and
+///   4. the mean drag acceleration projects dominantly onto gravity — up (against
+///      gravity) is `.swipeUp`, down is `.swipeDown`. No dominant vertical component
+///      means no direction can be trusted, so nothing fires.
+///
+/// Direction is a heuristic pending capture-study validation: the bud's reaction to a
+/// finger drag need not align with the drag itself. Presence detection (conditions 1–3)
+/// is the load-bearing part.
+public struct SwipeAnalyzer {
+    public let config: SwipeConfig
+
+    public init(config: SwipeConfig = .init()) {
+        self.config = config
+    }
+
+    /// `acceleration` and `gravity` are per-axis samples over the same trailing window,
+    /// oldest first; `rotation` is `|rotationRate|` over that window.
+    public func detect(acceleration: [MotionVector], gravity: [MotionVector],
+                       rotation: [Double]) -> MotionSwipeCommand? {
+        guard acceleration.count >= config.minSamples,
+              rotation.count >= config.minSamples else { return nil }
+
+        let magnitudes = acceleration.map(\.magnitude)
+        guard let peak = magnitudes.max(), peak < config.peakCeiling,
+              let maxRotation = rotation.max(), maxRotation < config.rotationQuiet,
+              let tail = magnitudes.last, tail < config.elevatedLevel else { return nil }
+
+        guard let run = longestElevatedRun(magnitudes),
+              run.length >= config.minElevatedSamples,
+              run.length <= config.maxElevatedSamples else { return nil }
+
+        // Mean drag acceleration and mean gravity over the elevated run only, so quiet
+        // lead-in/lead-out samples don't dilute the direction estimate.
+        let slice = run.range
+        let meanAcceleration = Self.mean(Array(acceleration[slice]))
+        let meanGravity = Self.mean(Array(gravity[slice]))
+        let gravityMagnitude = meanGravity.magnitude
+        guard gravityMagnitude > 1e-6 else { return nil }
+
+        // Gravity points down, so a positive component against gravity is "up".
+        let vertical = -(meanAcceleration.x * meanGravity.x
+            + meanAcceleration.y * meanGravity.y
+            + meanAcceleration.z * meanGravity.z) / gravityMagnitude
+        let total = meanAcceleration.magnitude
+        let residual = max(0, total * total - vertical * vertical).squareRoot()
+        guard abs(vertical) >= config.directionDominance * max(residual, 1e-6)
+        else { return nil }
+
+        return vertical > 0 ? .swipeUp : .swipeDown
+    }
+
+    private func longestElevatedRun(
+        _ magnitudes: [Double]
+    ) -> (range: Range<Int>, length: Int)? {
+        var best: Range<Int>?
+        var currentStart: Int?
+        for (index, value) in magnitudes.enumerated() {
+            if value >= config.elevatedLevel {
+                if currentStart == nil { currentStart = index }
+            } else if let start = currentStart {
+                if best == nil || (index - start) > best!.count { best = start..<index }
+                currentStart = nil
+            }
+        }
+        if let start = currentStart {
+            let end = magnitudes.count
+            if best == nil || (end - start) > best!.count { best = start..<end }
+        }
+        guard let range = best else { return nil }
+        return (range, range.count)
+    }
+
+    private static func mean(_ vectors: [MotionVector]) -> MotionVector {
+        guard !vectors.isEmpty else { return .zero }
+        let count = Double(vectors.count)
+        return MotionVector(
+            x: vectors.reduce(0) { $0 + $1.x } / count,
+            y: vectors.reduce(0) { $0 + $1.y } / count,
+            z: vectors.reduce(0) { $0 + $1.z } / count
+        )
+    }
+}

--- a/Sources/TapQDetectionBaseline/TiltAnalyzer.swift
+++ b/Sources/TapQDetectionBaseline/TiltAnalyzer.swift
@@ -1,38 +1,56 @@
 import Foundation
 import TapQContracts
 
-/// Detects a head tilt by peak displacement from the starting position. Fires on the
-/// dominant direction of motion even if the head returns to neutral afterward — matching
-/// the natural quick-tilt gesture (pitch down, return to rest).
+/// Pure single-tilt detector over windowed roll samples, with pitch/yaw passed alongside
+/// for crosstalk gating. Separated from CoreMotion so the logic is unit-testable with
+/// synthetic data, mirroring `GestureAnalyzer`.
+///
+/// A lateral tilt fires when, within the window:
+///   1. roll deviates from the window's starting posture by at least
+///      `amplitudeThreshold` toward exactly one side (both sides exceeded = ambiguous),
+///   2. the roll swing dominates pitch and yaw by `dominanceRatio` (a nod or shake can
+///      leak into roll; a deliberate lateral tilt is roll-dominant), and
+///   3. roll has returned toward neutral at the window's end — the gesture completed.
+///
+/// Sign convention: positive roll deviation is reported as `.tiltRight`. If a platform's
+/// attitude frame inverts this for worn earbuds, flip at the adapter boundary, not here.
+///
+/// The pitch-displacement tilt this replaces was retired for structural reasons: it
+/// listened on the axis nod pairing uses and fired on single glances at the keyboard.
 public struct TiltAnalyzer {
-    public var displacementThreshold: Double
-    public var minSamples: Int
+    public let config: TiltConfig
 
-    public init(displacementThreshold: Double = 0.10, minSamples: Int = 10) {
-        self.displacementThreshold = displacementThreshold
-        self.minSamples = minSamples
+    public init(config: TiltConfig = .init()) {
+        self.config = config
     }
 
-    public func detect(pitch: [Double]) -> TiltCommand? {
-        guard pitch.count >= minSamples,
-              let first = pitch.first else { return nil }
+    /// `roll`, `pitch`, and `yaw` cover the same trailing window, oldest first.
+    public func detect(roll: [Double], pitch: [Double], yaw: [Double]) -> TiltCommand? {
+        guard roll.count >= config.minSamples, let baseline = roll.first,
+              let last = roll.last else { return nil }
 
-        var peakDown = 0.0
-        var peakUp = 0.0
-        for p in pitch {
-            let d = p - first
-            if d < peakDown { peakDown = d }
-            if d > peakUp { peakUp = d }
+        var peakRight = 0.0
+        var peakLeft = 0.0
+        for value in roll {
+            let deviation = value - baseline
+            if deviation > peakRight { peakRight = deviation }
+            if -deviation > peakLeft { peakLeft = -deviation }
         }
 
-        let downMag = abs(peakDown)
-        let upMag = abs(peakUp)
-        guard max(downMag, upMag) >= displacementThreshold else { return nil }
+        let dominant = max(peakRight, peakLeft)
+        guard dominant >= config.amplitudeThreshold else { return nil }
+        if min(peakRight, peakLeft) >= config.amplitudeThreshold { return nil }
 
-        if downMag >= displacementThreshold && upMag >= displacementThreshold {
-            return nil
-        }
+        let rollStats = GestureAnalyzer.stats(roll)
+        let pitchStats = GestureAnalyzer.stats(pitch)
+        let yawStats = GestureAnalyzer.stats(yaw)
+        guard rollStats.peakToPeak >= config.dominanceRatio * max(pitchStats.peakToPeak, 1e-6),
+              rollStats.peakToPeak >= config.dominanceRatio * max(yawStats.peakToPeak, 1e-6)
+        else { return nil }
 
-        return downMag > upMag ? .tiltDown : .tiltUp
+        guard abs(last - baseline) <= config.amplitudeThreshold * config.returnFraction
+        else { return nil }
+
+        return peakRight > peakLeft ? .tiltRight : .tiltLeft
     }
 }

--- a/Sources/TapQDetectionBaseline/TiltConfig.swift
+++ b/Sources/TapQDetectionBaseline/TiltConfig.swift
@@ -1,0 +1,50 @@
+import Foundation
+import TapQContracts
+
+/// Tunable thresholds for lateral (roll-axis) tilt detection. A tilt is a single
+/// ear-toward-shoulder excursion that returns to neutral; the pipeline pairs two
+/// same-direction tilts into a command, mirroring double-nod/double-tap. Defaults are
+/// conservative uncalibrated starting points pending a per-axis capture study.
+public struct TiltConfig: Sendable, Codable, Equatable {
+    /// Minimum roll deviation (radians) from the window's starting posture to count as a
+    /// deliberate lateral tilt (~10°).
+    public var amplitudeThreshold: Double
+    /// How much the roll peak-to-peak must exceed pitch and yaw peak-to-peak — rejects
+    /// roll crosstalk from vigorous nods and shakes.
+    public var dominanceRatio: Double
+    /// The window-end deviation must fall below `amplitudeThreshold * returnFraction`,
+    /// so a tilt fires only after the head returns toward neutral (completed gesture),
+    /// never while the head is parked sideways.
+    public var returnFraction: Double
+    /// Sliding window over which one tilt excursion is judged.
+    public var windowSeconds: Double
+    /// Minimum samples in the window before attempting detection.
+    public var minSamples: Int
+    /// Ignore further tilts for this long after a double-tilt fires.
+    public var debounceSeconds: Double
+    /// Maximum interval between two same-direction tilts for them to pair.
+    public var doubleTiltWindowSeconds: Double
+    /// Minimum interval between the two tilts — rejects an echo of the first tilt's own
+    /// return motion (mirrors `minDoubleNodGap` / `minDoubleTapGap`).
+    public var minDoubleTiltGap: Double
+
+    public init(
+        amplitudeThreshold: Double = 0.18,
+        dominanceRatio: Double = 1.6,
+        returnFraction: Double = 0.4,
+        windowSeconds: Double = 0.9,
+        minSamples: Int = 8,
+        debounceSeconds: Double = 1.0,
+        doubleTiltWindowSeconds: Double = 1.6,
+        minDoubleTiltGap: Double = 0.25
+    ) {
+        self.amplitudeThreshold = amplitudeThreshold
+        self.dominanceRatio = dominanceRatio
+        self.returnFraction = returnFraction
+        self.windowSeconds = windowSeconds
+        self.minSamples = minSamples
+        self.debounceSeconds = debounceSeconds
+        self.doubleTiltWindowSeconds = doubleTiltWindowSeconds
+        self.minDoubleTiltGap = minDoubleTiltGap
+    }
+}

--- a/Sources/TapQInteractionBaseline/SelectionArbiter.swift
+++ b/Sources/TapQInteractionBaseline/SelectionArbiter.swift
@@ -61,7 +61,8 @@ import TapQContracts
         }
         tilts?.start { [weak self] tilt in
             self?.diagnostics.record("input.tilt", fields: ["tilt": "\(tilt)"])
-            self?.finish(tilt == .tiltDown ? .next : .previous)
+            // Spatial mapping: a right lean advances through options, a left lean goes back.
+            self?.finish(tilt == .tiltRight ? .next : .previous)
         }
         swipes?.start { [weak self] swipe in
             self?.diagnostics.record("input.swipe", fields: ["swipe": "\(swipe)"])

--- a/Tests/TapQCLITests/CaptureReplayTests.swift
+++ b/Tests/TapQCLITests/CaptureReplayTests.swift
@@ -221,7 +221,9 @@ final class CaptureReplayTests: XCTestCase {
                 GestureScores(values: [.shake: 0.95])
             }
         }
-        let samples = (0..<40).map { perAxisSample(at: Double($0) * 0.04) }
+        // Shake pairs like the heuristics, so four agreeing windows (two atoms) are
+        // needed for one deny event.
+        let samples = (0..<56).map { perAxisSample(at: Double($0) * 0.04) }
         let events = ReplayBackendRunner.encoderEvents(
             samples: samples, scorer: AlwaysShake())
         XCTAssertEqual(events.map(\.label), [.shake])

--- a/Tests/TapQCLITests/CaptureReplayTests.swift
+++ b/Tests/TapQCLITests/CaptureReplayTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+@testable import TapQCLI
+import TapQDetectionBaseline
+
+final class CaptureReplayTests: XCTestCase {
+    private func perAxisSample(at time: TimeInterval) -> HeadMotionSample {
+        HeadMotionSample(
+            timestamp: time, pitch: 0.1, yaw: -0.2, roll: 0.05,
+            userAcceleration: MotionVector(x: 0.01, y: -0.02, z: 0.03),
+            rotationRate: MotionVector(x: 0.4, y: -0.5, z: 0.6),
+            gravity: MotionVector(x: 0, y: 0.1, z: -0.99)
+        )
+    }
+
+    // MARK: Capture reading
+
+    func testJSONLRoundTripsThroughFormatter() throws {
+        let samples = (0..<3).map { perAxisSample(at: Double($0) * 0.04) }
+        let text = samples
+            .map { MotionSampleFormatter.line(for: $0, format: .jsonl) }
+            .joined(separator: "\n")
+        let decoded = try MotionCaptureReader.samples(fromText: text, format: .jsonl)
+        XCTAssertEqual(decoded, samples)
+        XCTAssertTrue(decoded.allSatisfy(\.hasPerAxisData))
+    }
+
+    func testCSVRoundTripsThroughFormatter() throws {
+        let samples = (0..<3).map { perAxisSample(at: Double($0) * 0.04) }
+        let text = ([MotionSampleFormatter.csvHeader]
+            + samples.map { MotionSampleFormatter.line(for: $0, format: .csv) })
+            .joined(separator: "\n")
+        let decoded = try MotionCaptureReader.samples(fromText: text, format: .csv)
+        XCTAssertEqual(decoded, samples)
+    }
+
+    func testLegacyMagnitudeOnlyJSONLStillDecodes() throws {
+        let line = #"{"timestamp":1.5,"pitch":0.2,"yaw":-0.1,"acceleration_magnitude":0.3,"rotation_magnitude":0.4}"#
+        let decoded = try MotionCaptureReader.samples(fromText: line, format: .jsonl)
+        XCTAssertEqual(decoded, [HeadMotionSample(
+            timestamp: 1.5, pitch: 0.2, yaw: -0.1,
+            accelerationMagnitude: 0.3, rotationMagnitude: 0.4
+        )])
+        XCTAssertFalse(decoded[0].hasPerAxisData)
+    }
+
+    func testLegacyFiveColumnCSVStillDecodes() throws {
+        let text = """
+        timestamp,pitch,yaw,acceleration_magnitude,rotation_magnitude
+        1.5,0.2,-0.1,0.3,0.4
+        """
+        let decoded = try MotionCaptureReader.samples(fromText: text, format: .csv)
+        XCTAssertEqual(decoded, [HeadMotionSample(
+            timestamp: 1.5, pitch: 0.2, yaw: -0.1,
+            accelerationMagnitude: 0.3, rotationMagnitude: 0.4
+        )])
+    }
+
+    func testFormatInferenceFromContentAndExtension() {
+        XCTAssertEqual(
+            MotionCaptureReader.inferFormat(text: "{\"a\":1}", pathExtension: ""), .jsonl)
+        XCTAssertEqual(
+            MotionCaptureReader.inferFormat(
+                text: "timestamp,pitch,yaw", pathExtension: ""), .csv)
+        XCTAssertEqual(
+            MotionCaptureReader.inferFormat(text: "???", pathExtension: "csv"), .csv)
+        XCTAssertNil(MotionCaptureReader.inferFormat(text: "???", pathExtension: "txt"))
+    }
+
+    func testMalformedJSONLReportsLineNumber() {
+        XCTAssertThrowsError(
+            try MotionCaptureReader.samples(fromText: "{}\nnot json", format: .jsonl)
+        ) { error in
+            guard case CaptureReadError.badLine(let line, _) = error else {
+                return XCTFail("unexpected error \(error)")
+            }
+            XCTAssertEqual(line, 1)
+        }
+    }
+
+    func testCSVMissingRequiredColumnFails() {
+        XCTAssertThrowsError(
+            try MotionCaptureReader.samples(fromText: "timestamp,pitch\n1,2", format: .csv)
+        ) { error in
+            guard case CaptureReadError.missingColumns = error else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+    }
+
+    // MARK: Labels
+
+    func testLabelSegmentsParseAndSort() throws {
+        let text = """
+        {"start": 10.0, "end": 12.0, "label": "tilt_left"}
+        {"start": 2.0, "end": 4.5, "label": "nod"}
+        """
+        let segments = try ReplayLabelReader.segments(fromText: text)
+        XCTAssertEqual(segments, [
+            ReplayLabelSegment(start: 2.0, end: 4.5, label: .nod),
+            ReplayLabelSegment(start: 10.0, end: 12.0, label: .tiltLeft),
+        ])
+    }
+
+    func testInvertedLabelSegmentFails() {
+        XCTAssertThrowsError(
+            try ReplayLabelReader.segments(
+                fromText: #"{"start": 5, "end": 3, "label": "nod"}"#)
+        )
+    }
+
+    func testUnknownLabelFails() {
+        XCTAssertThrowsError(
+            try ReplayLabelReader.segments(
+                fromText: #"{"start": 1, "end": 2, "label": "wink"}"#)
+        )
+    }
+
+    // MARK: Evaluation
+
+    func testEvaluatorCountsMatchesMissesAndFalsePositives() {
+        let segments = [
+            ReplayLabelSegment(start: 2, end: 4, label: .nod),
+            ReplayLabelSegment(start: 10, end: 12, label: .nod),
+            ReplayLabelSegment(start: 20, end: 22, label: .shake),
+        ]
+        let events = [
+            ReplayEvent(time: 4.5, label: .nod),    // inside tolerance → TP
+            ReplayEvent(time: 30.0, label: .nod),   // matches nothing → FP
+            ReplayEvent(time: 21.0, label: .tap),   // wrong label → FP
+        ]
+        let report = ReplayEvaluator.evaluate(
+            events: events, segments: segments, tolerance: 1.0, duration: 60)
+        XCTAssertEqual(report.metrics, [
+            ReplayLabelMetrics(label: .nod, truePositives: 1, falseNegatives: 1, falsePositives: 1),
+            ReplayLabelMetrics(label: .shake, truePositives: 0, falseNegatives: 1, falsePositives: 0),
+            ReplayLabelMetrics(label: .tap, truePositives: 0, falseNegatives: 0, falsePositives: 1),
+        ])
+        XCTAssertEqual(report.falsePositives, 2)
+        XCTAssertEqual(report.falsePositivesPerMinute ?? 0, 2.0, accuracy: 1e-9)
+    }
+
+    func testEvaluatorCountsDoubleFireAsFalsePositive() {
+        let segments = [ReplayLabelSegment(start: 2, end: 4, label: .nod)]
+        let events = [
+            ReplayEvent(time: 3.0, label: .nod),
+            ReplayEvent(time: 3.8, label: .nod),
+        ]
+        let report = ReplayEvaluator.evaluate(
+            events: events, segments: segments, tolerance: 1.0, duration: 60)
+        XCTAssertEqual(report.metrics, [
+            ReplayLabelMetrics(label: .nod, truePositives: 1, falseNegatives: 0, falsePositives: 1),
+        ])
+    }
+
+    func testEvaluatorRespectsToleranceBoundary() {
+        let segments = [ReplayLabelSegment(start: 2, end: 4, label: .shake)]
+        let lateEvent = [ReplayEvent(time: 5.5, label: .shake)]
+        let missed = ReplayEvaluator.evaluate(
+            events: lateEvent, segments: segments, tolerance: 1.0, duration: 60)
+        XCTAssertEqual(missed.metrics, [
+            ReplayLabelMetrics(label: .shake, truePositives: 0, falseNegatives: 1, falsePositives: 1),
+        ])
+        let allowed = ReplayEvaluator.evaluate(
+            events: lateEvent, segments: segments, tolerance: 2.0, duration: 60)
+        XCTAssertEqual(allowed.metrics, [
+            ReplayLabelMetrics(label: .shake, truePositives: 1, falseNegatives: 0, falsePositives: 0),
+        ])
+    }
+
+    func testPrecisionAndRecall() {
+        let metrics = ReplayLabelMetrics(
+            label: .nod, truePositives: 3, falseNegatives: 1, falsePositives: 2)
+        XCTAssertEqual(metrics.precision ?? 0, 0.6, accuracy: 1e-9)
+        XCTAssertEqual(metrics.recall ?? 0, 0.75, accuracy: 1e-9)
+        let silent = ReplayLabelMetrics(
+            label: .nod, truePositives: 0, falseNegatives: 2, falsePositives: 0)
+        XCTAssertNil(silent.precision)
+        XCTAssertEqual(silent.recall, 0)
+    }
+
+    // MARK: Backend running
+
+    func testHeuristicRunnerDetectsSyntheticDoubleNod() {
+        // Two single-cycle nod bursts; each is one detection (0.5 rad peak-to-peak,
+        // 2 reversals) and the pair completes the double nod. A longer burst would
+        // itself contain two nod cycles and pair on its own.
+        var samples: [HeadMotionSample] = []
+        var time = 0.0
+        func appendQuiet(_ seconds: Double) {
+            let count = Int(seconds / 0.04)
+            for _ in 0..<count {
+                samples.append(HeadMotionSample(
+                    timestamp: time, pitch: 0, yaw: 0,
+                    accelerationMagnitude: 0, rotationMagnitude: 0))
+                time += 0.04
+            }
+        }
+        func appendNodBurst() {
+            for index in 0..<20 {
+                let pitch = 0.25 * sin(Double(index) / 19 * 2 * .pi)
+                samples.append(HeadMotionSample(
+                    timestamp: time, pitch: pitch, yaw: 0,
+                    accelerationMagnitude: 0, rotationMagnitude: 0))
+                time += 0.04
+            }
+        }
+        appendQuiet(1.0)
+        appendNodBurst()
+        appendQuiet(0.6)
+        appendNodBurst()
+        appendQuiet(1.0)
+
+        let events = ReplayBackendRunner.heuristicEvents(
+            samples: samples, gestureConfig: HeadGestureConfig(), tapConfig: TapConfig())
+        XCTAssertEqual(events.map(\.label), [.nod])
+    }
+
+    func testEncoderRunnerUsesInjectedScorer() {
+        struct AlwaysShake: MotionWindowScoring {
+            func score(_ window: EncoderInputWindow) throws -> GestureScores {
+                GestureScores(values: [.shake: 0.95])
+            }
+        }
+        let samples = (0..<40).map { perAxisSample(at: Double($0) * 0.04) }
+        let events = ReplayBackendRunner.encoderEvents(
+            samples: samples, scorer: AlwaysShake())
+        XCTAssertEqual(events.map(\.label), [.shake])
+    }
+
+    func testReplayLabelsMapAllChannels() {
+        XCTAssertEqual(
+            MotionDetectionResult(gesture: .nod).replayLabels, [.nod])
+        XCTAssertEqual(
+            MotionDetectionResult(gesture: .shake).replayLabels, [.shake])
+        XCTAssertEqual(MotionDetectionResult(tap: .tap).replayLabels, [.tap])
+        XCTAssertEqual(
+            MotionDetectionResult(tilt: .tiltLeft).replayLabels, [.tiltLeft])
+        XCTAssertEqual(
+            MotionDetectionResult(tilt: .tiltRight).replayLabels, [.tiltRight])
+        XCTAssertEqual(
+            MotionDetectionResult(swipe: .swipeUp).replayLabels, [.swipeUp])
+        XCTAssertEqual(
+            MotionDetectionResult(swipe: .swipeDown).replayLabels, [.swipeDown])
+        XCTAssertEqual(MotionDetectionResult().replayLabels, [])
+    }
+}

--- a/Tests/TapQCLITests/MotionSampleFormatterTests.swift
+++ b/Tests/TapQCLITests/MotionSampleFormatterTests.swift
@@ -7,6 +7,16 @@ final class MotionSampleFormatterTests: XCTestCase {
         timestamp: 12.5,
         pitch: 0.25,
         yaw: -0.5,
+        roll: 0.125,
+        userAcceleration: MotionVector(x: 0.75, y: 0, z: 0),
+        rotationRate: MotionVector(x: 0, y: 1.25, z: 0),
+        gravity: MotionVector(x: 0, y: 0, z: -1)
+    )
+
+    private let legacySample = HeadMotionSample(
+        timestamp: 12.5,
+        pitch: 0.25,
+        yaw: -0.5,
         accelerationMagnitude: 0.75,
         rotationMagnitude: 1.25
     )
@@ -19,16 +29,31 @@ final class MotionSampleFormatterTests: XCTestCase {
         XCTAssertEqual(object["timestamp"], 12.5)
         XCTAssertEqual(object["acceleration_magnitude"], 0.75)
         XCTAssertEqual(object["rotation_magnitude"], 1.25)
+        XCTAssertEqual(object["roll"], 0.125)
+        XCTAssertEqual(object["user_acceleration_x"], 0.75)
+        XCTAssertEqual(object["rotation_rate_y"], 1.25)
+        XCTAssertEqual(object["gravity_z"], -1)
     }
 
     func testCSVHeaderAndLine() {
         XCTAssertEqual(
             MotionSampleFormatter.csvHeader,
-            "timestamp,pitch,yaw,acceleration_magnitude,rotation_magnitude"
+            "timestamp,pitch,yaw,acceleration_magnitude,rotation_magnitude,"
+                + "roll,user_acceleration_x,user_acceleration_y,user_acceleration_z,"
+                + "rotation_rate_x,rotation_rate_y,rotation_rate_z,gravity_x,gravity_y,gravity_z"
         )
         XCTAssertEqual(
             MotionSampleFormatter.line(for: sample, format: .csv),
-            "12.5,0.25,-0.5,0.75,1.25"
+            "12.5,0.25,-0.5,0.75,1.25,0.125,0.75,0,0,0,1.25,0,0,0,-1"
+        )
+    }
+
+    /// A magnitude-only sample (legacy adapter) still writes every column; per-axis
+    /// values are zero, and the magnitudes keep their original positions.
+    func testLegacySampleKeepsColumnPositions() {
+        XCTAssertEqual(
+            MotionSampleFormatter.line(for: legacySample, format: .csv),
+            "12.5,0.25,-0.5,0.75,1.25,0,0,0,0,0,0,0,0,0,0"
         )
     }
 }

--- a/Tests/TapQCLITests/ReplayCommandParsingTests.swift
+++ b/Tests/TapQCLITests/ReplayCommandParsingTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import TapQCLI
+import TapQDetectionBaseline
+
+final class ReplayCommandParsingTests: XCTestCase {
+    func testReplayParsesAllOptions() throws {
+        let command = try CLICommandParser.parse([
+            "replay", "--input", "capture.jsonl", "--labels", "labels.jsonl",
+            "--format", "csv", "--tolerance", "2.5", "--json",
+            "--encoder-model", "model.mlpackage",
+            "--gesture-profile", "g.json", "--tap-profile", "t.json",
+        ])
+        var expected = ReplayOptions()
+        expected.inputPath = "capture.jsonl"
+        expected.labelsPath = "labels.jsonl"
+        expected.format = .csv
+        expected.tolerance = 2.5
+        expected.json = true
+        expected.encoderModelPath = "model.mlpackage"
+        expected.gestureProfilePath = "g.json"
+        expected.tapProfilePath = "t.json"
+        XCTAssertEqual(command, .replay(expected))
+    }
+
+    func testReplayRequiresInput() {
+        XCTAssertThrowsError(try CLICommandParser.parse(["replay"]))
+        XCTAssertThrowsError(try CLICommandParser.parse(["replay", "--json"]))
+    }
+
+    func testReplayRejectsUnknownOption() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse(["replay", "--input", "x", "--bogus"]))
+    }
+
+    func testReplayHelp() throws {
+        XCTAssertEqual(try CLICommandParser.parse(["replay", "--help"]), .help(.replay))
+        XCTAssertEqual(try CLICommandParser.parse(["help", "replay"]), .help(.replay))
+    }
+
+    func testServeParsesEncoderOptions() throws {
+        let command = try CLICommandParser.parse([
+            "serve", "--encoder-model", "model.mlpackage", "--encoder-mode", "primary",
+        ])
+        var expected = ServeOptions()
+        expected.encoderModelPath = "model.mlpackage"
+        expected.encoderMode = .primary
+        XCTAssertEqual(command, .serve(expected))
+    }
+
+    func testServeEncoderModeDefaultsToShadow() throws {
+        let command = try CLICommandParser.parse([
+            "serve", "--encoder-model", "model.mlpackage",
+        ])
+        var expected = ServeOptions()
+        expected.encoderModelPath = "model.mlpackage"
+        XCTAssertEqual(command, .serve(expected))
+        XCTAssertEqual(expected.encoderMode, .shadow)
+    }
+
+    func testServeEncoderModeRequiresModel() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse(["serve", "--encoder-mode", "primary"]))
+    }
+
+    func testServeRejectsEncoderModeOff() {
+        XCTAssertThrowsError(try CLICommandParser.parse([
+            "serve", "--encoder-model", "m.mlpackage", "--encoder-mode", "off",
+        ]))
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/EncoderContractTests.swift
+++ b/Tests/TapQDetectionBaselineTests/EncoderContractTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import TapQDetectionBaseline
+
+/// Pins the feature contract shared with `ml/tapq1/layout.py`. A failure here means the
+/// Swift side changed without a new layout version — which would silently desynchronize
+/// training and runtime.
+final class EncoderContractTests: XCTestCase {
+    func testFeatureLayoutIsPinned() {
+        XCTAssertEqual(EncoderFeatureLayout.version, "tapq1-features-v1")
+        XCTAssertEqual(EncoderFeatureLayout.windowLength, 32)
+        XCTAssertEqual(EncoderFeatureLayout.accelerationFullScale, 2.0)
+        XCTAssertEqual(EncoderFeatureLayout.rotationFullScale, 8.0)
+        XCTAssertEqual(EncoderFeatureLayout.channelNames, [
+            "user_acceleration_x", "user_acceleration_y", "user_acceleration_z",
+            "rotation_rate_x", "rotation_rate_y", "rotation_rate_z",
+            "gravity_x", "gravity_y", "gravity_z",
+        ])
+    }
+
+    func testClassOrderIsPinned() {
+        XCTAssertEqual(
+            TapQ1ModelMetadata.expectedClasses,
+            "quiet,nod,shake,tilt_left,tilt_right,tap,swipe_up,swipe_down"
+        )
+    }
+
+    func testFeatureRowScalesAndClips() {
+        let sample = HeadMotionSample(
+            timestamp: 0, pitch: 0.3, yaw: -0.2, roll: 0.1,
+            userAcceleration: MotionVector(x: 1.0, y: 5.0, z: -0.5),
+            rotationRate: MotionVector(x: -100.0, y: -4.0, z: 2.0),
+            gravity: MotionVector(x: 0.0, y: 0.5, z: -1.0)
+        )
+        XCTAssertEqual(EncoderFeatureLayout.featureRow(for: sample), [
+            0.5, 1.0, -0.25,
+            -1.0, -0.5, 0.25,
+            0.0, 0.5, -1.0,
+        ])
+    }
+
+    func testRankedBreaksTiesByClassOrder() {
+        let scores = GestureScores(values: [.shake: 0.5, .nod: 0.5])
+        XCTAssertEqual(scores.ranked.first?.gestureClass, .nod)
+        XCTAssertEqual(scores.probability(of: .tap), 0)
+    }
+
+    private func perAxisSample(at time: TimeInterval) -> HeadMotionSample {
+        HeadMotionSample(
+            timestamp: time, pitch: 0, yaw: 0, roll: 0,
+            userAcceleration: MotionVector(x: 0.01, y: 0, z: 0),
+            rotationRate: .zero,
+            gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+    }
+
+    func testWindowBuilderEmitsAtWindowLengthThenEveryHop() {
+        var builder = EncoderWindowBuilder(windowLength: 32, hopSamples: 8)
+        var windows: [EncoderInputWindow] = []
+        for index in 0..<48 {
+            if let window = builder.push(perAxisSample(at: Double(index) * 0.04)) {
+                windows.append(window)
+            }
+        }
+        XCTAssertEqual(windows.count, 3)
+        XCTAssertEqual(windows[0].features.count, 32)
+        XCTAssertEqual(windows[0].features[0].count, 9)
+        XCTAssertEqual(windows[0].endTime, 31 * 0.04, accuracy: 1e-9)
+        XCTAssertEqual(windows[1].endTime, 39 * 0.04, accuracy: 1e-9)
+        XCTAssertEqual(windows[2].endTime, 47 * 0.04, accuracy: 1e-9)
+        XCTAssertEqual(
+            windows[2].endTime - windows[2].startTime, 31 * 0.04, accuracy: 1e-9)
+    }
+
+    func testWindowBuilderResetsAcrossStreamGap() {
+        var builder = EncoderWindowBuilder(windowLength: 32, hopSamples: 8)
+        for index in 0..<32 {
+            _ = builder.push(perAxisSample(at: Double(index) * 0.04))
+        }
+        // A gap longer than gapResetSeconds must clear the buffer: a window spanning a
+        // disconnect would splice unrelated motion.
+        let resumeAt = 32 * 0.04 + 1.0
+        var windows = 0
+        for index in 0..<40 {
+            if builder.push(perAxisSample(at: resumeAt + Double(index) * 0.04)) != nil {
+                windows += 1
+            }
+        }
+        XCTAssertEqual(windows, 2)
+    }
+
+    func testWindowBuilderIgnoresMagnitudeOnlySamples() {
+        var builder = EncoderWindowBuilder(windowLength: 32, hopSamples: 8)
+        for index in 0..<31 {
+            XCTAssertNil(builder.push(perAxisSample(at: Double(index) * 0.04)))
+        }
+        let legacy = HeadMotionSample(
+            timestamp: 31 * 0.04, pitch: 0, yaw: 0,
+            accelerationMagnitude: 0.1, rotationMagnitude: 0.1
+        )
+        XCTAssertNil(builder.push(legacy))
+        XCTAssertNotNil(builder.push(perAxisSample(at: 32 * 0.04)))
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/EncoderMotionPipelineTests.swift
+++ b/Tests/TapQDetectionBaselineTests/EncoderMotionPipelineTests.swift
@@ -69,13 +69,51 @@ final class EncoderMotionPipelineTests: XCTestCase {
         XCTAssertTrue(run(&pipeline, samples: 120).isEmpty)
     }
 
-    func testShakeEmitsWithoutPairing() {
+    func testTwoShakeAtomsPairIntoOneShake() {
+        // Deny is the most consequential command; it carries the same doubling
+        // requirement as the heuristic backend.
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([
+                confident(.shake), confident(.shake), confident(.shake), confident(.shake),
+            ])
+        )
+        let events = run(&pipeline, samples: 64)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].index, 55)
+        XCTAssertEqual(events[0].result, MotionDetectionResult(gesture: .shake))
+    }
+
+    func testLoneShakeAtomNeverDenies() {
         var pipeline = EncoderMotionPipeline(
             scorer: ScriptedScorer([confident(.shake), confident(.shake)])
         )
-        let events = run(&pipeline, samples: 48)
+        XCTAssertTrue(run(&pipeline, samples: 120).isEmpty)
+    }
+
+    func testNodAfterShakeClearsThePendingShake() {
+        // A nod between two shakes must not leave a half-formed deny armed.
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([
+                confident(.shake), confident(.shake),
+                confident(.nod), confident(.nod),
+                confident(.shake), confident(.shake),
+            ])
+        )
+        XCTAssertTrue(run(&pipeline, samples: 96).isEmpty)
+    }
+
+    func testStalePendingShakeExpires() {
+        let quiet = GestureScores(values: [.quiet: 1.0])
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer(
+                [confident(.shake), confident(.shake)]
+                    + Array(repeating: quiet, count: 5)
+                    + Array(repeating: confident(.shake), count: 4)
+            )
+        )
+        let events = run(&pipeline, samples: 112)
         XCTAssertEqual(events.count, 1)
-        XCTAssertEqual(events[0].index, 39)
+        XCTAssertEqual(events[0].index, 111)
         XCTAssertEqual(events[0].result, MotionDetectionResult(gesture: .shake))
     }
 
@@ -151,8 +189,10 @@ final class EncoderMotionPipelineTests: XCTestCase {
     }
 
     func testEventDebounceSuppressesSustainedMotionThenRearms() {
+        // Uses tap, which emits per atom, so the debounce is measured on its own
+        // rather than through a pairing channel.
         var pipeline = EncoderMotionPipeline(
-            scorer: ScriptedScorer(Array(repeating: confident(.shake), count: 6))
+            scorer: ScriptedScorer(Array(repeating: confident(.tap), count: 6))
         )
         let events = run(&pipeline, samples: 72)
         // Windows 3–4 produce an atom 0.64 s after the first event — inside the 1 s

--- a/Tests/TapQDetectionBaselineTests/EncoderMotionPipelineTests.swift
+++ b/Tests/TapQDetectionBaselineTests/EncoderMotionPipelineTests.swift
@@ -1,0 +1,218 @@
+import XCTest
+@testable import TapQDetectionBaseline
+import TapQContracts
+
+/// Returns scripted scores window-by-window; quiet once the script runs out.
+private final class ScriptedScorer: MotionWindowScoring {
+    private(set) var callCount = 0
+    private let script: [GestureScores]
+
+    init(_ script: [GestureScores]) {
+        self.script = script
+    }
+
+    func score(_ window: EncoderInputWindow) throws -> GestureScores {
+        defer { callCount += 1 }
+        guard callCount < script.count else { return GestureScores(values: [.quiet: 1.0]) }
+        return script[callCount]
+    }
+}
+
+private struct FailingScorer: MotionWindowScoring {
+    struct Failure: Error {}
+    func score(_ window: EncoderInputWindow) throws -> GestureScores { throw Failure() }
+}
+
+/// Defaults: window 32, hop 8 at 25 Hz → windows end at samples 31, 39, 47, …;
+/// agreement 2 → an atom lands on the second consecutive qualified window.
+final class EncoderMotionPipelineTests: XCTestCase {
+    private func sample(at time: TimeInterval) -> HeadMotionSample {
+        HeadMotionSample(
+            timestamp: time, pitch: 0, yaw: 0, roll: 0,
+            userAcceleration: MotionVector(x: 0.01, y: 0, z: 0),
+            rotationRate: .zero,
+            gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+    }
+
+    private func confident(_ gestureClass: GestureClass, _ probability: Float = 0.9) -> GestureScores {
+        GestureScores(values: [gestureClass: probability])
+    }
+
+    private func run(
+        _ pipeline: inout EncoderMotionPipeline, samples: Int
+    ) -> [(index: Int, result: MotionDetectionResult)] {
+        var events: [(Int, MotionDetectionResult)] = []
+        for index in 0..<samples {
+            let result = pipeline.ingest(sample(at: Double(index) * 0.04))
+            if result != MotionDetectionResult() { events.append((index, result)) }
+        }
+        return events
+    }
+
+    func testTwoNodAtomsPairIntoOneNod() {
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([
+                confident(.nod), confident(.nod), confident(.nod), confident(.nod),
+            ])
+        )
+        let events = run(&pipeline, samples: 64)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].index, 55)
+        XCTAssertEqual(events[0].result, MotionDetectionResult(gesture: .nod))
+    }
+
+    func testLoneNodAtomNeverEmits() {
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([confident(.nod), confident(.nod)])
+        )
+        XCTAssertTrue(run(&pipeline, samples: 120).isEmpty)
+    }
+
+    func testShakeEmitsWithoutPairing() {
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([confident(.shake), confident(.shake)])
+        )
+        let events = run(&pipeline, samples: 48)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].index, 39)
+        XCTAssertEqual(events[0].result, MotionDetectionResult(gesture: .shake))
+    }
+
+    func testTapAtomEmitsDirectly() {
+        // A tap atom already carries the whole double-tap pattern.
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([confident(.tap), confident(.tap)])
+        )
+        let events = run(&pipeline, samples: 48)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].result, MotionDetectionResult(tap: .tap))
+    }
+
+    func testSwipeEmitsDirectly() {
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([confident(.swipeDown), confident(.swipeDown)])
+        )
+        let events = run(&pipeline, samples: 48)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].result, MotionDetectionResult(swipe: .swipeDown))
+    }
+
+    func testTiltAtomsPairSameDirection() {
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([
+                confident(.tiltLeft), confident(.tiltLeft),
+                confident(.tiltLeft), confident(.tiltLeft),
+            ])
+        )
+        let events = run(&pipeline, samples: 64)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].result, MotionDetectionResult(tilt: .tiltLeft))
+    }
+
+    func testOppositeTiltReplacesPendingInsteadOfEmitting() {
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([
+                confident(.tiltLeft), confident(.tiltLeft),
+                confident(.tiltRight), confident(.tiltRight),
+                confident(.tiltRight), confident(.tiltRight),
+            ])
+        )
+        let events = run(&pipeline, samples: 80)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].index, 71)
+        XCTAssertEqual(events[0].result, MotionDetectionResult(tilt: .tiltRight))
+    }
+
+    func testBelowThresholdNeverEmits() {
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer(Array(repeating: confident(.shake, 0.6), count: 4))
+        )
+        XCTAssertTrue(run(&pipeline, samples: 64).isEmpty)
+    }
+
+    func testNarrowMarginNeverEmits() {
+        let nearTie = GestureScores(values: [.nod: 0.8, .shake: 0.65])
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer(Array(repeating: nearTie, count: 4))
+        )
+        XCTAssertTrue(run(&pipeline, samples: 64).isEmpty)
+    }
+
+    func testAlternatingWindowsNeverReachAgreement() {
+        let quiet = GestureScores(values: [.quiet: 1.0])
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer([
+                confident(.shake), quiet, confident(.shake), quiet,
+                confident(.shake), quiet,
+            ])
+        )
+        XCTAssertTrue(run(&pipeline, samples: 96).isEmpty)
+    }
+
+    func testEventDebounceSuppressesSustainedMotionThenRearms() {
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer(Array(repeating: confident(.shake), count: 6))
+        )
+        let events = run(&pipeline, samples: 72)
+        // Windows 3–4 produce an atom 0.64 s after the first event — inside the 1 s
+        // event debounce — so only windows 5–6 may fire again.
+        XCTAssertEqual(events.map(\.index), [39, 71])
+    }
+
+    func testStalePendingNodExpiresBeforePairing() {
+        let quiet = GestureScores(values: [.quiet: 1.0])
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer(
+                [confident(.nod), confident(.nod)]
+                    + Array(repeating: quiet, count: 5)
+                    + Array(repeating: confident(.nod), count: 4)
+            )
+        )
+        let events = run(&pipeline, samples: 112)
+        // The pending armed at 1.56 s expires (pair window 1.5 s) during the quiet
+        // stretch; the third atom re-arms and only the fourth completes the pair.
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].index, 111)
+        XCTAssertEqual(events[0].result, MotionDetectionResult(gesture: .nod))
+    }
+
+    func testScorerFailureIsContained() {
+        var pipeline = EncoderMotionPipeline(scorer: FailingScorer())
+        XCTAssertTrue(run(&pipeline, samples: 64).isEmpty)
+    }
+
+    func testMagnitudeOnlySamplesNeverReachTheScorer() {
+        let scorer = ScriptedScorer([confident(.shake), confident(.shake)])
+        var pipeline = EncoderMotionPipeline(scorer: scorer)
+        for index in 0..<64 {
+            let legacy = HeadMotionSample(
+                timestamp: Double(index) * 0.04, pitch: 0, yaw: 0,
+                accelerationMagnitude: 0.1, rotationMagnitude: 0.1
+            )
+            XCTAssertEqual(pipeline.ingest(legacy), MotionDetectionResult())
+        }
+        XCTAssertEqual(scorer.callCount, 0)
+    }
+
+    func testResetClearsPendingPairing() {
+        // A pair window far beyond the test duration isolates reset from expiry: if the
+        // pending armed before reset survived, the single post-reset atom would pair
+        // with it and emit.
+        var pipeline = EncoderMotionPipeline(
+            scorer: ScriptedScorer(Array(repeating: confident(.nod), count: 6)),
+            config: EncoderConfig(nodPairWindowSeconds: 10)
+        )
+        for index in 0..<48 {
+            _ = pipeline.ingest(sample(at: Double(index) * 0.04))
+        }
+        pipeline.reset()
+        var events = 0
+        for index in 48..<120 {
+            if pipeline.ingest(sample(at: Double(index) * 0.04)) != MotionDetectionResult() {
+                events += 1
+            }
+        }
+        XCTAssertEqual(events, 0)
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/HeadMotionSampleTests.swift
+++ b/Tests/TapQDetectionBaselineTests/HeadMotionSampleTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import TapQDetectionBaseline
+
+final class HeadMotionSampleTests: XCTestCase {
+    func testFullInitDerivesMagnitudesFromVectors() {
+        let sample = HeadMotionSample(
+            timestamp: 1, pitch: 0.1, yaw: 0.2, roll: 0.3,
+            userAcceleration: MotionVector(x: 3, y: 4, z: 0),
+            rotationRate: MotionVector(x: 0, y: 0, z: 2),
+            gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+        XCTAssertEqual(sample.accelerationMagnitude, 5, accuracy: 1e-12)
+        XCTAssertEqual(sample.rotationMagnitude, 2, accuracy: 1e-12)
+        XCTAssertTrue(sample.hasPerAxisData)
+    }
+
+    func testLegacyInitLeavesPerAxisAbsent() {
+        let sample = HeadMotionSample(
+            timestamp: 1, pitch: 0.1, yaw: 0.2,
+            accelerationMagnitude: 0.5, rotationMagnitude: 0.6
+        )
+        XCTAssertEqual(sample.roll, 0)
+        XCTAssertEqual(sample.userAcceleration, .zero)
+        XCTAssertFalse(sample.hasPerAxisData)
+    }
+
+    /// Records serialized before per-axis capture existed must still decode.
+    func testDecodingPrePerAxisRecordSucceeds() throws {
+        let legacyJSON = Data("""
+        {"timestamp": 2.5, "pitch": 0.1, "yaw": -0.2,
+         "accelerationMagnitude": 0.4, "rotationMagnitude": 0.8}
+        """.utf8)
+        let sample = try JSONDecoder().decode(HeadMotionSample.self, from: legacyJSON)
+        XCTAssertEqual(sample.timestamp, 2.5)
+        XCTAssertEqual(sample.accelerationMagnitude, 0.4)
+        XCTAssertEqual(sample.roll, 0)
+        XCTAssertEqual(sample.gravity, .zero)
+        XCTAssertFalse(sample.hasPerAxisData)
+    }
+
+    func testRoundTripPreservesPerAxisData() throws {
+        let original = HeadMotionSample(
+            timestamp: 3, pitch: 0.1, yaw: 0.2, roll: -0.3,
+            userAcceleration: MotionVector(x: 0.1, y: -0.2, z: 0.3),
+            rotationRate: MotionVector(x: -0.4, y: 0.5, z: -0.6),
+            gravity: MotionVector(x: 0.0, y: 0.1, z: -0.99)
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(HeadMotionSample.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/MotionPipelineTiltTests.swift
+++ b/Tests/TapQDetectionBaselineTests/MotionPipelineTiltTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import TapQDetectionBaseline
+import TapQContracts
+
+/// Double-tilt pairing and swipe gating at the pipeline level. Analyzer-shape coverage
+/// lives in `TiltAnalyzerTests`/`SwipeAnalyzerTests`; these tests drive timing.
+final class MotionPipelineTiltTests: XCTestCase {
+    private let sampleInterval = 0.04  // 25 Hz
+
+    /// Feeds one complete lateral tilt excursion (out and back) starting at `start`,
+    /// returning the timestamp after the excursion.
+    @discardableResult
+    private func feedTilt(
+        _ pipeline: inout MotionGesturePipeline,
+        direction: Double, start: TimeInterval,
+        collecting: inout [TiltCommand]
+    ) -> TimeInterval {
+        let samples = 24
+        for index in 0..<samples {
+            let phase = Double(index) / Double(samples - 1)
+            let roll = direction * 0.25 * sin(phase * .pi)
+            let time = start + Double(index) * sampleInterval
+            if let tilt = pipeline.ingestTilt(roll: roll, pitch: 0, yaw: 0, time: time) {
+                collecting.append(tilt)
+            }
+        }
+        return start + Double(samples) * sampleInterval
+    }
+
+    func testTwoSameDirectionTiltsEmitOneCommand() {
+        var pipeline = MotionGesturePipeline()
+        var emitted: [TiltCommand] = []
+        let afterFirst = feedTilt(&pipeline, direction: 1, start: 0, collecting: &emitted)
+        XCTAssertEqual(emitted, [], "a single tilt must never navigate")
+        feedTilt(&pipeline, direction: 1, start: afterFirst + 0.3, collecting: &emitted)
+        XCTAssertEqual(emitted, [.tiltRight])
+    }
+
+    func testTwoLeftTiltsEmitTiltLeft() {
+        var pipeline = MotionGesturePipeline()
+        var emitted: [TiltCommand] = []
+        let afterFirst = feedTilt(&pipeline, direction: -1, start: 0, collecting: &emitted)
+        feedTilt(&pipeline, direction: -1, start: afterFirst + 0.3, collecting: &emitted)
+        XCTAssertEqual(emitted, [.tiltLeft])
+    }
+
+    func testOppositeDirectionsRestartThePairInsteadOfEmitting() {
+        var pipeline = MotionGesturePipeline()
+        var emitted: [TiltCommand] = []
+        let afterFirst = feedTilt(&pipeline, direction: 1, start: 0, collecting: &emitted)
+        let afterSecond = feedTilt(
+            &pipeline, direction: -1, start: afterFirst + 0.3, collecting: &emitted)
+        XCTAssertEqual(emitted, [], "a right-left wobble is ambiguity, not navigation")
+        // The left tilt became the new pending half; a second left completes it.
+        feedTilt(&pipeline, direction: -1, start: afterSecond + 0.3, collecting: &emitted)
+        XCTAssertEqual(emitted, [.tiltLeft])
+    }
+
+    func testExpiredFirstTiltDoesNotPair() {
+        var pipeline = MotionGesturePipeline()
+        var emitted: [TiltCommand] = []
+        let afterFirst = feedTilt(&pipeline, direction: 1, start: 0, collecting: &emitted)
+        // Past doubleTiltWindowSeconds (1.6 s): the pending half expires; this tilt
+        // becomes a fresh first half, so still nothing fires.
+        feedTilt(&pipeline, direction: 1, start: afterFirst + 2.5, collecting: &emitted)
+        XCTAssertEqual(emitted, [])
+    }
+
+    func testSwipeChannelIsInertByDefault() {
+        var pipeline = MotionGesturePipeline()
+        let gravity = MotionVector(x: 0, y: 0, z: -1)
+        for index in 0..<30 {
+            let level = (6..<13).contains(index) ? 0.2 : 0.01
+            let sample = HeadMotionSample(
+                timestamp: Double(index) * sampleInterval,
+                pitch: 0, yaw: 0, roll: 0,
+                userAcceleration: MotionVector(x: 0, y: 0, z: level),
+                rotationRate: .zero,
+                gravity: gravity
+            )
+            XCTAssertNil(pipeline.ingest(sample).swipe)
+        }
+    }
+
+    func testSwipeEmitsWhenEnabledWithPerAxisData() {
+        var pipeline = MotionGesturePipeline()
+        pipeline.swipeDetectionEnabled = true
+        let gravity = MotionVector(x: 0, y: 0, z: -1)
+        var emitted: [MotionSwipeCommand] = []
+        for index in 0..<30 {
+            let level = (6..<13).contains(index) ? 0.2 : 0.01
+            let sample = HeadMotionSample(
+                timestamp: Double(index) * sampleInterval,
+                pitch: 0, yaw: 0, roll: 0,
+                userAcceleration: MotionVector(x: 0, y: 0, z: level),
+                rotationRate: .zero,
+                gravity: gravity
+            )
+            if let swipe = pipeline.ingest(sample).swipe { emitted.append(swipe) }
+        }
+        XCTAssertEqual(emitted, [.swipeUp])
+    }
+
+    func testSwipeStaysInertForMagnitudeOnlySamples() {
+        var pipeline = MotionGesturePipeline()
+        pipeline.swipeDetectionEnabled = true
+        for index in 0..<30 {
+            let level = (6..<13).contains(index) ? 0.2 : 0.01
+            let sample = HeadMotionSample(
+                timestamp: Double(index) * sampleInterval,
+                pitch: 0, yaw: 0,
+                accelerationMagnitude: level, rotationMagnitude: 0.05
+            )
+            XCTAssertNil(pipeline.ingest(sample).swipe)
+        }
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/SwipeAnalyzerTests.swift
+++ b/Tests/TapQDetectionBaselineTests/SwipeAnalyzerTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import TapQDetectionBaseline
+import TapQContracts
+
+final class SwipeAnalyzerTests: XCTestCase {
+    private let analyzer = SwipeAnalyzer()
+    /// Device-frame gravity for an upright wearer in these tests: straight down -z.
+    private let gravityDown = MotionVector(x: 0, y: 0, z: -1)
+
+    /// A drag: quiet lead-in, a sustained gentle acceleration plateau along `direction`,
+    /// quiet tail. 20 samples ≈ 0.8 s at 25 Hz.
+    private func drag(
+        direction: MotionVector, level: Double = 0.2,
+        elevated: Int = 7, lead: Int = 6, tail: Int = 7
+    ) -> [MotionVector] {
+        let quiet = MotionVector(x: 0.01, y: 0, z: 0)
+        let norm = direction.magnitude
+        let active = MotionVector(
+            x: direction.x / norm * level,
+            y: direction.y / norm * level,
+            z: direction.z / norm * level
+        )
+        return Array(repeating: quiet, count: lead)
+            + Array(repeating: active, count: elevated)
+            + Array(repeating: quiet, count: tail)
+    }
+
+    private func quietRotation(_ count: Int) -> [Double] {
+        Array(repeating: 0.05, count: count)
+    }
+
+    private func gravity(_ count: Int) -> [MotionVector] {
+        Array(repeating: gravityDown, count: count)
+    }
+
+    func testUpwardDragFiresSwipeUp() {
+        let accel = drag(direction: MotionVector(x: 0, y: 0, z: 1))
+        XCTAssertEqual(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: quietRotation(accel.count)),
+            .swipeUp
+        )
+    }
+
+    func testDownwardDragFiresSwipeDown() {
+        let accel = drag(direction: MotionVector(x: 0, y: 0, z: -1))
+        XCTAssertEqual(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: quietRotation(accel.count)),
+            .swipeDown
+        )
+    }
+
+    func testHorizontalDragHasNoTrustedDirection() {
+        // A drag orthogonal to gravity has no vertical dominance — report nothing
+        // rather than guessing.
+        let accel = drag(direction: MotionVector(x: 1, y: 0, z: 0))
+        XCTAssertNil(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: quietRotation(accel.count))
+        )
+    }
+
+    func testTapSpikeIsNotASwipe() {
+        // Brief and sharp: one strong sample, well over the peak ceiling.
+        var accel = Array(repeating: MotionVector(x: 0.01, y: 0, z: 0), count: 19)
+        accel[9] = MotionVector(x: 0, y: 0, z: 0.9)
+        XCTAssertNil(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: quietRotation(accel.count))
+        )
+    }
+
+    func testGentleBriefSpikeIsNotASwipe() {
+        // Under the tap ceiling but too short an elevated run to be a drag.
+        var accel = Array(repeating: MotionVector(x: 0.01, y: 0, z: 0), count: 19)
+        accel[9] = MotionVector(x: 0, y: 0, z: 0.2)
+        accel[10] = MotionVector(x: 0, y: 0, z: 0.2)
+        XCTAssertNil(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: quietRotation(accel.count))
+        )
+    }
+
+    func testHeadMotionRejectedByRotationGate() {
+        let accel = drag(direction: MotionVector(x: 0, y: 0, z: 1))
+        let rotation = Array(repeating: 1.2, count: accel.count)
+        XCTAssertNil(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: rotation)
+        )
+    }
+
+    func testSustainedAdjustmentIsNotASwipe() {
+        // An earbud adjustment holds elevated acceleration past the drag ceiling.
+        let accel = drag(direction: MotionVector(x: 0, y: 0, z: 1),
+                         elevated: 16, lead: 2, tail: 2)
+        XCTAssertNil(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: quietRotation(accel.count))
+        )
+    }
+
+    func testOngoingDragDoesNotFireUntilComplete() {
+        // Elevated at the window's end: the finger is still moving — wait.
+        let accel = drag(direction: MotionVector(x: 0, y: 0, z: 1),
+                         elevated: 7, lead: 12, tail: 0)
+        XCTAssertNil(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: quietRotation(accel.count))
+        )
+    }
+
+    func testMissingGravityReportsNothing() {
+        let accel = drag(direction: MotionVector(x: 0, y: 0, z: 1))
+        XCTAssertNil(
+            analyzer.detect(acceleration: accel,
+                            gravity: Array(repeating: .zero, count: accel.count),
+                            rotation: quietRotation(accel.count))
+        )
+    }
+
+    func testTooFewSamplesDoesNotFire() {
+        let accel = Array(repeating: MotionVector(x: 0.2, y: 0, z: 0), count: 3)
+        XCTAssertNil(
+            analyzer.detect(acceleration: accel, gravity: gravity(accel.count),
+                            rotation: quietRotation(accel.count))
+        )
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/TiltAnalyzerTests.swift
+++ b/Tests/TapQDetectionBaselineTests/TiltAnalyzerTests.swift
@@ -5,43 +5,95 @@ import TapQContracts
 final class TiltAnalyzerTests: XCTestCase {
     private let analyzer = TiltAnalyzer()
 
-    func testSustainedDownwardTilt() {
-        // Pitch decreasing steadily over 0.5s (~25 samples at 50Hz), no reversals
-        let pitch = (0..<25).map { Double($0) * -0.01 }  // 0.0 → -0.24 rad
-        XCTAssertEqual(analyzer.detect(pitch: pitch), .tiltDown)
+    /// A deliberate lateral tilt: roll leaves neutral, peaks well past the amplitude
+    /// threshold, and returns. 24 samples ≈ 1 s at 25 Hz.
+    private func tiltExcursion(peak: Double, samples: Int = 24) -> [Double] {
+        (0..<samples).map { index in
+            let phase = Double(index) / Double(samples - 1)
+            return peak * sin(phase * .pi)
+        }
     }
 
-    func testSustainedUpwardTilt() {
-        let pitch = (0..<25).map { Double($0) * 0.01 }  // 0.0 → +0.24 rad
-        XCTAssertEqual(analyzer.detect(pitch: pitch), .tiltUp)
+    private func quiet(_ count: Int) -> [Double] {
+        Array(repeating: 0.0, count: count)
     }
 
-    func testQuickTiltDownAndReturn() {
-        // Quick pitch down then return to neutral — peak displacement should fire tiltDown
-        let down = (0..<12).map { Double($0) * -0.02 }        // 0.0 → -0.22
-        let up = (0..<12).map { -0.22 + Double($0) * 0.02 }   // -0.22 → 0.0
-        XCTAssertEqual(analyzer.detect(pitch: down + up), .tiltDown)
+    func testRightTiltAndReturnFires() {
+        let roll = tiltExcursion(peak: 0.25)
+        XCTAssertEqual(
+            analyzer.detect(roll: roll, pitch: quiet(roll.count), yaw: quiet(roll.count)),
+            .tiltRight
+        )
     }
 
-    func testBidirectionalMotionDoesNotFire() {
-        // Significant displacement in both directions = ambiguous
-        let down = (0..<12).map { Double($0) * -0.02 }        // 0.0 → -0.22
-        let up = (0..<12).map { -0.22 + Double($0) * 0.04 }   // -0.22 → +0.22
-        XCTAssertNil(analyzer.detect(pitch: down + up))
+    func testLeftTiltAndReturnFires() {
+        let roll = tiltExcursion(peak: -0.25)
+        XCTAssertEqual(
+            analyzer.detect(roll: roll, pitch: quiet(roll.count), yaw: quiet(roll.count)),
+            .tiltLeft
+        )
+    }
+
+    func testHeadParkedSidewaysDoesNotFire() {
+        // Roll ramps out and stays there — the gesture never completes, so firing now
+        // would trigger on someone resting their head, not gesturing.
+        let roll = (0..<24).map { min(0.25, Double($0) * 0.02) }
+        XCTAssertNil(
+            analyzer.detect(roll: roll, pitch: quiet(roll.count), yaw: quiet(roll.count))
+        )
+    }
+
+    func testBidirectionalWobbleDoesNotFire() {
+        let right = tiltExcursion(peak: 0.25, samples: 12)
+        let left = tiltExcursion(peak: -0.25, samples: 12)
+        let roll = right + left
+        XCTAssertNil(
+            analyzer.detect(roll: roll, pitch: quiet(roll.count), yaw: quiet(roll.count))
+        )
+    }
+
+    func testNodCrosstalkIntoRollDoesNotFire() {
+        // A vigorous nod leaks some roll, but pitch swings harder — dominance gate.
+        let pitch = tiltExcursion(peak: 0.4)
+        let roll = tiltExcursion(peak: 0.2)
+        XCTAssertNil(
+            analyzer.detect(roll: roll, pitch: pitch, yaw: quiet(roll.count))
+        )
+    }
+
+    func testShakeCrosstalkIntoRollDoesNotFire() {
+        let yaw = tiltExcursion(peak: 0.4)
+        let roll = tiltExcursion(peak: 0.2)
+        XCTAssertNil(
+            analyzer.detect(roll: roll, pitch: quiet(roll.count), yaw: yaw)
+        )
     }
 
     func testStillBaselineDoesNotFire() {
-        let pitch = [0.001, -0.002, 0.001, 0.0, -0.001, 0.002, -0.001, 0.001]
-        XCTAssertNil(analyzer.detect(pitch: pitch))
-    }
-
-    func testTooFewSamplesDoesNotFire() {
-        XCTAssertNil(analyzer.detect(pitch: [-0.1, -0.2]))
+        let roll = [0.001, -0.002, 0.001, 0.0, -0.001, 0.002, -0.001, 0.001]
+        XCTAssertNil(
+            analyzer.detect(roll: roll, pitch: quiet(roll.count), yaw: quiet(roll.count))
+        )
     }
 
     func testSmallTiltBelowThresholdDoesNotFire() {
-        // Total displacement below threshold
-        let pitch = (0..<25).map { Double($0) * -0.002 }  // only -0.048 rad total
-        XCTAssertNil(analyzer.detect(pitch: pitch))
+        let roll = tiltExcursion(peak: 0.08)
+        XCTAssertNil(
+            analyzer.detect(roll: roll, pitch: quiet(roll.count), yaw: quiet(roll.count))
+        )
+    }
+
+    func testTooFewSamplesDoesNotFire() {
+        XCTAssertNil(analyzer.detect(roll: [0.0, 0.25, 0.0], pitch: [0, 0, 0], yaw: [0, 0, 0]))
+    }
+
+    func testDriftedBaselineStillDetectsRelativeExcursion() {
+        // The wearer's neutral roll is rarely exactly zero; detection is relative to the
+        // window's starting posture, not absolute zero.
+        let roll = tiltExcursion(peak: 0.25).map { $0 + 0.3 }
+        XCTAssertEqual(
+            analyzer.detect(roll: roll, pitch: quiet(roll.count), yaw: quiet(roll.count)),
+            .tiltRight
+        )
     }
 }

--- a/Tests/TapQInteractionBaselineTests/SelectionArbiterTests.swift
+++ b/Tests/TapQInteractionBaselineTests/SelectionArbiterTests.swift
@@ -58,14 +58,24 @@ final class SelectionArbiterTests: XCTestCase {
         XCTAssertEqual(result, .next)
     }
 
-    func testTiltDownResolvesNext() async {
+    func testTiltRightResolvesNext() async {
         let tilts = FakeTilts()
         let arbiter = SelectionArbiter(voice: nil, tilts: tilts, swipes: nil, taps: nil)
         let task = Task { await arbiter.listen(timeout: 5) }
         await tick()
-        tilts.fire(.tiltDown)
+        tilts.fire(.tiltRight)
         let result = await task.value
         XCTAssertEqual(result, .next)
+    }
+
+    func testTiltLeftResolvesPrevious() async {
+        let tilts = FakeTilts()
+        let arbiter = SelectionArbiter(voice: nil, tilts: tilts, swipes: nil, taps: nil)
+        let task = Task { await arbiter.listen(timeout: 5) }
+        await tick()
+        tilts.fire(.tiltLeft)
+        let result = await task.value
+        XCTAssertEqual(result, .previous)
     }
 
     func testSwipeDownResolvesNext() async {
@@ -145,7 +155,7 @@ final class SelectionArbiterTests: XCTestCase {
         let arbiter = SelectionArbiter(voice: voice, tilts: tilts, swipes: nil, taps: nil)
         let task = Task { await arbiter.listen(timeout: 5) }
         await tick()
-        tilts.fire(.tiltDown)
+        tilts.fire(.tiltRight)
         voice.fire(.next)  // ignored — already resolved
         let result = await task.value
         XCTAssertEqual(result, .next)
@@ -224,7 +234,7 @@ final class SelectionArbiterTests: XCTestCase {
         XCTAssertNotNil(tilts.onTilt, "tilt channel opens immediately during TTS")
         XCTAssertNil(voice.onCommand)
 
-        tilts.fire(.tiltDown) // navigate while the option is still being spoken
+        tilts.fire(.tiltRight) // navigate while the option is still being spoken
         let result = await task.value
         XCTAssertEqual(result, .next)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -142,9 +142,15 @@ Progress and the final sample count go to stderr, keeping stdout pipe-safe. CSV
 output begins with a header. Each record contains:
 
 - `timestamp`: hardware motion timestamp in seconds
-- `pitch` and `yaw`: attitude in radians
+- `pitch`, `yaw`, and `roll`: attitude in radians
 - `acceleration_magnitude`: user-acceleration magnitude in g
 - `rotation_magnitude`: rotation-rate magnitude in radians per second
+- `user_acceleration_x/y/z`: signed user acceleration in g, earbud frame
+- `rotation_rate_x/y/z`: signed rotation rate in radians per second, earbud frame
+- `gravity_x/y/z`: gravity direction in g, earbud frame
+
+The first five CSV columns keep their pre-per-axis positions, so tooling written
+against earlier captures keeps working; per-axis columns are appended.
 
 Capture does not run gesture classification. It requires macOS, compatible
 connected AirPods, and Motion permission. Linux returns an unavailable error.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -36,7 +36,7 @@ tapq version --json
 The JSON form includes the CLI version and wire protocol version:
 
 ```json
-{"name":"tapq","version":"0.1.0","wire_protocol":3}
+{"name":"tapq","version":"0.2.0","wire_protocol":3}
 ```
 
 The project is pre-1.0. Machine-readable formats are designed for automation,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,6 +17,7 @@ published yet.
 tapq calibration   Run, inspect, or reset AirPods calibration
 tapq calibrate     Shortcut for `tapq calibration run`
 tapq capture       Capture raw headphone motion as JSONL or CSV
+tapq replay        Replay a motion capture through detection backends offline
 tapq serve         Run the local agent-neutral broker
 tapq integration   Manage agent integrations
 tapq version       Print version information
@@ -65,6 +66,8 @@ The underlying command syntax is `tapq serve [options]`.
 | `--no-voice` | Do not request microphone/Speech access or start voice input |
 | `--no-announcements` | Suppress non-blocking waiting and completion announcements |
 | `--steering` | Enable opt-in structured-question guidance for adapters that support it (currently Claude Code) |
+| `--encoder-model PATH` | Load a TapQ-1 encoder model (`.mlpackage` or `.mlmodelc`) exported by `ml/tapq1/export.py` |
+| `--encoder-mode shadow\|primary` | `shadow` (default) records encoder detections as diagnostics while heuristics drive events; `primary` lets the encoder drive events with heuristic detections logged for comparison. Requires `--encoder-model`; a model that fails to load degrades to heuristics and reports it |
 
 On macOS, `tapq serve`:
 
@@ -154,6 +157,51 @@ against earlier captures keeps working; per-axis columns are appended.
 
 Capture does not run gesture classification. It requires macOS, compatible
 connected AirPods, and Motion permission. Linux returns an unavailable error.
+
+## Replay and evaluation
+
+```bash
+tapq replay --input capture.jsonl
+tapq replay --input capture.jsonl --labels capture.labels.jsonl
+tapq replay --input capture.jsonl --labels capture.labels.jsonl \
+    --encoder-model models/tapq1.mlpackage --json
+```
+
+Replays a recorded capture through TapQ's detection backends, entirely offline
+and on any platform — no AirPods or permissions required. This is the evaluation
+harness for the capture study: record once, then measure every tuning or backend
+change against the same data.
+
+| Option | Default or behavior |
+|---|---|
+| `--input PATH`, `-i PATH` | Required; a `tapq capture` file |
+| `--labels PATH` | Optional JSONL expectation segments (see below) |
+| `--format jsonl\|csv` | Auto-detected from extension or content |
+| `--tolerance SECONDS` | `1.0`; grace period after a segment in which its event may still fire |
+| `--encoder-model PATH` | Also replay through a TapQ-1 encoder model (macOS only) |
+| `--gesture-profile PATH` | Replay with a calibrated gesture profile instead of defaults |
+| `--tap-profile PATH` | Replay with a calibrated tap profile instead of defaults |
+| `--json` | Emit the machine-readable report |
+
+Without labels, replay lists every emitted event with its offset. With labels,
+it adds per-gesture true/false positives, misses, precision, recall, and false
+positives per minute — run it on confounder recordings (typing, bud adjustments,
+desk motion) with an empty label file to measure false-positive rates directly.
+
+Each label line marks the complete command the wearer performed, in the
+capture's own timestamp clock:
+
+```json
+{"start": 12.4, "end": 14.1, "label": "nod"}
+```
+
+Valid labels: `nod`, `shake`, `tilt_left`, `tilt_right`, `tap`, `swipe_up`,
+`swipe_down`. A `nod` segment spans the full double nod and a `tap` segment the
+full double tap, matching what the pipelines emit. Motion-swipe detection is
+enabled during replay even though it ships disabled live, so experimental
+channels can be evaluated from the same recordings. Magnitude-only captures from
+before per-axis capture replay through the heuristic backend; the encoder
+backend needs per-axis data.
 
 ## Calibration
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -214,8 +214,9 @@ capture's own timestamp clock:
 ```
 
 Valid labels: `nod`, `shake`, `tilt_left`, `tilt_right`, `tap`, `swipe_up`,
-`swipe_down`. A `nod` segment spans the full double nod and a `tap` segment the
-full double tap, matching what the pipelines emit. Motion-swipe detection is
+`swipe_down`. Segments span the complete doubled gesture — a `nod` segment covers
+the full double nod, `shake` the full double shake, `tap` the full double tap —
+matching what the pipelines emit. Motion-swipe detection is
 enabled during replay even though it ships disabled live, so experimental
 channels can be evaluated from the same recordings. Magnitude-only captures from
 before per-axis capture replay through the heuristic backend; the encoder

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,0 +1,108 @@
+# TapQ-1 training pipeline
+
+Training and Core ML export for **TapQ-1 stage 1**: a ~70k-parameter
+LIMU-BERT-style transformer that classifies 1.28 s windows of AirPods head-motion
+IMU (25 Hz, 9 channels) into gesture atoms — `quiet`, `nod`, `shake`,
+`tilt_left`, `tilt_right`, `tap`, `swipe_up`, `swipe_down`. The Swift runtime
+(`EncoderMotionPipeline`) turns those window scores into the same doubled
+commands as the deterministic heuristics, which remain the offline fallback.
+
+## The contract
+
+`tapq1/layout.py` mirrors `Sources/TapQDetectionBaseline/EncoderContract.swift`
+exactly: channel order, fixed physical scaling (accel ÷ 2 g, gyro ÷ 8 rad/s,
+gravity as-is, all clipped to [-1, 1]), window length 32, and class order.
+The Swift test suite pins these values; exported models embed the layout version
+in metadata and `CoreMLMotionScorer` refuses to load a mismatch. Change the
+contract only by bumping `VERSION` on both sides.
+
+Label semantics: a segment spans the **complete command** the wearer performed.
+A `nod` segment covers the full double nod; a `tap` segment covers the full
+double tap (both transients fit inside one window, so the model learns the
+doubled pattern for taps, while nod/tilt doubling stays deterministic in Swift).
+Confounder recordings (bud adjustments, scratching, desk motion, typing) go in
+the manifest **without** label files — their windows train `quiet` and drive
+pretraining.
+
+## Setup
+
+```sh
+cd ml
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Workflow
+
+1. **Record** with the Phase 0 tooling (per-axis format is required):
+
+   ```sh
+   tapq capture --duration 60 --output data/session-01.jsonl
+   ```
+
+2. **Label** each recording as JSONL segments in the capture's own timestamp
+   clock (same format `tapq replay --labels` consumes):
+
+   ```json
+   {"start": 12.4, "end": 14.1, "label": "nod"}
+   ```
+
+3. **Manifest** — `data/manifest.json`, paths relative to the manifest:
+
+   ```json
+   [
+     {"capture": "session-01.jsonl", "labels": "session-01.labels.jsonl"},
+     {"capture": "confounders-desk.jsonl"}
+   ]
+   ```
+
+4. **Pretrain** on everything (masked reconstruction, no labels needed):
+
+   ```sh
+   python -m tapq1.pretrain --manifest data/manifest.json --out checkpoints/pretrained.pt
+   ```
+
+5. **Train** the joint head (time-warp/rotation/noise augmentation built in):
+
+   ```sh
+   python -m tapq1.train --manifest data/manifest.json \
+       --pretrained checkpoints/pretrained.pt --out checkpoints/tapq1.pt
+   ```
+
+6. **Export** to Core ML with the embedded contract:
+
+   ```sh
+   python -m tapq1.export --checkpoint checkpoints/tapq1.pt --out models/tapq1.mlpackage
+   ```
+
+7. **Evaluate offline** against the heuristic baseline on held-out recordings —
+   the go/no-go gate before the model ever runs live:
+
+   ```sh
+   tapq replay --input data/holdout.jsonl --labels data/holdout.labels.jsonl \
+       --encoder-model models/tapq1.mlpackage
+   ```
+
+8. **Shadow live**, then promote only after the diagnostics agree:
+
+   ```sh
+   tapq serve --encoder-model models/tapq1.mlpackage                        # shadow (default)
+   tapq serve --encoder-model models/tapq1.mlpackage --encoder-mode primary
+   ```
+
+## Smoke test
+
+No captured data yet? Verify the whole pipeline on synthetic motion:
+
+```sh
+python -m tapq1.smoke                                    # train + budget checks
+python -m tapq1.smoke --export /tmp/tapq1-smoke.mlpackage  # + Core ML export
+```
+
+The smoke export is also the quickest way to exercise `tapq replay
+--encoder-model` and the serve shadow mode before real training.
+
+## Privacy
+
+Raw captures and checkpoints stay local; nothing here uploads anything. Keep
+`data/` and `checkpoints/` out of version control.

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.26
+torch>=2.2
+coremltools>=8.0

--- a/ml/tapq1/__init__.py
+++ b/ml/tapq1/__init__.py
@@ -1,0 +1,1 @@
+"""TapQ-1 stage-1 training pipeline. See ml/README.md for the workflow."""

--- a/ml/tapq1/augment.py
+++ b/ml/tapq1/augment.py
@@ -1,0 +1,63 @@
+"""Training-time augmentation for scaled IMU windows [N, WINDOW_LENGTH, 9].
+
+The three vector triads (acceleration, rotation rate, gravity) live in the same
+earbud frame, so geometric transforms must rotate all three identically —
+independently perturbing them would fabricate physically impossible samples.
+Time warping addresses the papers' consistent finding that gesture *speed* varies
+per user more than gesture *shape* (EarDA; DTW's warping invariance).
+"""
+
+import numpy as np
+
+
+def _random_rotation(rng, max_radians):
+    axis = rng.normal(size=3)
+    axis /= np.linalg.norm(axis) + 1e-12
+    angle = rng.uniform(-max_radians, max_radians)
+    x, y, z = axis * np.sin(angle / 2)
+    w = np.cos(angle / 2)
+    return np.array([
+        [1 - 2 * (y * y + z * z), 2 * (x * y - w * z), 2 * (x * z + w * y)],
+        [2 * (x * y + w * z), 1 - 2 * (x * x + z * z), 2 * (y * z - w * x)],
+        [2 * (x * z - w * y), 2 * (y * z + w * x), 1 - 2 * (x * x + y * y)],
+    ], dtype=np.float32)
+
+
+def rotate(windows, rng, max_radians=0.2):
+    """Small random 3D rotation, one per window, applied to every triad — models
+    ear-fit variation between insertions."""
+    out = windows.copy()
+    for index in range(len(out)):
+        rotation = _random_rotation(rng, max_radians)
+        for triad in range(0, 9, 3):
+            out[index, :, triad:triad + 3] = out[index, :, triad:triad + 3] @ rotation.T
+    return out
+
+
+def time_warp(windows, rng, low=0.8, high=1.2):
+    """Linear-resample each window at a random speed, then crop/pad back to length."""
+    length = windows.shape[1]
+    out = np.empty_like(windows)
+    grid = np.arange(length)
+    for index in range(len(windows)):
+        speed = rng.uniform(low, high)
+        source = np.clip(grid * speed, 0, length - 1)
+        floor = source.astype(int)
+        ceil = np.minimum(floor + 1, length - 1)
+        fraction = (source - floor)[:, None].astype(np.float32)
+        out[index] = (1 - fraction) * windows[index, floor] + fraction * windows[index, ceil]
+    return out
+
+
+def jitter(windows, rng, scale_sigma=0.05, noise_sigma=0.01):
+    """Per-window amplitude scale plus white noise on the motion channels (gravity
+    is a direction, not an amplitude — leave it out of scaling)."""
+    out = windows.copy()
+    scales = rng.normal(1.0, scale_sigma, size=(len(out), 1, 1)).astype(np.float32)
+    out[:, :, :6] *= scales
+    out += rng.normal(0.0, noise_sigma, size=out.shape).astype(np.float32)
+    return np.clip(out, -1.0, 1.0)
+
+
+def augment(windows, rng):
+    return jitter(time_warp(rotate(windows, rng), rng), rng)

--- a/ml/tapq1/data.py
+++ b/ml/tapq1/data.py
@@ -1,0 +1,134 @@
+"""Loading `tapq capture` recordings and label segments into training windows.
+
+Capture files come from `tapq capture --format jsonl|csv` (per-axis format from
+Phase 0). Label files are the same JSONL segment format `tapq replay --labels`
+consumes: {"start": s, "end": s, "label": "nod"}, in the capture's own timestamp
+clock, where a segment spans the complete command (a `nod` segment covers the full
+double nod, a `tap` segment the full double tap).
+"""
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+
+from . import layout
+
+_AXIS_KEYS = [
+    "user_acceleration_x", "user_acceleration_y", "user_acceleration_z",
+    "rotation_rate_x", "rotation_rate_y", "rotation_rate_z",
+    "gravity_x", "gravity_y", "gravity_z",
+]
+
+
+def load_capture(path):
+    """Returns (timestamps [T], raw channels [T, 9]) in CHANNEL_NAMES order.
+
+    Rejects magnitude-only captures from before per-axis capture: the encoder's
+    contract needs signed axes.
+    """
+    path = Path(path)
+    text = path.read_text()
+    if path.suffix in (".jsonl", ".json") or text.lstrip().startswith("{"):
+        rows = [json.loads(line) for line in text.splitlines() if line.strip()]
+        _require_axis_fields(rows[0].keys() if rows else [], path)
+        timestamps = np.array([row["timestamp"] for row in rows], dtype=np.float64)
+        channels = np.array(
+            [[row[key] for key in _AXIS_KEYS] for row in rows], dtype=np.float32)
+    else:
+        reader = csv.DictReader(text.splitlines())
+        rows = list(reader)
+        _require_axis_fields(reader.fieldnames or [], path)
+        timestamps = np.array([float(row["timestamp"]) for row in rows], dtype=np.float64)
+        channels = np.array(
+            [[float(row[key]) for key in _AXIS_KEYS] for row in rows], dtype=np.float32)
+    return timestamps, channels
+
+
+def _require_axis_fields(fields, path):
+    missing = [key for key in _AXIS_KEYS if key not in fields]
+    if missing:
+        raise ValueError(
+            f"{path} lacks per-axis columns {missing}; re-record with a current "
+            "`tapq capture` (magnitude-only captures cannot train the encoder)")
+
+
+def load_labels(path):
+    """Returns [(start, end, class_index)] sorted by start."""
+    segments = []
+    for line in Path(path).read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        record = json.loads(line)
+        label = record["label"]
+        if label not in layout.CLASSES or label == "quiet":
+            raise ValueError(f"unknown label '{label}' in {path}")
+        start, end = float(record["start"]), float(record["end"])
+        if start > end:
+            raise ValueError(f"label segment start {start} is after end {end} in {path}")
+        segments.append((start, end, layout.CLASSES.index(label)))
+    return sorted(segments)
+
+
+def windows(timestamps, channels, hop=8, gap_reset_seconds=0.5):
+    """Slices a capture into scaled [N, WINDOW_LENGTH, 9] windows plus center times.
+
+    Mirrors ``EncoderWindowBuilder``: windows never span a stream gap.
+    """
+    scaled = layout.scale(channels)
+    length = layout.WINDOW_LENGTH
+    starts, centers, slices = [], [], []
+    run_start = 0
+    for index in range(len(timestamps)):
+        if index > 0 and (
+            timestamps[index] < timestamps[index - 1]
+            or timestamps[index] - timestamps[index - 1] > gap_reset_seconds
+        ):
+            run_start = index
+        if index - run_start + 1 >= length and (index - run_start + 1 - length) % hop == 0:
+            begin = index + 1 - length
+            slices.append(scaled[begin:index + 1])
+            starts.append(timestamps[begin])
+            centers.append((timestamps[begin] + timestamps[index]) / 2)
+    if not slices:
+        return np.zeros((0, length, layout.CHANNEL_COUNT), np.float32), np.zeros(0)
+    return np.stack(slices), np.array(centers)
+
+
+def label_windows(centers, segments):
+    """A window takes the class of the segment covering its center; quiet otherwise."""
+    labels = np.zeros(len(centers), dtype=np.int64)
+    for start, end, class_index in segments:
+        labels[(centers >= start) & (centers <= end)] = class_index
+    return labels
+
+
+def load_manifest(path):
+    """Manifest: JSON array of {"capture": path, "labels": path?}. Paths are
+    relative to the manifest file. Entries without labels contribute unlabeled
+    windows (pretraining); labeled entries contribute (window, class) pairs.
+    """
+    manifest_path = Path(path)
+    entries = json.loads(manifest_path.read_text())
+    labeled_x, labeled_y, unlabeled = [], [], []
+    for entry in entries:
+        capture = manifest_path.parent / entry["capture"]
+        timestamps, channels = load_capture(capture)
+        x, centers = windows(timestamps, channels)
+        if len(x) == 0:
+            continue
+        if entry.get("labels"):
+            segments = load_labels(manifest_path.parent / entry["labels"])
+            labeled_x.append(x)
+            labeled_y.append(label_windows(centers, segments))
+        else:
+            unlabeled.append(x)
+
+    empty = np.zeros((0, layout.WINDOW_LENGTH, layout.CHANNEL_COUNT), np.float32)
+    return (
+        np.concatenate(labeled_x) if labeled_x else empty,
+        np.concatenate(labeled_y) if labeled_y else np.zeros(0, np.int64),
+        np.concatenate(unlabeled) if unlabeled else empty,
+    )

--- a/ml/tapq1/export.py
+++ b/ml/tapq1/export.py
@@ -1,0 +1,62 @@
+"""Core ML export with the embedded runtime contract.
+
+    python -m tapq1.export --checkpoint checkpoints/tapq1.pt --out models/tapq1.mlpackage
+
+The exported model carries the feature-layout version, class order, and window
+length as creator-defined metadata; ``CoreMLMotionScorer`` refuses to load any
+model whose metadata disagrees with the Swift runtime, so a stale export fails
+loudly instead of misclassifying quietly.
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from . import layout
+from .model import ExportWrapper, TapQ1Encoder
+
+
+def export(checkpoint_path, out_path):
+    import coremltools as ct
+
+    encoder = TapQ1Encoder()
+    encoder.load_state_dict(torch.load(checkpoint_path, weights_only=True))
+    encoder.eval()
+    wrapper = ExportWrapper(encoder).eval()
+
+    example = torch.zeros(1, layout.WINDOW_LENGTH, layout.CHANNEL_COUNT)
+    traced = torch.jit.trace(wrapper, example)
+    model = ct.convert(
+        traced,
+        convert_to="mlprogram",
+        inputs=[ct.TensorType(name="features", shape=example.shape)],
+        compute_units=ct.ComputeUnit.ALL,
+    )
+    model.user_defined_metadata[layout.METADATA_FEATURE_LAYOUT_KEY] = layout.VERSION
+    model.user_defined_metadata[layout.METADATA_CLASSES_KEY] = ",".join(layout.CLASSES)
+    model.user_defined_metadata[layout.METADATA_WINDOW_LENGTH_KEY] = str(
+        layout.WINDOW_LENGTH)
+    model.short_description = (
+        "TapQ-1 stage-1 gesture encoder "
+        f"({encoder.parameter_count()} parameters, {layout.VERSION})")
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    model.save(str(out_path))
+    return out_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--out", required=True)
+    arguments = parser.parse_args()
+    saved = export(arguments.checkpoint, arguments.out)
+    print(f"exported {saved}")
+    print("try it: tapq replay --input capture.jsonl --labels labels.jsonl "
+          f"--encoder-model {saved}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/tapq1/layout.py
+++ b/ml/tapq1/layout.py
@@ -1,0 +1,52 @@
+"""Feature contract shared with the Swift runtime.
+
+This file mirrors ``Sources/TapQDetectionBaseline/EncoderContract.swift`` — the two
+must agree exactly. The Swift test suite pins these values
+(``EncoderContractTests``); any change here without a matching Swift change and a
+new VERSION string will be refused at model load by ``CoreMLMotionScorer``.
+"""
+
+VERSION = "tapq1-features-v1"
+
+CHANNEL_NAMES = [
+    "user_acceleration_x", "user_acceleration_y", "user_acceleration_z",
+    "rotation_rate_x", "rotation_rate_y", "rotation_rate_z",
+    "gravity_x", "gravity_y", "gravity_z",
+]
+CHANNEL_COUNT = len(CHANNEL_NAMES)
+
+WINDOW_LENGTH = 32
+SAMPLE_RATE_HZ = 25.0
+
+ACCELERATION_FULL_SCALE = 2.0
+ROTATION_FULL_SCALE = 8.0
+
+# Output-vector order of the joint classification head. "quiet" is the background
+# class; "tap" means the complete double-tap pattern within one window (both
+# transients of a double tap fit in 1.28 s) — lone bumps are labeled quiet.
+CLASSES = [
+    "quiet", "nod", "shake", "tilt_left", "tilt_right",
+    "tap", "swipe_up", "swipe_down",
+]
+CLASS_COUNT = len(CLASSES)
+
+METADATA_FEATURE_LAYOUT_KEY = "com.tapq.tapq1.feature_layout"
+METADATA_CLASSES_KEY = "com.tapq.tapq1.classes"
+METADATA_WINDOW_LENGTH_KEY = "com.tapq.tapq1.window_length"
+
+# Per-channel full-scale divisors, in CHANNEL_NAMES order.
+CHANNEL_FULL_SCALES = (
+    [ACCELERATION_FULL_SCALE] * 3 + [ROTATION_FULL_SCALE] * 3 + [1.0] * 3
+)
+
+
+def scale(raw):
+    """Normalize raw channel values into [-1, 1] with fixed physical full scales.
+
+    ``raw`` is an array shaped [..., CHANNEL_COUNT] in CHANNEL_NAMES order.
+    Mirrors ``EncoderFeatureLayout.featureRow``.
+    """
+    import numpy as np
+
+    scales = np.asarray(CHANNEL_FULL_SCALES, dtype=np.float32)
+    return np.clip(np.asarray(raw, dtype=np.float32) / scales, -1.0, 1.0)

--- a/ml/tapq1/model.py
+++ b/ml/tapq1/model.py
@@ -1,0 +1,54 @@
+"""TapQ-1 stage-1 encoder: a LIMU-BERT-scale transformer for 25 Hz earbud IMU.
+
+Sized to ~70k parameters — small enough for always-on ANE inference, large enough
+for the 8-class window vocabulary. The same trunk serves masked-reconstruction
+pretraining (unlabeled captures) and the supervised joint head.
+"""
+
+import torch
+from torch import nn
+
+from . import layout
+
+
+class TapQ1Encoder(nn.Module):
+    def __init__(self, d_model=64, n_layers=2, n_heads=4, d_ff=128, dropout=0.1):
+        super().__init__()
+        self.input_projection = nn.Linear(layout.CHANNEL_COUNT, d_model)
+        self.positional = nn.Parameter(torch.zeros(layout.WINDOW_LENGTH, d_model))
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model, nhead=n_heads, dim_feedforward=d_ff,
+            dropout=dropout, activation="gelu", batch_first=True, norm_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, n_layers)
+        self.norm = nn.LayerNorm(d_model)
+        self.classifier = nn.Linear(d_model, layout.CLASS_COUNT)
+        self.reconstructor = nn.Linear(d_model, layout.CHANNEL_COUNT)
+        nn.init.trunc_normal_(self.positional, std=0.02)
+
+    def features(self, x):
+        """[B, WINDOW_LENGTH, 9] → per-timestep features [B, WINDOW_LENGTH, d]."""
+        return self.norm(self.encoder(self.input_projection(x) + self.positional))
+
+    def forward(self, x):
+        """Class logits [B, CLASS_COUNT] via mean pooling."""
+        return self.classifier(self.features(x).mean(dim=1))
+
+    def reconstruct(self, x):
+        """Per-timestep channel reconstruction, for masked pretraining."""
+        return self.reconstructor(self.features(x))
+
+    def parameter_count(self):
+        return sum(parameter.numel() for parameter in self.parameters())
+
+
+class ExportWrapper(nn.Module):
+    """Inference-only view matching the runtime contract: probabilities, not
+    logits, so `EncoderMotionPipeline` thresholds are calibrated quantities."""
+
+    def __init__(self, encoder):
+        super().__init__()
+        self.encoder = encoder
+
+    def forward(self, features):
+        return torch.softmax(self.encoder(features), dim=-1)

--- a/ml/tapq1/pretrain.py
+++ b/ml/tapq1/pretrain.py
@@ -1,0 +1,84 @@
+"""Masked-reconstruction pretraining on unlabeled captures (LIMU-BERT recipe).
+
+Random spans of timesteps are zeroed out and the trunk learns to reconstruct the
+missing channels — motion structure without labels. Usage:
+
+    python -m tapq1.pretrain --manifest data/manifest.json --out checkpoints/pretrained.pt
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch import nn
+
+from . import data
+from .model import TapQ1Encoder
+
+
+def mask_spans(windows, rng, span=4, mask_fraction=0.3):
+    """Zeroes random spans covering ~mask_fraction of timesteps; returns the
+    masked windows plus a boolean [N, T] mask of which timesteps were hidden."""
+    masked = windows.clone()
+    hidden = torch.zeros(windows.shape[:2], dtype=torch.bool)
+    length = windows.shape[1]
+    spans_per_window = max(1, int(length * mask_fraction / span))
+    for index in range(len(windows)):
+        for _ in range(spans_per_window):
+            start = int(rng.integers(0, length - span + 1))
+            masked[index, start:start + span] = 0
+            hidden[index, start:start + span] = True
+    return masked, hidden
+
+
+def pretrain(windows, epochs=50, batch_size=64, learning_rate=1e-3, seed=0,
+             log=print):
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    encoder = TapQ1Encoder()
+    optimizer = torch.optim.AdamW(encoder.parameters(), lr=learning_rate)
+    tensor = torch.from_numpy(windows)
+
+    for epoch in range(epochs):
+        permutation = torch.randperm(len(tensor))
+        total, batches = 0.0, 0
+        for begin in range(0, len(tensor), batch_size):
+            batch = tensor[permutation[begin:begin + batch_size]]
+            masked, hidden = mask_spans(batch, rng)
+            reconstruction = encoder.reconstruct(masked)
+            loss = nn.functional.mse_loss(reconstruction[hidden], batch[hidden])
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            total += float(loss)
+            batches += 1
+        log(f"pretrain epoch {epoch + 1}/{epochs} loss {total / max(1, batches):.5f}")
+    return encoder
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--epochs", type=int, default=50)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--seed", type=int, default=0)
+    arguments = parser.parse_args()
+
+    labeled_x, _, unlabeled = data.load_manifest(arguments.manifest)
+    windows = np.concatenate([labeled_x, unlabeled]) if len(labeled_x) else unlabeled
+    if len(windows) == 0:
+        raise SystemExit("manifest produced no windows")
+    print(f"pretraining on {len(windows)} windows")
+    encoder = pretrain(
+        windows, epochs=arguments.epochs, batch_size=arguments.batch_size,
+        learning_rate=arguments.learning_rate, seed=arguments.seed)
+    Path(arguments.out).parent.mkdir(parents=True, exist_ok=True)
+    torch.save(encoder.state_dict(), arguments.out)
+    print(f"saved {arguments.out} ({encoder.parameter_count()} parameters)")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/tapq1/smoke.py
+++ b/ml/tapq1/smoke.py
@@ -1,0 +1,92 @@
+"""End-to-end smoke test on synthetic motion — no captured data required.
+
+    python -m tapq1.smoke [--export /tmp/tapq1-smoke.mlpackage]
+
+Fabricates windows with class-distinct synthetic signatures, runs a few
+pretraining and training steps, checks the parameter budget, and (when
+coremltools is installed) exports and re-loads a Core ML package. Proves the
+pipeline end to end before any capture study data exists; the accuracy numbers
+it prints are meaningless by design.
+"""
+
+import argparse
+
+import numpy as np
+import torch
+
+from . import layout
+from .model import TapQ1Encoder
+from .pretrain import pretrain
+from .train import train
+
+
+def synthetic_windows(per_class=40, seed=0):
+    """Each class gets a crude, well-separated signature on the channels its real
+    counterpart would excite. This validates plumbing, not detection."""
+    rng = np.random.default_rng(seed)
+    length = layout.WINDOW_LENGTH
+    grid = np.linspace(0, 2 * np.pi, length, dtype=np.float32)
+    windows, labels = [], []
+    for class_index in range(layout.CLASS_COUNT):
+        for _ in range(per_class):
+            window = rng.normal(0, 0.02, (length, layout.CHANNEL_COUNT)).astype(np.float32)
+            window[:, 8] -= 0.9  # gravity mostly -z, as worn
+            amplitude = rng.uniform(0.3, 0.6)
+            if class_index == 1:    # nod: pitch-axis rotation oscillation
+                window[:, 3] += amplitude * np.sin(2 * grid)
+            elif class_index == 2:  # shake: yaw-axis oscillation, faster
+                window[:, 5] += amplitude * np.sin(4 * grid)
+            elif class_index == 3:  # tilt left: one roll excursion
+                window[:, 4] -= amplitude * np.sin(grid)
+            elif class_index == 4:  # tilt right
+                window[:, 4] += amplitude * np.sin(grid)
+            elif class_index == 5:  # double tap: two sharp accel spikes
+                for center in (length // 3, 2 * length // 3):
+                    window[center:center + 2, 0:3] += amplitude
+            elif class_index == 6:  # swipe up: sustained accel plateau, +gravity axis
+                window[8:20, 2] += 0.5 * amplitude
+            elif class_index == 7:  # swipe down
+                window[8:20, 2] -= 0.5 * amplitude
+            windows.append(np.clip(window, -1, 1))
+            labels.append(class_index)
+    return np.stack(windows), np.array(labels, dtype=np.int64)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--export", help="also export a Core ML package to this path")
+    arguments = parser.parse_args()
+
+    encoder = TapQ1Encoder()
+    parameters = encoder.parameter_count()
+    print(f"parameter count: {parameters}")
+    assert 40_000 <= parameters <= 120_000, "outside the tiny-encoder budget"
+
+    x, y = synthetic_windows()
+    print(f"synthetic windows: {len(x)}")
+    pretrain(x, epochs=2, log=lambda message: print(f"  {message}"))
+    trained = train(x, y, epochs=5, log=lambda message: print(f"  {message}"))
+
+    with torch.no_grad():
+        probabilities = torch.softmax(trained(torch.from_numpy(x[:4])), dim=-1)
+    assert probabilities.shape == (4, layout.CLASS_COUNT)
+    assert torch.allclose(probabilities.sum(dim=-1), torch.ones(4), atol=1e-5)
+    print("forward pass OK")
+
+    if arguments.export:
+        import tempfile
+        from pathlib import Path
+
+        from .export import export
+
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "smoke.pt"
+            torch.save(trained.state_dict(), checkpoint)
+            saved = export(checkpoint, arguments.export)
+            print(f"export OK: {saved}")
+
+    print("smoke test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/tapq1/train.py
+++ b/ml/tapq1/train.py
@@ -1,0 +1,115 @@
+"""Supervised fine-tuning of the joint gesture head on labeled captures.
+
+    python -m tapq1.train --manifest data/manifest.json \
+        --pretrained checkpoints/pretrained.pt --out checkpoints/tapq1.pt
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch import nn
+
+from . import augment, data, layout
+from .model import TapQ1Encoder
+
+
+def class_weights(labels):
+    """Inverse-frequency weights: quiet dominates any honest capture and would
+    otherwise swallow the gesture classes."""
+    counts = np.bincount(labels, minlength=layout.CLASS_COUNT).astype(np.float64)
+    weights = np.where(counts > 0, 1.0 / np.maximum(counts, 1), 0.0)
+    total = weights.sum()
+    if total > 0:
+        weights = weights * layout.CLASS_COUNT / total
+    return torch.tensor(weights, dtype=torch.float32)
+
+
+def split(x, y, validation_fraction, rng):
+    order = rng.permutation(len(x))
+    cut = max(1, int(len(x) * validation_fraction)) if len(x) > 1 else 0
+    validation, training = order[:cut], order[cut:]
+    return x[training], y[training], x[validation], y[validation]
+
+
+def per_class_report(model, x, y, log=print):
+    if len(x) == 0:
+        return
+    with torch.no_grad():
+        predictions = model(torch.from_numpy(x)).argmax(dim=-1).numpy()
+    for index, name in enumerate(layout.CLASSES):
+        expected = y == index
+        emitted = predictions == index
+        if not expected.any() and not emitted.any():
+            continue
+        true_positives = int((expected & emitted).sum())
+        precision = true_positives / max(1, int(emitted.sum()))
+        recall = true_positives / max(1, int(expected.sum()))
+        log(f"  {name:12s} precision {precision:.2f}  recall {recall:.2f}  "
+            f"support {int(expected.sum())}")
+
+
+def train(x, y, pretrained=None, epochs=100, batch_size=64, learning_rate=5e-4,
+          validation_fraction=0.2, seed=0, log=print):
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    encoder = TapQ1Encoder()
+    if pretrained:
+        encoder.load_state_dict(torch.load(pretrained, weights_only=True))
+        log(f"loaded pretrained trunk from {pretrained}")
+
+    train_x, train_y, validation_x, validation_y = split(
+        x, y, validation_fraction, rng)
+    criterion = nn.CrossEntropyLoss(weight=class_weights(train_y))
+    optimizer = torch.optim.AdamW(encoder.parameters(), lr=learning_rate)
+
+    for epoch in range(epochs):
+        order = rng.permutation(len(train_x))
+        total, batches = 0.0, 0
+        for begin in range(0, len(train_x), batch_size):
+            chosen = order[begin:begin + batch_size]
+            batch = torch.from_numpy(augment.augment(train_x[chosen], rng))
+            loss = criterion(encoder(batch), torch.from_numpy(train_y[chosen]))
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            total += float(loss)
+            batches += 1
+        if (epoch + 1) % 10 == 0 or epoch == epochs - 1:
+            log(f"train epoch {epoch + 1}/{epochs} loss {total / max(1, batches):.5f}")
+
+    encoder.eval()
+    log("validation:")
+    per_class_report(encoder, validation_x, validation_y, log=log)
+    return encoder
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--pretrained")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--epochs", type=int, default=100)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--learning-rate", type=float, default=5e-4)
+    parser.add_argument("--validation-fraction", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    arguments = parser.parse_args()
+
+    x, y, _ = data.load_manifest(arguments.manifest)
+    if len(x) == 0:
+        raise SystemExit("manifest contains no labeled windows")
+    gesture_windows = int((y != 0).sum())
+    print(f"training on {len(x)} windows ({gesture_windows} non-quiet)")
+    encoder = train(
+        x, y, pretrained=arguments.pretrained, epochs=arguments.epochs,
+        batch_size=arguments.batch_size, learning_rate=arguments.learning_rate,
+        validation_fraction=arguments.validation_fraction, seed=arguments.seed)
+    Path(arguments.out).parent.mkdir(parents=True, exist_ok=True)
+    torch.save(encoder.state_dict(), arguments.out)
+    print(f"saved {arguments.out} ({encoder.parameter_count()} parameters)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Phases 0–2 of the sensor and detection-accuracy roadmap, plus the release stamp for 0.2.0.

## What's here

**Per-axis motion (Phase 0).** `HeadMotionSample` now carries roll attitude and signed 3-axis user acceleration, rotation rate, and gravity alongside the existing magnitudes — the full `CMDeviceMotion` payload the runtime was previously discarding. `tapq capture` writes the new fields in JSONL and CSV, with the original five CSV columns keeping their positions so existing tooling keeps working, and older recordings still decode.

**Double roll-tilt navigation (Phase 1).** Two quick same-direction lateral tilts select next (right) or previous (left). Roll is the axis nothing else uses: nod owns pitch, shake owns yaw. Detection is roll-dominant with pitch/yaw crosstalk gates, requires a return to neutral, and pairs two tilts — the three structural failures that forced the original pitch-based tilt out of the runtime. This brings option navigation to AirPods models with no capacitive stem.

**Experimental motion swipes (Phase 1).** Recognizes sustained gentle drags on the earbud from per-axis acceleration with gravity-referenced direction — the signal `TapAnalyzer` already rejects as `spikeTooWide`. Ships disabled (`MotionGesturePipeline.swipeDetectionEnabled`) pending capture-study validation; direction separability at 25 Hz is unproven.

**TapQ-1 stage-1 encoder (Phase 2).** A versioned feature contract (`EncoderFeatureLayout`: 9 channels × 32 samples at 25 Hz, fixed physical scaling), a window builder, the `MotionWindowScoring` backend protocol, and `EncoderMotionPipeline`, which turns per-window class scores into the same doubled commands as the heuristics. `CoreMLMotionScorer` runs exported models and refuses any whose embedded contract metadata disagrees with the runtime. `tapq serve --encoder-model PATH [--encoder-mode shadow|primary]` attaches one; shadow is the default and records detections as diagnostics without affecting behavior. **The deterministic heuristics always keep running and are the fallback** — a model that fails to load degrades to them and says so.

**`tapq replay`.** Streams a recorded capture through the detection backends offline, on any platform, no AirPods or permissions needed. With a JSONL label file it reports per-gesture precision/recall and false positives per minute; `--encoder-model` adds a side-by-side encoder run. This is the evaluation yardstick the capture study and any future tuning depend on.

**`ml/`.** The training pipeline: LIMU-BERT-style masked-reconstruction pretraining, supervised joint-head training with time-warp/rotation/noise augmentation, Core ML export embedding the contract metadata, and a synthetic smoke test covering train → export → load with no captured data.

## Behavior and API changes

- **Denying an approval now requires a double shake** (this came from `main`; it had shipped with no changelog entry, so it is documented here for the first time, along with the selectable question classifiers and the 105→245s interaction budget).
- **Source-breaking for library consumers:** `TiltCommand` cases are `tiltLeft`/`tiltRight`, the pitch-based `tiltUp`/`tiltDown` and its displacement analyzer are retired, and `TiltAnalyzer.detect` now takes roll, pitch, and yaw.
- **Wire protocol unchanged at version 3** — hooks and brokers built against 0.1.0 stay compatible.

## Note on merging

This branch contains one merge commit (`31ffd6d`, merging `main` in and resolving 15 conflict hunks), which the `main` ruleset forbids. **Please use "Squash and merge."** "Rebase and merge" will not work: rebase drops that merge commit, and the three commits that predate it would replay onto `main` and re-surface the conflicts it resolved.

## Verification

559 tests pass, `scripts/check-public-boundary.sh` passes, and the Python pipeline compiles. No model has been trained yet — the encoder path is infrastructure, validated end to end via the synthetic smoke model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
