### PR TITLE
Prefer a downloaded high-quality Samantha for the default voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
+### Changed
+
+- The default voice now prefers a downloaded high-quality Samantha. The generic English
+  selection (`en-US`/`en`, including the default) resolves to premium or enhanced
+  Samantha when one is installed and only falls back to the compact system pick — Eddy
+  on a bare machine — when the user never downloaded a voice. Regional tags (`en-GB`)
+  and explicit voice identifiers are never redirected, so a deliberate Eddy pin still
+  gets Eddy. A future cloud or custom local TTS provider will slot in ahead of this
+  preference; today the chain is downloaded Samantha, then the system default.
+
 ## [0.3.0] - 2026-07-29
 
 ### Added

--- a/Sources/TapQAppleAdapters/SpeechEngine.swift
+++ b/Sources/TapQAppleAdapters/SpeechEngine.swift
@@ -55,8 +55,40 @@ import AVFoundation
         if let voice = AVSpeechSynthesisVoice(identifier: selection), voice.identifier == selection {
             return voice
         }
+        // The generic English selection — which is also TapQ's default — means "a good
+        // English voice", not "whatever macOS considers the en-US default". On a bare
+        // machine that default is Eddy, an Eloquence formant synthesizer kept for
+        // accessibility users who prefer its 1980s articulation. Anyone who wants Eddy,
+        // or any other specific voice, can still pin it by identifier above.
+        if isGenericEnglishSelection(selection) {
+            for identifier in preferredEnUSVoiceIdentifiers {
+                if let voice = AVSpeechSynthesisVoice(identifier: identifier),
+                   voice.identifier == identifier {
+                    return voice
+                }
+            }
+        }
         guard let voice = AVSpeechSynthesisVoice(language: selection) else { return nil }
         return languageMatches(voice.language, requested: selection) ? voice : nil
+    }
+
+    /// The downloadable Samantha tiers, best first. Apple's voice catalog for this OS
+    /// generation offers exactly one high-tier US English voice — Samantha — and which
+    /// identifier it registers under varies (the catalog's "premium" asset installs as
+    /// `enhanced` on macOS 26), so both spellings are tried. None installed means the
+    /// user never downloaded a voice, and resolution falls through to the system pick.
+    /// A cloud or custom local TTS provider, when one exists, will slot in ahead of
+    /// this list; today the chain is downloaded Samantha, then the system default.
+    static let preferredEnUSVoiceIdentifiers = [
+        "com.apple.voice.premium.en-US.Samantha",
+        "com.apple.voice.enhanced.en-US.Samantha",
+    ]
+
+    /// Only "en" and "en-US" are generic: they ask for English without choosing a
+    /// regional voice. "en-GB" is a deliberate regional choice and is never redirected.
+    static func isGenericEnglishSelection(_ selection: String) -> Bool {
+        selection.caseInsensitiveCompare("en") == .orderedSame
+            || selection.caseInsensitiveCompare("en-US") == .orderedSame
     }
 
     /// Primary-subtag comparison: "en" accepts an en-US voice, and "en-GB" accepts a

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -1168,10 +1168,13 @@ public struct TapQCLIIO {
       --no-voice               Disable microphone speech recognition
       --speech-voice VOICE     Voice for spoken output: a language tag (en-US, zh-CN) or
                                a system voice identifier (default: en-US, also settable
-                               with TAPQ_SPEECH_VOICE). Unset, macOS picks the voice from
-                               the system language regardless of what TapQ says, which
-                               garbles the readout on a non-English Mac. This selects the
-                               voice only — TapQ's own prompts are English either way.
+                               with TAPQ_SPEECH_VOICE). The en-US default prefers a
+                               downloaded high-quality Samantha and only takes the
+                               compact system pick when none is installed. Unset, macOS
+                               picks the voice from the system language regardless of
+                               what TapQ says, which garbles the readout on a
+                               non-English Mac. This selects the voice only — TapQ's
+                               own prompts are English either way.
       --no-announcements       Disable non-blocking agent status announcements
       --steering               Ask supported adapters to prefer structured questions
       --question-classifier P  Use auto, apple, anthropic, openai, or local (default: auto)

