### PR TITLE
Stop re-teaching the selection controls on every question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Changed
 
+- Multi-option selection no longer re-teaches its controls on every question. "Volume, then
+  nod twice or double-tap." is spoken on the session's first selection and whenever the user
+  asks to repeat, and is dropped from every other prompt — the controls do not change
+  between questions, and the suffix was a third of the opening utterance. Navigation
+  announcements were already terse and are unaffected.
 - `SpeechEngine.voiceIdentifier` is replaced by `SpeechEngine.voiceSelection`, which also
   accepts language tags and is resolved once on assignment rather than per utterance. The
   old property accepted only voice identifiers and no supported configuration path ever

--- a/Sources/TapQInteractionBaseline/SelectionController.swift
+++ b/Sources/TapQInteractionBaseline/SelectionController.swift
@@ -23,6 +23,9 @@ import TapQContracts
     /// Clock seam: all deadline math reads time through this, so tests can advance a
     /// virtual clock instead of racing real sub-second deadlines against CI preemption.
     var now: () -> ContinuousClock.Instant = { .now }
+    /// The controls are taught once per runtime session. The controller outlives every
+    /// individual request, so this survives across questions by design.
+    private var hasAnnouncedControls = false
 
     public init(speech: SpeechPresenting, arbiter: SelectionArbitrating,
                 timeout: TimeInterval = 240,
@@ -55,7 +58,14 @@ import TapQContracts
         var cursor = 0
         // Spoken concurrently with the next listen window (barge-in), so input while
         // the option is still being announced is not lost.
-        var utterance: String? = promptText(request, cursor: cursor)
+        //
+        // The controls ride along only on the session's first selection. Marking them
+        // announced here rather than after the utterance completes is deliberate: a user
+        // who barges in before the hint finishes already knows the controls, and
+        // re-arming would put the hint back on the next question.
+        var utterance: String? = promptText(request, cursor: cursor,
+                                            includeControls: !hasAnnouncedControls)
+        hasAnnouncedControls = true
         while true {
             let remaining = deadline.seconds(after: now())
             guard remaining > 0 else {
@@ -91,7 +101,9 @@ import TapQContracts
                 diagnostics.record("selection.resolved", fields: ["cursor": "\(index)"])
                 return selection(at: index, request: request)
             case .repeatRequest:
-                utterance = promptText(request, cursor: cursor)
+                // An explicit repeat is the one moment the user has signalled they are
+                // lost, so the controls come back even after the session's first prompt.
+                utterance = promptText(request, cursor: cursor, includeControls: true)
             case .none:
                 outcome = "timeout"
                 diagnostics.record("selection.timeout")
@@ -113,7 +125,16 @@ import TapQContracts
         SelectionResult(choices: [.init(index: index, label: request.options[index].label)])
     }
 
-    private func promptText(_ request: SelectionRequest, cursor: Int) -> String {
+    /// How to navigate and confirm. The controls never change between selections, so
+    /// repeating them on every question is 37 characters the user must sit through before
+    /// reaching the option they are actually choosing between.
+    static let controlsHint = "Volume, then nod twice or double-tap."
+
+    private func promptText(
+        _ request: SelectionRequest,
+        cursor: Int,
+        includeControls: Bool
+    ) -> String {
         let option = request.options[cursor]
         let question = SpokenText.condensed(
             request.question,
@@ -125,7 +146,8 @@ import TapQContracts
             maxWords: 6,
             maxCharacters: 48
         )
-        return "\(SpokenText.sentence(question)) \(cursor + 1) of \(request.options.count): \(SpokenText.sentence(label)) Volume, then nod twice or double-tap."
+        let prompt = "\(SpokenText.sentence(question)) \(cursor + 1) of \(request.options.count): \(SpokenText.sentence(label))"
+        return includeControls ? "\(prompt) \(Self.controlsHint)" : prompt
     }
 
     private func optionText(_ request: SelectionRequest, cursor: Int) -> String {

--- a/Tests/TapQInteractionBaselineTests/SelectionControllerTests.swift
+++ b/Tests/TapQInteractionBaselineTests/SelectionControllerTests.swift
@@ -164,6 +164,39 @@ final class SelectionControllerTests: XCTestCase {
         )
     }
 
+    func testControlsHintIsDroppedAfterTheFirstSelection() async {
+        let speech = FakeSpeech()
+        // One controller serves the whole runtime session, so the second resolve is a
+        // second question asked of a user who has already been taught the controls.
+        let controller = SelectionController(speech: speech, arbiter: ScriptedArbiter([.select, .select]))
+        _ = await controller.resolve(request())
+        _ = await controller.resolve(request())
+        XCTAssertEqual(speech.spoken[0], "Which color? 1 of 3: Option 1. \(SelectionController.controlsHint)")
+        XCTAssertEqual(speech.spoken[1], "Which color? 1 of 3: Option 1.")
+    }
+
+    func testRepeatRestoresControlsHintOnLaterSelections() async {
+        let speech = FakeSpeech()
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.select, .repeatRequest, .select])
+        )
+        _ = await controller.resolve(request())
+        _ = await controller.resolve(request())
+        XCTAssertEqual(speech.spoken[1], "Which color? 1 of 3: Option 1.",
+                       "the second question opens without the hint")
+        XCTAssertEqual(speech.spoken[2], "Which color? 1 of 3: Option 1. \(SelectionController.controlsHint)",
+                       "asking to repeat is the one signal that the user wants the controls again")
+    }
+
+    func testNavigationNeverSpeaksControlsHint() async {
+        let speech = FakeSpeech()
+        let controller = SelectionController(speech: speech, arbiter: ScriptedArbiter([.next, .next, .select]))
+        _ = await controller.resolve(request())
+        XCTAssertFalse(speech.spoken.dropFirst().contains { $0.contains(SelectionController.controlsHint) },
+                       "only the opening prompt may carry the hint")
+    }
+
     func testDoubleTapConfirmsSelection() async {
         // .allow is what double-tap maps to; in selection context it means "confirm current"
         let controller = SelectionController(speech: FakeSpeech(), arbiter: ScriptedArbiter([.next, .allow]))


### PR DESCRIPTION
Every multi-option prompt ended with "Volume, then nod twice or double-tap." — 37 characters of unchanging instruction, about a third of the opening utterance, sitting between the user and the option they were choosing.

The hint is now spoken on the session's first selection and whenever the user explicitly asks to repeat, which is the one moment they have signalled they are lost. `SelectionController` outlives individual requests, so the flag is session-scoped by construction.

Marked announced at enqueue rather than after the utterance finishes: a user who barges in already knows the controls, and re-arming would put the hint back on the next question. Navigation announcements were already terse and are unchanged.

Example: `Which deployment target…? 1 of 4: Staging. Volume, then nod twice or double-tap.` → `Which deployment target…? 1 of 4: Staging.` (125 → 88 chars)

562 tests pass; public boundary check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)