### PR TITLE
Fix voice capture across macOS audio route changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -166,8 +166,21 @@ products += [
 
 targets += [
     .target(
+        name: "TapQAudioCaptureBridge",
+        dependencies: [],
+        linkerSettings: [
+            .linkedFramework("AVFoundation"),
+            .linkedFramework("Foundation"),
+        ]
+    ),
+    .target(
         name: "TapQAppleAdapters",
-        dependencies: ["TapQContracts", "TapQDetectionBaseline", "TapQInteractionBaseline"],
+        dependencies: [
+            "TapQAudioCaptureBridge",
+            "TapQContracts",
+            "TapQDetectionBaseline",
+            "TapQInteractionBaseline",
+        ],
         swiftSettings: swiftSettings
     ),
     .executableTarget(
@@ -176,9 +189,17 @@ targets += [
         path: "Executables/TapQMotionSpike",
         swiftSettings: swiftSettings
     ),
+    .target(
+        name: "TapQAudioCaptureBridgeTestSupport",
+        dependencies: ["TapQAudioCaptureBridge"],
+        path: "Tests/TapQAudioCaptureBridgeTestSupport",
+        linkerSettings: [.linkedFramework("AVFoundation")]
+    ),
     .testTarget(
         name: "TapQAppleAdaptersTests",
         dependencies: [
+            "TapQAudioCaptureBridge",
+            "TapQAudioCaptureBridgeTestSupport",
             "TapQContracts",
             "TapQDetectionBaseline",
             "TapQInteractionBaseline",

--- a/Sources/TapQAppleAdapters/VoiceAudioSource.swift
+++ b/Sources/TapQAppleAdapters/VoiceAudioSource.swift
@@ -1,0 +1,194 @@
+import Foundation
+import TapQAudioCaptureBridge
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+
+#if canImport(AVFoundation)
+struct VoiceAudioSourceFailure: Error, Equatable, CustomStringConvertible {
+    enum Stage: String {
+        case inputFormat = "input_format"
+        case audioSetup = "audio_setup"
+        case engineStart = "engine_start"
+        case configurationChanged = "configuration_changed"
+    }
+
+    let stage: Stage
+    let detail: String
+
+    var description: String {
+        "\(stage.rawValue): \(detail)"
+    }
+}
+
+/// Hardware boundary for one microphone window. A source is single-use in production:
+/// its fresh AVAudioEngine cannot retain formats from an earlier audio route.
+@MainActor protocol VoiceAudioSource: AnyObject {
+    func start(
+        onBuffer: @escaping (AVAudioPCMBuffer) -> Void,
+        onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
+    ) throws
+    func stop()
+}
+
+enum VoiceAudioSourceStartResult {
+    case started
+    case alreadyRunning
+    case failed(any Error)
+}
+
+/// Owns the current per-window source and rejects callbacks from discarded sources.
+/// Keeping this lifecycle outside VoiceListener makes route/failure behavior testable
+/// without asking XCTest to touch audio hardware.
+@MainActor final class VoiceAudioSourceController {
+    private let makeSource: @MainActor () -> any VoiceAudioSource
+    private var source: (any VoiceAudioSource)?
+    private var sourceGeneration: UInt64 = 0
+
+    init(makeSource: @escaping @MainActor () -> any VoiceAudioSource) {
+        self.makeSource = makeSource
+    }
+
+    var isRunning: Bool {
+        source != nil
+    }
+
+    func start(
+        onBuffer: @escaping (AVAudioPCMBuffer) -> Void,
+        onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
+    ) -> VoiceAudioSourceStartResult {
+        guard source == nil else { return .alreadyRunning }
+
+        sourceGeneration &+= 1
+        let generation = sourceGeneration
+        let newSource = makeSource()
+        source = newSource
+        var invalidationDuringStart: VoiceAudioSourceFailure?
+
+        do {
+            try newSource.start(
+                onBuffer: onBuffer,
+                onInvalidation: { [weak self] failure in
+                    invalidationDuringStart = failure
+                    self?.invalidate(
+                        generation: generation,
+                        failure: failure,
+                        handler: onInvalidation
+                    )
+                }
+            )
+        } catch {
+            guard sourceGeneration == generation else {
+                return .failed(invalidationDuringStart ?? error)
+            }
+            stop()
+            return .failed(error)
+        }
+
+        if let invalidationDuringStart {
+            return .failed(invalidationDuringStart)
+        }
+        return .started
+    }
+
+    func stop() {
+        sourceGeneration &+= 1
+        let oldSource = source
+        source = nil
+        oldSource?.stop()
+    }
+
+    private func invalidate(
+        generation: UInt64,
+        failure: VoiceAudioSourceFailure,
+        handler: @MainActor (VoiceAudioSourceFailure) -> Void
+    ) {
+        guard sourceGeneration == generation, source != nil else { return }
+        stop()
+        handler(failure)
+    }
+}
+
+/// Production microphone source. It contains every AVFAudio call that depends on live
+/// route state and converts both NSError and legacy NSException failures into a failed
+/// voice window.
+@MainActor final class AVAudioEngineVoiceAudioSource: VoiceAudioSource {
+    private let capture: TapQAudioCaptureEngine
+    private var configurationObserver: NSObjectProtocol?
+    private var subscriptionGeneration: UInt64 = 0
+    private var started = false
+
+    init(capture: TapQAudioCaptureEngine = TapQAudioCaptureEngine()) {
+        self.capture = capture
+    }
+
+    func start(
+        onBuffer: @escaping (AVAudioPCMBuffer) -> Void,
+        onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
+    ) throws {
+        guard !started else { return }
+
+        subscriptionGeneration &+= 1
+        let generation = subscriptionGeneration
+        observeConfigurationChanges(generation: generation, onInvalidation: onInvalidation)
+
+        var captureError: NSError?
+        guard TapQAudioCaptureEngineStart(
+            capture,
+            1024,
+            { buffer, _ in onBuffer(buffer) },
+            &captureError
+        ) else {
+            throw Self.failure(from: captureError)
+        }
+        started = true
+    }
+
+    func stop() {
+        subscriptionGeneration &+= 1
+        started = false
+
+        if let configurationObserver {
+            NotificationCenter.default.removeObserver(configurationObserver)
+            self.configurationObserver = nil
+        }
+
+        var ignoredError: NSError?
+        _ = TapQAudioCaptureEngineStop(capture, &ignoredError)
+    }
+
+    private func observeConfigurationChanges(
+        generation: UInt64,
+        onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
+    ) {
+        configurationObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: capture.engine,
+            queue: .main
+        ) { [weak self] _ in
+            // Apple warns against releasing the engine from inside its configuration
+            // notification. Yield first, then let the controller tear this source down.
+            Task { @MainActor [weak self] in
+                await Task.yield()
+                guard let self,
+                      self.subscriptionGeneration == generation,
+                      self.started else { return }
+                onInvalidation(VoiceAudioSourceFailure(
+                    stage: .configurationChanged,
+                    detail: "audio input route changed"
+                ))
+            }
+        }
+    }
+
+    private static func failure(from error: NSError?) -> VoiceAudioSourceFailure {
+        let stageName = error?.userInfo[TapQAudioCaptureFailureStageKey] as? String
+        let stage = VoiceAudioSourceFailure.Stage(rawValue: stageName ?? "")
+            ?? .audioSetup
+        return VoiceAudioSourceFailure(
+            stage: stage,
+            detail: error?.localizedDescription ?? "audio capture failed"
+        )
+    }
+}
+#endif

--- a/Sources/TapQAppleAdapters/VoiceListener.swift
+++ b/Sources/TapQAppleAdapters/VoiceListener.swift
@@ -8,6 +8,51 @@ import Speech
 import AVFoundation
 #endif
 
+#if canImport(Speech)
+@MainActor protocol VoiceRecognitionTasking: AnyObject {
+    func cancel()
+}
+
+extension SFSpeechRecognitionTask: VoiceRecognitionTasking {}
+
+@MainActor protocol VoiceSpeechRecognizing: AnyObject {
+    var isAvailable: Bool { get }
+    var supportsOnDeviceRecognition: Bool { get }
+    var localeIdentifier: String? { get }
+    func recognitionTask(
+        with request: SFSpeechAudioBufferRecognitionRequest,
+        resultHandler: @escaping (SFSpeechRecognitionResult?, (any Error)?) -> Void
+    ) -> (any VoiceRecognitionTasking)?
+}
+
+@MainActor final class AppleVoiceSpeechRecognizer: VoiceSpeechRecognizing {
+    private let recognizer: SFSpeechRecognizer?
+
+    init(locale: Locale) {
+        recognizer = SFSpeechRecognizer(locale: locale)
+    }
+
+    var isAvailable: Bool {
+        recognizer?.isAvailable ?? false
+    }
+
+    var supportsOnDeviceRecognition: Bool {
+        recognizer?.supportsOnDeviceRecognition ?? false
+    }
+
+    var localeIdentifier: String? {
+        recognizer?.locale.identifier
+    }
+
+    func recognitionTask(
+        with request: SFSpeechAudioBufferRecognitionRequest,
+        resultHandler: @escaping (SFSpeechRecognitionResult?, (any Error)?) -> Void
+    ) -> (any VoiceRecognitionTasking)? {
+        recognizer?.recognitionTask(with: request, resultHandler: resultHandler)
+    }
+}
+#endif
+
 /// Opens the microphone for one window and resolves a short voice command via on-device
 /// speech recognition. The mic is only live while `start` is active — never always-on.
 @MainActor public final class VoiceListener: VoiceCommandProviding {
@@ -18,29 +63,57 @@ import AVFoundation
     nonisolated public static let grammarLocale = Locale(identifier: "en-US")
 
     #if canImport(Speech)
-    private let recognizer = SFSpeechRecognizer(locale: VoiceListener.grammarLocale)
-    private var task: SFSpeechRecognitionTask?
+    private let recognizer: any VoiceSpeechRecognizing
+    private var task: (any VoiceRecognitionTasking)?
     private var request: SFSpeechAudioBufferRecognitionRequest?
     #endif
     #if canImport(AVFoundation)
-    private let engine = AVAudioEngine()
+    private let audioSource: VoiceAudioSourceController
     #endif
 
     private var onCommand: (@MainActor (VoiceCommand) -> Void)?
     private var running = false
+    /// Invalidates delayed recognition/configuration callbacks from a prior route or
+    /// listening window before a fresh session can start.
+    private var sessionGeneration: UInt64 = 0
     private let diagnostics: TapQDiagnosticEmitter
     public var preferOnDevice = true
 
     var recognizerLocaleForTesting: String? {
         #if canImport(Speech)
-        return recognizer?.locale.identifier
+        return recognizer.localeIdentifier
         #else
         return nil
         #endif
     }
 
     public init(diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        #if canImport(Speech)
+        self.recognizer = AppleVoiceSpeechRecognizer(locale: Self.grammarLocale)
+        #endif
+        #if canImport(AVFoundation)
+        self.audioSource = VoiceAudioSourceController {
+            AVAudioEngineVoiceAudioSource()
+        }
+        #endif
         self.diagnostics = TapQDiagnosticEmitter(category: "Voice", sink: diagnosticSink)
+    }
+
+    #if canImport(Speech) && canImport(AVFoundation)
+    /// Test seam: fakes exercise listener lifecycle without touching Speech or AVFAudio.
+    init(
+        recognizer: any VoiceSpeechRecognizing,
+        makeAudioSource: @escaping @MainActor () -> any VoiceAudioSource,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.recognizer = recognizer
+        self.audioSource = VoiceAudioSourceController(makeSource: makeAudioSource)
+        self.diagnostics = TapQDiagnosticEmitter(category: "Voice", sink: diagnosticSink)
+    }
+    #endif
+
+    var isRunningForTesting: Bool {
+        running
     }
 
     /// Requests speech + microphone authorization. Call once before first use.
@@ -62,11 +135,24 @@ import AVFoundation
 
     public func start(onCommand: @escaping @MainActor (VoiceCommand) -> Void) {
         #if canImport(Speech) && canImport(AVFoundation)
-        guard !running, let recognizer, recognizer.isAvailable else {
-            diagnostics.record("start.skipped", fields: ["running": "\(running)"])
+        guard !running else {
+            diagnostics.record(
+                "start.skipped",
+                fields: ["reason": "already_running", "running": "true"]
+            )
             return
         }
-        diagnostics.record("listening.started", fields: ["locale": Self.grammarLocale.identifier])
+        guard recognizer.isAvailable else {
+            diagnostics.record(
+                "start.skipped",
+                level: .warning,
+                fields: ["reason": "recognizer_unavailable", "running": "false"]
+            )
+            return
+        }
+
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
         self.onCommand = onCommand
 
         let request = SFSpeechAudioBufferRecognitionRequest()
@@ -76,44 +162,59 @@ import AVFoundation
         }
         self.request = request
 
-        let input = engine.inputNode
-        let format = input.outputFormat(forBus: 0)
-        input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
-            request.append(buffer)
-        }
-        engine.prepare()
-        do {
-            try engine.start()
-        } catch {
-            diagnostics.record("engine.start_failed", level: .error,
-                               fields: ["error": "\(error)"])
-            teardown()
+        let audioResult = audioSource.start(
+            onBuffer: { buffer in
+                request.append(buffer)
+            },
+            onInvalidation: { [weak self] failure in
+                self?.audioSourceInvalidated(failure, generation: generation)
+            }
+        )
+        switch audioResult {
+        case .started:
+            break
+        case .alreadyRunning:
+            diagnostics.record(
+                "capture.start_failed",
+                level: .error,
+                fields: ["reason": "audio_source_already_running"]
+            )
+            teardown(expectedGeneration: generation)
+            return
+        case .failed(let error):
+            diagnostics.record(
+                "capture.start_failed",
+                level: .warning,
+                fields: Self.failureFields(error)
+            )
+            teardown(expectedGeneration: generation)
             return
         }
+
+        guard sessionGeneration == generation else { return }
         running = true
 
-        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
-            guard let self else { return }
-            if let result, VoiceCommandMatcher.match(result.bestTranscription.formattedString) != nil || result.isFinal {
-                Task { @MainActor in
-                    self.diagnostics.record("transcript.received")
-                }
-            }
-            if let result, let command = VoiceCommandMatcher.match(result.bestTranscription.formattedString) {
-                Task { @MainActor in self.fire(command) }
-            } else if error != nil {
-                Task { @MainActor in self.teardown() }
-            } else if let result, result.isFinal {
-                // The user said something the grammar doesn't know — log it so a
-                // "voice does nothing" report is diagnosable from the log file.
-                let transcript = result.bestTranscription.formattedString
-                Task { @MainActor in
-                    self.diagnostics.record("transcript.rejected",
-                                            fields: ["reason": "unmatched",
-                                                     "length": "\(transcript.count)"])
-                }
+        let recognitionTask = recognizer.recognitionTask(with: request) {
+            [weak self] result, error in
+            Task { @MainActor in
+                self?.handleRecognition(
+                    result: result,
+                    error: error,
+                    generation: generation
+                )
             }
         }
+        guard let recognitionTask else {
+            diagnostics.record(
+                "recognition.start_failed",
+                level: .warning,
+                fields: ["reason": "task_unavailable"]
+            )
+            teardown(expectedGeneration: generation)
+            return
+        }
+        task = recognitionTask
+        diagnostics.record("listening.started", fields: ["locale": Self.grammarLocale.identifier])
         #else
         _ = onCommand
         #endif
@@ -123,20 +224,78 @@ import AVFoundation
         teardown()
     }
 
-    private func fire(_ command: VoiceCommand) {
-        guard running else { return }
+    #if canImport(Speech) && canImport(AVFoundation)
+    private func handleRecognition(
+        result: SFSpeechRecognitionResult?,
+        error: (any Error)?,
+        generation: UInt64
+    ) {
+        guard running, sessionGeneration == generation else { return }
+
+        if let result,
+           VoiceCommandMatcher.match(result.bestTranscription.formattedString) != nil
+            || result.isFinal {
+            diagnostics.record("transcript.received")
+        }
+        if let result,
+           let command = VoiceCommandMatcher.match(
+               result.bestTranscription.formattedString
+           ) {
+            fire(command, generation: generation)
+        } else if error != nil {
+            teardown(expectedGeneration: generation)
+        } else if let result, result.isFinal {
+            // The user said something the grammar doesn't know — log it so a
+            // "voice does nothing" report is diagnosable from the log file.
+            let transcript = result.bestTranscription.formattedString
+            diagnostics.record(
+                "transcript.rejected",
+                fields: ["reason": "unmatched", "length": "\(transcript.count)"]
+            )
+        }
+    }
+
+    private func audioSourceInvalidated(
+        _ failure: VoiceAudioSourceFailure,
+        generation: UInt64
+    ) {
+        guard running, sessionGeneration == generation else { return }
+        diagnostics.record(
+            "capture.invalidated",
+            level: .warning,
+            fields: [
+                "stage": failure.stage.rawValue,
+                "error": failure.detail,
+            ]
+        )
+        teardown(expectedGeneration: generation)
+    }
+
+    private static func failureFields(_ error: any Error) -> [String: String] {
+        if let failure = error as? VoiceAudioSourceFailure {
+            return ["stage": failure.stage.rawValue, "error": failure.detail]
+        }
+        return ["stage": "unknown", "error": String(describing: error)]
+    }
+    #endif
+
+    private func fire(_ command: VoiceCommand, generation: UInt64) {
+        guard running, sessionGeneration == generation else { return }
         diagnostics.record("command.matched", fields: ["command": "\(command)"])
         let callback = onCommand
-        teardown()
+        teardown(expectedGeneration: generation)
         callback?(command)
     }
 
-    private func teardown() {
+    private func teardown(expectedGeneration: UInt64? = nil) {
+        if let expectedGeneration, expectedGeneration != sessionGeneration {
+            return
+        }
+        sessionGeneration &+= 1
         running = false
         onCommand = nil
         #if canImport(AVFoundation)
-        if engine.isRunning { engine.stop() }
-        engine.inputNode.removeTap(onBus: 0)
+        audioSource.stop()
         #endif
         #if canImport(Speech)
         request?.endAudio()

--- a/Sources/TapQAudioCaptureBridge/TapQAudioCaptureBridge.m
+++ b/Sources/TapQAudioCaptureBridge/TapQAudioCaptureBridge.m
@@ -1,0 +1,157 @@
+#import "TapQAudioCaptureBridge.h"
+#import <math.h>
+
+NSString * const TapQAudioCaptureErrorDomain = @"ai.tapq.audio.capture";
+NSString * const TapQAudioCaptureFailureStageKey = @"stage";
+
+static NSString * const TapQInputFormatStage = @"input_format";
+static NSString * const TapQAudioSetupStage = @"audio_setup";
+static NSString * const TapQEngineStartStage = @"engine_start";
+static NSString * const TapQAudioTeardownStage = @"audio_teardown";
+
+BOOL TapQAudioInputFormatIsUsable(
+    double sampleRate,
+    AVAudioChannelCount channelCount
+) {
+    return isfinite(sampleRate) && sampleRate > 0 && channelCount > 0;
+}
+
+@interface TapQAudioCaptureEngine ()
+
+@property(nonatomic, strong, readwrite) AVAudioEngine *engine;
+@property(nonatomic, strong, nullable) AVAudioInputNode *inputNode;
+@property(nonatomic) BOOL tapInstalled;
+
+@end
+
+@implementation TapQAudioCaptureEngine
+
+- (instancetype)init {
+    self = [super init];
+    if (self != nil) {
+        _engine = [[AVAudioEngine alloc] init];
+    }
+    return self;
+}
+
+@end
+
+static NSError *TapQCaptureError(
+    NSString *stage,
+    NSString *description,
+    NSError * _Nullable underlyingError
+) {
+    NSMutableDictionary *userInfo = [@{
+        NSLocalizedDescriptionKey: description,
+        TapQAudioCaptureFailureStageKey: stage,
+    } mutableCopy];
+    if (underlyingError != nil) {
+        userInfo[NSUnderlyingErrorKey] = underlyingError;
+    }
+    return [NSError errorWithDomain:TapQAudioCaptureErrorDomain
+                               code:1
+                           userInfo:userInfo];
+}
+
+static NSError *TapQExceptionError(NSString *stage, NSException *exception) {
+    NSString *reason = exception.reason ?: @"AVFAudio raised an exception";
+    return TapQCaptureError(
+        stage,
+        [NSString stringWithFormat:@"%@: %@", exception.name, reason],
+        nil
+    );
+}
+
+BOOL TapQAudioCaptureEngineStart(
+    TapQAudioCaptureEngine *capture,
+    AVAudioFrameCount bufferSize,
+    AVAudioNodeTapBlock tapBlock,
+    NSError * _Nullable * _Nullable error
+) {
+    @try {
+        AVAudioInputNode *input = capture.engine.inputNode;
+        AVAudioFormat *hardwareFormat = [input inputFormatForBus:0];
+        double sampleRate = hardwareFormat.sampleRate;
+        AVAudioChannelCount channelCount = hardwareFormat.channelCount;
+        if (!TapQAudioInputFormatIsUsable(sampleRate, channelCount)) {
+            if (error != NULL) {
+                *error = TapQCaptureError(
+                    TapQInputFormatStage,
+                    [NSString stringWithFormat:
+                        @"unavailable input (sample_rate=%g, channels=%u)",
+                        sampleRate, (unsigned int)channelCount],
+                    nil
+                );
+            }
+            return NO;
+        }
+
+        capture.inputNode = input;
+        // A nil tap format follows this fresh input node's native output format. A
+        // nonnil stale client format is what makes AVFAudio reject a changed route.
+        [input installTapOnBus:0
+                   bufferSize:bufferSize
+                       format:nil
+                        block:tapBlock];
+        capture.tapInstalled = YES;
+        [capture.engine prepare];
+
+        NSError *startError = nil;
+        if (![capture.engine startAndReturnError:&startError]) {
+            if (error != NULL) {
+                *error = TapQCaptureError(
+                    TapQEngineStartStage,
+                    startError.localizedDescription ?: @"AVAudioEngine failed to start",
+                    startError
+                );
+            }
+            return NO;
+        }
+        return YES;
+    } @catch (NSException *exception) {
+        if (error != NULL) {
+            *error = TapQExceptionError(TapQAudioSetupStage, exception);
+        }
+        return NO;
+    }
+}
+
+BOOL TapQAudioCaptureEngineStop(
+    TapQAudioCaptureEngine *capture,
+    NSError * _Nullable * _Nullable error
+) {
+    NSError *firstError = nil;
+
+    @try {
+        if (capture.engine.running) {
+            [capture.engine stop];
+        }
+    } @catch (NSException *exception) {
+        firstError = TapQExceptionError(TapQAudioTeardownStage, exception);
+    }
+
+    if (capture.tapInstalled && capture.inputNode != nil) {
+        @try {
+            [capture.inputNode removeTapOnBus:0];
+        } @catch (NSException *exception) {
+            if (firstError == nil) {
+                firstError = TapQExceptionError(TapQAudioTeardownStage, exception);
+            }
+        }
+    }
+
+    @try {
+        [capture.engine reset];
+    } @catch (NSException *exception) {
+        if (firstError == nil) {
+            firstError = TapQExceptionError(TapQAudioTeardownStage, exception);
+        }
+    }
+
+    capture.tapInstalled = NO;
+    capture.inputNode = nil;
+    if (error != NULL) {
+        *error = firstError;
+    }
+    return firstError == nil;
+}

--- a/Sources/TapQAudioCaptureBridge/include/TapQAudioCaptureBridge.h
+++ b/Sources/TapQAudioCaptureBridge/include/TapQAudioCaptureBridge.h
@@ -1,0 +1,44 @@
+#ifndef TAPQ_AUDIO_CAPTURE_BRIDGE_H
+#define TAPQ_AUDIO_CAPTURE_BRIDGE_H
+
+#import <AVFoundation/AVFoundation.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSString * const TapQAudioCaptureErrorDomain;
+FOUNDATION_EXPORT NSString * const TapQAudioCaptureFailureStageKey;
+
+FOUNDATION_EXPORT BOOL TapQAudioInputFormatIsUsable(
+    double sampleRate,
+    AVAudioChannelCount channelCount
+);
+
+/// Owns one fresh AVAudioEngine and its exact tapped input node. All operations that
+/// may raise an AVFAudio NSException are performed by the typed Objective-C functions
+/// below, so an exception never unwinds through a Swift frame.
+@interface TapQAudioCaptureEngine : NSObject
+
+@property(nonatomic, strong, readonly) AVAudioEngine *engine;
+
+- (instancetype)init;
+
+@end
+
+FOUNDATION_EXPORT BOOL TapQAudioCaptureEngineStart(
+    TapQAudioCaptureEngine *capture,
+    AVAudioFrameCount bufferSize,
+    AVAudioNodeTapBlock tapBlock,
+    NSError * _Nullable * _Nullable error
+);
+
+/// Best-effort and idempotent. Stop, tap removal, and reset each have an independent
+/// Objective-C exception boundary so cleanup continues if one operation fails.
+FOUNDATION_EXPORT BOOL TapQAudioCaptureEngineStop(
+    TapQAudioCaptureEngine *capture,
+    NSError * _Nullable * _Nullable error
+);
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Tests/TapQAppleAdaptersTests/VoiceListenerTests.swift
+++ b/Tests/TapQAppleAdaptersTests/VoiceListenerTests.swift
@@ -1,8 +1,117 @@
 import XCTest
+import AVFoundation
+import Speech
+import TapQAudioCaptureBridge
+import TapQAudioCaptureBridgeTestSupport
+import TapQContracts
+import TapQInteractionBaseline
 @testable import TapQAppleAdapters
 
+@MainActor
 final class VoiceListenerTests: XCTestCase {
-    @MainActor
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    private final class FakeRecognitionTask: VoiceRecognitionTasking {
+        private(set) var cancellations = 0
+        func cancel() {
+            cancellations += 1
+        }
+    }
+
+    private final class FakeRecognizer: VoiceSpeechRecognizing {
+        var isAvailable = true
+        var supportsOnDeviceRecognition = true
+        var localeIdentifier: String? = "en-US"
+        var returnsTask = true
+        private(set) var requests: [SFSpeechAudioBufferRecognitionRequest] = []
+        private(set) var handlers: [
+            (SFSpeechRecognitionResult?, (any Error)?) -> Void
+        ] = []
+        private(set) var tasks: [FakeRecognitionTask] = []
+
+        func recognitionTask(
+            with request: SFSpeechAudioBufferRecognitionRequest,
+            resultHandler: @escaping (SFSpeechRecognitionResult?, (any Error)?) -> Void
+        ) -> (any VoiceRecognitionTasking)? {
+            requests.append(request)
+            handlers.append(resultHandler)
+            guard returnsTask else { return nil }
+            let task = FakeRecognitionTask()
+            tasks.append(task)
+            return task
+        }
+
+        func fail(call index: Int) {
+            handlers[index](nil, TestFailure.expected)
+        }
+    }
+
+    private final class FakeAudioSource: VoiceAudioSource {
+        var startFailure: (any Error)?
+        var synchronousInvalidation: VoiceAudioSourceFailure?
+        private(set) var starts = 0
+        private(set) var stops = 0
+        private var invalidation: (@MainActor (VoiceAudioSourceFailure) -> Void)?
+
+        func start(
+            onBuffer: @escaping (AVAudioPCMBuffer) -> Void,
+            onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
+        ) throws {
+            _ = onBuffer
+            starts += 1
+            invalidation = onInvalidation
+            if let synchronousInvalidation {
+                onInvalidation(synchronousInvalidation)
+            }
+            if let startFailure {
+                throw startFailure
+            }
+        }
+
+        func stop() {
+            stops += 1
+        }
+
+        func invalidate(
+            _ failure: VoiceAudioSourceFailure = .init(
+                stage: .configurationChanged,
+                detail: "test route change"
+            )
+        ) {
+            invalidation?(failure)
+        }
+    }
+
+    private final class FakeActivity: SpeechActivitySignaling {
+        private(set) var isSpeaking = false
+        var onSpeakingChange: (@MainActor (Bool) -> Void)?
+
+        func setSpeaking(_ speaking: Bool) {
+            guard speaking != isSpeaking else { return }
+            isSpeaking = speaking
+            onSpeakingChange?(speaking)
+        }
+    }
+
+    private enum TestFailure: Error {
+        case expected
+    }
+
     func testRecognizerPinnedToGrammarLocale() async throws {
         XCTAssertEqual(VoiceListener.grammarLocale.identifier, "en-US")
         let listener = VoiceListener()
@@ -10,5 +119,297 @@ final class VoiceListenerTests: XCTestCase {
             throw XCTSkip("SFSpeechRecognizer unavailable for en-US on this machine")
         }
         XCTAssertEqual(localeID.replacingOccurrences(of: "_", with: "-"), "en-US")
+    }
+
+    func testHardwareFormatValidationRejectsUnavailableInput() {
+        XCTAssertFalse(TapQAudioInputFormatIsUsable(0, 1))
+        XCTAssertFalse(TapQAudioInputFormatIsUsable(48_000, 0))
+        XCTAssertFalse(TapQAudioInputFormatIsUsable(.nan, 1))
+        XCTAssertTrue(TapQAudioInputFormatIsUsable(24_000, 1))
+        XCTAssertTrue(TapQAudioInputFormatIsUsable(48_000, 2))
+    }
+
+    func testObjectiveCBridgeContainsStartAndTeardownExceptions() {
+        let capture = TapQThrowingAudioCaptureEngine()
+        var startError: NSError?
+        let started = TapQAudioCaptureEngineStart(
+            capture,
+            1024,
+            { _, _ in XCTFail("failed capture must not deliver audio") },
+            &startError
+        )
+
+        XCTAssertFalse(started)
+        XCTAssertEqual(
+            startError?.userInfo[TapQAudioCaptureFailureStageKey] as? String,
+            "audio_setup"
+        )
+        XCTAssertTrue(
+            startError?.localizedDescription.contains("simulated input-node") == true
+        )
+        XCTAssertEqual(capture.inputNodeCallCount, 1)
+
+        var stopError: NSError?
+        XCTAssertFalse(TapQAudioCaptureEngineStop(capture, &stopError))
+        XCTAssertEqual(
+            stopError?.userInfo[TapQAudioCaptureFailureStageKey] as? String,
+            "audio_teardown"
+        )
+        XCTAssertTrue(stopError?.localizedDescription.contains("engine-running") == true)
+        XCTAssertEqual(capture.runningCallCount, 1)
+        XCTAssertEqual(
+            capture.resetCallCount,
+            1,
+            "reset still runs after the independent stop exception is caught"
+        )
+    }
+
+    func testAudioSourceControllerUsesFreshSourceOnRestartAndIsIdempotent() {
+        let first = FakeAudioSource()
+        let second = FakeAudioSource()
+        let sources = [first, second]
+        var factoryCalls = 0
+        let controller = VoiceAudioSourceController {
+            defer { factoryCalls += 1 }
+            return sources[factoryCalls]
+        }
+
+        guard case .started = controller.start(onBuffer: { _ in }, onInvalidation: { _ in })
+        else { return XCTFail("first source should start") }
+        guard case .alreadyRunning = controller.start(
+            onBuffer: { _ in },
+            onInvalidation: { _ in }
+        ) else { return XCTFail("duplicate start should be idempotent") }
+        XCTAssertEqual(factoryCalls, 1)
+        XCTAssertEqual(first.starts, 1)
+
+        controller.stop()
+        controller.stop()
+        XCTAssertEqual(first.stops, 1)
+
+        guard case .started = controller.start(onBuffer: { _ in }, onInvalidation: { _ in })
+        else { return XCTFail("restart should use a fresh source") }
+        XCTAssertEqual(factoryCalls, 2)
+        XCTAssertEqual(second.starts, 1)
+    }
+
+    func testAudioSourceControllerFailsClosedAndCanRetryFresh() {
+        let failure = VoiceAudioSourceFailure(
+            stage: .inputFormat,
+            detail: "unavailable input (sample_rate=0, channels=1)"
+        )
+        let rejected = FakeAudioSource()
+        rejected.startFailure = failure
+        let recovered = FakeAudioSource()
+        let sources = [rejected, recovered]
+        var factoryCalls = 0
+        let controller = VoiceAudioSourceController {
+            defer { factoryCalls += 1 }
+            return sources[factoryCalls]
+        }
+
+        guard case .failed(let error) = controller.start(
+            onBuffer: { _ in },
+            onInvalidation: { _ in }
+        ) else { return XCTFail("invalid input must fail") }
+        XCTAssertEqual(error as? VoiceAudioSourceFailure, failure)
+        XCTAssertFalse(controller.isRunning)
+        XCTAssertEqual(rejected.stops, 1)
+
+        guard case .started = controller.start(onBuffer: { _ in }, onInvalidation: { _ in })
+        else { return XCTFail("later route should get a fresh source") }
+        XCTAssertTrue(controller.isRunning)
+        XCTAssertEqual(factoryCalls, 2)
+    }
+
+    func testConfigurationChangeInvalidatesOnlyItsOwnSourceGeneration() {
+        let first = FakeAudioSource()
+        let second = FakeAudioSource()
+        let sources = [first, second]
+        var factoryCalls = 0
+        var invalidations: [VoiceAudioSourceFailure] = []
+        let controller = VoiceAudioSourceController {
+            defer { factoryCalls += 1 }
+            return sources[factoryCalls]
+        }
+        let invalidationHandler: @MainActor (VoiceAudioSourceFailure) -> Void = {
+            invalidations.append($0)
+        }
+
+        guard case .started = controller.start(
+            onBuffer: { _ in },
+            onInvalidation: invalidationHandler
+        ) else { return XCTFail("first source should start") }
+        first.invalidate()
+        XCTAssertFalse(controller.isRunning)
+        XCTAssertEqual(first.stops, 1)
+        XCTAssertEqual(invalidations.count, 1)
+
+        guard case .started = controller.start(
+            onBuffer: { _ in },
+            onInvalidation: invalidationHandler
+        ) else { return XCTFail("second source should start") }
+        first.invalidate()
+        XCTAssertTrue(controller.isRunning, "stale route callback must not stop new input")
+        XCTAssertEqual(second.stops, 0)
+        XCTAssertEqual(invalidations.count, 1)
+
+        second.invalidate()
+        XCTAssertFalse(controller.isRunning)
+        XCTAssertEqual(second.stops, 1)
+        XCTAssertEqual(invalidations.count, 2)
+    }
+
+    func testConfigurationChangeDuringStartFailsClosed() {
+        let source = FakeAudioSource()
+        let failure = VoiceAudioSourceFailure(
+            stage: .configurationChanged,
+            detail: "route changed during start"
+        )
+        source.synchronousInvalidation = failure
+        var invalidations: [VoiceAudioSourceFailure] = []
+        let controller = VoiceAudioSourceController { source }
+
+        guard case .failed(let error) = controller.start(
+            onBuffer: { _ in },
+            onInvalidation: { invalidations.append($0) }
+        ) else { return XCTFail("route change during start must fail the source") }
+
+        XCTAssertEqual(error as? VoiceAudioSourceFailure, failure)
+        XCTAssertFalse(controller.isRunning)
+        XCTAssertEqual(source.stops, 1)
+        XCTAssertEqual(invalidations, [failure])
+    }
+
+    func testTTSCompletionReopenFailsClosedWithoutStartingRecognition() {
+        let recognizer = FakeRecognizer()
+        let source = FakeAudioSource()
+        source.startFailure = VoiceAudioSourceFailure(
+            stage: .audioSetup,
+            detail: "NSInternalInconsistencyException: format mismatch"
+        )
+        let sink = RecordingSink()
+        let listener = VoiceListener(
+            recognizer: recognizer,
+            makeAudioSource: { source },
+            diagnosticSink: sink
+        )
+        let activity = FakeActivity()
+        let gated = SpeechGatedVoice(wrapping: listener, activity: activity)
+
+        activity.setSpeaking(true)
+        gated.start { _ in XCTFail("failed voice source cannot emit a command") }
+        XCTAssertEqual(source.starts, 0)
+        activity.setSpeaking(false)
+
+        XCTAssertEqual(source.starts, 1)
+        XCTAssertEqual(source.stops, 1)
+        XCTAssertFalse(listener.isRunningForTesting)
+        XCTAssertEqual(recognizer.requests.count, 0)
+        let failure = sink.events.last { $0.name == "capture.start_failed" }
+        XCTAssertEqual(failure?.level, .warning)
+        XCTAssertEqual(failure?.fields["stage"], "audio_setup")
+        XCTAssertTrue(failure?.fields["error"]?.contains("format mismatch") == true)
+
+        // Voice failure is local to the source; ordinary window teardown remains safe.
+        gated.stop()
+        XCTAssertEqual(source.stops, 1)
+    }
+
+    func testListenerRestartIgnoresLateRecognitionAndRouteCallbacks() async {
+        let recognizer = FakeRecognizer()
+        let first = FakeAudioSource()
+        let second = FakeAudioSource()
+        let sources = [first, second]
+        var factoryCalls = 0
+        let listener = VoiceListener(
+            recognizer: recognizer,
+            makeAudioSource: {
+                defer { factoryCalls += 1 }
+                return sources[factoryCalls]
+            }
+        )
+
+        listener.start { _ in }
+        listener.start { _ in XCTFail("duplicate start must not replace the session") }
+        XCTAssertTrue(listener.isRunningForTesting)
+        XCTAssertEqual(factoryCalls, 1)
+        XCTAssertEqual(recognizer.requests.count, 1)
+        XCTAssertTrue(recognizer.requests[0].requiresOnDeviceRecognition)
+
+        listener.stop()
+        listener.stop()
+        XCTAssertEqual(first.stops, 1)
+        XCTAssertEqual(recognizer.tasks[0].cancellations, 1)
+
+        listener.start { _ in }
+        XCTAssertTrue(listener.isRunningForTesting)
+        XCTAssertEqual(factoryCalls, 2)
+        XCTAssertEqual(recognizer.requests.count, 2)
+
+        recognizer.fail(call: 0)
+        await Task.yield()
+        XCTAssertTrue(
+            listener.isRunningForTesting,
+            "late error from generation 1 must not tear down generation 2"
+        )
+        XCTAssertEqual(second.stops, 0)
+
+        first.invalidate()
+        XCTAssertTrue(
+            listener.isRunningForTesting,
+            "late route callback from generation 1 must not tear down generation 2"
+        )
+        XCTAssertEqual(second.stops, 0)
+
+        second.invalidate()
+        XCTAssertFalse(listener.isRunningForTesting)
+        XCTAssertEqual(second.stops, 1)
+        XCTAssertEqual(recognizer.tasks[1].cancellations, 1)
+    }
+
+    func testNilRecognitionTaskTearsDownCapture() {
+        let recognizer = FakeRecognizer()
+        recognizer.returnsTask = false
+        let source = FakeAudioSource()
+        let sink = RecordingSink()
+        let listener = VoiceListener(
+            recognizer: recognizer,
+            makeAudioSource: { source },
+            diagnosticSink: sink
+        )
+
+        listener.start { _ in }
+
+        XCTAssertFalse(listener.isRunningForTesting)
+        XCTAssertEqual(source.stops, 1)
+        XCTAssertEqual(
+            sink.events.last { $0.name == "recognition.start_failed" }?.fields["reason"],
+            "task_unavailable"
+        )
+    }
+
+    func testEngineStartFailureLogsStageAndTearsDownCapture() {
+        let recognizer = FakeRecognizer()
+        let source = FakeAudioSource()
+        source.startFailure = VoiceAudioSourceFailure(
+            stage: .engineStart,
+            detail: "input device disappeared"
+        )
+        let sink = RecordingSink()
+        let listener = VoiceListener(
+            recognizer: recognizer,
+            makeAudioSource: { source },
+            diagnosticSink: sink
+        )
+
+        listener.start { _ in }
+
+        XCTAssertFalse(listener.isRunningForTesting)
+        XCTAssertEqual(source.stops, 1)
+        XCTAssertEqual(recognizer.requests.count, 0)
+        let failure = sink.events.last { $0.name == "capture.start_failed" }
+        XCTAssertEqual(failure?.fields["stage"], "engine_start")
+        XCTAssertEqual(failure?.fields["error"], "input device disappeared")
     }
 }

--- a/Tests/TapQAudioCaptureBridgeTestSupport/TapQAudioCaptureBridgeTestSupport.m
+++ b/Tests/TapQAudioCaptureBridgeTestSupport/TapQAudioCaptureBridgeTestSupport.m
@@ -1,0 +1,67 @@
+#import "TapQAudioCaptureBridgeTestSupport.h"
+
+@interface TapQThrowingAVAudioEngine : AVAudioEngine
+
+@property(nonatomic) NSUInteger inputNodeCallCount;
+@property(nonatomic) NSUInteger runningCallCount;
+@property(nonatomic) NSUInteger resetCallCount;
+
+@end
+
+@implementation TapQThrowingAVAudioEngine
+
+- (AVAudioInputNode *)inputNode {
+    self.inputNodeCallCount += 1;
+    [NSException raise:NSInternalInconsistencyException
+                format:@"simulated input-node route exception"];
+    return [super inputNode];
+}
+
+- (BOOL)isRunning {
+    self.runningCallCount += 1;
+    [NSException raise:NSInternalInconsistencyException
+                format:@"simulated engine-running exception"];
+    return NO;
+}
+
+- (void)reset {
+    self.resetCallCount += 1;
+    [NSException raise:NSInternalInconsistencyException
+                format:@"simulated engine-reset exception"];
+}
+
+@end
+
+@interface TapQThrowingAudioCaptureEngine ()
+
+@property(nonatomic, strong) TapQThrowingAVAudioEngine *throwingEngine;
+
+@end
+
+@implementation TapQThrowingAudioCaptureEngine
+
+- (instancetype)init {
+    self = [super init];
+    if (self != nil) {
+        _throwingEngine = [[TapQThrowingAVAudioEngine alloc] init];
+    }
+    return self;
+}
+
+- (AVAudioEngine *)engine {
+    return self.throwingEngine;
+}
+
+- (NSUInteger)inputNodeCallCount {
+    return self.throwingEngine.inputNodeCallCount;
+}
+
+- (NSUInteger)runningCallCount {
+    return self.throwingEngine.runningCallCount;
+}
+
+- (NSUInteger)resetCallCount {
+    return self.throwingEngine.resetCallCount;
+}
+
+@end

--- a/Tests/TapQAudioCaptureBridgeTestSupport/include/TapQAudioCaptureBridgeTestSupport.h
+++ b/Tests/TapQAudioCaptureBridgeTestSupport/include/TapQAudioCaptureBridgeTestSupport.h
@@ -1,0 +1,20 @@
+#ifndef TAPQ_AUDIO_CAPTURE_BRIDGE_TEST_SUPPORT_H
+#define TAPQ_AUDIO_CAPTURE_BRIDGE_TEST_SUPPORT_H
+
+#import "TapQAudioCaptureBridge.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Test-only capture whose AVAudioEngine raises from route-sensitive accessors.
+/// It proves the production bridge catches NSException before returning to Swift.
+@interface TapQThrowingAudioCaptureEngine : TapQAudioCaptureEngine
+
+@property(nonatomic, readonly) NSUInteger inputNodeCallCount;
+@property(nonatomic, readonly) NSUInteger runningCallCount;
+@property(nonatomic, readonly) NSUInteger resetCallCount;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif


### PR DESCRIPTION
## Summary

- create a fresh `AVAudioEngine` for each listening window and follow the current hardware input format
- contain AVFAudio `NSException` failures in a typed Objective-C bridge so voice fails closed without taking down the broker
- invalidate changed routes safely and ignore callbacks from stale capture or recognition generations
- add deterministic lifecycle, failure, route-change, and Objective-C exception regression coverage

## Root cause

After the input route changed from the 48 kHz built-in microphone to the 24 kHz AirPods microphone, the retained engine reused its stale 48 kHz client format. Installing the tap with that explicit format raised an uncaught AVFAudio exception before Swift error handling could run.

## Verification

- [x] `swift test --filter VoiceListenerTests` — 11 tests passed
- [x] `swift test` — 761 tests passed
- [x] `scripts/check-public-boundary.sh`
- [x] `swift build -c release`
- [x] `scripts/package-runtime-app.sh debug`
- [x] live 48 kHz built-in to 24 kHz AirPods route transition: TTS completed, microphone reopened, listener started, and no crash report was generated

## Checklist

- [x] change is scoped to the Apple voice hardware boundary
- [x] behavior changes include deterministic regression tests
- [x] portable targets remain free of Apple framework imports
- [x] no credentials, private captures, or unrelated files are included