### PR TITLE
Add native MCP approvals to Codex adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
+### Added
+
+- Codex native `PermissionRequest` coverage for canonical MCP connector tools. TapQ
+  forwards the original tool name and arguments to its local broker while spoken
+  summaries identify only the humanized server and operation, never arbitrary argument
+  values. Existing Codex permission rules and native fail-through behavior remain
+  authoritative. Existing users must rerun `tapq integration codex install`, then review
+  and trust the changed hook definition with `/hooks`.
+
 ### Changed
 
 - The default voice now prefers a downloaded high-quality Samantha. The generic English

--- a/README.md
+++ b/README.md
@@ -286,8 +286,11 @@ The current supported slice is deliberately narrow:
 - `PreToolUse` handles root-agent `request_user_input` calls containing one
   single-select question with two or three listed options. A TapQ selection is returned
   to the model without opening Codex’s selector.
-- `PermissionRequest` handles native approval prompts for `Bash` and `apply_patch` only.
-  Commands and patches that Codex does not prompt for never reach TapQ.
+- `PermissionRequest` handles native approval prompts for `Bash`, `apply_patch`, and
+  canonical `mcp__<server>__<tool>` connector calls. Operations that Codex does not
+  prompt for never reach TapQ. MCP speech identifies the server and operation without
+  reading argument values; the original arguments remain in the local broker request
+  context and are not spoken.
 - `Stop` reports completion and can route an explicit final-response question using
   Codex’s stable `last_assistant_message` field. It does not parse Codex transcripts.
 - Broker absence, timeout, an incompatible wire version, invalid data, or no hands-free
@@ -297,10 +300,11 @@ The current supported slice is deliberately narrow:
 - There is no broad Codex strict `PreToolUse` policy, `UserPromptSubmit` steering, or
   generic notification-hook parity.
 
-TapQ’s lifecycle-hook contract floor is Codex CLI `0.142.5`. The versioned
-`request_user_input` hook fixture and executable-to-broker test target Codex CLI
-`0.146.0`. The adapter targets local Codex clients that load user lifecycle hooks;
-hosted Codex Cloud tasks are outside this integration surface.
+TapQ’s lifecycle-hook contract floor is Codex CLI `0.142.5`. Versioned
+`request_user_input` and MCP `PermissionRequest` fixtures plus real
+executable-to-broker tests target Codex CLI `0.146.0`. The adapter targets local Codex
+clients that load user lifecycle hooks; hosted Codex Cloud tasks are outside this
+integration surface.
 
 ## Questions in final responses
 
@@ -384,8 +388,8 @@ exposed by each platform and manufacturer.
 - [x] **Claude Code** — approvals, denials, option selection, notifications, and
   questions in final responses.
 - [x] **Codex supported slice** — structured single-choice `request_user_input`,
-  native `PermissionRequest` approvals for `Bash` and `apply_patch`, plus `Stop`
-  completion and final-response questions with fail-through.
+  native `PermissionRequest` approvals for `Bash`, `apply_patch`, and MCP connector
+  tools, plus `Stop` completion and final-response questions with fail-through.
 - [ ] **Cursor — next agent priority** — identify the most stable integration surface
   for permission requests, questions, and completion events, then connect it to the
   existing TapQ broker with native fail-through behavior.

--- a/Sources/TapQCodexAdapter/CodexHookInstaller.swift
+++ b/Sources/TapQCodexAdapter/CodexHookInstaller.swift
@@ -93,8 +93,9 @@ public struct CodexHookInstaller {
         let timeout: Double
     }
 
