### PR TITLE
Add Codex request_user_input interception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Assemble and verify headless runtime app
         run: scripts/package-runtime-app.sh release
       - name: Test complete macOS graph
-        run: swift test
+        run: TAPQ_CODEX_HOOK_EXECUTABLE="$(swift build -c release --show-bin-path)/tapq-codex-hook" swift test
 
   linux:
     runs-on: ubuntu-24.04
@@ -51,4 +51,4 @@ jobs:
       - name: Build portable and POSIX graph
         run: swift build -c release
       - name: Test portable and POSIX graph
-        run: swift test
+        run: TAPQ_CODEX_HOOK_EXECUTABLE="$(swift build -c release --show-bin-path)/tapq-codex-hook" swift test

--- a/Package.swift
+++ b/Package.swift
@@ -150,6 +150,16 @@ var targets: [Target] = [
         swiftSettings: swiftSettings
     ),
     .testTarget(
+        name: "TapQCodexProcessTests",
+        dependencies: [
+            "TapQBrokerRuntime",
+            "TapQContracts",
+            "TapQWireProtocol",
+        ],
+        resources: [.copy("Fixtures")],
+        swiftSettings: swiftSettings
+    ),
+    .testTarget(
         name: "TapQCLITests",
         dependencies: ["TapQCLI", "TapQDetectionBaseline", "TapQWireProtocol"],
         swiftSettings: swiftSettings

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ compatibility set.
 - For the live hands-free runtime: macOS 14 or newer, Xcode 16 or a compatible Swift
   toolchain, and AirPods that expose headphone motion through CoreMotion
 - For an agent integration: Claude Code with hook support, or a local Codex client with
-  stable lifecycle hooks (the contract is tested against Codex CLI `0.142.5`)
+  stable lifecycle hooks. The lifecycle floor is tested against Codex CLI `0.142.5`;
+  structured `request_user_input` interception is tested against `0.146.0`
 
 Keep the AirPods connected, in-ear, and selected as the audio output. Quit any
 other process using headphone motion before starting TapQ; competing CoreMotion clients
@@ -280,20 +281,26 @@ Installation does not grant hook trust. After every new or changed definition, o
 Codex and use `/hooks` to review and trust the exact TapQ hooks. `status` verifies the
 file layout only; Codex remains the authority for trust state.
 
-The current stable slice is deliberately narrow:
+The current supported slice is deliberately narrow:
 
+- `PreToolUse` handles root-agent `request_user_input` calls containing one
+  single-select question with two or three listed options. A TapQ selection is returned
+  to the model without opening Codex’s selector.
 - `PermissionRequest` handles native approval prompts for `Bash` and `apply_patch` only.
   Commands and patches that Codex does not prompt for never reach TapQ.
 - `Stop` reports completion and can route an explicit final-response question using
   Codex’s stable `last_assistant_message` field. It does not parse Codex transcripts.
 - Broker absence, timeout, an incompatible wire version, invalid data, or no hands-free
-  answer emits no hook decision, leaving Codex’s normal approval or turn flow in control.
-- There is no Codex strict `PreToolUse` policy, structured `request_user_input`
-  interception, `UserPromptSubmit` steering, or generic notification-hook parity yet.
+  answer emits no hook decision, leaving Codex’s normal selector, approval, or turn flow
+  in control. Multiple questions, auto-resolving questions, unsupported option shapes,
+  secret questions, and subagent calls also stay native.
+- There is no broad Codex strict `PreToolUse` policy, `UserPromptSubmit` steering, or
+  generic notification-hook parity.
 
-TapQ’s tested contract floor is Codex CLI `0.142.5`, where lifecycle hooks are stable.
-The adapter targets local Codex clients that load user lifecycle hooks; hosted Codex
-Cloud tasks are outside this integration surface.
+TapQ’s lifecycle-hook contract floor is Codex CLI `0.142.5`. The versioned
+`request_user_input` hook fixture and executable-to-broker test target Codex CLI
+`0.146.0`. The adapter targets local Codex clients that load user lifecycle hooks;
+hosted Codex Cloud tasks are outside this integration surface.
 
 ## Questions in final responses
 
@@ -376,14 +383,15 @@ exposed by each platform and manufacturer.
 
 - [x] **Claude Code** — approvals, denials, option selection, notifications, and
   questions in final responses.
-- [x] **Codex stable slice** — native `PermissionRequest` approvals for `Bash` and
-  `apply_patch`, plus `Stop` completion and final-response questions with fail-through.
+- [x] **Codex supported slice** — structured single-choice `request_user_input`,
+  native `PermissionRequest` approvals for `Bash` and `apply_patch`, plus `Stop`
+  completion and final-response questions with fail-through.
 - [ ] **Cursor — next agent priority** — identify the most stable integration surface
   for permission requests, questions, and completion events, then connect it to the
   existing TapQ broker with native fail-through behavior.
-- [ ] **Codex expanded parity** — add strict pre-tool interception, structured
-  `request_user_input`, and generic notification equivalents only when their contracts
-  are stable enough to preserve native fallback behavior.
+- [ ] **Codex expanded parity** — add prompt steering and generic notification
+  equivalents when their contracts are stable enough to preserve native fallback
+  behavior.
 - [ ] **Gemini CLI and GitHub Copilot CLI** — build adapters around their native hook
   systems and reuse the agent-neutral TapQ wire protocol.
 - [ ] **OpenCode and additional agents** — extend support to OpenCode, Windsurf,

--- a/Sources/TapQCodexAdapter/CodexHookInstaller.swift
+++ b/Sources/TapQCodexAdapter/CodexHookInstaller.swift
@@ -95,7 +95,13 @@ public struct CodexHookInstaller {
 
     /// Codex reports unified exec as `Bash` and patch mutations as `apply_patch`.
     static let permissionMatcher = "^(Bash|apply_patch)$"
+    static let requestUserInputMatcher = "^request_user_input$"
     static let specs: [Spec] = [
+        Spec(
+            event: "PreToolUse",
+            matcher: requestUserInputMatcher,
+            timeout: InteractionBudget.hookTimeout
+        ),
         Spec(
             event: "PermissionRequest",
             matcher: permissionMatcher,

--- a/Sources/TapQCodexAdapter/CodexHookShim.swift
+++ b/Sources/TapQCodexAdapter/CodexHookShim.swift
@@ -59,6 +59,8 @@ public struct CodexHookShim {
         ])
 
         switch event {
+        case "PreToolUse":
+            return handlePreToolUse(input, diagnostics: diagnostics, send: send)
         case "PermissionRequest":
             return handlePermissionRequest(input, diagnostics: diagnostics, send: send)
         case "Stop":
@@ -66,6 +68,168 @@ public struct CodexHookShim {
         default:
             return passThrough
         }
+    }
+
+    // MARK: - PreToolUse
+
+    /// The only Codex PreToolUse request currently managed by TapQ is the structured
+    /// `request_user_input` tool. Other tools pass through even if this executable is
+    /// invoked by a user-authored matcher.
+    private static func handlePreToolUse(
+        _ input: [String: JSONValue],
+        diagnostics: TapQDiagnosticEmitter,
+        send: (_ message: [String: JSONValue], _ timeout: TimeInterval) throws -> Data
+    ) -> Result {
+        guard input["tool_name"]?.stringValue == "request_user_input" else {
+            return passThrough
+        }
+        return handleRequestUserInput(input, diagnostics: diagnostics, send: send)
+    }
+
+    /// Codex 0.146 exposes `request_user_input` as a PreToolUse function call. TapQ can
+    /// answer one listed single-choice question. Blocking the tool with model-visible
+    /// feedback prevents Codex's native selector from opening while still delivering the
+    /// selected answer to the model.
+    private static func handleRequestUserInput(
+        _ input: [String: JSONValue],
+        diagnostics: TapQDiagnosticEmitter,
+        send: (_ message: [String: JSONValue], _ timeout: TimeInterval) throws -> Data
+    ) -> Result {
+        guard hasRequiredStringFields(
+            ["session_id", "turn_id", "cwd", "model"],
+            in: input
+        ), hasSupportedPermissionMode(input),
+              isNullableString(input["transcript_path"]),
+              input["agent_id"] == nil,
+              input["agent_type"] == nil,
+              let requestID = nonempty(input["tool_use_id"]?.stringValue),
+              let toolInput = input["tool_input"]?.objectValue,
+              isAbsentOrNull(toolInput["autoResolutionMs"]),
+              let questions = toolInput["questions"]?.arrayValue,
+              questions.count == 1,
+              let question = questions.first?.objectValue,
+              isAbsentOrFalse(question["isSecret"]),
+              let questionID = nonempty(question["id"]?.stringValue),
+              nonempty(question["header"]?.stringValue) != nil,
+              let questionText = nonempty(question["question"]?.stringValue),
+              let optionValues = question["options"]?.arrayValue,
+              (2...3).contains(optionValues.count) else {
+            diagnostics.record("request_user_input.invalid_input", level: .warning)
+            return passThrough
+        }
+
+        var wireOptions: [JSONValue] = []
+        var optionLabels: [String] = []
+        var listedLabels: Set<String> = []
+        for optionValue in optionValues {
+            guard let option = optionValue.objectValue,
+                  let label = nonempty(option["label"]?.stringValue),
+                  let description = option["description"]?.stringValue,
+                  listedLabels.insert(label).inserted else {
+                diagnostics.record("request_user_input.invalid_option", level: .warning)
+                return passThrough
+            }
+            wireOptions.append(.object([
+                "label": .string(label),
+                "description": .string(description),
+            ]))
+            optionLabels.append(label)
+        }
+
+        let message: [String: JSONValue] = [
+            "type": .string(WireType.selection),
+            "agent": agentIdentity,
+            "session_id": .string(input["session_id"]?.stringValue ?? ""),
+            "request_id": .string(requestID),
+            "question": .string(questionText),
+            "options": .array(wireOptions),
+            "multi_select": .bool(false),
+            "protocol_version": .number(Double(WireProtocol.version)),
+        ]
+
+        let reply: Data
+        do {
+            reply = try send(message, approvalTimeout)
+        } catch {
+            diagnostics.record(
+                "request_user_input.send_failed",
+                level: .warning,
+                fields: ["error": "\(error)"]
+            )
+            return passThrough
+        }
+
+        guard let response = try? JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: reply
+        ), response["error"] == nil,
+              let selectedIndices = response["selected_indices"]?.arrayValue,
+              selectedIndices.count == 1,
+              case .number(let selectedIndexNumber) = selectedIndices[0],
+              let selectedIndex = Int(exactly: selectedIndexNumber),
+              optionLabels.indices.contains(selectedIndex),
+              let selectedValues = response["selected_labels"]?.arrayValue,
+              selectedValues.count == 1,
+              let selection = nonempty(selectedValues.first?.stringValue),
+              selection == optionLabels[selectedIndex] else {
+            diagnostics.record("request_user_input.no_selection")
+            return passThrough
+        }
+
+        diagnostics.record(
+            "request_user_input.selected",
+            fields: ["selection": selection]
+        )
+        guard let responseJSON = requestUserInputResponseJSON(
+            questionID: questionID,
+            selection: selection
+        ) else {
+            diagnostics.record("request_user_input.response_encode_failed", level: .warning)
+            return passThrough
+        }
+        let reason =
+            "User answered via TapQ hands-free interface. Treat this request_user_input "
+            + "call as successful with response JSON: \(responseJSON). Do not re-ask this question."
+        return emitPreToolUseDeny(reason)
+    }
+
+    private static func requestUserInputResponseJSON(
+        questionID: String,
+        selection: String
+    ) -> String? {
+        let response = RequestUserInputResponse(
+            answers: [questionID: .init(answers: [selection])]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let encoded = try? encoder.encode(response) else { return nil }
+        return String(data: encoded, encoding: .utf8)
+    }
+
+    private struct RequestUserInputResponse: Encodable {
+        struct Answer: Encodable {
+            let answers: [String]
+        }
+
+        let answers: [String: Answer]
+    }
+
+    private static func emitPreToolUseDeny(_ reason: String) -> Result {
+        let output = PreToolUseOutput(
+            hookSpecificOutput: .init(permissionDecisionReason: reason)
+        )
+        let encoded = (try? JSONEncoder().encode(output)) ?? Data("{}".utf8)
+        return Result(stdout: String(decoding: encoded, as: UTF8.self), exitCode: 0)
+    }
+
+    private struct PreToolUseOutput: Encodable {
+        struct Inner: Encodable {
+            let hookEventName = "PreToolUse"
+            let permissionDecision = "deny"
+            let permissionDecisionReason: String
+        }
+
+        let hookSpecificOutput: Inner
     }
 
     // MARK: - PermissionRequest
@@ -320,5 +484,17 @@ public struct CodexHookShim {
         default:
             return false
         }
+    }
+
+    private static func isAbsentOrNull(_ value: JSONValue?) -> Bool {
+        guard let value else { return true }
+        if case .null = value { return true }
+        return false
+    }
+
+    private static func isAbsentOrFalse(_ value: JSONValue?) -> Bool {
+        guard let value else { return true }
+        if case .bool(false) = value { return true }
+        return false
     }
 }

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -147,16 +147,18 @@ tapq integration codex install
 ```
 
 A configured status does not mean Codex trusts the command. Open an interactive Codex
-session, run `/hooks`, review the TapQ `PermissionRequest` and `Stop` entries, and trust
-their exact current definitions. Codex deliberately skips new or changed non-managed
-hooks until this step is complete. Also confirm that hooks have not been disabled by
-local or managed Codex configuration.
+session, run `/hooks`, review the TapQ `PreToolUse`, `PermissionRequest`, and `Stop`
+entries, and trust their exact current definitions. Codex deliberately skips new or
+changed non-managed hooks until this step is complete. Also confirm that hooks have not
+been disabled by local or managed Codex configuration.
 
-The current adapter handles native `PermissionRequest` prompts for `Bash` and
-`apply_patch` only. Read-only commands, allow rules, permission modes, or sandboxed
-operations that Codex does not prompt for legitimately bypass TapQ. There is no Codex
-strict `PreToolUse` policy, structured `request_user_input` interception, or generic
-notification-hook parity yet. Codex CLI `0.142.5` is the tested contract floor.
+The current adapter handles one root-agent, single-choice `request_user_input` call and
+native `PermissionRequest` prompts for `Bash` and `apply_patch`. Multiple or
+auto-resolving questions, unsupported option shapes, secret questions, subagent calls,
+read-only commands, allow rules, permission modes, and sandboxed operations can
+legitimately bypass TapQ. There is no broad Codex strict `PreToolUse` policy or generic
+notification-hook parity. Codex CLI `0.142.5` is the lifecycle contract floor;
+structured-question coverage is tested against `0.146.0`.
 
 If status is incomplete, run uninstall and install again. TapQ preserves unrelated hook
 groups, but do not edit `hooks.json` while the installer is running.

--- a/Tests/TapQCodexAdapterTests/CodexHookInstallerTests.swift
+++ b/Tests/TapQCodexAdapterTests/CodexHookInstallerTests.swift
@@ -101,10 +101,21 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertEqual(CodexHookInstaller.trustCommand, "/hooks")
     }
 
-    func testInstallCreatesStablePermissionAndStopHooks() throws {
+    func testInstallCreatesStableQuestionPermissionAndStopHooks() throws {
         let report = try installer().install()
         let root = try read()
         let hooks = try XCTUnwrap(root["hooks"]?.objectValue)
+
+        let preToolUse = try XCTUnwrap(hooks["PreToolUse"]?.arrayValue?.first)
+        XCTAssertEqual(preToolUse["matcher"]?.stringValue, "^request_user_input$")
+        let questionHook = try XCTUnwrap(preToolUse["hooks"]?.arrayValue?.first)
+        XCTAssertEqual(questionHook["type"]?.stringValue, "command")
+        XCTAssertEqual(questionHook["command"]?.stringValue, quotedCommand)
+        if case .number(let timeout)? = questionHook["timeout"] {
+            XCTAssertEqual(timeout, InteractionBudget.hookTimeout)
+        } else {
+            XCTFail("PreToolUse timeout is missing")
+        }
 
         let permission = try XCTUnwrap(hooks["PermissionRequest"]?.arrayValue?.first)
         XCTAssertEqual(permission["matcher"]?.stringValue, "^(Bash|apply_patch)$")
@@ -160,6 +171,9 @@ final class CodexHookInstallerTests: XCTestCase {
             "PermissionRequest":[{"matcher":"mcp__custom__.*","hooks":[
               {"type":"command","command":"/usr/bin/custom-approval","timeout":20}
             ]}],
+            "PreToolUse":[{"matcher":"custom_tool","hooks":[
+              {"type":"command","command":"/usr/bin/custom-pre-tool","timeout":20}
+            ]}],
             "Stop":[{"hooks":[
               {"type":"command","command":"/usr/bin/user-stop","timeout":10}
             ]}]
@@ -183,6 +197,11 @@ final class CodexHookInstallerTests: XCTestCase {
         }
         XCTAssertTrue(permissionCommands.contains("/usr/bin/custom-approval"))
         XCTAssertTrue(permissionCommands.contains(quotedCommand))
+        let preToolCommands = (hooks["PreToolUse"]?.arrayValue ?? []).flatMap {
+            ($0["hooks"]?.arrayValue ?? []).compactMap { $0["command"]?.stringValue }
+        }
+        XCTAssertTrue(preToolCommands.contains("/usr/bin/custom-pre-tool"))
+        XCTAssertTrue(preToolCommands.contains(quotedCommand))
         let stopCommands = (hooks["Stop"]?.arrayValue ?? []).flatMap {
             ($0["hooks"]?.arrayValue ?? []).compactMap { $0["command"]?.stringValue }
         }
@@ -202,6 +221,7 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertTrue(try backupURLs().isEmpty)
 
         let hooks = try XCTUnwrap(try read()["hooks"]?.objectValue)
+        XCTAssertEqual(tapQHandlers(event: "PreToolUse", in: hooks).count, 1)
         XCTAssertEqual(tapQHandlers(event: "PermissionRequest", in: hooks).count, 1)
         XCTAssertEqual(tapQHandlers(event: "Stop", in: hooks).count, 1)
     }
@@ -259,6 +279,7 @@ final class CodexHookInstallerTests: XCTestCase {
         try installer().install()
 
         let hooks = try XCTUnwrap(try read()["hooks"]?.objectValue)
+        XCTAssertEqual(tapQHandlers(event: "PreToolUse", in: hooks).count, 1)
         XCTAssertEqual(tapQHandlers(event: "PermissionRequest", in: hooks).count, 1)
         XCTAssertEqual(tapQHandlers(event: "Stop", in: hooks).count, 1)
         let allCommands = hooks.values.flatMap { event in
@@ -283,6 +304,13 @@ final class CodexHookInstallerTests: XCTestCase {
                 {"type":"command","command":"/usr/bin/user-audit","timeout":5}
               ]
             }],
+            "PreToolUse":[{
+              "matcher":"^request_user_input$",
+              "hooks":[
+                {"type":"command","command":"\(quotedCommand)","timeout":120},
+                {"type":"command","command":"/usr/bin/user-question-audit","timeout":5}
+              ]
+            }],
             "Stop":[{"hooks":[
               {"type":"command","command":"\(quotedCommand)","timeout":120}
             ]}],
@@ -300,6 +328,10 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertEqual(root["description"]?.stringValue, "keep me")
         let hooks = try XCTUnwrap(root["hooks"]?.objectValue)
         XCTAssertNil(hooks["Stop"])
+        XCTAssertEqual(
+            hooks["PreToolUse"]?.arrayValue?.first?["hooks"]?.arrayValue?.first?["command"]?.stringValue,
+            "/usr/bin/user-question-audit"
+        )
         XCTAssertEqual(
             hooks["PermissionRequest"]?.arrayValue?.first?["hooks"]?.arrayValue?.first?["command"]?.stringValue,
             "/usr/bin/user-audit"

--- a/Tests/TapQCodexAdapterTests/CodexHookShimTests.swift
+++ b/Tests/TapQCodexAdapterTests/CodexHookShimTests.swift
@@ -32,6 +32,74 @@ final class CodexHookShimTests: XCTestCase {
         try! JSONEncoder().encode(permissionObject(toolName: toolName, toolInput: toolInput))
     }
 
+    private func requestUserOption(
+        label: String,
+        description: String
+    ) -> JSONValue {
+        .object([
+            "label": .string(label),
+            "description": .string(description),
+        ])
+    }
+
+    private func requestUserQuestion(
+        id: String = "deployment_target",
+        header: String = "Deploy",
+        question: String = "Where should this be deployed?",
+        options: [JSONValue]? = nil
+    ) -> JSONValue {
+        .object([
+            "id": .string(id),
+            "header": .string(header),
+            "question": .string(question),
+            "options": .array(options ?? [
+                requestUserOption(
+                    label: "Staging",
+                    description: "Deploy to the staging environment."
+                ),
+                requestUserOption(
+                    label: "Production",
+                    description: "Deploy to the production environment."
+                ),
+            ]),
+        ])
+    }
+
+    private func requestUserInputObject(
+        questions: [JSONValue]? = nil,
+        toolUseID: String? = "tool-use-1"
+    ) -> [String: JSONValue] {
+        let defaultQuestions: [JSONValue] = [
+            requestUserQuestion(),
+        ]
+        var object: [String: JSONValue] = [
+            "hook_event_name": .string("PreToolUse"),
+            "session_id": .string("session-1"),
+            "turn_id": .string("turn-1"),
+            "transcript_path": .null,
+            "cwd": .string("/tmp/project"),
+            "model": .string("gpt-5.6"),
+            "permission_mode": .string("default"),
+            "tool_name": .string("request_user_input"),
+            "tool_input": .object([
+                "questions": .array(questions ?? defaultQuestions),
+            ]),
+        ]
+        if let toolUseID {
+            object["tool_use_id"] = .string(toolUseID)
+        }
+        return object
+    }
+
+    private func requestUserInput(
+        questions: [JSONValue]? = nil,
+        toolUseID: String? = "tool-use-1"
+    ) -> Data {
+        try! JSONEncoder().encode(
+            requestUserInputObject(questions: questions, toolUseID: toolUseID)
+        )
+    }
+
     private func stopObject(
         message: JSONValue = .string("Continue?"),
         active: Bool = false
@@ -68,6 +136,290 @@ final class CodexHookShimTests: XCTestCase {
             decision?["behavior"]?.stringValue ?? "",
             decision?["message"]?.stringValue
         )
+    }
+
+    // MARK: - PreToolUse request_user_input
+
+    func testRequestUserInputForwardsSelectionAndReturnsModelVisibleDeny() throws {
+        var captured: [String: JSONValue]?
+        var capturedTimeout: TimeInterval?
+        let result = CodexHookShim.handle(stdinData: requestUserInput()) { message, timeout in
+            captured = message
+            capturedTimeout = timeout
+            return Data(
+                #"{"selected_indices":[1],"selected_labels":["Production"]}"#.utf8
+            )
+        }
+
+        XCTAssertEqual(result.exitCode, 0)
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: Data(try XCTUnwrap(result.stdout).utf8)
+        )
+        let inner = try XCTUnwrap(output["hookSpecificOutput"]?.objectValue)
+        XCTAssertEqual(Set(inner.keys), [
+            "hookEventName", "permissionDecision", "permissionDecisionReason",
+        ])
+        XCTAssertEqual(inner["hookEventName"]?.stringValue, "PreToolUse")
+        XCTAssertEqual(inner["permissionDecision"]?.stringValue, "deny")
+        let reason = try XCTUnwrap(inner["permissionDecisionReason"]?.stringValue)
+        XCTAssertTrue(
+            reason.contains(
+                #"{"answers":{"deployment_target":{"answers":["Production"]}}}"#
+            )
+        )
+        XCTAssertTrue(reason.contains("Treat this request_user_input call as successful"))
+        XCTAssertTrue(reason.contains("Do not re-ask this question"))
+        XCTAssertNil(output["decision"])
+
+        XCTAssertEqual(captured?["type"]?.stringValue, WireType.selection)
+        XCTAssertEqual(captured?["agent"]?["id"]?.stringValue, "codex")
+        XCTAssertEqual(captured?["agent"]?["display_name"]?.stringValue, "Codex")
+        XCTAssertEqual(captured?["session_id"]?.stringValue, "session-1")
+        XCTAssertEqual(captured?["request_id"]?.stringValue, "tool-use-1")
+        XCTAssertEqual(
+            captured?["question"]?.stringValue,
+            "Where should this be deployed?"
+        )
+        XCTAssertEqual(captured?["multi_select"]?.boolValue, false)
+        XCTAssertEqual(captured?["options"]?.arrayValue?.count, 2)
+        XCTAssertEqual(
+            captured?["options"]?.arrayValue?.first?["label"]?.stringValue,
+            "Staging"
+        )
+        XCTAssertEqual(
+            captured?["options"]?.arrayValue?.last?["description"]?.stringValue,
+            "Deploy to the production environment."
+        )
+        XCTAssertEqual(captured?["protocol_version"]?.intValue, WireProtocol.version)
+        XCTAssertEqual(capturedTimeout, CodexHookShim.approvalTimeout)
+
+        var authenticated = try XCTUnwrap(captured)
+        authenticated["token"] = .string("token")
+        let request = try BrokerRequest(from: JSONEncoder().encode(authenticated))
+        guard case .selection(let selection) = request else {
+            return XCTFail("expected selection request")
+        }
+        XCTAssertEqual(selection.requestID, "tool-use-1")
+        XCTAssertEqual(selection.agent, AgentIdentity(id: "codex", displayName: "Codex"))
+        XCTAssertFalse(selection.multiSelect)
+    }
+
+    func testRequestUserInputAcceptsThreeValidOptionsAndExplicitNonsecret() {
+        var question = requestUserQuestion(options: [
+            requestUserOption(label: "One", description: "First option."),
+            requestUserOption(label: "Two", description: "Second option."),
+            requestUserOption(label: "Three", description: "Third option."),
+        ]).objectValue ?? [:]
+        question["isSecret"] = .bool(false)
+        var optionCount: Int?
+        let result = CodexHookShim.handle(
+            stdinData: requestUserInput(questions: [.object(question)])
+        ) { message, _ in
+            optionCount = message["options"]?.arrayValue?.count
+            return Data(#"{"selected_indices":[2],"selected_labels":["Three"]}"#.utf8)
+        }
+
+        XCTAssertEqual(optionCount, 3)
+        XCTAssertNotNil(result.stdout)
+    }
+
+    func testRequestUserInputResponseJSONSafelyEscapesTheSelectedLabel() throws {
+        let selectedLabel = #"Production "blue""#
+        let question = requestUserQuestion(options: [
+            requestUserOption(label: "Staging", description: "Use staging."),
+            requestUserOption(label: selectedLabel, description: "Use production."),
+        ])
+        let brokerReply = try JSONEncoder().encode([
+            "selected_indices": JSONValue.array([.number(1)]),
+            "selected_labels": .array([.string(selectedLabel)]),
+        ])
+        let result = CodexHookShim.handle(
+            stdinData: requestUserInput(questions: [question])
+        ) { _, _ in
+            brokerReply
+        }
+
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: Data(try XCTUnwrap(result.stdout).utf8)
+        )
+        let reason = try XCTUnwrap(
+            output["hookSpecificOutput"]?["permissionDecisionReason"]?.stringValue
+        )
+        let prefix = try XCTUnwrap(reason.range(of: "response JSON: "))
+        let suffix = try XCTUnwrap(
+            reason.range(
+                of: ". Do not re-ask",
+                range: prefix.upperBound..<reason.endIndex
+            )
+        )
+        let responseJSON = String(reason[prefix.upperBound..<suffix.lowerBound])
+        let response = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: Data(responseJSON.utf8)
+        )
+        XCTAssertEqual(
+            response["answers"]?["deployment_target"]?["answers"]?
+                .arrayValue?.first?.stringValue,
+            selectedLabel
+        )
+    }
+
+    func testRequestUserInputRequiresNonblankToolUseID() {
+        for toolUseID in [nil, "   "] as [String?] {
+            var called = false
+            let result = CodexHookShim.handle(
+                stdinData: requestUserInput(toolUseID: toolUseID)
+            ) { _, _ in
+                called = true
+                return Data()
+            }
+            XCTAssertFalse(called)
+            XCTAssertEqual(result, CodexHookShim.passThrough)
+        }
+    }
+
+    func testRequestUserInputWithAutoResolutionPassesThrough() {
+        for milliseconds in [60_000, 240_000] {
+            var object = requestUserInputObject()
+            var toolInput = object["tool_input"]?.objectValue ?? [:]
+            toolInput["autoResolutionMs"] = .number(Double(milliseconds))
+            object["tool_input"] = .object(toolInput)
+
+            var called = false
+            let result = CodexHookShim.handle(
+                stdinData: try! JSONEncoder().encode(object)
+            ) { _, _ in
+                called = true
+                return Data()
+            }
+            XCTAssertFalse(called)
+            XCTAssertEqual(result, CodexHookShim.passThrough)
+        }
+    }
+
+    func testRequestUserInputFromSubagentPassesThrough() {
+        for field in ["agent_id", "agent_type"] {
+            var object = requestUserInputObject()
+            object[field] = .string(field == "agent_id" ? "agent-1" : "worker")
+
+            var called = false
+            let result = CodexHookShim.handle(
+                stdinData: try! JSONEncoder().encode(object)
+            ) { _, _ in
+                called = true
+                return Data()
+            }
+            XCTAssertFalse(called)
+            XCTAssertEqual(result, CodexHookShim.passThrough)
+        }
+    }
+
+    func testSecretRequestUserInputPassesThroughWithoutReachingTapQ() {
+        var question = requestUserQuestion().objectValue ?? [:]
+        question["isSecret"] = .bool(true)
+
+        var called = false
+        let result = CodexHookShim.handle(
+            stdinData: requestUserInput(questions: [.object(question)])
+        ) { _, _ in
+            called = true
+            return Data()
+        }
+
+        XCTAssertFalse(called)
+        XCTAssertEqual(result, CodexHookShim.passThrough)
+    }
+
+    func testRequestUserInputMalformedAndMultipleQuestionsFailThrough() {
+        let validQuestion = requestUserQuestion()
+        let validOptions = [
+            requestUserOption(label: "One", description: "First option."),
+            requestUserOption(label: "Two", description: "Second option."),
+        ]
+        let malformedOption: JSONValue = .object([
+            "label": .string("Missing description"),
+        ])
+        let duplicateOptions = [
+            requestUserOption(label: "Same", description: "First duplicate."),
+            requestUserOption(label: "Same", description: "Second duplicate."),
+        ]
+        let blankLabelOptions = [
+            requestUserOption(label: "   ", description: "Blank label."),
+            validOptions[1],
+        ]
+        let fourOptions = validOptions + [
+            requestUserOption(label: "Three", description: "Third option."),
+            requestUserOption(label: "Four", description: "Fourth option."),
+        ]
+
+        var invalid = [
+            requestUserInputObject(questions: []),
+            requestUserInputObject(questions: [validQuestion, validQuestion]),
+            requestUserInputObject(questions: [
+                requestUserQuestion(options: []),
+            ]),
+            requestUserInputObject(questions: [
+                requestUserQuestion(options: [validOptions[0]]),
+            ]),
+            requestUserInputObject(questions: [
+                requestUserQuestion(options: fourOptions),
+            ]),
+            requestUserInputObject(questions: [
+                requestUserQuestion(options: [malformedOption, validOptions[1]]),
+            ]),
+            requestUserInputObject(questions: [
+                requestUserQuestion(options: duplicateOptions),
+            ]),
+            requestUserInputObject(questions: [
+                requestUserQuestion(options: blankLabelOptions),
+            ]),
+        ]
+        var missingSession = requestUserInputObject()
+        missingSession.removeValue(forKey: "session_id")
+        invalid.append(missingSession)
+        var otherTool = requestUserInputObject()
+        otherTool["tool_name"] = .string("exec")
+        invalid.append(otherTool)
+
+        for object in invalid {
+            var called = false
+            let result = CodexHookShim.handle(
+                stdinData: try! JSONEncoder().encode(object)
+            ) { _, _ in
+                called = true
+                return Data()
+            }
+            XCTAssertFalse(called)
+            XCTAssertEqual(result, CodexHookShim.passThrough)
+        }
+    }
+
+    func testRequestUserInputUnansweredAndInvalidRepliesFailThrough() {
+        for reply in [
+            #"{"error":"timeout"}"#,
+            #"{"selected_indices":[],"selected_labels":[]}"#,
+            #"{"selected_labels":["Staging"]}"#,
+            #"{"selected_indices":[0]}"#,
+            #"{"selected_indices":[0,1],"selected_labels":["Staging","Production"]}"#,
+            #"{"selected_indices":[0],"selected_labels":["Staging","Production"]}"#,
+            #"{"selected_indices":[2],"selected_labels":["Production"]}"#,
+            #"{"selected_indices":[0.5],"selected_labels":["Staging"]}"#,
+            #"{"selected_indices":[1],"selected_labels":["Staging"]}"#,
+            #"{"selected_indices":[0],"selected_labels":["Unknown"]}"#,
+            #"not json"#,
+        ] {
+            let result = CodexHookShim.handle(stdinData: requestUserInput()) { _, _ in
+                Data(reply.utf8)
+            }
+            XCTAssertEqual(result, CodexHookShim.passThrough)
+        }
+
+        let unavailable = CodexHookShim.handle(stdinData: requestUserInput()) { _, _ in
+            throw StubError.unreachable
+        }
+        XCTAssertEqual(unavailable, CodexHookShim.passThrough)
     }
 
     // MARK: - PermissionRequest
@@ -436,7 +788,7 @@ final class CodexHookShimTests: XCTestCase {
     // MARK: - Generic fail-open behavior
 
     func testUnknownEventAndMalformedStdinDoNothing() {
-        for stdin in [input(#"{"hook_event_name":"PreToolUse"}"#), input("not json")] {
+        for stdin in [input(#"{"hook_event_name":"PostToolUse"}"#), input("not json")] {
             var called = false
             let result = CodexHookShim.handle(stdinData: stdin) { _, _ in
                 called = true

--- a/Tests/TapQCodexProcessTests/CodexHookProcessContractTests.swift
+++ b/Tests/TapQCodexProcessTests/CodexHookProcessContractTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import TapQBrokerRuntime
+import TapQContracts
+import TapQWireProtocol
+import XCTest
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+@MainActor
+final class CodexHookProcessContractTests: XCTestCase {
+    func testCodex01460RequestUserInputReachesBrokerAndBlocksWithSelection() async throws {
+        let hookExecutable = try hookExecutableURL()
+        let testRoot = URL(
+            fileURLWithPath: "/tmp/tapq-codex-contract-\(UUID().uuidString.prefix(12))",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: testRoot,
+            withIntermediateDirectories: true
+        )
+
+        let discovery = BrokerRuntimeDiscovery(supportDirectory: testRoot)
+        try discovery.prepareDirectory()
+        let token = BrokerRuntimeDiscovery.generateToken()
+        let transport = UnixSocketTransport(path: discovery.socketPath)
+        let recorder = SelectionRecorder()
+        let server = BrokerServer(
+            transport: transport,
+            token: token,
+            onApproval: { _ in .ask },
+            onNotification: { _ in },
+            onSelection: { request in
+                recorder.requests.append(request)
+                return SelectionResult(choices: [
+                    .init(index: 1, label: request.options[1].label),
+                ])
+            }
+        )
+        try server.start()
+        try discovery.publish(token: token)
+        defer {
+            server.stop()
+            discovery.remove()
+            try? FileManager.default.removeItem(at: testRoot)
+        }
+
+        let fixtureURL = try XCTUnwrap(Bundle.module.url(
+            forResource: "pre-tool-use-request-user-input-single-choice",
+            withExtension: "json",
+            subdirectory: "Fixtures/codex-cli-0.146.0"
+        ))
+        let fixture = try Data(contentsOf: fixtureURL)
+        let fixtureObject = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: fixture
+        )
+        XCTAssertEqual(
+            Set(fixtureObject.keys),
+            [
+                "session_id", "turn_id", "transcript_path", "cwd",
+                "hook_event_name", "model", "permission_mode", "tool_name",
+                "tool_input", "tool_use_id",
+            ],
+            "the versioned root fixture must preserve the exact Codex 0.146 envelope"
+        )
+        XCTAssertNil(fixtureObject["agent_id"])
+        XCTAssertNil(fixtureObject["agent_type"])
+        XCTAssertNil(fixtureObject["request_id"])
+
+        let process = Process()
+        process.executableURL = hookExecutable
+        process.currentDirectoryURL = testRoot
+        var environment = ProcessInfo.processInfo.environment
+        environment["TAPQ_BROKER_DIR"] = testRoot.path
+        process.environment = environment
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        try stdin.fileHandleForWriting.write(contentsOf: fixture)
+        try stdin.fileHandleForWriting.close()
+
+        let exited = await waitUntilExit(process, timeout: 5)
+        if !exited {
+            process.terminate()
+            let terminated = await waitUntilExit(process, timeout: 1)
+            if !terminated {
+                forceTerminate(process)
+                _ = await waitUntilExit(process, timeout: 1)
+            }
+            return XCTFail("tapq-codex-hook did not exit within the process-contract deadline")
+        }
+
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertTrue(
+            stderrData.isEmpty,
+            "unexpected hook stderr: \(String(decoding: stderrData, as: UTF8.self))"
+        )
+
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: stdoutData
+        )
+        let hookOutput = try XCTUnwrap(output["hookSpecificOutput"]?.objectValue)
+        XCTAssertEqual(Set(output.keys), ["hookSpecificOutput"])
+        XCTAssertEqual(
+            Set(hookOutput.keys),
+            ["hookEventName", "permissionDecision", "permissionDecisionReason"]
+        )
+        XCTAssertEqual(hookOutput["hookEventName"]?.stringValue, "PreToolUse")
+        XCTAssertEqual(hookOutput["permissionDecision"]?.stringValue, "deny")
+        XCTAssertEqual(
+            hookOutput["permissionDecisionReason"]?.stringValue,
+            "User answered via TapQ hands-free interface. Treat this request_user_input "
+                + "call as successful with response JSON: "
+                + #"{"answers":{"choice":{"answers":["BETA"]}}}"#
+                + ". Do not re-ask this question."
+        )
+
+        let request = try XCTUnwrap(recorder.requests.only)
+        XCTAssertEqual(request.sessionID, "019fb3cc-0000-7000-8000-000000000001")
+        XCTAssertEqual(request.id, "call_fixture_request_user_input_001")
+        XCTAssertEqual(request.agent, .codex)
+        XCTAssertEqual(request.question, "Choose a value.")
+        XCTAssertEqual(
+            request.options,
+            [
+                .init(label: "ALPHA", description: "First choice"),
+                .init(label: "BETA", description: "Second choice"),
+                .init(label: "GAMMA", description: "Third choice"),
+            ]
+        )
+        XCTAssertFalse(request.multiSelect)
+    }
+
+    private func hookExecutableURL() throws -> URL {
+        if let override = ProcessInfo.processInfo.environment[
+            "TAPQ_CODEX_HOOK_EXECUTABLE"
+        ], !override.isEmpty {
+            let url = URL(fileURLWithPath: override)
+            guard FileManager.default.isExecutableFile(atPath: url.path) else {
+                throw ContractTestError.hookIsNotExecutable(url.path)
+            }
+            return url
+        }
+
+        let testBundleURL = Bundle(for: Self.self).bundleURL
+        let productsDirectory = testBundleURL.pathExtension == "xctest"
+            ? testBundleURL.deletingLastPathComponent()
+            : testBundleURL
+        let candidate = productsDirectory.appendingPathComponent("tapq-codex-hook")
+        guard FileManager.default.isExecutableFile(atPath: candidate.path) else {
+            throw XCTSkip(
+                "tapq-codex-hook is not colocated with the test bundle; "
+                    + "set TAPQ_CODEX_HOOK_EXECUTABLE to run this process contract"
+            )
+        }
+        return candidate
+    }
+
+    private func waitUntilExit(_ process: Process, timeout: TimeInterval) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning {
+            guard Date() < deadline else { return false }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return true
+    }
+
+    private func forceTerminate(_ process: Process) {
+        guard process.isRunning else { return }
+        #if canImport(Darwin)
+        _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        #elseif canImport(Glibc)
+        _ = Glibc.kill(process.processIdentifier, SIGKILL)
+        #endif
+    }
+}
+
+@MainActor
+private final class SelectionRecorder {
+    var requests: [SelectionRequest] = []
+}
+
+private enum ContractTestError: Error {
+    case hookIsNotExecutable(String)
+}
+
+private extension Array {
+    var only: Element? {
+        count == 1 ? first : nil
+    }
+}

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/README.md
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/README.md
@@ -1,0 +1,16 @@
+# Codex CLI 0.146.0 hook fixture
+
+`pre-tool-use-request-user-input-single-choice.json` is a sanitized capture of
+the complete `PreToolUse` stdin emitted by Codex CLI `0.146.0` for a root
+`request_user_input` call. Only session/turn/tool identifiers and local paths
+were replaced with stable test values; all keys, nesting, and other values are
+preserved.
+
+The capture was also checked against the exact `rust-v0.146.0` serializer and
+generated schema:
+
+- `codex-rs/hooks/src/events/pre_tool_use.rs`
+- `codex-rs/hooks/schema/generated/pre-tool-use.command.input.schema.json`
+
+Keep fixtures versioned by Codex CLI release. A contract change should add a new
+version directory instead of silently rewriting this fixture.

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/pre-tool-use-request-user-input-single-choice.json
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/pre-tool-use-request-user-input-single-choice.json
@@ -1,0 +1,34 @@
+{
+  "session_id": "019fb3cc-0000-7000-8000-000000000001",
+  "turn_id": "019fb3cc-0000-7000-8000-000000000002",
+  "transcript_path": "/tmp/codex-session.jsonl",
+  "cwd": "/tmp/tapq-codex-fixture-workspace",
+  "hook_event_name": "PreToolUse",
+  "model": "gpt-5.6-luna",
+  "permission_mode": "bypassPermissions",
+  "tool_name": "request_user_input",
+  "tool_input": {
+    "questions": [
+      {
+        "header": "Test",
+        "id": "choice",
+        "question": "Choose a value.",
+        "options": [
+          {
+            "label": "ALPHA",
+            "description": "First choice"
+          },
+          {
+            "label": "BETA",
+            "description": "Second choice"
+          },
+          {
+            "label": "GAMMA",
+            "description": "Third choice"
+          }
+        ]
+      }
+    ]
+  },
+  "tool_use_id": "call_fixture_request_user_input_001"
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -488,19 +488,28 @@ can pass `--hooks PATH`.
 
 Installation is not activation. Codex requires users to review and trust the exact
 definition of every non-managed command hook. After installation, open an interactive
-Codex session, run `/hooks`, inspect both TapQ entries, and trust their current
+Codex session, run `/hooks`, inspect all three TapQ entries, and trust their current
 definitions. Changed definitions receive a new hash and must be reviewed again. The
 `status` command validates only TapQ’s file layout; it cannot read or change Codex’s
 trust decision.
 
-### Stable Codex event slice
+### Supported Codex event slice
 
-TapQ installs two lifecycle hooks:
+TapQ installs three lifecycle hooks:
 
 | Event | Matcher | Current behavior |
 |---|---|---|
+| `PreToolUse` | `request_user_input` | Answers one supported root-agent single-choice question before Codex opens its native selector |
 | `PermissionRequest` | `Bash`, `apply_patch` | Answers only native approval prompts Codex was already going to show |
 | `Stop` | All root turns | Sends completion and optionally routes an explicit final-response question |
+
+For `request_user_input`, TapQ supports exactly one question with two or three valid,
+uniquely labelled options. A hands-free selection is delivered to the model through
+Codex’s documented `PreToolUse` deny feedback, so the native selector does not also
+open. Multiple questions, auto-resolving questions, unsupported option shapes,
+secret questions, subagent calls, unanswered interactions, broker failures, and missing
+runtimes emit no hook output; Codex then retains its native behavior, including its
+free-form `Other` choice.
 
 For `PermissionRequest`, an allow or deny becomes Codex’s documented event-specific
 decision. A broker timeout, `.ask`, invalid reply, incompatible wire version, or missing
@@ -522,14 +531,15 @@ output falls through to the deterministic local heuristic and then Codex's norma
 Because provider selection is runtime-wide, any Claude Code adapter connected to the
 same instance also uses Luna in this mode.
 
-The Codex adapter currently has no strict `PreToolUse` mode, no structured
-`request_user_input` interception, no `UserPromptSubmit` steering, and no generic
-notification-hook equivalent. Completion notification is derived from `Stop`; these
-limitations are intentional rather than installation errors.
+The Codex adapter has no broad strict `PreToolUse` mode, `UserPromptSubmit` steering, or
+generic notification-hook equivalent. Completion notification is derived from `Stop`;
+these limitations are intentional rather than installation errors.
 
-Codex CLI `0.142.5` is TapQ’s tested contract floor for this stable lifecycle-hook slice.
-Older Codex hook contracts are unsupported. This adapter targets local Codex clients
-that load user lifecycle hooks; it does not attach to hosted Codex Cloud tasks.
+Codex CLI `0.142.5` is TapQ’s tested lifecycle-hook contract floor. Structured
+`request_user_input` uses a versioned Codex CLI `0.146.0` fixture and a real
+hook-executable-to-broker test. Older hook contracts are unsupported. This adapter
+targets local Codex clients that load user lifecycle hooks; it does not attach to hosted
+Codex Cloud tasks.
 
 ## Environment variables and local data
 

--- a/docs/CODEX_ADAPTER_MANUAL_TEST_PLAN.md
+++ b/docs/CODEX_ADAPTER_MANUAL_TEST_PLAN.md
@@ -6,18 +6,21 @@ Use this plan to validate the TapQ Codex adapter as one tester on one Mac. It co
 
 - Codex hook installation, status, repair, idempotence, backup, and removal.
 - Codex hook review and trust.
+- Root-agent `request_user_input` handling for one single-choice question.
 - Native `PermissionRequest` handling for `Bash` and `apply_patch`.
 - `Stop` completion announcements and final-response question continuation.
 - Fail-open behavior when TapQ is unavailable.
 - Preservation of unrelated Codex hook configuration.
 
-The release contract tested by this plan is the local Codex CLI lifecycle-hook contract
-from Codex CLI `0.142.5`. Hosted Codex Cloud tasks are out of scope.
+The lifecycle-hook floor tested by this plan is Codex CLI `0.142.5`. Structured
+`request_user_input` coverage uses the Codex CLI `0.146.0` contract. Hosted Codex Cloud
+tasks are out of scope.
 
 ## Supported and unsupported behavior
 
 | Area | Expected adapter behavior |
 |---|---|
+| Root `request_user_input` with one question and two or three options | TapQ may return one listed choice before Codex opens its native selector. |
 | `PermissionRequest` for `Bash` | TapQ may answer allow or deny when Codex was already going to prompt. |
 | `PermissionRequest` for `apply_patch` | TapQ may answer allow or deny when Codex was already going to prompt. |
 | `Stop` without a supported question | Announce `Codex finished.` and let the turn finish normally. |
@@ -25,9 +28,10 @@ from Codex CLI `0.142.5`. Hosted Codex Cloud tasks are out of scope.
 | Missing runtime, timeout, invalid reply, or unsupported input | Emit no decision and leave Codex's native flow in control. |
 | Other tools or operations that Codex does not prompt for | Do not intercept. |
 
-Strict `PreToolUse`, structured `request_user_input`, `UserPromptSubmit`, generic
-notification hooks, and hosted Cloud tasks are intentionally unsupported. Do not file a
-defect merely because one of those paths stays in Codex's normal interface.
+Multiple or auto-resolving questions, unsupported option shapes, and subagent
+`request_user_input` calls intentionally stay in Codex’s native flow. Broad strict
+`PreToolUse`, `UserPromptSubmit`, generic notification hooks, and hosted Cloud tasks are
+unsupported.
 
 ## Test environment
 
@@ -35,7 +39,8 @@ defect merely because one of those paths stays in Codex's normal interface.
 
 - macOS 14 or newer.
 - Swift 6 and a compatible Xcode toolchain.
-- Local Codex CLI `0.142.5` or a version being evaluated against that contract.
+- Local Codex CLI `0.146.0` for the complete plan. Version `0.142.5` remains the
+  lifecycle-only compatibility floor.
 - A working Codex login.
 - Two terminals: one for TapQ and one for Codex.
 - For full hands-free coverage, connected in-ear AirPods, completed TapQ calibration,
@@ -121,7 +126,7 @@ test -x "$CODEX_ADAPTER_HOOK" && echo "hook executable: yes"
 
 Expected:
 
-- Codex reports `0.142.5`, or the newer version under compatibility evaluation.
+- Codex reports `0.146.0`, or the newer version under compatibility evaluation.
 - TapQ prints valid version JSON.
 - The hook is executable.
 - No command crashes.
@@ -153,6 +158,7 @@ Expected:
 - Install output says `Permission policy: native Codex prompts` and tells the tester to
   review the definitions with `/hooks`.
 - The JSON has exactly one TapQ group for each of these events:
+  - `PreToolUse`, matcher `^request_user_input$`.
   - `PermissionRequest`, matcher `^(Bash|apply_patch)$`.
   - `Stop`, with no matcher.
 - Each handler is a command pointing to the quoted absolute hook path, with timeout `260`.
@@ -208,7 +214,7 @@ Expected:
 
 - Top-level `marker: keep-me` remains.
 - The unrelated `SessionStart` group and `/usr/bin/true` handler remain unchanged.
-- The two TapQ groups are added.
+- The three TapQ groups are added.
 - The active hooks file and new backup both have mode `600`.
 - The newest backup contains the exact pre-install JSON.
 
@@ -224,7 +230,7 @@ Steps:
 Expected:
 
 - Status first reports `incomplete`.
-- Reinstall restores one current `PermissionRequest` group and one current `Stop` group.
+- Reinstall restores one current `PreToolUse`, `PermissionRequest`, and `Stop` group.
 - Unrelated JSON remains intact.
 - The changed definition requires review in `/hooks`.
 
@@ -248,7 +254,7 @@ Expected:
 
 - Status is `not installed`.
 - The `marker` and unrelated `SessionStart` hook still exist.
-- No TapQ hook remains in `PermissionRequest` or `Stop`.
+- No TapQ hook remains in `PreToolUse`, `PermissionRequest`, or `Stop`.
 - The CLI tells the tester to confirm removal in Codex.
 
 ## Phase 2: install and trust in the active Codex client
@@ -271,16 +277,16 @@ Steps:
 
 3. Start an interactive local Codex session.
 4. Run `/hooks`.
-5. Inspect both TapQ entries before trusting them. Confirm the command is exactly the
+5. Inspect all three TapQ entries before trusting them. Confirm the command is exactly the
    current absolute `tapq-codex-hook` path and that the events/matcher match CX-002.
-6. Trust both current definitions.
+6. Trust all three current definitions.
 7. Run `/hooks` again.
 
 Expected:
 
 - CLI status is `configured`, but does not claim to know the trust state.
 - Before approval, Codex shows the TapQ definitions as needing review or untrusted.
-- After approval, Codex shows both exact definitions as trusted.
+- After approval, Codex shows all three exact definitions as trusted.
 - No unrelated hook trust or hook definition changes.
 
 Record the active hooks-file backup name before continuing. If the checkout or runtime
@@ -397,7 +403,57 @@ Expected:
 - A later `Codex finished.` announcement from `Stop` is allowed and must not be mistaken
   for an approval interaction.
 
-## Phase 5: Stop lifecycle behavior
+## Phase 5: structured tool questions
+
+Codex CLI `0.146.0` exposes `request_user_input` in default mode behind a feature flag.
+For these cases, start a fresh session with:
+
+```bash
+codex -C "$CODEX_ADAPTER_WORKSPACE" \
+  --enable default_mode_request_user_input \
+  --sandbox read-only \
+  --ask-for-approval never \
+  --no-alt-screen
+```
+
+### CX-013 — Select a `request_user_input` option through TapQ — P0
+
+Prompt Codex:
+
+> Call `request_user_input` exactly once with one question. Use header `Marker`, id
+> `marker`, and question `Which marker should I print?`. Offer `ALPHA`, `BETA`, and
+> `GAMMA`, each with a short description. After receiving the answer, print exactly
+> `SELECTED: <answer>` and do not ask again.
+
+Select `BETA` hands-free by saying `two`, or navigate to it and confirm.
+
+Expected:
+
+- TapQ presents the three listed alternatives.
+- Runtime debug output records `Selection.selection.resolved`.
+- Codex’s native selector does not also open.
+- Codex treats the hook feedback as the successful tool response and prints
+  `SELECTED: BETA` without re-asking.
+
+### CX-014 — Deferring `request_user_input` returns to Codex’s native selector — P0
+
+Repeat CX-013 in a fresh session. Say `skip`, `later`, or `not sure` instead of selecting
+an option.
+
+Expected:
+
+- TapQ emits no hook decision.
+- Codex opens its native selector with the three listed alternatives and its free-form
+  `Other` choice.
+- Choosing `BETA` on screen completes the tool normally and produces `SELECTED: BETA`.
+- There is no hook error, denial, or duplicate selector.
+
+Multiple questions, fewer than two or more than three options, duplicate or malformed
+labels, secret questions, `autoResolutionMs`, and calls carrying subagent fields are automated
+fail-through cases. They do not need to be forced through the live model for this manual
+release gate.
+
+## Phase 6: Stop lifecycle behavior
 
 For these cases, start Codex with no approval prompts and instruct it not to call tools:
 
@@ -408,7 +464,7 @@ codex -C "$CODEX_ADAPTER_WORKSPACE" \
   --no-alt-screen
 ```
 
-### CX-013 — Completion notification without a question — P0
+### CX-015 — Completion notification without a question — P0
 
 Prompt Codex:
 
@@ -421,7 +477,7 @@ Expected:
 - Debug output includes `notification.received` with agent `codex` and event `stop`.
 - There is no question or approval interaction.
 
-### CX-014 — Structured final question continues exactly once — P0
+### CX-016 — Structured final question continues exactly once — P0
 
 Prompt Codex:
 
@@ -442,9 +498,9 @@ Expected:
 - The question is not presented a second time when `stop_hook_active` is true.
 - The continued turn finishes and produces one final completion notification.
 
-### CX-015 — Deferring a final question leaves it on screen — P0
+### CX-017 — Deferring a final question leaves it on screen — P0
 
-Repeat CX-014 in a fresh session. Say `skip`, `later`, or `not sure` instead of selecting
+Repeat CX-016 in a fresh session. Say `skip`, `later`, or `not sure` instead of selecting
 an option.
 
 Expected:
@@ -454,7 +510,7 @@ Expected:
 - The original question remains in Codex's normal interface.
 - The turn completes without hanging.
 
-### CX-016 — Open-ended question is not intercepted — P1
+### CX-018 — Open-ended question is not intercepted — P1
 
 Prompt Codex:
 
@@ -466,7 +522,7 @@ Expected:
 - The question remains on screen.
 - The turn completes normally and may produce the ordinary completion announcement.
 
-### CX-017 — Optional yes/no classifier coverage — P2
+### CX-019 — Optional yes/no classifier coverage — P2
 
 This is not a portable release gate because yes/no classification depends on an available
 local Foundation Model or an explicitly configured classifier. Do not enable a paid cloud
@@ -484,9 +540,9 @@ Expected when a yes/no classifier is available:
 Expected when none is available: the question stays on screen and Codex completes
 normally; record the case as `Not applicable`, not failed.
 
-## Phase 6: fail-open and trust boundaries
+## Phase 7: fail-open and trust boundaries
 
-### CX-018 — Runtime absent falls back to the native Codex prompt — P0
+### CX-020 — Runtime absent falls back to the native Codex approval prompt — P0
 
 1. Stop TapQ with Control-C and confirm the runtime process has exited.
 2. Start a fresh Codex session with the permission settings from Phase 4.
@@ -504,7 +560,18 @@ Expected:
 - After the native one-time approval, `native-fallback.txt` contains
   `native-fallback`.
 
-### CX-019 — Runtime absent does not block Stop — P0
+### CX-021 — Runtime absent leaves `request_user_input` native — P0
+
+With TapQ still stopped, start Codex with the structured-question settings from Phase 5
+and repeat the CX-013 prompt.
+
+Expected:
+
+- The hook fails through without a denial, error, or long hang.
+- Codex’s native selector opens and remains usable.
+- Selecting `BETA` on screen produces `SELECTED: BETA`.
+
+### CX-022 — Runtime absent does not block Stop — P0
 
 With TapQ still stopped, ask Codex to reply with a short statement and no tools.
 
@@ -514,7 +581,7 @@ Expected:
 - There is no long wait, hook error, or duplicate final response.
 - No TapQ announcement occurs because the runtime is absent.
 
-### CX-020 — Untrusted definitions are not treated as active — P1
+### CX-023 — Untrusted definitions are not treated as active — P1
 
 Run this only when changing trust state is acceptable.
 
@@ -532,8 +599,8 @@ Expected:
 
 ## Input-modality extension
 
-After all P0 adapter cases pass with one reliable modality, repeat CX-008, CX-009, and
-CX-014 with every modality claimed for the release:
+After all P0 adapter cases pass with one reliable modality, repeat CX-008, CX-009,
+CX-013, and CX-016 with every modality claimed for the release:
 
 | Intent | Motion or hardware | Voice example | Result |
 |---|---|---|---|
@@ -557,8 +624,8 @@ output says voice is unavailable while the chosen AirPods input still resolves t
    "$CODEX_ADAPTER_TAPQ" integration codex status
    ```
 
-3. Open Codex, run `/hooks`, and verify that neither TapQ entry remains while unrelated
-   hooks remain.
+3. Open Codex, run `/hooks`, and verify that none of the three TapQ entries remain while
+   unrelated hooks remain.
 4. Keep the disposable directory until evidence and defects are filed. When it is no
    longer needed, reveal it in Finder and move that exact directory to Trash:
 
@@ -575,6 +642,8 @@ The adapter is ready for the tested environment when:
 
 - All P0 cases pass.
 - No unrelated hook data or trust entry is lost.
+- A supported `request_user_input` choice reaches Codex exactly once, while deferral or
+  runtime absence leaves the native selector usable.
 - `Bash` and `apply_patch` each honor both allow and deny.
 - Supported final questions continue exactly once and never loop.
 - Runtime absence leaves Codex's native permission and final-response flow usable.


### PR DESCRIPTION
## Summary

- install an exact `PreToolUse` hook for root-agent `request_user_input` calls
- route supported one-question, 2–3 option selections through the existing TapQ broker and return Codex-compatible response feedback
- preserve native fallback for malformed, multi-question, auto-resolving, secret, subagent, unanswered, and broker-failure cases
- add a sanitized Codex CLI 0.146.0 fixture and a real hook executable → discovery → Unix socket → broker process contract test on macOS and Linux CI
- update integration, troubleshooting, and manual-test documentation

## Scope

Broad strict `PreToolUse` mode is intentionally not included. The matcher targets only `request_user_input`.

## Validation

- [x] 47 Codex-focused tests
- [x] 771 full-suite tests
- [x] release build
- [x] release-executable process contract test
- [x] public and portability boundary check
- [x] runtime app packaging and signature verification
- [x] `git diff --check`