--- a/Tests/TapQAppleAdaptersTests/SpeechEngineVoiceTests.swift
+++ b/Tests/TapQAppleAdaptersTests/SpeechEngineVoiceTests.swift
@@ -55,6 +55,52 @@ final class SpeechEngineVoiceTests: XCTestCase {
         XCTAssertFalse(SpeechEngine.languageMatches("en-US", requested: ""))
     }
 
+    // The Samantha preference only applies to selections that mean "English, any voice".
+    // The classifier is what guarantees a regional or specific selection is never
+    // redirected, so it is asserted directly and host-independently.
+
+    func testGenericEnglishSelectionsAreClassified() {
+        XCTAssertTrue(SpeechEngine.isGenericEnglishSelection("en"))
+        XCTAssertTrue(SpeechEngine.isGenericEnglishSelection("en-US"))
+        XCTAssertTrue(SpeechEngine.isGenericEnglishSelection("EN-us"))
+    }
+
+    func testRegionalAndSpecificSelectionsAreNotGeneric() {
+        XCTAssertFalse(SpeechEngine.isGenericEnglishSelection("en-GB"),
+                       "a regional choice must reach the voice for that region")
+        XCTAssertFalse(SpeechEngine.isGenericEnglishSelection("zh-CN"))
+        XCTAssertFalse(SpeechEngine.isGenericEnglishSelection("com.apple.eloquence.en-US.Eddy"),
+                       "an explicit Eddy pin must still get Eddy")
+        XCTAssertFalse(SpeechEngine.isGenericEnglishSelection(""))
+    }
+
+    /// Whether a high-tier Samantha is installed varies by host (the CI runner has none;
+    /// a machine that ran the download has enhanced). The assertion adapts: with one
+    /// installed, the generic selection must resolve to it; the skip records why the
+    /// preference went unexercised.
+    func testGenericEnglishPrefersDownloadedSamantha() throws {
+        let installed = SpeechEngine.preferredEnUSVoiceIdentifiers.first { identifier in
+            AVSpeechSynthesisVoice(identifier: identifier)?.identifier == identifier
+        }
+        guard let expected = installed else {
+            throw XCTSkip("no downloadable-tier Samantha on this host; nothing to prefer")
+        }
+        XCTAssertEqual(SpeechEngine.resolveVoice("en-US")?.identifier, expected)
+        XCTAssertEqual(SpeechEngine.resolveVoice("en")?.identifier, expected)
+    }
+
+    func testExplicitIdentifierBypassesTheSamanthaPreference() throws {
+        let compact = AVSpeechSynthesisVoice.speechVoices().first {
+            $0.language == "en-US" && $0.quality == .default
+        }
+        guard let compact else {
+            throw XCTSkip("no compact en-US voice on this host")
+        }
+        XCTAssertEqual(SpeechEngine.resolveVoice(compact.identifier)?.identifier,
+                       compact.identifier,
+                       "pinning a specific voice must return exactly that voice")
+    }
+
     /// An unresolvable selection must be visible: silently falling back to the
     /// system-locale voice is the exact bug this option exists to fix.
     func testUnresolvableSelectionRecordsDiagnostic() {


### PR DESCRIPTION
The generic English selection (`en-US`/`en`, including the default) now resolves to premium or enhanced Samantha when installed, falling back to the compact system pick — Eddy on a bare machine — only when the user never downloaded a voice.

- Regional tags (`en-GB`) and explicit identifiers are never redirected; a deliberate Eddy pin still gets Eddy.
- Both Samantha identifier spellings are tried: the catalog's premium asset registers as `enhanced` on macOS 26.
- A future cloud/custom local TTS provider will slot in ahead of this preference.

Tests are host-adaptive: the preference assertion runs where a high-tier Samantha is installed and skips (with the reason recorded) where none is, so CI passes on bare runners without weakening the local assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)