### PR TITLE
Pin spoken output to en-US and make the voice selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
+### Added
+
+- `tapq serve --speech-voice VOICE` and `TAPQ_SPEECH_VOICE` select the voice used for
+  spoken output, accepting either a BCP-47 language tag (`en-US`, `zh-CN`) or a macOS
+  voice identifier. The environment variable is the practical control for the packaged
+  runtime app, which is launched through `open` and takes no flags. A selection that
+  matches no installed voice is reported as a `voice.unavailable` warning instead of
+  silently falling back. This selects a voice, not a translation: TapQ's spoken
+  scaffolding is still English regardless of the value.
+
+### Fixed
+
+- Spoken output no longer follows the system language. `SpeechEngine` left
+  `AVSpeechUtterance.voice` unset, so AVFoundation resolved a voice from the system
+  language and never from the text — on a Chinese-language Mac every English prompt was
+  read by a Chinese voice, mixing English and Chinese phonology and rendering the readout
+  barely intelligible. Synthesis now pins to `en-US` by default, matching the en-US pin
+  `VoiceListener.grammarLocale` already applied to recognition.
+
+### Changed
+
+- `SpeechEngine.voiceIdentifier` is replaced by `SpeechEngine.voiceSelection`, which also
+  accepts language tags and is resolved once on assignment rather than per utterance. The
+  old property accepted only voice identifiers and no supported configuration path ever
+  set it.
+- `TapQRuntimeConfiguration` carries `speechVoice`; hosts must apply it to their
+  synthesizer.
+
 ## [0.2.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ All notable changes to TapQ will be recorded in this file. The project uses
   voice identifier. The environment variable is the practical control for the packaged
   runtime app, which is launched through `open` and takes no flags. A selection that
   matches no installed voice is reported as a `voice.unavailable` warning instead of
-  silently falling back. This selects a voice, not a translation: TapQ's spoken
+  silently falling back; a regional substitution inside the requested language (`en-GB` →
+  `en-US`) is accepted, a cross-language one never is, regardless of which way the host's
+  AVFoundation happens to fall back. This selects a voice, not a translation: TapQ's spoken
   scaffolding is still English regardless of the value.
 
 ### Fixed

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -44,6 +44,10 @@ import Darwin
             ]
         ))
         let speech = SpeechEngine(diagnosticSink: diagnostics)
+        // Pin the voice before anything can speak. Unset, AVFoundation would follow the
+        // system language and read TapQ's English prompts with whatever voice that
+        // implies — the counterpart to VoiceListener's en-US recognizer pin.
+        speech.voiceSelection = configuration.speechVoice
         let gestures = HeadGestureDetector(
             config: gestureProfile?.config ?? HeadGestureConfig(),
             tapConfig: tapProfile?.config ?? TapConfig(),

--- a/Sources/TapQAppleAdapters/SpeechEngine.swift
+++ b/Sources/TapQAppleAdapters/SpeechEngine.swift
@@ -44,8 +44,32 @@ import AVFoundation
 
     /// Accepts either spelling so callers can pin a language without knowing which
     /// concrete voice is installed. Returns nil when neither form matches.
+    ///
+    /// Neither AVFoundation initializer reliably fails closed. `init(language:)` returns nil
+    /// for an unparseable tag on some macOS versions and the system-default voice on others
+    /// — the CI runner hands back en-US Samantha for "not-a-real-voice" while a local
+    /// macOS 26 machine returns nil. Accepting that substitution would reinstate the silent
+    /// system-language fallback this whole property exists to remove, so both results are
+    /// checked against what was actually asked for.
     static func resolveVoice(_ selection: String) -> AVSpeechSynthesisVoice? {
-        AVSpeechSynthesisVoice(identifier: selection) ?? AVSpeechSynthesisVoice(language: selection)
+        if let voice = AVSpeechSynthesisVoice(identifier: selection), voice.identifier == selection {
+            return voice
+        }
+        guard let voice = AVSpeechSynthesisVoice(language: selection) else { return nil }
+        return languageMatches(voice.language, requested: selection) ? voice : nil
+    }
+
+    /// Primary-subtag comparison: "en" accepts an en-US voice, and "en-GB" accepts a
+    /// substituted en-US one, because a regional substitution still speaks the requested
+    /// language. "not-a-real-voice" never accepts en-US. Substituting within a language is
+    /// acceptable; substituting across languages is the bug.
+    static func languageMatches(_ language: String, requested: String) -> Bool {
+        func primarySubtag(_ tag: String) -> Substring? {
+            tag.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: true).first
+        }
+        guard let spoken = primarySubtag(language),
+              let asked = primarySubtag(requested) else { return false }
+        return spoken.caseInsensitiveCompare(asked) == .orderedSame
     }
 
     /// Warns once at configuration time rather than per utterance: a silent fallback to