-    /// Codex reports unified exec as `Bash` and patch mutations as `apply_patch`.
-    static let permissionMatcher = "^(Bash|apply_patch)$"
+    /// Codex reports unified exec as `Bash`, patch mutations as `apply_patch`, and
+    /// connector calls using the canonical `mcp__<server>__<tool>` name.
+    static let permissionMatcher = "^(Bash|apply_patch|mcp__.+__.+)$"
     static let requestUserInputMatcher = "^request_user_input$"
     static let specs: [Spec] = [
         Spec(

--- a/Sources/TapQCodexAdapter/CodexToolSummary.swift
+++ b/Sources/TapQCodexAdapter/CodexToolSummary.swift
@@ -6,6 +6,8 @@ import TapQWireProtocol
 public enum CodexToolSummary {
     private static let summaryWordLimit = 6
     private static let summaryCharacterLimit = 64
+    private static let mcpDetailWordLimit = 18
+    private static let mcpDetailCharacterLimit = 160
 
     public static func render(
         toolName: String,
@@ -28,6 +30,9 @@ public enum CodexToolSummary {
                 fallback: fallback
             ))
 
+        case let name where name.hasPrefix("mcp__"):
+            return mcpPresentation(toolName: name)
+
         default:
             let fallback = compactJSON(input)
             return (
@@ -35,6 +40,73 @@ public enum CodexToolSummary {
                 detail(description: input["description"]?.stringValue, fallback: fallback)
             )
         }
+    }
+
+    /// MCP arguments are an open-ended third-party schema and may contain credentials,
+    /// private paths, message bodies, or other content. Presentation therefore derives
+    /// exclusively from Codex's canonical `mcp__<server>__<tool>` name and never from
+    /// argument values.
+    private static func mcpPresentation(
+        toolName: String
+    ) -> (summary: String, detail: String) {
+        let prefix = "mcp__"
+        let remainder = toolName.dropFirst(prefix.count)
+        guard let separator = remainder.range(of: "__") else {
+            return ("use an MCP tool", "Use an MCP tool")
+        }
+
+        let server = humanizeMCPIdentifier(remainder[..<separator.lowerBound])
+        let operation = humanizeMCPIdentifier(remainder[separator.upperBound...])
+        guard !server.isEmpty, !operation.isEmpty else {
+            return ("use an MCP tool", "Use an MCP tool")
+        }
+
+        return (
+            boundedMCPText(
+                "use \(operation) from \(server)",
+                wordLimit: summaryWordLimit,
+                characterLimit: summaryCharacterLimit
+            ),
+            boundedMCPText(
+                "Use \(operation) from the \(server) MCP server",
+                wordLimit: mcpDetailWordLimit,
+                characterLimit: mcpDetailCharacterLimit
+            )
+        )
+    }
+
+    private static func humanizeMCPIdentifier(_ identifier: Substring) -> String {
+        identifier
+            .map { character in
+                character.isLetter || character.isNumber ? String(character) : " "
+            }
+            .joined()
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    private static func boundedMCPText(
+        _ text: String,
+        wordLimit: Int,
+        characterLimit: Int
+    ) -> String {
+        let words = text.split(whereSeparator: \.isWhitespace)
+        var result = words.prefix(wordLimit).joined(separator: " ")
+        var truncated = words.count > wordLimit
+        if result.count > characterLimit {
+            truncated = true
+        }
+        guard truncated else { return result }
+
+        let contentLimit = max(0, characterLimit - 1)
+        if result.count > contentLimit {
+            let limit = result.index(result.startIndex, offsetBy: contentLimit)
+            result = String(result[..<limit])
+            if let lastSpace = result.lastIndex(of: " ") {
+                result = String(result[..<lastSpace])
+            }
+        }
+        return result + "…"
     }
 
     private static func detail(description: String?, fallback: String) -> String {

--- a/Tests/TapQCodexAdapterTests/CodexHookInstallerTests.swift
+++ b/Tests/TapQCodexAdapterTests/CodexHookInstallerTests.swift
@@ -118,7 +118,10 @@ final class CodexHookInstallerTests: XCTestCase {
         }
 
         let permission = try XCTUnwrap(hooks["PermissionRequest"]?.arrayValue?.first)
-        XCTAssertEqual(permission["matcher"]?.stringValue, "^(Bash|apply_patch)$")
+        XCTAssertEqual(
+            permission["matcher"]?.stringValue,
+            "^(Bash|apply_patch|mcp__.+__.+)$"
+        )
         let permissionHook = try XCTUnwrap(permission["hooks"]?.arrayValue?.first)
         XCTAssertEqual(permissionHook["type"]?.stringValue, "command")
         XCTAssertEqual(permissionHook["command"]?.stringValue, quotedCommand)
@@ -257,6 +260,37 @@ final class CodexHookInstallerTests: XCTestCase {
 
         try Data(#"{"hooks":"invalid"}"#.utf8).write(to: hooksURL)
         XCTAssertEqual(installer().installationStatus(), .partial)
+    }
+
+    func testInstallRepairsLegacyPermissionMatcherAndRequiresRetrust() throws {
+        let legacy = """
+        {"hooks":{
+          "PreToolUse":[{"matcher":"^request_user_input$","hooks":[
+            {"type":"command","command":"\(quotedCommand)","timeout":\(InteractionBudget.hookTimeout)}
+          ]}],
+          "PermissionRequest":[{"matcher":"^(Bash|apply_patch)$","hooks":[
+            {"type":"command","command":"\(quotedCommand)","timeout":\(InteractionBudget.hookTimeout)}
+          ]}],
+          "Stop":[{"hooks":[
+            {"type":"command","command":"\(quotedCommand)","timeout":\(InteractionBudget.hookTimeout)}
+          ]}]
+        }}
+        """
+        try Data(legacy.utf8).write(to: hooksURL)
+
+        XCTAssertEqual(installer().installationStatus(), .partial)
+
+        let report = try installer().install()
+        let hooks = try XCTUnwrap(try read()["hooks"]?.objectValue)
+        let permissionGroups = try XCTUnwrap(hooks["PermissionRequest"]?.arrayValue)
+        XCTAssertEqual(permissionGroups.count, 1)
+        XCTAssertEqual(
+            permissionGroups.first?["matcher"]?.stringValue,
+            "^(Bash|apply_patch|mcp__.+__.+)$"
+        )
+        XCTAssertTrue(report.didChange)
+        XCTAssertEqual(report.status, .installed)
+        XCTAssertEqual(report.trustAction, .reviewRequired)
     }
 
     func testInstallMigratesRecognizedPreviousPathWithoutDuplicates() throws {

--- a/Tests/TapQCodexAdapterTests/CodexHookShimTests.swift
+++ b/Tests/TapQCodexAdapterTests/CodexHookShimTests.swift
@@ -481,6 +481,83 @@ final class CodexHookShimTests: XCTestCase {
         XCTAssertEqual(approval.approvalSource, .permissionRequest)
     }
 
+    func testMCPPermissionRequestForwardsCanonicalPayloadWithSecretSafePresentation() throws {
+        let toolInput: JSONValue = .object([
+            "path": .string("/Users/example/private/customer-record.txt"),
+            "token": .string("tapq-secret-token"),
+            "nested": .object([
+                "authorization": .string("Bearer tapq-secret-authorization"),
+                "content": .string("tapq-secret-content"),
+            ]),
+        ])
+        var captured: [String: JSONValue]?
+
+        let result = CodexHookShim.handle(
+            stdinData: permissionInput(
+                toolName: "mcp__filesystem__read_file",
+                toolInput: toolInput
+            )
+        ) { message, _ in
+            captured = message
+            return Data(#"{"decision":"allow"}"#.utf8)
+        }
+
+        XCTAssertEqual(try permissionOutput(result.stdout).behavior, "allow")
+        XCTAssertEqual(captured?["tool_name"]?.stringValue, "mcp__filesystem__read_file")
+        XCTAssertEqual(captured?["tool_input"], toolInput)
+        XCTAssertEqual(
+            captured?["approval_source"]?.stringValue,
+            ApprovalSource.permissionRequest.rawValue
+        )
+
+        let summary = try XCTUnwrap(captured?["summary"]?.stringValue)
+        let detail = try XCTUnwrap(captured?["detail"]?.stringValue)
+        for presentation in [summary, detail] {
+            XCTAssertTrue(presentation.localizedCaseInsensitiveContains("filesystem"))
+            XCTAssertTrue(presentation.localizedCaseInsensitiveContains("read file"))
+            XCTAssertFalse(presentation.contains("mcp__"))
+            XCTAssertFalse(presentation.contains("\n"))
+            for secret in [
+                "/Users/example/private/customer-record.txt",
+                "tapq-secret-token",
+                "tapq-secret-authorization",
+                "tapq-secret-content",
+            ] {
+                XCTAssertFalse(presentation.contains(secret))
+            }
+        }
+        XCTAssertLessThanOrEqual(summary.count, 64)
+    }
+
+    func testMCPPermissionRequestDenyAndDeferralPreserveNativeSemantics() throws {
+        let stdin = permissionInput(
+            toolName: "mcp__github__create_issue",
+            toolInput: .object([
+                "owner": .string("example"),
+                "title": .string("Test issue"),
+            ])
+        )
+
+        let denied = CodexHookShim.handle(stdinData: stdin) { _, _ in
+            Data(#"{"decision":"deny","reason":"Connector call declined"}"#.utf8)
+        }
+        XCTAssertEqual(try permissionOutput(denied.stdout).behavior, "deny")
+        XCTAssertEqual(
+            try permissionOutput(denied.stdout).message,
+            "Connector call declined"
+        )
+
+        let deferred = CodexHookShim.handle(stdinData: stdin) { _, _ in
+            Data(#"{"decision":"ask"}"#.utf8)
+        }
+        XCTAssertEqual(deferred, CodexHookShim.passThrough)
+
+        let unavailable = CodexHookShim.handle(stdinData: stdin) { _, _ in
+            throw StubError.unreachable
+        }
+        XCTAssertEqual(unavailable, CodexHookShim.passThrough)
+    }
+
     func testPermissionRequestDenyUsesBrokerReason() throws {
         let stdin = permissionInput(
             toolName: "apply_patch",

--- a/Tests/TapQCodexAdapterTests/CodexToolSummaryTests.swift
+++ b/Tests/TapQCodexAdapterTests/CodexToolSummaryTests.swift
@@ -52,16 +52,87 @@ final class CodexToolSummaryTests: XCTestCase {
         XCTAssertEqual(presentation.detail, "Update the parser")
     }
 
-    func testUnknownToolFallsBackToCompactArguments() {
+    func testCanonicalMCPToolGetsHumanizedWithoutSpeakingArguments() {
         let presentation = CodexToolSummary.render(
             toolName: "mcp__filesystem__read_file",
             input: ["path": .string("/tmp/a")]
         )
 
-        XCTAssertEqual(
-            presentation.summary,
-            "use the mcp__filesystem__read_file tool"
+        XCTAssertEqual(presentation.summary, "use read file from filesystem")
+        XCTAssertEqual(presentation.detail, "Use read file from the filesystem MCP server")
+        XCTAssertFalse(presentation.summary.contains("/tmp/a"))
+        XCTAssertFalse(presentation.detail.contains("/tmp/a"))
+    }
+
+    func testMCPPresentationNeverIncludesArbitraryNestedArgumentValues() {
+        let secrets = [
+            "tapq-secret-token-7",
+            "/Users/example/.ssh/id_ed25519",
+            "private message body\nwith another line",
+            "Bearer private-authorization",
+            "description supplied by an untrusted tool",
+        ]
+        let presentation = CodexToolSummary.render(
+            toolName: "mcp__github__create_issue",
+            input: [
+                "token": .string(secrets[0]),
+                "path": .string(secrets[1]),
+                "content": .string(secrets[2]),
+                "nested": .object([
+                    "authorization": .string(secrets[3]),
+                ]),
+                "description": .string(secrets[4]),
+            ]
         )
+
+        XCTAssertEqual(presentation.summary, "use create issue from github")
+        XCTAssertEqual(presentation.detail, "Use create issue from the github MCP server")
+        for secret in secrets {
+            XCTAssertFalse(presentation.summary.contains(secret))
+            XCTAssertFalse(presentation.detail.contains(secret))
+        }
+        XCTAssertFalse(presentation.summary.contains("\n"))
+        XCTAssertFalse(presentation.detail.contains("\n"))
+    }
+
+    func testMCPPresentationIsBoundedAndNewlineFreeForAdversarialNames() {
+        let server = String(repeating: "private_server_", count: 30) + "\ncredentials"
+        let operation = String(repeating: "write_content_", count: 30) + "\nnow"
+        let presentation = CodexToolSummary.render(
+            toolName: "mcp__\(server)__\(operation)",
+            input: ["content": .string("never speak this content")]
+        )
+
+        XCTAssertLessThanOrEqual(presentation.summary.count, 64)
+        XCTAssertLessThanOrEqual(presentation.detail.count, 160)
+        XCTAssertTrue(presentation.summary.hasSuffix("…"))
+        XCTAssertTrue(presentation.detail.hasSuffix("…"))
+        XCTAssertFalse(presentation.summary.contains("\n"))
+        XCTAssertFalse(presentation.detail.contains("\n"))
+        XCTAssertFalse(presentation.summary.contains("never speak this content"))
+        XCTAssertFalse(presentation.detail.contains("never speak this content"))
+    }
+
+    func testMalformedMCPNameUsesSafeGenericPresentation() {
+        let presentation = CodexToolSummary.render(
+            toolName: "mcp__missing_separator",
+            input: ["password": .string("do-not-speak")]
+        )
+
+        XCTAssertEqual(presentation.summary, "use an MCP tool")
+        XCTAssertEqual(presentation.detail, "Use an MCP tool")
+        XCTAssertFalse(presentation.summary.contains("do-not-speak"))
+        XCTAssertFalse(presentation.detail.contains("do-not-speak"))
+    }
+
+    func testNonMCPUnknownToolKeepsCompactArgumentFallback() {
+        let presentation = CodexToolSummary.render(
+            toolName: "custom_tool",
+            input: ["path": .string("/tmp/a")]
+        )
+
+        XCTAssertEqual(presentation.summary, "use the custom_tool tool")
         XCTAssertTrue(presentation.detail.contains("path"))
+        XCTAssertTrue(presentation.detail.contains("tmp"))
     }
 }

--- a/Tests/TapQCodexProcessTests/CodexHookProcessContractTests.swift
+++ b/Tests/TapQCodexProcessTests/CodexHookProcessContractTests.swift
@@ -13,14 +13,7 @@ import Glibc
 final class CodexHookProcessContractTests: XCTestCase {
     func testCodex01460RequestUserInputReachesBrokerAndBlocksWithSelection() async throws {
         let hookExecutable = try hookExecutableURL()
-        let testRoot = URL(
-            fileURLWithPath: "/tmp/tapq-codex-contract-\(UUID().uuidString.prefix(12))",
-            isDirectory: true
-        )
-        try FileManager.default.createDirectory(
-            at: testRoot,
-            withIntermediateDirectories: true
-        )
+        let testRoot = try makeTestRoot()
 
         let discovery = BrokerRuntimeDiscovery(supportDirectory: testRoot)
         try discovery.prepareDirectory()
@@ -47,12 +40,9 @@ final class CodexHookProcessContractTests: XCTestCase {
             try? FileManager.default.removeItem(at: testRoot)
         }
 
-        let fixtureURL = try XCTUnwrap(Bundle.module.url(
-            forResource: "pre-tool-use-request-user-input-single-choice",
-            withExtension: "json",
-            subdirectory: "Fixtures/codex-cli-0.146.0"
-        ))
-        let fixture = try Data(contentsOf: fixtureURL)
+        let fixture = try fixtureData(
+            named: "pre-tool-use-request-user-input-single-choice"
+        )
         let fixtureObject = try JSONDecoder().decode(
             [String: JSONValue].self,
             from: fixture
@@ -70,46 +60,21 @@ final class CodexHookProcessContractTests: XCTestCase {
         XCTAssertNil(fixtureObject["agent_type"])
         XCTAssertNil(fixtureObject["request_id"])
 
-        let process = Process()
-        process.executableURL = hookExecutable
-        process.currentDirectoryURL = testRoot
-        var environment = ProcessInfo.processInfo.environment
-        environment["TAPQ_BROKER_DIR"] = testRoot.path
-        process.environment = environment
-
-        let stdin = Pipe()
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardInput = stdin
-        process.standardOutput = stdout
-        process.standardError = stderr
-
-        try process.run()
-        try stdin.fileHandleForWriting.write(contentsOf: fixture)
-        try stdin.fileHandleForWriting.close()
-
-        let exited = await waitUntilExit(process, timeout: 5)
-        if !exited {
-            process.terminate()
-            let terminated = await waitUntilExit(process, timeout: 1)
-            if !terminated {
-                forceTerminate(process)
-                _ = await waitUntilExit(process, timeout: 1)
-            }
-            return XCTFail("tapq-codex-hook did not exit within the process-contract deadline")
-        }
-
-        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
-        XCTAssertEqual(process.terminationStatus, 0)
+        let processResult = try await runHook(
+            executable: hookExecutable,
+            fixture: fixture,
+            testRoot: testRoot
+        )
+        XCTAssertEqual(processResult.terminationStatus, 0)
         XCTAssertTrue(
-            stderrData.isEmpty,
-            "unexpected hook stderr: \(String(decoding: stderrData, as: UTF8.self))"
+            processResult.stderr.isEmpty,
+            "unexpected hook stderr: "
+                + String(decoding: processResult.stderr, as: UTF8.self)
         )
 
         let output = try JSONDecoder().decode(
             [String: JSONValue].self,
-            from: stdoutData
+            from: processResult.stdout
         )
         let hookOutput = try XCTUnwrap(output["hookSpecificOutput"]?.objectValue)
         XCTAssertEqual(Set(output.keys), ["hookSpecificOutput"])
@@ -141,6 +106,171 @@ final class CodexHookProcessContractTests: XCTestCase {
             ]
         )
         XCTAssertFalse(request.multiSelect)
+    }
+
+    func testCodex01460MCPPermissionRequestReachesBrokerAndAllows() async throws {
+        let hookExecutable = try hookExecutableURL()
+        let testRoot = try makeTestRoot()
+
+        let discovery = BrokerRuntimeDiscovery(supportDirectory: testRoot)
+        try discovery.prepareDirectory()
+        let token = BrokerRuntimeDiscovery.generateToken()
+        let transport = UnixSocketTransport(path: discovery.socketPath)
+        let recorder = ApprovalRecorder()
+        let server = BrokerServer(
+            transport: transport,
+            token: token,
+            onApproval: { request in
+                recorder.requests.append(request)
+                return .allow
+            },
+            onNotification: { _ in }
+        )
+        try server.start()
+        try discovery.publish(token: token)
+        defer {
+            server.stop()
+            discovery.remove()
+            try? FileManager.default.removeItem(at: testRoot)
+        }
+
+        let fixture = try fixtureData(
+            named: "permission-request-mcp-memory-create-entities"
+        )
+        let fixtureObject = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: fixture
+        )
+        XCTAssertEqual(
+            Set(fixtureObject.keys),
+            [
+                "session_id", "turn_id", "transcript_path", "cwd",
+                "hook_event_name", "model", "permission_mode", "tool_name",
+                "tool_input",
+            ],
+            "the source-derived fixture must preserve the exact Codex 0.146 envelope"
+        )
+        for absentKey in [
+            "agent_id", "agent_type", "tool_use_id", "request_id", "call_id",
+            "run_id_suffix",
+        ] {
+            XCTAssertNil(fixtureObject[absentKey])
+        }
+
+        let processResult = try await runHook(
+            executable: hookExecutable,
+            fixture: fixture,
+            testRoot: testRoot
+        )
+        XCTAssertEqual(processResult.terminationStatus, 0)
+        XCTAssertTrue(
+            processResult.stderr.isEmpty,
+            "unexpected hook stderr: "
+                + String(decoding: processResult.stderr, as: UTF8.self)
+        )
+
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: processResult.stdout
+        )
+        XCTAssertEqual(output, [
+            "hookSpecificOutput": .object([
+                "hookEventName": .string("PermissionRequest"),
+                "decision": .object([
+                    "behavior": .string("allow"),
+                ]),
+            ]),
+        ])
+
+        let request = try XCTUnwrap(recorder.requests.only)
+        XCTAssertEqual(request.sessionID, "019fb3cc-0000-7000-8000-000000000003")
+        XCTAssertFalse(request.id.isEmpty)
+        XCTAssertNotNil(
+            UUID(uuidString: request.id),
+            "PermissionRequest has no call ID, so the hook must generate a UUID request ID"
+        )
+        XCTAssertEqual(request.agent, .codex)
+        XCTAssertEqual(request.toolName, "mcp__memory__create_entities")
+        XCTAssertEqual(request.toolInput, [
+            "entities": .array([
+                .object([
+                    "name": .string("Ada"),
+                    "entityType": .string("person"),
+                ]),
+            ]),
+        ])
+        XCTAssertEqual(request.cwd, "/tmp/tapq-codex-fixture-workspace")
+        XCTAssertEqual(request.permissionMode, "default")
+        XCTAssertEqual(request.approvalSource, .permissionRequest)
+        XCTAssertEqual(request.kind, .toolApproval)
+        XCTAssertEqual(request.summary, "use create entities from memory")
+        XCTAssertEqual(request.detail, "Use create entities from the memory MCP server")
+        for argumentValue in ["Ada", "person"] {
+            XCTAssertFalse(request.summary.contains(argumentValue))
+            XCTAssertFalse(request.detail.contains(argumentValue))
+        }
+    }
+
+    private func makeTestRoot() throws -> URL {
+        let testRoot = URL(
+            fileURLWithPath: "/tmp/tapq-codex-contract-\(UUID().uuidString.prefix(12))",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: testRoot,
+            withIntermediateDirectories: true
+        )
+        return testRoot
+    }
+
+    private func fixtureData(named name: String) throws -> Data {
+        let fixtureURL = try XCTUnwrap(Bundle.module.url(
+            forResource: name,
+            withExtension: "json",
+            subdirectory: "Fixtures/codex-cli-0.146.0"
+        ))
+        return try Data(contentsOf: fixtureURL)
+    }
+
+    private func runHook(
+        executable: URL,
+        fixture: Data,
+        testRoot: URL
+    ) async throws -> HookProcessResult {
+        let process = Process()
+        process.executableURL = executable
+        process.currentDirectoryURL = testRoot
+        var environment = ProcessInfo.processInfo.environment
+        environment["TAPQ_BROKER_DIR"] = testRoot.path
+        process.environment = environment
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        try stdin.fileHandleForWriting.write(contentsOf: fixture)
+        try stdin.fileHandleForWriting.close()
+
+        let exited = await waitUntilExit(process, timeout: 5)
+        if !exited {
+            process.terminate()
+            let terminated = await waitUntilExit(process, timeout: 1)
+            if !terminated {
+                forceTerminate(process)
+                _ = await waitUntilExit(process, timeout: 1)
+            }
+            throw ContractTestError.hookTimedOut
+        }
+
+        return HookProcessResult(
+            terminationStatus: process.terminationStatus,
+            stdout: stdout.fileHandleForReading.readDataToEndOfFile(),
+            stderr: stderr.fileHandleForReading.readDataToEndOfFile()
+        )
     }
 
     private func hookExecutableURL() throws -> URL {
@@ -192,8 +322,20 @@ private final class SelectionRecorder {
     var requests: [SelectionRequest] = []
 }
 
+@MainActor
+private final class ApprovalRecorder {
+    var requests: [ApprovalRequest] = []
+}
+
+private struct HookProcessResult {
+    let terminationStatus: Int32
+    let stdout: Data
+    let stderr: Data
+}
+
 private enum ContractTestError: Error {
     case hookIsNotExecutable(String)
+    case hookTimedOut
 }
 
 private extension Array {

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/README.md
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/README.md
@@ -1,4 +1,4 @@
-# Codex CLI 0.146.0 hook fixture
+# Codex CLI 0.146.0 hook fixtures
 
 `pre-tool-use-request-user-input-single-choice.json` is a sanitized capture of
 the complete `PreToolUse` stdin emitted by Codex CLI `0.146.0` for a root
@@ -11,6 +11,25 @@ generated schema:
 
 - `codex-rs/hooks/src/events/pre_tool_use.rs`
 - `codex-rs/hooks/schema/generated/pre-tool-use.command.input.schema.json`
+
+`permission-request-mcp-memory-create-entities.json` is an
+**official-source-derived fixture**, not a runtime capture. It comes from the
+exact MCP hook stdin asserted by Codex's
+`permission_request_hook_allows_mcp_tool_call` test at:
+
+- tag: `rust-v0.146.0`
+- commit: `e363b08c9175ac1cbe5893615dd2cb9ddf95043b`
+- test: `codex-rs/core/src/mcp_tool_call_tests.rs`
+
+The canonical tool name `mcp__memory__create_entities` and its complete
+`tool_input` value are copied exactly from that upstream test. Only the dynamic
+`session_id`, `turn_id`, `cwd`, and `model` values were normalized for this
+fixture. Its envelope and response contract were also verified against:
+
+- `codex-rs/hooks/src/events/permission_request.rs`
+- `codex-rs/hooks/schema/generated/permission-request.command.input.schema.json`
+- `codex-rs/hooks/schema/generated/permission-request.command.output.schema.json`
+- `codex-rs/core/src/hook_runtime.rs`
 
 Keep fixtures versioned by Codex CLI release. A contract change should add a new
 version directory instead of silently rewriting this fixture.

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/permission-request-mcp-memory-create-entities.json
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/permission-request-mcp-memory-create-entities.json
@@ -1,0 +1,18 @@
+{
+  "session_id": "019fb3cc-0000-7000-8000-000000000003",
+  "turn_id": "019fb3cc-0000-7000-8000-000000000004",
+  "transcript_path": null,
+  "cwd": "/tmp/tapq-codex-fixture-workspace",
+  "hook_event_name": "PermissionRequest",
+  "model": "gpt-5.6-luna",
+  "permission_mode": "default",
+  "tool_name": "mcp__memory__create_entities",
+  "tool_input": {
+    "entities": [
+      {
+        "name": "Ada",
+        "entityType": "person"
+      }
+    ]
+  }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -500,7 +500,7 @@ TapQ installs three lifecycle hooks:
 | Event | Matcher | Current behavior |
 |---|---|---|
 | `PreToolUse` | `request_user_input` | Answers one supported root-agent single-choice question before Codex opens its native selector |
-| `PermissionRequest` | `Bash`, `apply_patch` | Answers only native approval prompts Codex was already going to show |
+| `PermissionRequest` | `Bash`, `apply_patch`, `mcp__<server>__<tool>` | Answers only native approval prompts Codex was already going to show |
 | `Stop` | All root turns | Sends completion and optionally routes an explicit final-response question |
 
 For `request_user_input`, TapQ supports exactly one question with two or three valid,
@@ -515,7 +515,12 @@ For `PermissionRequest`, an allow or deny becomes Codex’s documented event-spe
 decision. A broker timeout, `.ask`, invalid reply, incompatible wire version, or missing
 runtime emits no hook output, so Codex retains its native approval prompt. Existing
 Codex rules, sandbox policy, and permission modes remain authoritative; an operation
-that does not produce a native `PermissionRequest` does not reach TapQ.
+that does not produce a native `PermissionRequest` does not reach TapQ. For MCP tools,
+TapQ speaks a humanized server and operation name but never renders argument values in
+the summary or detail. The original `tool_input` remains in the local broker request
+context and is not spoken or logged. A hook allow applies to that call only; persistent
+connector rules, connector authentication, and MCP-generated elicitation remain in
+Codex's native flow.
 
 For `Stop`, Codex supplies the final text through `last_assistant_message`; TapQ does not
 parse Codex transcript files. Replies without `?`, inconclusive classifications, and
@@ -536,10 +541,10 @@ generic notification-hook equivalent. Completion notification is derived from `S
 these limitations are intentional rather than installation errors.
 
 Codex CLI `0.142.5` is TapQ’s tested lifecycle-hook contract floor. Structured
-`request_user_input` uses a versioned Codex CLI `0.146.0` fixture and a real
-hook-executable-to-broker test. Older hook contracts are unsupported. This adapter
-targets local Codex clients that load user lifecycle hooks; it does not attach to hosted
-Codex Cloud tasks.
+`request_user_input` and MCP `PermissionRequest` use versioned Codex CLI `0.146.0`
+fixtures and real hook-executable-to-broker tests. Older hook contracts are unsupported.
+This adapter targets local Codex clients that load user lifecycle hooks; it does not
+attach to hosted Codex Cloud tasks.
 
 ## Environment variables and local data
 

--- a/docs/CODEX_ADAPTER_MANUAL_TEST_PLAN.md
+++ b/docs/CODEX_ADAPTER_MANUAL_TEST_PLAN.md
@@ -7,14 +7,14 @@ Use this plan to validate the TapQ Codex adapter as one tester on one Mac. It co
 - Codex hook installation, status, repair, idempotence, backup, and removal.
 - Codex hook review and trust.
 - Root-agent `request_user_input` handling for one single-choice question.
-- Native `PermissionRequest` handling for `Bash` and `apply_patch`.
+- Native `PermissionRequest` handling for `Bash`, `apply_patch`, and MCP connector tools.
 - `Stop` completion announcements and final-response question continuation.
 - Fail-open behavior when TapQ is unavailable.
 - Preservation of unrelated Codex hook configuration.
 
 The lifecycle-hook floor tested by this plan is Codex CLI `0.142.5`. Structured
-`request_user_input` coverage uses the Codex CLI `0.146.0` contract. Hosted Codex Cloud
-tasks are out of scope.
+`request_user_input` and MCP `PermissionRequest` coverage use the Codex CLI `0.146.0`
+contract. Hosted Codex Cloud tasks are out of scope.
 
 ## Supported and unsupported behavior
 
@@ -23,6 +23,7 @@ tasks are out of scope.
 | Root `request_user_input` with one question and two or three options | TapQ may return one listed choice before Codex opens its native selector. |
 | `PermissionRequest` for `Bash` | TapQ may answer allow or deny when Codex was already going to prompt. |
 | `PermissionRequest` for `apply_patch` | TapQ may answer allow or deny when Codex was already going to prompt. |
+| `PermissionRequest` for `mcp__<server>__<tool>` | TapQ may answer a native connector prompt without speaking its argument values. |
 | `Stop` without a supported question | Announce `Codex finished.` and let the turn finish normally. |
 | `Stop` with a supported final question | Return one hands-free answer as a Codex continuation, then prevent a re-ask loop. |
 | Missing runtime, timeout, invalid reply, or unsupported input | Emit no decision and leave Codex's native flow in control. |
@@ -159,7 +160,7 @@ Expected:
   review the definitions with `/hooks`.
 - The JSON has exactly one TapQ group for each of these events:
   - `PreToolUse`, matcher `^request_user_input$`.
-  - `PermissionRequest`, matcher `^(Bash|apply_patch)$`.
+  - `PermissionRequest`, matcher `^(Bash|apply_patch|mcp__.+__.+)$`.
   - `Stop`, with no matcher.
 - Each handler is a command pointing to the quoted absolute hook path, with timeout `260`.
 - File mode is `600`.
@@ -597,6 +598,34 @@ Expected:
 - TapQ's CLI status can say `configured` while Codex remains the authority on trust.
 - The normal Codex approval path remains available.
 
+## Phase 8: MCP connector permission requests
+
+### CX-024 — Allow and deny a native MCP connector request — P1
+
+This case requires a disposable MCP server with a harmless operation that Codex is
+configured to ask before invoking. If no such connector is available, record this case
+as `Blocked`, not `Pass`. Do not put real secrets or private paths in the test input.
+
+1. Record the connector's canonical Codex tool name, which must have the form
+   `mcp__<server>__<tool>`.
+2. Ask Codex to invoke it exactly once with a unique non-sensitive sentinel argument,
+   such as `tapq-mcp-value-must-not-be-spoken`.
+3. Approve through TapQ.
+4. Repeat in a fresh Codex session and deny through TapQ.
+
+Expected:
+
+- Both interactions are sourced from Codex's native `PermissionRequest`; a connector
+  call that Codex allows without prompting still bypasses TapQ.
+- TapQ identifies the humanized MCP server and operation.
+- TapQ never speaks the sentinel or any other MCP argument value, including after a
+  `details` command.
+- Approval runs the connector operation without a second native prompt.
+- The denied connector invocation does not execute. Any later model-issued call is a
+  separate request and must pass through native approval handling again.
+- Runtime absence, deferral, or a malformed broker response leaves Codex's native
+  connector approval prompt usable.
+
 ## Input-modality extension
 
 After all P0 adapter cases pass with one reliable modality, repeat CX-008, CX-009,
@@ -644,7 +673,7 @@ The adapter is ready for the tested environment when:
 - No unrelated hook data or trust entry is lost.
 - A supported `request_user_input` choice reaches Codex exactly once, while deferral or
   runtime absence leaves the native selector usable.
-- `Bash` and `apply_patch` each honor both allow and deny.
+- `Bash`, `apply_patch`, and a configured MCP connector each honor both allow and deny.
 - Supported final questions continue exactly once and never loop.
 - Runtime absence leaves Codex's native permission and final-response flow usable.
 - Active uninstall removes only TapQ-managed hooks.


### PR DESCRIPTION
## Summary

- expand the Codex native `PermissionRequest` matcher to canonical `mcp__<server>__<tool>` connector calls without adding strict mode
- humanize and bound MCP speech while never rendering arbitrary argument values; preserve exact structured input in the local broker request
- preserve native fail-through behavior and migrate legacy matcher installs with explicit `/hooks` re-trust
- add an official-source-derived Codex 0.146 MCP fixture and a real hook executable → discovery → Unix socket → broker process contract
- update the integration documentation and manual test plan

## Validation

- `scripts/check-public-boundary.sh`
- `swift build -c release`
- `scripts/package-runtime-app.sh release`
- `TAPQ_CODEX_HOOK_EXECUTABLE="$(swift build -c release --show-bin-path)/tapq-codex-hook" swift test` — 783 passed
- focused Codex adapter suite — 53 passed
- focused real-executable process contracts — 2 passed
- `git diff --check`

## Upgrade note

After merging and rebuilding, existing users must rerun `tapq integration codex install`, then review and trust the changed definition with `/hooks`.