--- a/Sources/TapQAppleAdapters/SpeechEngine.swift
+++ b/Sources/TapQAppleAdapters/SpeechEngine.swift
@@ -25,8 +25,46 @@ import AVFoundation
         complete(ObjectIdentifier(currentUtterance))
     }
 
-    public var voiceIdentifier: String?
+    /// Which voice speaks: a BCP-47 language tag ("en-US", "zh-CN") or a full
+    /// `AVSpeechSynthesisVoice` identifier. Resolved once on assignment, not per utterance.
+    ///
+    /// Leaving this nil is the failure mode this property exists to prevent: AVFoundation
+    /// then picks the default voice for the SYSTEM language and never looks at the text,
+    /// so English prompts on a Chinese-language Mac come out of a Chinese voice — digits
+    /// and unrecognized words in Chinese phonology, the rest mangled. Hosts should always
+    /// set it; `TapQRuntimeConfiguration.speechVoice` carries the user's choice.
+    public var voiceSelection: String? {
+        didSet {
+            guard voiceSelection != oldValue else { return }
+            resolveSelectedVoice()
+        }
+    }
+    private var selectedVoice: AVSpeechSynthesisVoice?
     public var rate: Float = AVSpeechUtteranceDefaultSpeechRate
+
+    /// Accepts either spelling so callers can pin a language without knowing which
+    /// concrete voice is installed. Returns nil when neither form matches.
+    static func resolveVoice(_ selection: String) -> AVSpeechSynthesisVoice? {
+        AVSpeechSynthesisVoice(identifier: selection) ?? AVSpeechSynthesisVoice(language: selection)
+    }
+
+    /// Warns once at configuration time rather than per utterance: a silent fallback to
+    /// the system-locale voice is exactly the bug `voiceSelection` exists to fix, so it
+    /// must be visible while the user can still act on it.
+    private func resolveSelectedVoice() {
+        guard let voiceSelection else {
+            selectedVoice = nil
+            return
+        }
+        selectedVoice = Self.resolveVoice(voiceSelection)
+        if selectedVoice == nil {
+            diagnostics.record(
+                "voice.unavailable",
+                level: .warning,
+                fields: ["selection": voiceSelection]
+            )
+        }
+    }
 
     public override init() {
         super.init()
@@ -78,9 +116,8 @@ import AVFoundation
         guard let item = queue.startNext() else { return }
 
         let utterance = AVSpeechUtterance(string: item.text)
-        if let voiceIdentifier, let voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier) {
-            utterance.voice = voice
-        }
+        // Left nil, AVFoundation substitutes the system-language voice at speak time.
+        utterance.voice = selectedVoice
         utterance.rate = rate
         utteranceItems[ObjectIdentifier(utterance)] = item
         currentUtterance = utterance

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -30,6 +30,10 @@ struct ServeOptions: Equatable {
     var tapProfilePath: String?
     var interactionTimeout: TimeInterval = 240
     var voiceEnabled = true
+    /// Synthesis voice for spoken output — unrelated to `voiceEnabled`, which gates the
+    /// microphone. nil means unspecified, leaving `TAPQ_SPEECH_VOICE` and the en-US
+    /// default their turn in `SpeechVoiceSelection.resolve`.
+    var speechVoice: String?
     var announcementsEnabled = true
     var steeringEnabled = false
     var questionClassifier: QuestionClassifierProvider = .auto
@@ -230,6 +234,8 @@ enum CLICommandParser {
                     cursor.requireValue(for: argument), flag: argument)
             case "--no-voice":
                 options.voiceEnabled = false
+            case "--speech-voice":
+                options.speechVoice = try cursor.requireValue(for: argument)
             case "--no-announcements":
                 options.announcementsEnabled = false
             case "--steering":

--- a/Sources/TapQCLI/RuntimeService.swift
+++ b/Sources/TapQCLI/RuntimeService.swift
@@ -10,6 +10,10 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
     public let tapProfileURL: URL
     public let interactionTimeout: TimeInterval
     public let voiceEnabled: Bool
+    /// Synthesis voice for spoken output: a BCP-47 language tag or a platform voice
+    /// identifier. Hosts must apply it — an unset voice follows the system language and
+    /// mispronounces everything TapQ says on a non-English machine.
+    public let speechVoice: String
     public let announcementsEnabled: Bool
     public let steeringEnabled: Bool
     public let questionClassifier: QuestionClassifierProvider
@@ -24,6 +28,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         tapProfileURL: URL,
         interactionTimeout: TimeInterval = 240,
         voiceEnabled: Bool = true,
+        speechVoice: String = SpeechVoiceSelection.defaultSelection,
         announcementsEnabled: Bool = true,
         steeringEnabled: Bool = false,
         questionClassifier: QuestionClassifierProvider = .auto,
@@ -35,6 +40,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         self.tapProfileURL = tapProfileURL
         self.interactionTimeout = interactionTimeout
         self.voiceEnabled = voiceEnabled
+        self.speechVoice = speechVoice
         self.announcementsEnabled = announcementsEnabled
         self.steeringEnabled = steeringEnabled
         self.questionClassifier = questionClassifier

--- a/Sources/TapQCLI/SpeechVoiceSelection.swift
+++ b/Sources/TapQCLI/SpeechVoiceSelection.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Chooses which synthesizer voice TapQ speaks with.
+///
+/// Left unset, AVFoundation resolves the voice from the *system language* and never from
+/// the text, so a Chinese-language Mac reads TapQ's English prompts with a Chinese voice
+/// and the readout is barely intelligible. The default pins synthesis to en-US, mirroring
+/// `VoiceListener.grammarLocale`: TapQ's own spoken scaffolding ("Approve?", "Volume, then
+/// nod twice or double-tap.") is hardcoded English, and the command grammar only
+/// understands English.
+///
+/// This selects a VOICE, not a translation. Agent-supplied summaries and option labels
+/// pass through verbatim, so a non-English selection changes how TapQ's English
+/// scaffolding is pronounced without localizing it. Localizing the spoken copy — and
+/// lifting the recognizer's English pin with it — is separate work.
+public enum SpeechVoiceSelection {
+    /// Matches `VoiceListener.grammarLocale`; the two must move together.
+    public static let defaultSelection = "en-US"
+    public static let environmentKey = "TAPQ_SPEECH_VOICE"
+
+    /// `--speech-voice` wins over `TAPQ_SPEECH_VOICE`, which wins over the en-US pin.
+    /// The environment variable matters for the packaged runtime app, which is launched
+    /// through `open` and cannot take CLI flags.
+    public static func resolve(flag: String?, environment: [String: String]) -> String {
+        if let flag = normalized(flag) { return flag }
+        if let value = normalized(environment[environmentKey]) { return value }
+        return defaultSelection
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -134,6 +134,10 @@ public struct TapQCLIIO {
                 InteractionBudget.maxListenWindow
             ),
             voiceEnabled: options.voiceEnabled,
+            speechVoice: SpeechVoiceSelection.resolve(
+                flag: options.speechVoice,
+                environment: environment
+            ),
             announcementsEnabled: options.announcementsEnabled,
             steeringEnabled: options.steeringEnabled,
             questionClassifier: options.questionClassifier,
@@ -774,6 +778,12 @@ public struct TapQCLIIO {
       --tap-profile PATH       Override the tap calibration profile
       --timeout SECONDS        Per-listen input timeout (default: 240; values are capped at 240)
       --no-voice               Disable microphone speech recognition
+      --speech-voice VOICE     Voice for spoken output: a language tag (en-US, zh-CN) or
+                               a system voice identifier (default: en-US, also settable
+                               with TAPQ_SPEECH_VOICE). Unset, macOS picks the voice from
+                               the system language regardless of what TapQ says, which
+                               garbles the readout on a non-English Mac. This selects the
+                               voice only — TapQ's own prompts are English either way.
       --no-announcements       Disable non-blocking agent status announcements
       --steering               Ask supported adapters to prefer structured questions
       --question-classifier P  Use auto, apple, anthropic, openai, or local (default: auto)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -85,10 +85,27 @@ short command such as `yes`, `no`, `next`, `previous`, or `select`. Verify Speec
 Recognition and Microphone authorization and check that the runtime was not
 started with `--no-voice`.
 
-Speech output uses the macOS system synthesizer. Voice quality can be changed in
-the macOS spoken-content or system-voice settings; downloading an enhanced
-English voice usually improves output. Setting the system language to English is
-not required for TapQ’s command grammar.
+Setting the system language to English is not required for TapQ’s command grammar:
+the recognizer is pinned to `en-US` independently of the system language.
+
+## Spoken prompts are garbled or mix two languages
+
+TapQ speaks through the macOS system synthesizer with an `en-US` voice by default.
+If prompts sound like a mix of English and another language, the runtime is
+probably speaking through a non-English voice — check the `--speech-voice` value
+and `TAPQ_SPEECH_VOICE`, and look for a `voice.unavailable` warning under
+`TAPQ_DEBUG=1`, which means the requested voice is not installed and macOS fell
+back to the system-language voice.
+
+Note that this setting selects a *voice*, not a translation. TapQ’s own spoken
+copy (“Approve?”, “Volume, then nod twice or double-tap.”) is English, so pointing
+`--speech-voice` at another language makes that copy be pronounced by a voice that
+does not speak it. Agent-supplied text is spoken verbatim as well, so an agent
+replying in another language is still read by the selected voice.
+
+Voice quality is a separate axis: downloading an enhanced or premium voice in the
+macOS spoken-content settings usually improves output, and its identifier can be
+passed to `--speech-voice` directly.
 
 ## Claude Code does not trigger TapQ
 

--- a/Tests/TapQAppleAdaptersTests/SpeechEngineVoiceTests.swift
+++ b/Tests/TapQAppleAdaptersTests/SpeechEngineVoiceTests.swift
@@ -37,6 +37,24 @@ final class SpeechEngineVoiceTests: XCTestCase {
         XCTAssertNil(SpeechEngine.resolveVoice("not-a-real-voice"))
     }
 
+    // The substitution rule is asserted directly because whether AVFoundation substitutes
+    // at all varies by macOS version and installed voice set: the CI runner returns en-US
+    // Samantha for "not-a-real-voice" where a local macOS 26 machine returns nil. These
+    // hold on any host.
+
+    func testRegionalSubstitutionWithinTheSameLanguageIsAccepted() {
+        XCTAssertTrue(SpeechEngine.languageMatches("en-US", requested: "en-GB"))
+        XCTAssertTrue(SpeechEngine.languageMatches("en-US", requested: "en"))
+        XCTAssertTrue(SpeechEngine.languageMatches("en-US", requested: "EN-us"))
+    }
+
+    func testCrossLanguageSubstitutionIsRejected() {
+        XCTAssertFalse(SpeechEngine.languageMatches("en-US", requested: "not-a-real-voice"),
+                       "the CI substitution that made this suite fail")
+        XCTAssertFalse(SpeechEngine.languageMatches("en-US", requested: "zh-CN"))
+        XCTAssertFalse(SpeechEngine.languageMatches("en-US", requested: ""))
+    }
+
     /// An unresolvable selection must be visible: silently falling back to the
     /// system-locale voice is the exact bug this option exists to fix.
     func testUnresolvableSelectionRecordsDiagnostic() {

--- a/Tests/TapQAppleAdaptersTests/SpeechEngineVoiceTests.swift
+++ b/Tests/TapQAppleAdaptersTests/SpeechEngineVoiceTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import TapQAppleAdapters
+import AVFoundation
+import TapQContracts
+
+@MainActor
+final class SpeechEngineVoiceTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+    }
+
+    func testResolvesBCP47LanguageTag() throws {
+        let voice = try XCTUnwrap(SpeechEngine.resolveVoice("en-US"))
+        XCTAssertEqual(voice.language, "en-US")
+    }
+
+    func testResolvesFullVoiceIdentifier() throws {
+        let reference = try XCTUnwrap(AVSpeechSynthesisVoice(language: "en-US"))
+        let voice = try XCTUnwrap(SpeechEngine.resolveVoice(reference.identifier))
+        XCTAssertEqual(voice.identifier, reference.identifier)
+    }
+
+    func testUnknownSelectionResolvesToNil() {
+        XCTAssertNil(SpeechEngine.resolveVoice("not-a-real-voice"))
+    }
+
+    /// An unresolvable selection must be visible: silently falling back to the
+    /// system-locale voice is the exact bug this option exists to fix.
+    func testUnresolvableSelectionRecordsDiagnostic() {
+        let sink = RecordingSink()
+        let engine = SpeechEngine(diagnosticSink: sink)
+        engine.synthesisForTesting = { _ in }
+        engine.voiceSelection = "not-a-real-voice"
+
+        engine.speak("hello", priority: .progress, onFinish: nil)
+
+        XCTAssertTrue(sink.names.contains("voice.unavailable"))
+    }
+
+    func testResolvableSelectionRecordsNoWarning() {
+        let sink = RecordingSink()
+        let engine = SpeechEngine(diagnosticSink: sink)
+        engine.synthesisForTesting = { _ in }
+        engine.voiceSelection = "en-US"
+
+        engine.speak("hello", priority: .progress, onFinish: nil)
+
+        XCTAssertFalse(sink.names.contains("voice.unavailable"))
+    }
+}

--- a/Tests/TapQCLITests/CLICommandParserTests.swift
+++ b/Tests/TapQCLITests/CLICommandParserTests.swift
@@ -43,6 +43,35 @@ final class CLICommandParserTests: XCTestCase {
         )))
     }
 
+    func testServeSpeechVoiceOption() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(
+            ["serve", "--speech-voice", "zh-CN"]
+        ) else { return XCTFail("Expected a serve command.") }
+        XCTAssertEqual(options.speechVoice, "zh-CN")
+    }
+
+    /// nil means "unspecified" so `TAPQ_SPEECH_VOICE` still gets a turn; the en-US
+    /// default is applied downstream by SpeechVoiceSelection, not by the parser.
+    func testServeSpeechVoiceDefaultsToUnspecified() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(["serve"])
+        else { return XCTFail("Expected a serve command.") }
+        XCTAssertNil(options.speechVoice)
+    }
+
+    func testServeSpeechVoiceRequiresValue() {
+        XCTAssertThrowsError(try CLICommandParser.parse(["serve", "--speech-voice"]))
+    }
+
+    /// `--no-voice` gates the microphone; `--speech-voice` picks the synthesis voice.
+    /// They are independent, and disabling input must not silence output.
+    func testSpeechVoiceIsIndependentOfMicrophoneToggle() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(
+            ["serve", "--no-voice", "--speech-voice", "zh-CN"]
+        ) else { return XCTFail("Expected a serve command.") }
+        XCTAssertFalse(options.voiceEnabled)
+        XCTAssertEqual(options.speechVoice, "zh-CN")
+    }
+
     func testServeDefaultsToAutomaticQuestionClassifier() throws {
         XCTAssertEqual(
             try CLICommandParser.parse(["serve"]),

--- a/Tests/TapQCLITests/SpeechVoiceSelectionTests.swift
+++ b/Tests/TapQCLITests/SpeechVoiceSelectionTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import TapQCLI
+
+final class SpeechVoiceSelectionTests: XCTestCase {
+    /// The default must match the recognizer pin: TapQ's spoken scaffolding is hardcoded
+    /// English and `VoiceListener.grammarLocale` is en-US.
+    func testDefaultIsEnglish() {
+        XCTAssertEqual(SpeechVoiceSelection.defaultSelection, "en-US")
+    }
+
+    func testDefaultsToEnglishWhenNothingIsConfigured() {
+        XCTAssertEqual(
+            SpeechVoiceSelection.resolve(flag: nil, environment: [:]),
+            "en-US"
+        )
+    }
+
+    func testEnvironmentOverridesDefault() {
+        XCTAssertEqual(
+            SpeechVoiceSelection.resolve(
+                flag: nil,
+                environment: [SpeechVoiceSelection.environmentKey: "zh-CN"]
+            ),
+            "zh-CN"
+        )
+    }
+
+    func testFlagOverridesEnvironment() {
+        XCTAssertEqual(
+            SpeechVoiceSelection.resolve(
+                flag: "ja-JP",
+                environment: [SpeechVoiceSelection.environmentKey: "zh-CN"]
+            ),
+            "ja-JP"
+        )
+    }
+
+    func testBlankEnvironmentValueFallsBackToDefault() {
+        XCTAssertEqual(
+            SpeechVoiceSelection.resolve(
+                flag: nil,
+                environment: [SpeechVoiceSelection.environmentKey: "   "]
+            ),
+            "en-US"
+        )
+    }
+
+    func testEnvironmentValueIsTrimmed() {
+        XCTAssertEqual(
+            SpeechVoiceSelection.resolve(
+                flag: nil,
+                environment: [SpeechVoiceSelection.environmentKey: " zh-CN\n"]
+            ),
+            "zh-CN"
+        )
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -68,6 +68,7 @@ The underlying command syntax is `tapq serve [options]`.
 | `--tap-profile PATH` | Override the tap profile |
 | `--timeout SECONDS` | Input timeout; default and maximum are 240 seconds |
 | `--no-voice` | Do not request microphone/Speech access or start voice input |
+| `--speech-voice VOICE` | Voice used for spoken output: a language tag (`en-US`, `zh-CN`) or a macOS voice identifier. Default `en-US`; also settable with `TAPQ_SPEECH_VOICE`. Unrelated to `--no-voice`, which gates the microphone |
 | `--no-announcements` | Suppress non-blocking waiting and completion announcements |
 | `--steering` | Enable opt-in structured-question guidance for adapters that support it (currently Claude Code) |
 | `--encoder-model PATH` | Load a TapQ-1 encoder model (`.mlpackage` or `.mlmodelc`) exported by `ml/tapq1/export.py` |
@@ -442,6 +443,7 @@ that load user lifecycle hooks; it does not attach to hosted Codex Cloud tasks.
 |---|---|
 | `TAPQ_DEBUG=1` | Enable verbose console diagnostics |
 | `TAPQ_BROKER_DIR` | Override the runtime discovery/socket directory |
+| `TAPQ_SPEECH_VOICE` | Voice used for spoken output when `--speech-voice` is not passed. Primary control for the packaged runtime app, which is launched through `open` and takes no flags |
 | `TAPQ_CONFIG_DIR` | Override calibration profile storage |
 | `CODEX_HOME` | Select the Codex state directory whose `hooks.json` the integration command manages |
 | `ANTHROPIC_API_KEY` | Authenticate classification requests selected with `--question-classifier anthropic` |


### PR DESCRIPTION
Spoken prompts followed the **system language**, not the text. `SpeechEngine` never set `AVSpeechUtterance.voice`, so on a Chinese-language Mac every English prompt was read by a Chinese voice — mixing two phonologies and leaving the readout barely intelligible.

Synthesis now pins to `en-US`, the counterpart to the pin `VoiceListener.grammarLocale` already applies to recognition. Selectable via `--speech-voice` or `TAPQ_SPEECH_VOICE` (the env var is the practical control — the runtime app launches through `open` and takes no flags).

Selects a **voice, not a translation**: spoken scaffolding stays English regardless of the value.

**Breaking:** `SpeechEngine.voiceIdentifier` → `voiceSelection`. Accepts BCP-47 tags as well as identifiers, resolved once on assignment. An unresolvable value logs `voice.unavailable` rather than silently falling back.

574 tests pass; public boundary check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)