### PR TITLE
Fix remaining Codex adapter P1 gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,52 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Added
 
+- Opt-in Codex `UserPromptSubmit` steering for root turns. The matcherless hook emits one
+  fixed instruction to use `request_user_input` “when available” only while a live,
+  wire-compatible TapQ runtime advertises `--steering`. After reading discovery it makes
+  a bounded EOF-only Unix-socket connection to verify liveness, without sending a broker
+  request or application data and without a request/response round-trip. It otherwise
+  emits nothing, preserving native prompt submission. Existing three-hook installations
+  must rerun `tapq integration codex install` to add this fourth hook, then review it in
+  `/hooks`.
+- Root-agent structured `request_user_input` interception through Codex `PreToolUse`.
+  TapQ handles exactly one non-secret, non-auto-resolving single-choice question with two
+  or three uniquely labelled options; a selection is returned through Codex's documented
+  deny-feedback contract so the native selector does not also open. Unsupported shapes,
+  subagents, unanswered interactions, and broker failures emit no hook output and stay in
+  Codex's native flow.
 - Codex native `PermissionRequest` coverage for canonical MCP connector tools. TapQ
   forwards the original tool name and arguments to its local broker while spoken
   summaries identify only the humanized server and operation, never arbitrary argument
   values. Existing Codex permission rules and native fail-through behavior remain
   authoritative. Existing users must rerun `tapq integration codex install`, then review
   and trust the changed hook definition with `/hooks`.
+- Best-effort `tapq integration codex status` diagnostics for the discovered Codex
+  executable, version, lifecycle-hook feature, and
+  `default_mode_request_user_input`. Plan mode is the reliable structured-question
+  surface in Codex CLI `0.146.0`; default-mode availability follows that Codex feature.
+  Status resolves and executes fixed `codex --version` and `codex features list` probes
+  from the caller's `PATH` under a minimal allowlisted environment; it distinguishes a
+  missing executable from a resolved probe that fails or times out. A detected version
+  below the tested `0.142.5` lifecycle floor produces a warning. Probe results do not
+  change hooks-file status, and trust remains inspectable only in Codex's `/hooks` view.
+- Versioned Codex CLI `0.142.5` fixtures for `PermissionRequest` and `Stop`, alongside
+  `0.146.0` structured-question, MCP, and `UserPromptSubmit` fixtures. Hook-process-to-
+  broker contracts now exercise supported denial and native fail-through for missing
+  discovery and incompatible versions; authenticated model-level Codex execution
+  remains a manual release boundary.
 
 ### Changed
 
+- The in-process reasoner context now carries the exact canonical argument object for a
+  Codex MCP call. At the model prompt boundary, complete inputs use sorted JSON and
+  oversized inputs use key-balanced excerpts spanning early and late top-level keys,
+  with balanced head/tail excerpts of selected values. Non-ASCII scalars and Unicode line
+  separators are escaped before budgeting, and the full rendered input including markers
+  stays within 4,000 characters. Connector values are not spoken, diagnosed, cloud-sent,
+  or persisted in the reasoner review log. MCP review rows also omit the model's free-text
+  note and confidence so neither can echo an argument value; constrained tier/code remain
+  when the model decided, and outcome remains for every row.
 - The default voice now prefers a downloaded high-quality Samantha. The generic English
   selection (`en-US`/`en`, including the default) resolves to premium or enhanced
   Samantha when one is installed and only falls back to the compact system pick — Eddy
@@ -139,9 +176,9 @@ All notable changes to TapQ will be recorded in this file. The project uses
   working directory, or spoken summary — is sent anywhere. Selecting a reasoner enables no
   network processing of any kind; cloud processing remains the separate, explicit
   `--question-classifier anthropic|openai` choice.
-- A reasoner is shown more than the question classifier is: the complete tool input for the
-  request it is judging, rather than assistant reply text alone. All of it stays on the
-  machine.
+- A reasoner is shown more than the question classifier is: the established command/path
+  context for the request it is judging, rather than assistant reply text alone. All of it
+  stays on the machine.
 - `reasoner-log.jsonl` is new local state of the same sensitivity class as `broker.json`.
   It omits the full command line, the working directory, and the adapter's detail, but the
   `summary` it records is the text TapQ speaks aloud, and for a `Bash` request that summary
@@ -249,8 +286,9 @@ All notable changes to TapQ will be recorded in this file. The project uses
   trust new or changed TapQ command hooks through `/hooks`; TapQ does not bypass or write
   Codex trust state.
 
-The Codex slice does not yet provide strict `PreToolUse`, structured
-`request_user_input`, `UserPromptSubmit` steering, or generic notification-hook parity.
+Version `0.2.0` did not yet provide strict `PreToolUse`, structured
+`request_user_input`, `UserPromptSubmit` steering, MCP approvals, or generic
+notification-hook parity.
 
 [Unreleased]: https://github.com/spaceamoeba-t/tapq/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/spaceamoeba-t/tapq/releases/tag/v0.3.0

--- a/Executables/tapq-codex-hook/main.swift
+++ b/Executables/tapq-codex-hook/main.swift
@@ -9,8 +9,10 @@ import Glibc
 #endif
 
 // Thin executable edge for Codex lifecycle hooks: stdin JSON in, one authenticated broker
-// round-trip per supported event, documented hook JSON out. Decision and fail-open policy
-// live in CodexHookShim so they can be tested without a real socket.
+// round-trip per broker-backed event, documented hook JSON out. UserPromptSubmit reads
+// discovery and opens a bounded EOF-only liveness connection, but sends no broker request
+// or application data. Decision and fail-open policy live in CodexHookShim so they can be
+// tested independently of the executable edge.
 
 let stdinData = FileHandle.standardInput.readDataToEndOfFile()
 let discovery = BrokerDiscovery()
@@ -20,7 +22,16 @@ enum CodexShimVersionError: Error {
     case unknownApprovalSource(String)
 }
 
-let result = CodexHookShim.handle(stdinData: stdinData) { message, timeout in
+let result = CodexHookShim.handle(stdinData: stdinData, steeringEnabled: {
+    // Steering injects only when the broker is live, its wire version is compatible,
+    // and the runtime was explicitly launched with steering enabled. Any doubt is silent.
+    guard let discovered = try? discovery.readLiveDiscovery(),
+          WireProtocol.outboundVersion(
+              for: discovered.protocolVersion,
+              approvalSource: nil
+          ) != nil else { return false }
+    return discovered.steeringEnabled
+}) { message, timeout in
     let (socketPath, token, appVersion, _) = try discovery.readDiscovery()
 
     let sourceRaw = message["approval_source"]?.stringValue

--- a/Executables/tapq-hook/main.swift
+++ b/Executables/tapq-hook/main.swift
@@ -23,10 +23,10 @@ enum ShimVersionError: Error {
 }
 
 let result = HookShim.handle(stdinData: stdinData, steeringEnabled: {
-    // Steering injects only when the broker is live (discovery file present), speaks a
+    // Steering injects only when the discovery publisher is still live, speaks a
     // safely bridgeable wire version, and the user has the flag on. Anything else →
     // inject nothing.
-    guard let discovered = try? discovery.readDiscovery(),
+    guard let discovered = try? discovery.readLiveDiscovery(),
           WireProtocol.outboundVersion(
               for: discovered.protocolVersion,
               approvalSource: nil

--- a/Executables/tapq/ReasonerShadowLog.swift
+++ b/Executables/tapq/ReasonerShadowLog.swift
@@ -19,6 +19,13 @@ import TapQContracts
 /// fragment, a token passed as an early argument — because it is the *front* of the
 /// command line, not a sanitized description of it.
 ///
+/// For a canonical MCP row, the raw connector argument object is also absent. Its model-
+/// generated rationale note is deliberately omitted as well: even though the prompt
+/// tells the model not to copy request text, that instruction is not a redaction
+/// boundary and the note could otherwise echo an argument value into this file. The
+/// tier, closed rationale code, and outcome remain available for review. Confidence is
+/// omitted too because arbitrary numeric precision could become a smaller echo channel.
+///
 /// For a question row (`tool_name` `AgentQuestion`) `summary` is the question itself, as
 /// the classifier extracted it from the agent's final reply — the same sentence TapQ read
 /// out and asked the user to answer. A question row carries no command line, no `cwd`,
@@ -101,8 +108,17 @@ import TapQContracts
             mode: mode.rawValue,
             riskTier: assessment.decision?.riskTier.rawValue,
             code: assessment.decision?.rationale.code.rawValue,
-            note: assessment.decision?.rationale.note,
-            confidence: assessment.decision?.confidence,
+            // An MCP context carries arbitrary third-party values. Never persist a
+            // free-text model field derived from that context: constrained tier/code
+            // values provide the review signal without creating an echo channel.
+            note: ReasonerReviewDisclosure.persistedNote(
+                from: assessment.decision,
+                context: context
+            ),
+            confidence: ReasonerReviewDisclosure.persistedConfidence(
+                from: assessment.decision,
+                context: context
+            ),
             abstained: assessment.decision == nil ? true : nil,
             abstainReason: assessment.abstention?.rawValue,
             reasonerLatencyMilliseconds: assessment.latencyMilliseconds,

--- a/Package.swift
+++ b/Package.swift
@@ -73,6 +73,7 @@ var targets: [Target] = [
             "TapQContextBaseline",
             "TapQContracts",
             "TapQDetectionBaseline",
+            "TapQPOSIXSupport",
             "TapQWireProtocol",
         ],
         swiftSettings: swiftSettings

--- a/README.md
+++ b/README.md
@@ -275,11 +275,18 @@ The installer writes only TapQ-managed groups in `~/.codex/hooks.json`, or in
 `$CODEX_HOME/hooks.json` when `CODEX_HOME` is set. It points to the
 `tapq-codex-hook` executable installed beside `tapq`, preserves unrelated hook data, and
 creates a restrictive backup before changing an existing file. Custom installations can
-pass `--hooks PATH` and `--hook PATH`.
+pass `--hooks PATH` and `--hook PATH`. Rerun `install` directly to repair missing or stale
+registrations whose command is the current hook, the bare `tapq-codex-hook` command, or a
+recognized TapQ app/build path. Unfamiliar custom executable paths are preserved as
+unrelated hooks. Users upgrading from the earlier three-hook layout must rerun `install`
+to add `UserPromptSubmit`, then review the changed definitions in `/hooks`.
 
 Installation does not grant hook trust. After every new or changed definition, open
-Codex and use `/hooks` to review and trust the exact TapQ hooks. `status` verifies the
-file layout only; Codex remains the authority for trust state.
+Codex and use `/hooks` to review and trust the four current TapQ registrations at the
+selected hook path. Unrecognized custom-path hooks may also remain as unrelated data.
+`status` verifies the recognized layout and reports best-effort local Codex compatibility
+diagnostics, but Codex remains the authority for trust state; that state is not inspectable
+by TapQ.
 
 The current supported slice is deliberately narrow:
 
@@ -290,20 +297,45 @@ The current supported slice is deliberately narrow:
   canonical `mcp__<server>__<tool>` connector calls. Operations that Codex does not
   prompt for never reach TapQ. MCP speech identifies the server and operation without
   reading argument values; the original arguments remain in the local broker request
-  context and are not spoken.
+  context and are not spoken. When the on-device stage-2 reasoner is enabled, it sees
+  complete sorted JSON when the argument object fits. Oversized objects become
+  key-balanced excerpts across early and late top-level keys, with the start and end of
+  each selected value retained. Non-ASCII text, including Unicode line separators, is
+  escaped before budgeting, and the complete rendered input including truncation markers
+  stays within 4,000 characters. MCP values are not spoken, diagnosed, or cloud-sent.
+  MCP review rows omit the arguments, model note, and confidence while retaining the
+  interaction outcome and, for a decided row, the closed tier/code.
 - `Stop` reports completion and can route an explicit final-response question using
   Codex’s stable `last_assistant_message` field. It does not parse Codex transcripts.
+- Matcherless `UserPromptSubmit` provides one fixed root-turn steering hint when a live,
+  wire-compatible TapQ runtime advertises `--steering`: use `request_user_input` “when
+  available” for choices or confirmation. It reads discovery and opens a bounded,
+  EOF-only Unix-socket connection to verify broker liveness, but sends no broker request
+  or application data and performs no request/response round-trip. Otherwise it emits
+  nothing so Codex keeps its native behavior.
 - Broker absence, timeout, an incompatible wire version, invalid data, or no hands-free
   answer emits no hook decision, leaving Codex’s normal selector, approval, or turn flow
   in control. Multiple questions, auto-resolving questions, unsupported option shapes,
   secret questions, and subagent calls also stay native.
-- There is no broad Codex strict `PreToolUse` policy, `UserPromptSubmit` steering, or
-  generic notification-hook parity.
+- There is no broad Codex strict `PreToolUse` policy or generic notification-hook parity.
+
+In Codex CLI `0.146.0`, Plan mode is the reliable surface for
+`request_user_input`. Availability in default mode depends on Codex's
+`default_mode_request_user_input` feature. `tapq integration codex status` resolves
+`codex` from the caller's `PATH`, reports that executable, and runs only `--version` and
+`features list` under a minimal allowlisted environment. A missing executable is distinct
+from a resolved executable whose probe fails or times out; neither changes file-status
+exit semantics. Because status executes the resolved path, use a trusted `PATH`. Use Codex's
+`/hooks` view for the authoritative activation and trust result. A parsed version below
+`0.142.5` produces a compatibility warning without changing status exit semantics.
 
 TapQ’s lifecycle-hook contract floor is Codex CLI `0.142.5`. Versioned
-`request_user_input` and MCP `PermissionRequest` fixtures plus real
-executable-to-broker tests target Codex CLI `0.146.0`. The adapter targets local Codex
-clients that load user lifecycle hooks; hosted Codex Cloud tasks are outside this
+`PermissionRequest` and `Stop` fixtures cover that floor; versioned
+`request_user_input`, MCP `PermissionRequest`, and `UserPromptSubmit` fixtures target
+Codex CLI `0.146.0`. Real hook-process-to-broker contracts cover supported decisions and
+native fail-through,
+but are not an authenticated model-level Codex end-to-end test. The adapter targets local
+Codex clients that load user lifecycle hooks; hosted Codex Cloud tasks are outside this
 integration surface.
 
 ## Questions in final responses
@@ -350,11 +382,17 @@ A device where the model is unavailable keeps serving without risk escalation an
 it. Strict-policy requests that Claude reports in an auto permission mode are allowed
 before an approval is built, so they are never assessed.
 
-Assessment is on-device only: the reasoner reads the full tool input for the request it is
-judging and never sends it to a cloud provider. Selecting a reasoner also starts a local
-shadow-review log at `<broker-dir>/reasoner-log.jsonl`, which records what each decision
-asked for against what the user then did; see the [security policy](SECURITY.md) for what a
-line can contain, and the [CLI reference](docs/CLI.md) for the full option list.
+Assessment is on-device only. For canonical Codex MCP calls, the reasoner receives
+complete sorted JSON when it fits. Oversized objects are represented by key-balanced
+top-level excerpts; all rendered input, including truncation markers, is capped at 4,000
+characters after non-ASCII and line-separator escaping. Other supported tools keep their
+established command/path context. MCP argument values are never spoken, diagnosed, or
+cloud-sent. Their review rows also omit the model's free-text note and confidence,
+retaining the interaction outcome and, for a decided row, constrained tier/code metadata. Selecting a
+reasoner starts a local shadow-review log at `<broker-dir>/reasoner-log.jsonl`, which
+records what each decision asked for against what the user then did; see the
+[security policy](SECURITY.md) for what a line can contain, and the
+[CLI reference](docs/CLI.md) for the full option list.
 `tapq bench reasoner` scores a reasoner against the labeled corpus in
 [bench/](bench/README.md), and [docs/TAPQ1_STAGE2.md](docs/TAPQ1_STAGE2.md) documents the
 design.
@@ -389,13 +427,13 @@ exposed by each platform and manufacturer.
   questions in final responses.
 - [x] **Codex supported slice** — structured single-choice `request_user_input`,
   native `PermissionRequest` approvals for `Bash`, `apply_patch`, and MCP connector
-  tools, plus `Stop` completion and final-response questions with fail-through.
+  tools, opt-in root-turn prompt steering, plus `Stop` completion and final-response
+  questions with fail-through.
 - [ ] **Cursor — next agent priority** — identify the most stable integration surface
   for permission requests, questions, and completion events, then connect it to the
   existing TapQ broker with native fail-through behavior.
-- [ ] **Codex expanded parity** — add prompt steering and generic notification
-  equivalents when their contracts are stable enough to preserve native fallback
-  behavior.
+- [ ] **Codex expanded parity** — add a generic notification equivalent when its
+  contract is stable enough to preserve native fallback behavior.
 - [ ] **Gemini CLI and GitHub Copilot CLI** — build adapters around their native hook
   systems and reuse the agent-neutral TapQ wire protocol.
 - [ ] **OpenCode and additional agents** — extend support to OpenCode, Windsurf,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,11 +37,12 @@ sandbox between mutually untrusted processes running as the same user: a process
 that can read the discovery record can obtain the bearer token.
 
 Agent hooks send the complete supported tool input to the local broker over this socket.
-For Claude Code this can include Bash commands and file contents. The current Codex
-slice forwards native `PermissionRequest` inputs for `Bash` and `apply_patch`, including
-the command or patch text. Adapters also supply normalized summaries and details used by
-the reference broker, but the complete input is still carried and decoded locally.
-Hosts and debugging tools must treat every request as sensitive.
+For Claude Code this can include Bash commands and file contents. The Codex slice
+forwards native `PermissionRequest` inputs for `Bash`, `apply_patch`, and canonical
+`mcp__<server>__<tool>` calls, including their command, patch, or connector arguments.
+Adapters also supply normalized summaries and details used by the reference broker, but
+the complete input is still carried and decoded locally. Hosts and debugging tools must
+treat every request as sensitive.
 
 ## External data processing
 
@@ -78,10 +79,16 @@ no part of the request reaches a network service. Selecting a reasoner never ena
 processing; that remains the separate, explicit `--question-classifier` decision above.
 
 What a reasoner is shown is a strictly larger surface than what the question classifier is
-shown. The classifier sees assistant reply text. The reasoner sees the complete tool input
-for the action it is judging: the full Bash command line, `apply_patch` patch text, file
-paths, the working directory, and the summary TapQ speaks. That context is carried in
-process, is kept out of diagnostics and spoken output, and does not leave the machine.
+shown. The classifier sees assistant reply text. The reasoner sees the established
+command/path context for supported closed-schema tools and, for a canonical Codex MCP
+call, the server-defined argument object. Complete objects are encoded as sorted JSON.
+Oversized objects become key-balanced excerpts spanning early and late top-level keys,
+with balanced head/tail excerpts of selected values so one large early field cannot hide
+later destinations or flags. Non-ASCII scalars, including Unicode line and paragraph
+separators, are escaped before size accounting. The entire rendered input, including its
+truncation header, omitted-key notice, and per-value markers, is at most 4,000 characters.
+This context stays in process and connector values are not spoken, written to diagnostics,
+or sent to a cloud service.
 
 A reasoner's only power is raising the confirmation bar. It cannot approve, deny, resolve,
 or weaken a request, and no configuration grants it those. Every failure mode — no model,
@@ -98,11 +105,17 @@ behavior described under *Authorization and failure behavior*.
 
 Selecting a reasoner also starts a local shadow-review log at
 `<broker-dir>/reasoner-log.jsonl`: one JSON line per reasoner-observed approval, recording
-the risk tier, rationale code, the model's bounded note, confidence or abstention reason,
-latency, the confirmation the decision implied, and what the user then decided. The full
-command line, the working directory, and the adapter's detail are deliberately absent, but
-the recorded `summary` is the same text TapQ speaks aloud, and for a `Bash` request that
-summary is the *front* of the command line — its first six words, capped at 64 characters.
+the risk tier, rationale code, disclosure-permitted model note and confidence or an
+abstention reason, latency, the confirmation the decision implied, and what the user then
+decided. The full command line, working directory, adapter detail, and MCP argument values
+are deliberately absent. MCP rows also omit the model-generated free-text note, because
+an instruction not to copy request data is not a redaction boundary. They omit model
+confidence as well,
+because a numeric field can echo an argument value. Their constrained tier and rationale
+code remain reviewable when a decision exists, and the interaction outcome remains on
+every row. The recorded `summary` is the same
+text TapQ speaks aloud. For a `Bash` request that summary is the *front* of the command
+line — its first six words, capped at 64 characters.
 That prefix can carry a real secret: a connection string, a header fragment, a token passed
 as an early argument. Treat the file as the same class of local state as `broker.json`. It
 is created `0600` inside the `0700` runtime directory, is capped at roughly 5 MB with a
@@ -132,6 +145,18 @@ non-managed command-hook definition and skips new or changed definitions until t
 reviews and trusts them through `/hooks`. Do not use
 `--dangerously-bypass-hook-trust` as a substitute for that review.
 
+`tapq integration codex status` resolves `codex` from the invoking process's `PATH` and
+may execute that resolved file with two fixed read-only argument sets: `--version`, then
+`features list` when the first probe completes. It supplies a minimal allowlisted
+environment containing only process/configuration lookup, temporary-directory, and locale
+values, with `NO_COLOR=1` and `TERM=dumb`; API keys, SSH agent paths, and unrelated
+inherited variables are omitted. This limits accidental credential inheritance but does
+not sandbox the executable. A malicious or
+unexpected file earlier on `PATH` still runs with the user's authority. Invoke status
+only with a trusted `PATH`. TapQ bounds probe time/output and distinguishes “not found on
+PATH” from “executable found, but diagnostics failed or timed out”; probe failure never
+changes the hooks-file status result.
+
 ## Authorization and failure behavior
 
 The Claude Code and Codex hooks are designed to leave the agent’s normal on-screen flow
@@ -146,12 +171,23 @@ Claude Code chooses to emit; Claude allow rules and `bypassPermissions` can
 bypass TapQ entirely. Choose the policy as part of the host’s authorization and
 risk model.
 
-Codex currently has native behavior only: TapQ answers `PermissionRequest` events for
-`Bash` and `apply_patch` that Codex was already going to show. It does not install a
-strict `PreToolUse` policy, intercept structured `request_user_input`, or replace Codex’s
-generic notification behavior. Commands and patches that Codex permits without a native
+Codex has native approval behavior only: TapQ answers `PermissionRequest` events for
+`Bash`, `apply_patch`, and canonical MCP calls that Codex was already going to show. A
+narrow `PreToolUse` hook handles one supported root-agent `request_user_input`; there is
+no broad strict policy. Commands and connector calls that Codex permits without a native
 prompt do not reach TapQ. Every missing runtime, timeout, `.ask`, invalid response, and
 unsupported input emits no decision, preserving Codex’s own sandbox and approval flow.
+
+The matcherless root-only `UserPromptSubmit` hook is advisory and opt-in. It injects one
+fixed instruction to use `request_user_input` “when available” only when a live,
+wire-compatible local TapQ runtime advertises `--steering`. It reads discovery and opens
+then closes a bounded EOF-only Unix-socket connection to verify liveness. That probe
+sends no request bytes or application data and performs no broker request/response
+round-trip. The hook emits nothing for subagents, invalid input, a stopped runtime, an
+incompatible wire version, or disabled steering. It does not create a strict policy or
+replace Codex's generic notification behavior. The submitted prompt is validated in the
+hook process but is never copied into the fixed output, sent to the broker, or written to
+diagnostics.
 
 The Codex Stop hook can turn one explicit final-response question into a continuation
 prompt only after the broker returns an answer. It uses `last_assistant_message`, never

--- a/Sources/TapQBrokerRuntime/BrokerRuntimeDiscovery.swift
+++ b/Sources/TapQBrokerRuntime/BrokerRuntimeDiscovery.swift
@@ -62,7 +62,8 @@ public struct BrokerRuntimeDiscovery: Sendable {
             socket: socketPath,
             token: token,
             protocolVersion: WireProtocol.version,
-            steeringEnabled: steeringEnabled
+            steeringEnabled: steeringEnabled,
+            processID: ProcessInfo.processInfo.processIdentifier
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -98,12 +99,13 @@ public struct BrokerRuntimeDiscovery: Sendable {
         let token: String
         let protocolVersion: Int
         let steeringEnabled: Bool
+        let processID: Int32
 
         enum CodingKeys: String, CodingKey {
             case socket, token
             case protocolVersion = "protocol_version"
             case steeringEnabled = "steering_enabled"
+            case processID = "process_id"
         }
     }
 }
-

--- a/Sources/TapQCLI/CodexCLIProbe.swift
+++ b/Sources/TapQCLI/CodexCLIProbe.swift
@@ -407,6 +407,7 @@ private final class BoundedPipeDrain: @unchecked Sendable {
     private let handle: FileHandle
     private let retainedByteLimit: Int
     private let group: DispatchGroup
+    private let cleanupQueue = DispatchQueue(label: "tapq.codex-cli-probe.pipe-cleanup")
     private let lock = NSLock()
     private var stored = Data()
     private var isFinished = false
@@ -429,7 +430,7 @@ private final class BoundedPipeDrain: @unchecked Sendable {
 
     func cancel() {
         let shouldFinish = markFinished()
-        if shouldFinish { closeAndLeaveGroup() }
+        if shouldFinish { scheduleCleanup() }
     }
 
     private func consumeAvailableData() {
@@ -445,7 +446,7 @@ private final class BoundedPipeDrain: @unchecked Sendable {
             }
         }
         lock.unlock()
-        if shouldFinish { closeAndLeaveGroup() }
+        if shouldFinish { scheduleCleanup() }
     }
 
     private func markFinished() -> Bool {
@@ -456,9 +457,13 @@ private final class BoundedPipeDrain: @unchecked Sendable {
         return true
     }
 
-    private func closeAndLeaveGroup() {
-        handle.readabilityHandler = nil
-        try? handle.close()
-        group.leave()
+    private func scheduleCleanup() {
+        cleanupQueue.async { [self] in
+            // swift-corelibs-foundation closes FileHandle by synchronizing with its monitoring
+            // queue. Closing from that queue's callback traps in libdispatch, so tear down here.
+            handle.readabilityHandler = nil
+            try? handle.close()
+            group.leave()
+        }
     }
 }

--- a/Sources/TapQCLI/CodexCLIProbe.swift
+++ b/Sources/TapQCLI/CodexCLIProbe.swift
@@ -1,0 +1,464 @@
+import Foundation
+import TapQPOSIXSupport
+
+/// The observable result of one best-effort Codex CLI diagnostic command.
+///
+/// TapQ never uses this runner to change Codex configuration. The public shape exists so
+/// embedders and tests can supply a process boundary without depending on a local Codex install.
+public enum CodexCLICommandResult: Equatable, Sendable {
+    /// The resolved command could not be launched, completed, or drained within its bounds.
+    /// Executable absence is tracked separately by the resolver.
+    case unavailable
+    case completed(status: Int32, standardOutput: String, standardError: String)
+}
+
+enum CodexFeatureState: Equatable {
+    case enabled(stage: String)
+    case disabled(stage: String)
+    case unknown
+}
+
+enum CodexCLIAvailability: Equatable {
+    case notFound
+    case probeFailed
+    case detected
+}
+
+struct CodexCLIActivationStatus: Equatable {
+    let availability: CodexCLIAvailability
+    let executablePath: String?
+    let version: String?
+    let hooks: CodexFeatureState
+    let defaultModeRequestUserInput: CodexFeatureState
+
+    var isAvailable: Bool { availability == .detected }
+
+    var isBelowTestedLifecycleFloor: Bool? {
+        version.flatMap(CodexCLIProbe.isBelowTestedLifecycleFloor)
+    }
+
+    static let notFound = CodexCLIActivationStatus(
+        availability: .notFound,
+        executablePath: nil,
+        version: nil,
+        hooks: .unknown,
+        defaultModeRequestUserInput: .unknown
+    )
+}
+
+enum CodexCLIProbe {
+    static let testedLifecycleFloor = "0.142.5"
+    private static let maximumVersionTokenBytes = 128
+
+    static func probe(
+        executablePath: String? = nil,
+        executableWasResolved: Bool = true,
+        using run: ([String]) -> CodexCLICommandResult
+    ) -> CodexCLIActivationStatus {
+        guard executableWasResolved else { return .notFound }
+        let versionResult = run(["--version"])
+        guard case .completed(let versionStatus, let versionOutput, let versionError) =
+                versionResult else {
+            return CodexCLIActivationStatus(
+                availability: .probeFailed,
+                executablePath: executablePath,
+                version: nil,
+                hooks: .unknown,
+                defaultModeRequestUserInput: .unknown
+            )
+        }
+
+        let version = versionStatus == 0
+            ? parseVersion(from: versionOutput + "\n" + versionError)
+            : nil
+        let featuresResult = run(["features", "list"])
+        guard case .completed(let featureStatus, let featureOutput, let featureError) =
+                featuresResult,
+              featureStatus == 0 else {
+            return CodexCLIActivationStatus(
+                availability: versionStatus == 0 ? .detected : .probeFailed,
+                executablePath: executablePath,
+                version: version,
+                hooks: .unknown,
+                defaultModeRequestUserInput: .unknown
+            )
+        }
+
+        let features = featureOutput + "\n" + featureError
+        return CodexCLIActivationStatus(
+            availability: .detected,
+            executablePath: executablePath,
+            version: version,
+            hooks: parseFeature(named: "hooks", from: features),
+            defaultModeRequestUserInput: parseFeature(
+                named: "default_mode_request_user_input",
+                from: features
+            )
+        )
+    }
+
+    static func parseVersion(from output: String) -> String? {
+        let punctuation = CharacterSet(charactersIn: ",;()[]{}")
+        for line in output.components(separatedBy: .newlines) {
+            let tokens = line.split(whereSeparator: \Character.isWhitespace).map(String.init)
+            guard tokens.contains(where: { $0.lowercased().contains("codex") }) else {
+                continue
+            }
+            for token in tokens {
+                let candidate = token.trimmingCharacters(in: punctuation)
+                guard isSafeVersionToken(candidate) else { continue }
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    /// Version text is rendered directly in terminal diagnostics. Accept the numeric core and
+    /// SemVer-shaped ASCII prerelease/build identifiers, but never relay arbitrary CLI output.
+    private static func isSafeVersionToken(_ candidate: String) -> Bool {
+        guard !candidate.isEmpty, candidate.utf8.count <= maximumVersionTokenBytes else {
+            return false
+        }
+        let buildPieces = candidate.split(
+            separator: "+",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )
+        guard buildPieces.count <= 2,
+              buildPieces.count == 1 || isSafeVersionSuffix(buildPieces[1]) else {
+            return false
+        }
+        let releasePieces = buildPieces[0].split(
+            separator: "-",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )
+        guard releasePieces.count <= 2,
+              releasePieces.count == 1 || isSafeVersionSuffix(releasePieces[1]) else {
+            return false
+        }
+        let numericComponents = releasePieces[0].split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        )
+        return numericComponents.count >= 2 && numericComponents.allSatisfy { component in
+            !component.isEmpty && component.utf8.allSatisfy { byte in
+                byte >= Character("0").asciiValue! && byte <= Character("9").asciiValue!
+            }
+        }
+    }
+
+    private static func isSafeVersionSuffix(_ suffix: Substring) -> Bool {
+        let identifiers = suffix.split(separator: ".", omittingEmptySubsequences: false)
+        return !identifiers.isEmpty && identifiers.allSatisfy { identifier in
+            !identifier.isEmpty && identifier.utf8.allSatisfy { byte in
+                (byte >= Character("0").asciiValue! && byte <= Character("9").asciiValue!)
+                    || (byte >= Character("A").asciiValue! && byte <= Character("Z").asciiValue!)
+                    || (byte >= Character("a").asciiValue! && byte <= Character("z").asciiValue!)
+                    || byte == Character("-").asciiValue!
+            }
+        }
+    }
+
+    static func parseFeature(named name: String, from output: String) -> CodexFeatureState {
+        for line in output.components(separatedBy: .newlines) {
+            let fields = line.split(whereSeparator: \Character.isWhitespace).map(String.init)
+            guard fields.first == name, fields.count >= 3 else { continue }
+            guard let stage = recognizedFeatureStage(fields.dropFirst().dropLast()) else {
+                continue
+            }
+            switch fields.last?.lowercased() {
+            case "true": return .enabled(stage: stage)
+            case "false": return .disabled(stage: stage)
+            default: continue
+            }
+        }
+        return .unknown
+    }
+
+    /// Codex owns this output, but it is rendered directly in TapQ's terminal diagnostics.
+    /// Keep the accepted vocabulary closed so a malformed or hostile executable cannot relay
+    /// control characters, bidi markers, or arbitrarily long stage labels to the terminal.
+    private static func recognizedFeatureStage<C: Collection>(_ fields: C) -> String?
+    where C.Element == String {
+        switch Array(fields) {
+        case ["stable"]:
+            return "stable"
+        case ["experimental"]:
+            return "experimental"
+        case ["under", "development"]:
+            return "under development"
+        case ["removed"]:
+            return "removed"
+        case ["deprecated"]:
+            return "deprecated"
+        default:
+            return nil
+        }
+    }
+
+    static func isBelowTestedLifecycleFloor(_ version: String) -> Bool? {
+        compare(version, with: testedLifecycleFloor).map { $0 < 0 }
+    }
+
+    /// Semver-shaped comparison for Codex's numeric CLI releases. Unknown shapes stay unknown
+    /// rather than being treated as incompatible. A prerelease of the exact floor is older than
+    /// the stable floor; build metadata does not affect ordering.
+    private static func compare(_ lhs: String, with rhs: String) -> Int? {
+        guard let left = semanticVersion(lhs), let right = semanticVersion(rhs) else {
+            return nil
+        }
+        let count = max(left.components.count, right.components.count)
+        for index in 0..<count {
+            let leftValue = index < left.components.count ? left.components[index] : 0
+            let rightValue = index < right.components.count ? right.components[index] : 0
+            if leftValue != rightValue { return leftValue < rightValue ? -1 : 1 }
+        }
+        if left.prerelease == right.prerelease { return 0 }
+        if left.prerelease == nil { return 1 }
+        if right.prerelease == nil { return -1 }
+        return left.prerelease! < right.prerelease! ? -1 : 1
+    }
+
+    private static func semanticVersion(
+        _ value: String
+    ) -> (components: [Int], prerelease: String?)? {
+        let withoutBuildMetadata = value.split(separator: "+", maxSplits: 1).first.map(String.init)
+            ?? value
+        let pieces = withoutBuildMetadata.split(
+            separator: "-",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )
+        guard let numericText = pieces.first, !numericText.isEmpty else { return nil }
+        let numeric = numericText.split(separator: ".", omittingEmptySubsequences: false)
+        guard numeric.count >= 3 else { return nil }
+        let components = numeric.compactMap { Int($0) }
+        guard components.count == numeric.count else { return nil }
+        let prerelease: String?
+        if pieces.count == 2 {
+            guard !pieces[1].isEmpty else { return nil }
+            prerelease = String(pieces[1])
+        } else {
+            prerelease = nil
+        }
+        return (components, prerelease)
+    }
+}
+
+struct ResolvedCodexCLIProcessRunner {
+    let executableURL: URL
+    let environment: [String: String]
+    let currentDirectory: URL
+
+    func run(arguments: [String]) -> CodexCLICommandResult {
+        CodexCLIProcessRunner.run(
+            executableURL: executableURL,
+            arguments: arguments,
+            environment: environment,
+            currentDirectory: currentDirectory,
+            timeout: CodexCLIProcessRunner.commandTimeout
+        )
+    }
+}
+
+enum CodexCLIProcessRunner {
+    fileprivate static let commandTimeout: TimeInterval = 3
+    private static let terminationGrace: TimeInterval = 0.5
+    static let maximumCapturedOutputBytes = 1_048_576
+
+    static func resolve(
+        environment: [String: String],
+        currentDirectory: URL
+    ) -> ResolvedCodexCLIProcessRunner? {
+        guard let executableURL = executableURL(
+            environment: environment,
+            currentDirectory: currentDirectory
+        ) else {
+            return nil
+        }
+        return ResolvedCodexCLIProcessRunner(
+            executableURL: executableURL,
+            environment: probeEnvironment(from: environment),
+            currentDirectory: currentDirectory
+        )
+    }
+
+    /// These diagnostics are fixed, local-only Codex commands. Pass only process-discovery,
+    /// configuration-home, temporary-directory, and locale values they may need; unrelated
+    /// credentials and application-specific state must not reach a PATH-resolved executable.
+    static func probeEnvironment(from environment: [String: String]) -> [String: String] {
+        let retainedKeys = [
+            "PATH",
+            "HOME",
+            "CODEX_HOME",
+            "XDG_CONFIG_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_DATA_HOME",
+            "TMPDIR",
+            "TMP",
+            "TEMP",
+            "LANG",
+            "LC_ALL",
+            "LC_CTYPE",
+        ]
+        var result = environment.filter { retainedKeys.contains($0.key) }
+        result["NO_COLOR"] = "1"
+        result["TERM"] = "dumb"
+        return result
+    }
+
+    static func run(
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        currentDirectory: URL,
+        timeout: TimeInterval
+    ) -> CodexCLICommandResult {
+        let process = Process()
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        let termination = DispatchSemaphore(value: 0)
+        let drains = DispatchGroup()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.environment = environment
+        process.currentDirectoryURL = currentDirectory
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+        process.terminationHandler = { _ in termination.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            return .unavailable
+        }
+
+        let outputDrain = BoundedPipeDrain(
+            handle: standardOutput.fileHandleForReading,
+            retainedByteLimit: maximumCapturedOutputBytes,
+            group: drains
+        )
+        let errorDrain = BoundedPipeDrain(
+            handle: standardError.fileHandleForReading,
+            retainedByteLimit: maximumCapturedOutputBytes,
+            group: drains
+        )
+        let pipeDrains = [outputDrain, errorDrain]
+
+        guard termination.wait(timeout: .now() + max(0, timeout)) == .success else {
+            stop(process, termination: termination)
+            finishDrains(pipeDrains, group: drains)
+            return .unavailable
+        }
+        guard drains.wait(timeout: .now() + terminationGrace) == .success else {
+            pipeDrains.forEach { $0.cancel() }
+            _ = drains.wait(timeout: .now() + terminationGrace)
+            return .unavailable
+        }
+        return .completed(
+            status: process.terminationStatus,
+            standardOutput: String(decoding: outputDrain.data, as: UTF8.self),
+            standardError: String(decoding: errorDrain.data, as: UTF8.self)
+        )
+    }
+
+    private static func finishDrains(
+        _ drains: [BoundedPipeDrain],
+        group: DispatchGroup
+    ) {
+        if group.wait(timeout: .now() + terminationGrace) == .success { return }
+        drains.forEach { $0.cancel() }
+        _ = group.wait(timeout: .now() + terminationGrace)
+    }
+
+    private static func stop(_ process: Process, termination: DispatchSemaphore) {
+        if process.isRunning { process.terminate() }
+        if termination.wait(timeout: .now() + terminationGrace) == .success { return }
+        if process.isRunning {
+            POSIXProcessControl.forceTerminate(processIdentifier: process.processIdentifier)
+        }
+        _ = termination.wait(timeout: .now() + terminationGrace)
+    }
+
+    private static func executableURL(
+        environment: [String: String],
+        currentDirectory: URL
+    ) -> URL? {
+        guard let path = environment["PATH"] else { return nil }
+        for component in path.split(separator: ":", omittingEmptySubsequences: false) {
+            let directory = component.isEmpty
+                ? currentDirectory
+                : URL(fileURLWithPath: String(component), isDirectory: true)
+            let candidate = directory.appendingPathComponent("codex").standardizedFileURL
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+}
+
+/// Event-driven pipe draining avoids tying up a global worker on a blocking read when a
+/// descendant inherits the pipe after the direct child exits. Output beyond the retention cap
+/// is still consumed so a noisy Codex process cannot deadlock on a full pipe.
+private final class BoundedPipeDrain: @unchecked Sendable {
+    private let handle: FileHandle
+    private let retainedByteLimit: Int
+    private let group: DispatchGroup
+    private let lock = NSLock()
+    private var stored = Data()
+    private var isFinished = false
+
+    init(handle: FileHandle, retainedByteLimit: Int, group: DispatchGroup) {
+        self.handle = handle
+        self.retainedByteLimit = max(0, retainedByteLimit)
+        self.group = group
+        group.enter()
+        handle.readabilityHandler = { [weak self] _ in
+            self?.consumeAvailableData()
+        }
+    }
+
+    var data: Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    func cancel() {
+        let shouldFinish = markFinished()
+        if shouldFinish { closeAndLeaveGroup() }
+    }
+
+    private func consumeAvailableData() {
+        var shouldFinish = false
+        lock.lock()
+        if !isFinished {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                isFinished = true
+                shouldFinish = true
+            } else if stored.count < retainedByteLimit {
+                stored.append(chunk.prefix(retainedByteLimit - stored.count))
+            }
+        }
+        lock.unlock()
+        if shouldFinish { closeAndLeaveGroup() }
+    }
+
+    private func markFinished() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isFinished else { return false }
+        isFinished = true
+        return true
+    }
+
+    private func closeAndLeaveGroup() {
+        handle.readabilityHandler = nil
+        try? handle.close()
+        group.leave()
+    }
+}

--- a/Sources/TapQCLI/CodexCLIProbe.swift
+++ b/Sources/TapQCLI/CodexCLIProbe.swift
@@ -346,6 +346,7 @@ enum CodexCLIProcessRunner {
             group: drains
         )
         let pipeDrains = [outputDrain, errorDrain]
+        defer { pipeDrains.forEach { $0.closeFromOwner() } }
 
         guard termination.wait(timeout: .now() + max(0, timeout)) == .success else {
             stop(process, termination: termination)
@@ -407,7 +408,6 @@ private final class BoundedPipeDrain: @unchecked Sendable {
     private let handle: FileHandle
     private let retainedByteLimit: Int
     private let group: DispatchGroup
-    private let cleanupQueue = DispatchQueue(label: "tapq.codex-cli-probe.pipe-cleanup")
     private let lock = NSLock()
     private var stored = Data()
     private var isFinished = false
@@ -430,7 +430,15 @@ private final class BoundedPipeDrain: @unchecked Sendable {
 
     func cancel() {
         let shouldFinish = markFinished()
-        if shouldFinish { scheduleCleanup() }
+        if shouldFinish { group.leave() }
+    }
+
+    /// The runner owns teardown so it cannot race FileHandle's handler installation. This must
+    /// not run from the readability callback: swift-corelibs-foundation closes FileHandle by
+    /// synchronizing with its monitoring queue, which traps when invoked from that same queue.
+    func closeFromOwner() {
+        handle.readabilityHandler = nil
+        try? handle.close()
     }
 
     private func consumeAvailableData() {
@@ -446,7 +454,7 @@ private final class BoundedPipeDrain: @unchecked Sendable {
             }
         }
         lock.unlock()
-        if shouldFinish { scheduleCleanup() }
+        if shouldFinish { group.leave() }
     }
 
     private func markFinished() -> Bool {
@@ -455,15 +463,5 @@ private final class BoundedPipeDrain: @unchecked Sendable {
         guard !isFinished else { return false }
         isFinished = true
         return true
-    }
-
-    private func scheduleCleanup() {
-        cleanupQueue.async { [self] in
-            // swift-corelibs-foundation closes FileHandle by synchronizing with its monitoring
-            // queue. Closing from that queue's callback traps in libdispatch, so tear down here.
-            handle.readabilityHandler = nil
-            try? handle.close()
-            group.leave()
-        }
     }
 }

--- a/Sources/TapQCLI/CodexCLIProbe.swift
+++ b/Sources/TapQCLI/CodexCLIProbe.swift
@@ -358,6 +358,7 @@ enum CodexCLIProcessRunner {
             _ = drains.wait(timeout: .now() + terminationGrace)
             return .unavailable
         }
+        guard pipeDrains.allSatisfy(\.succeeded) else { return .unavailable }
         return .completed(
             status: process.terminationStatus,
             standardOutput: String(decoding: outputDrain.data, as: UTF8.self),
@@ -405,18 +406,29 @@ enum CodexCLIProcessRunner {
 /// descendant inherits the pipe after the direct child exits. Output beyond the retention cap
 /// is still consumed so a noisy Codex process cannot deadlock on a full pipe.
 private final class BoundedPipeDrain: @unchecked Sendable {
+    private static let readBufferSize = 64 * 1024
+
     private let handle: FileHandle
+    private let descriptor: Int32
     private let retainedByteLimit: Int
     private let group: DispatchGroup
     private let lock = NSLock()
     private var stored = Data()
     private var isFinished = false
+    private var didFail = false
 
     init(handle: FileHandle, retainedByteLimit: Int, group: DispatchGroup) {
         self.handle = handle
+        self.descriptor = handle.fileDescriptor
         self.retainedByteLimit = max(0, retainedByteLimit)
         self.group = group
         group.enter()
+        guard POSIXNonblockingIO.configure(descriptor) else {
+            isFinished = true
+            didFail = true
+            group.leave()
+            return
+        }
         handle.readabilityHandler = { [weak self] _ in
             self?.consumeAvailableData()
         }
@@ -426,6 +438,12 @@ private final class BoundedPipeDrain: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return stored
+    }
+
+    var succeeded: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !didFail
     }
 
     func cancel() {
@@ -442,19 +460,54 @@ private final class BoundedPipeDrain: @unchecked Sendable {
     }
 
     private func consumeAvailableData() {
-        var shouldFinish = false
-        lock.lock()
-        if !isFinished {
-            let chunk = handle.availableData
-            if chunk.isEmpty {
-                isFinished = true
-                shouldFinish = true
-            } else if stored.count < retainedByteLimit {
-                stored.append(chunk.prefix(retainedByteLimit - stored.count))
+        var buffer = [UInt8](repeating: 0, count: Self.readBufferSize)
+        while true {
+            if finished { return }
+            let result = buffer.withUnsafeMutableBytes {
+                POSIXNonblockingIO.read(descriptor, into: $0)
+            }
+            switch result {
+            case .bytes(let count):
+                guard retain(buffer, count: count) else { return }
+            case .wouldBlock:
+                return
+            case .endOfFile:
+                finish(failed: false)
+                return
+            case .failed:
+                finish(failed: true)
+                return
             }
         }
+    }
+
+    private var finished: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isFinished
+    }
+
+    private func retain(_ buffer: [UInt8], count: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isFinished else { return false }
+        if stored.count < retainedByteLimit {
+            let retainedCount = min(count, retainedByteLimit - stored.count)
+            stored.append(contentsOf: buffer[..<retainedCount])
+        }
+        return true
+    }
+
+    private func finish(failed: Bool) {
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
+        didFail = failed
         lock.unlock()
-        if shouldFinish { group.leave() }
+        group.leave()
     }
 
     private func markFinished() -> Bool {

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -53,6 +53,9 @@ public struct TapQCLIIO {
     private let executableURL: URL
     private let currentDirectory: URL
     private let monotonicNow: () -> TimeInterval
+    private let codexCLICommandRunner: ([String]) -> CodexCLICommandResult
+    private let codexCLIExecutablePath: String?
+    private let codexCLIExecutableWasResolved: Bool
 
     public init(
         io: TapQCLIIO = .live,
@@ -70,7 +73,9 @@ public struct TapQCLIIO {
         ),
         monotonicNow: @escaping () -> TimeInterval = {
             ProcessInfo.processInfo.systemUptime
-        }
+        },
+        codexCLICommandRunner: (([String]) -> CodexCLICommandResult)? = nil,
+        codexCLIResolvedExecutableURL: URL? = nil
     ) {
         self.io = io
         self.motionCapture = motionCapture
@@ -83,6 +88,22 @@ public struct TapQCLIIO {
         self.executableURL = executableURL
         self.currentDirectory = currentDirectory
         self.monotonicNow = monotonicNow
+        if let codexCLICommandRunner {
+            self.codexCLICommandRunner = codexCLICommandRunner
+            self.codexCLIExecutablePath = codexCLIResolvedExecutableURL?.path
+            self.codexCLIExecutableWasResolved = true
+        } else if let runner = CodexCLIProcessRunner.resolve(
+                environment: environment,
+                currentDirectory: currentDirectory
+        ) {
+            self.codexCLICommandRunner = runner.run(arguments:)
+            self.codexCLIExecutablePath = runner.executableURL.path
+            self.codexCLIExecutableWasResolved = true
+        } else {
+            self.codexCLICommandRunner = { _ in .unavailable }
+            self.codexCLIExecutablePath = nil
+            self.codexCLIExecutableWasResolved = false
+        }
     }
 
     @discardableResult
@@ -1022,20 +1043,21 @@ public struct TapQCLIIO {
             }
             outputLine("Start the hands-free runtime with `tapq serve`.")
         case .status:
-            switch installer.installationStatus() {
+            let installationStatus = installer.installationStatus()
+            switch installationStatus {
             case .installed:
                 outputLine("Codex integration: configured")
                 outputLine("Hooks: \(hooksURL.path)")
                 outputLine("Hook: \(hookURL.path)")
-                outputLine("Trust: verify in Codex with `/hooks`")
             case .partial:
                 outputLine("Codex integration: incomplete")
                 outputLine("Hooks: \(hooksURL.path)")
                 outputLine("Hook: \(hookURL.path)")
-                outputLine("Re-run `tapq integration codex install` to repair it, then trust it with `/hooks`.")
+                outputLine("Re-run `tapq integration codex install` to repair it.")
             case .notInstalled:
                 outputLine("Codex integration: not installed")
             }
+            reportCodexActivationStatus(hasHookDefinition: installationStatus != .notInstalled)
         case .uninstall:
             try installer.uninstall()
             outputLine("Codex integration removed from \(hooksURL.path).")
@@ -1050,6 +1072,102 @@ public struct TapQCLIIO {
             return resolvedURL(for: path).appendingPathComponent("hooks.json")
         }
         return homeDirectory.appendingPathComponent(".codex/hooks.json")
+    }
+
+    private func reportCodexActivationStatus(hasHookDefinition: Bool) {
+        let status = CodexCLIProbe.probe(
+            executablePath: codexCLIExecutablePath,
+            executableWasResolved: codexCLIExecutableWasResolved,
+            using: codexCLICommandRunner
+        )
+        switch status.availability {
+        case .detected:
+            outputLine("Codex CLI: \(status.version ?? "detected; version unknown")")
+        case .probeFailed:
+            outputLine("Codex CLI: executable found, but diagnostics failed or timed out")
+        case .notFound:
+            outputLine("Codex CLI: not found on PATH")
+        }
+        if let executablePath = status.executablePath {
+            outputLine("Codex CLI executable: \(terminalSafePath(executablePath))")
+        }
+        outputLine("Codex feature `hooks`: \(featureDescription(status.hooks))")
+        outputLine(
+            "Codex feature `default_mode_request_user_input`: "
+            + featureDescription(status.defaultModeRequestUserInput)
+        )
+        if status.isBelowTestedLifecycleFloor == true, let version = status.version {
+            outputLine(
+                "Compatibility warning: Codex \(version) is below TapQ's tested "
+                + "lifecycle-hook floor \(CodexCLIProbe.testedLifecycleFloor); update Codex "
+                + "before relying on this integration."
+            )
+        }
+
+        switch status.hooks {
+        case .disabled:
+            outputLine(
+                "Hook activation: disabled in Codex; enable the `hooks` feature before "
+                + "expecting TapQ interception."
+            )
+        case .unknown:
+            outputLine("Hook activation: unknown; verify the `hooks` feature in Codex.")
+        case .enabled:
+            break
+        }
+
+        switch status.defaultModeRequestUserInput {
+        case .enabled:
+            outputLine(
+                "Questions: `request_user_input` is available in Plan mode and enabled "
+                + "for Default mode."
+            )
+        case .disabled:
+            outputLine(
+                "Questions: use Plan mode for `request_user_input`; Default mode requires "
+                + "Codex feature `default_mode_request_user_input`, which is disabled."
+            )
+        case .unknown:
+            outputLine(
+                "Questions: use Plan mode for `request_user_input`; Default-mode availability "
+                + "is unknown."
+            )
+        }
+        if hasHookDefinition {
+            outputLine(
+                "Trust: owned by Codex; TapQ cannot inspect or grant it. "
+                + "To verify in Codex with `/hooks`, review the current hook definitions."
+            )
+        } else {
+            outputLine("Trust: owned by Codex; TapQ cannot inspect or grant it.")
+        }
+    }
+
+    private func featureDescription(_ state: CodexFeatureState) -> String {
+        switch state {
+        case .enabled(let stage): "enabled (\(stage))"
+        case .disabled(let stage): "disabled (\(stage))"
+        case .unknown: "unknown"
+        }
+    }
+
+    private func terminalSafePath(_ path: String) -> String {
+        let scalarLimit = 256
+        var result = ""
+        var scalarCount = 0
+        for scalar in path.unicodeScalars {
+            guard scalarCount < scalarLimit else {
+                result += "..."
+                break
+            }
+            scalarCount += 1
+            if scalar.value >= 0x20, scalar.value <= 0x7E {
+                result.unicodeScalars.append(scalar)
+            } else {
+                result += "\\u{\(String(scalar.value, radix: 16, uppercase: true))}"
+            }
+        }
+        return result
     }
 
     private func warnIfNativeBypassesTapQ(
@@ -1308,9 +1426,18 @@ public struct TapQCLIIO {
     leaving recognized read-only Bash commands uninterrupted. Re-run install with the other
     policy to switch without changing unrelated Claude settings or hooks.
 
-    Codex uses native PermissionRequest and Stop lifecycle hooks from ~/.codex/hooks.json
-    (or $CODEX_HOME/hooks.json). After installation, open `/hooks` in Codex and trust the
-    exact TapQ hook definition. Codex skips new or changed non-managed hooks until trusted.
+    Codex installs four managed lifecycle definitions in ~/.codex/hooks.json (or
+    $CODEX_HOME/hooks.json): PreToolUse intercepts structured `request_user_input`,
+    PermissionRequest covers Bash, apply_patch, and canonical MCP tools, Stop handles
+    completion/question fallback, and matcherless UserPromptSubmit supplies the opt-in
+    root-turn steering hint. Native Codex behavior remains authoritative whenever TapQ
+    fails through. After installation, open `/hooks` in Codex and trust the four current
+    TapQ-managed definitions; Codex skips new or changed non-managed hooks until trusted.
+
+    `tapq integration codex status` resolves the first executable `codex` on PATH and runs
+    the read-only commands `codex --version` and `codex features list` with a minimal
+    environment. It reports lifecycle-feature availability, Plan/default-mode question
+    guidance, and the executable path; hook trust itself remains visible only in `/hooks`.
     """
 }
 

--- a/Sources/TapQClaudeAdapter/HookInstaller.swift
+++ b/Sources/TapQClaudeAdapter/HookInstaller.swift
@@ -47,7 +47,8 @@ public struct HookInstaller {
 
     /// Interaction timeout (~240 s) sits under the InteractionBudget.hookTimeout ceiling.
     /// Stop shares that ceiling: an intercepted question runs a full interaction window.
-    /// UserPromptSubmit only reads the local discovery file — 5 s is generous.
+    /// UserPromptSubmit reads discovery and makes a bounded connection-only liveness probe;
+    /// 5 s is generous.
     private static let sharedSpecs: [Spec] = [
         Spec(event: "Notification", matcher: "idle_prompt|permission_prompt", timeout: 10),
         Spec(event: "Stop", matcher: nil, timeout: InteractionBudget.hookTimeout),

--- a/Sources/TapQClaudeAdapter/HookShim.swift
+++ b/Sources/TapQClaudeAdapter/HookShim.swift
@@ -296,9 +296,9 @@ public struct HookShim {
     /// Exact nudge copy from the spec — do not reword without updating the spec.
     static let steeringNudge = "When you need the user to choose between options or confirm a decision, ask via the AskUserQuestion tool rather than in plain text."
 
-    /// Steering is decided entirely from the discovery file (is the broker live, does it
-    /// speak our protocol version, is the flag on) so the prompt path adds no socket
-    /// latency. Any doubt → silence: a missing/stale/mismatched discovery injects nothing.
+    /// The executable derives steering from discovery plus a bounded connection-only
+    /// liveness probe. The shim itself sends no broker request or application data. Any
+    /// doubt → silence: a missing/stale/mismatched discovery injects nothing.
     private static func handleUserPromptSubmit(steeringEnabled: () -> Bool) -> Result {
         guard steeringEnabled() else { return passThrough }
         let output = UserPromptSubmitOutput(hookSpecificOutput: .init(additionalContext: steeringNudge))

--- a/Sources/TapQCodexAdapter/CodexHookInstaller.swift
+++ b/Sources/TapQCodexAdapter/CodexHookInstaller.swift
@@ -95,6 +95,8 @@ public struct CodexHookInstaller {
 
     /// Codex reports unified exec as `Bash`, patch mutations as `apply_patch`, and
     /// connector calls using the canonical `mcp__<server>__<tool>` name.
+    /// UserPromptSubmit only reads discovery and makes a bounded connection-only liveness
+    /// probe, so it needs no user-interaction budget.
     static let permissionMatcher = "^(Bash|apply_patch|mcp__.+__.+)$"
     static let requestUserInputMatcher = "^request_user_input$"
     static let specs: [Spec] = [
@@ -109,6 +111,7 @@ public struct CodexHookInstaller {
             timeout: InteractionBudget.hookTimeout
         ),
         Spec(event: "Stop", matcher: nil, timeout: InteractionBudget.hookTimeout),
+        Spec(event: "UserPromptSubmit", matcher: nil, timeout: 5),
     ]
     private static let managedEvents = Set(specs.map(\.event))
 

--- a/Sources/TapQCodexAdapter/CodexHookShim.swift
+++ b/Sources/TapQCodexAdapter/CodexHookShim.swift
@@ -40,6 +40,7 @@ public struct CodexHookShim {
 
     public static func handle(
         stdinData: Data,
+        steeringEnabled: () -> Bool = { false },
         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
         send: (_ message: [String: JSONValue], _ timeout: TimeInterval) throws -> Data
     ) -> Result {
@@ -65,9 +66,60 @@ public struct CodexHookShim {
             return handlePermissionRequest(input, diagnostics: diagnostics, send: send)
         case "Stop":
             return handleStop(input, diagnostics: diagnostics, send: send)
+        case "UserPromptSubmit":
+            return handleUserPromptSubmit(
+                input,
+                diagnostics: diagnostics,
+                steeringEnabled: steeringEnabled
+            )
         default:
             return passThrough
         }
+    }
+
+    // MARK: - UserPromptSubmit steering
+
+    /// Exact nudge copy from the adapter contract. Default-mode Codex may not expose the
+    /// structured question tool, so steering must remain conditional in its wording.
+    static let steeringNudge =
+        "When you need the user to choose between options or confirm a decision, use "
+        + "request_user_input when available rather than asking in plain text."
+
+    /// Steering is a root-thread hint, not a broker request. The executable derives
+    /// `steeringEnabled` from a live, compatible discovery record and bounded connection-
+    /// only liveness probe. Invalid inputs, subagents, and every disabled/unavailable
+    /// discovery state emit nothing.
+    private static func handleUserPromptSubmit(
+        _ input: [String: JSONValue],
+        diagnostics: TapQDiagnosticEmitter,
+        steeringEnabled: () -> Bool
+    ) -> Result {
+        guard hasRequiredStringFields(
+            ["session_id", "turn_id", "cwd", "model", "prompt"],
+            in: input
+        ), hasSupportedPermissionMode(input),
+              isNullableString(input["transcript_path"]),
+              input["agent_id"] == nil,
+              input["agent_type"] == nil else {
+            diagnostics.record("user_prompt_submit.invalid_input", level: .warning)
+            return passThrough
+        }
+        guard steeringEnabled() else { return passThrough }
+
+        let output = UserPromptSubmitOutput(
+            hookSpecificOutput: .init(additionalContext: steeringNudge)
+        )
+        let encoded = (try? JSONEncoder().encode(output)) ?? Data("{}".utf8)
+        return Result(stdout: String(decoding: encoded, as: UTF8.self), exitCode: 0)
+    }
+
+    private struct UserPromptSubmitOutput: Encodable {
+        struct Inner: Encodable {
+            let hookEventName = "UserPromptSubmit"
+            let additionalContext: String
+        }
+
+        let hookSpecificOutput: Inner
     }
 
     // MARK: - PreToolUse

--- a/Sources/TapQContextBaseline/ReasonerContract.swift
+++ b/Sources/TapQContextBaseline/ReasonerContract.swift
@@ -206,7 +206,7 @@ public struct ReasonerDecision: Sendable, Codable, Equatable {
 
 /// Everything a stage-2 reasoner is given about a pending action.
 ///
-/// Deliberately decoupled from `TapQContracts.ApprovalRequest`: the reasoner sees a flat,
+/// Deliberately decoupled from `TapQContracts.ApprovalRequest`: the reasoner sees a
 /// portable description, and the mapping from a broker request lives with the broker.
 /// That keeps this target free of transport concerns and lets scenario corpora construct
 /// a context without a live approval.
@@ -217,7 +217,7 @@ public struct ReasonerDecision: Sendable, Codable, Equatable {
 /// pending *question* are both things the runtime makes the user answer, so both are
 /// described by this one type rather than by two parallel ones. Fields a given request
 /// has no value for stay absent — a tool call carries no `questionText`, and a question
-/// carries no `commandText`.
+/// carries no `commandText` or `toolInput`.
 public struct ReasonerContext: Sendable, Codable, Equatable {
     /// The tool the agent asked to run, as the adapter named it (`Bash`, `Write`, ...).
     ///
@@ -228,6 +228,14 @@ public struct ReasonerContext: Sendable, Codable, Equatable {
     /// The command line or primary argument, when the tool has one. Absent for tools
     /// whose input is not a command.
     public let commandText: String?
+    /// The complete argument object for an open-schema tool, when its values are needed
+    /// to judge the action. The bundled mapping currently supplies this for canonical
+    /// Codex MCP calls: their server-defined schemas cannot be reduced to one stable
+    /// command/path field without hiding the destination, content, or requested effect.
+    ///
+    /// This is sensitive request data. It is rendered only inside the reasoner's
+    /// untrusted-data fence, under a hard size cap, and must never be logged or spoken.
+    public let toolInput: [String: JSONValue]?
     /// The agent's working directory, which is what makes a path argument interpretable.
     public let cwd: String?
     /// Display name of the originating agent, for diagnostics and prompt context.
@@ -247,6 +255,7 @@ public struct ReasonerContext: Sendable, Codable, Equatable {
     public init(
         toolName: String,
         commandText: String? = nil,
+        toolInput: [String: JSONValue]? = nil,
         cwd: String? = nil,
         agentName: String? = nil,
         summary: String,
@@ -256,6 +265,7 @@ public struct ReasonerContext: Sendable, Codable, Equatable {
     ) {
         self.toolName = toolName
         self.commandText = commandText
+        self.toolInput = toolInput
         self.cwd = cwd
         self.agentName = agentName
         self.summary = summary
@@ -267,6 +277,7 @@ public struct ReasonerContext: Sendable, Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case toolName = "tool_name"
         case commandText = "command_text"
+        case toolInput = "tool_input"
         case cwd
         case agentName = "agent_name"
         case summary
@@ -285,6 +296,10 @@ public struct ReasonerContext: Sendable, Codable, Equatable {
         self.init(
             toolName: try container.decode(String.self, forKey: .toolName),
             commandText: try container.decodeIfPresent(String.self, forKey: .commandText),
+            toolInput: try container.decodeIfPresent(
+                [String: JSONValue].self,
+                forKey: .toolInput
+            ),
             cwd: try container.decodeIfPresent(String.self, forKey: .cwd),
             agentName: try container.decodeIfPresent(String.self, forKey: .agentName),
             summary: try container.decode(String.self, forKey: .summary),

--- a/Sources/TapQContextBaseline/ReasonerPrompt.swift
+++ b/Sources/TapQContextBaseline/ReasonerPrompt.swift
@@ -38,6 +38,22 @@ enum ReasonerPromptContract {
     /// thousand characters are what carry the risk signal anyway.
     static let commandTextCharacterLimit = 4_000
 
+    /// Cap on the rendered representation of an open-schema tool input, including any
+    /// truncation/excerpt markers.
+    ///
+    /// MCP servers own their argument schemas, so the complete object is the evidence
+    /// rather than one guessed field. The context contract keeps that object losslessly;
+    /// the bound belongs here, where it becomes model input. Complete inputs render as
+    /// canonical JSON; oversized inputs use key-balanced excerpts. The cap matches the
+    /// command content cap so an MCP request cannot consume an unbounded prompt.
+    static let toolInputCharacterLimit = 4_000
+
+    /// Absolute UTF-8 cap for the same field. A Swift `Character` is an unbounded
+    /// grapheme cluster, so the character cap alone would still admit a megabyte of
+    /// combining marks as one "character". Prompt JSON escapes non-ASCII scalars, and the
+    /// generic bound still cuts on scalar boundaries as a second independent guard.
+    static let toolInputByteLimit = 16_000
+
     /// Cap on each of the two free-text description fields, in characters.
     ///
     /// `summary` and `detail` are adapter-rendered prose and are short in practice — the
@@ -143,10 +159,13 @@ enum ReasonerPromptContract {
     /// directory that is somehow blank, which is a claim the context never made. Blank
     /// values are treated the same as absent ones for the same reason.
     ///
-    /// Field values are emitted verbatim apart from the caps: `command_text` at
+    /// Free-text fields are emitted verbatim apart from their caps: `command_text` at
     /// `commandTextCharacterLimit`, `summary`, `detail`, and `question_text` at
     /// `descriptionCharacterLimit`, and each option label at
     /// `optionLabelCharacterLimit` with the list itself cut to `optionLabelCountLimit`.
+    /// Complete `tool_input` renders as prompt-safe canonical JSON; oversized input uses
+    /// key-balanced excerpts, with the entire representation capped by
+    /// `toolInputCharacterLimit`.
     /// `tool`, `agent`, and `cwd` are structurally short — a tool name, an agent display
     /// name, a path — and are left alone.
     ///
@@ -181,6 +200,15 @@ enum ReasonerPromptContract {
             limit: descriptionCharacterLimit
         )
         appendOptionLabels(&lines, context.optionLabels)
+        if let toolInput = context.toolInput,
+           let renderedInput = renderedToolInput(toolInput) {
+            // Canonical JSON keeps nested structure and values without allowing embedded
+            // line separators to masquerade as prompt fields. Oversized objects become
+            // key-balanced excerpts so one early padding value cannot hide every later
+            // argument. Everything remains untrusted and bounded before reaching the model.
+            lines.append("tool_input:")
+            lines.append(renderedInput)
+        }
         if let commandText = context.commandText, !isBlank(commandText) {
             // Last, and on its own lines: it is the longest field and the only one that
             // is routinely multi-line, so nothing else has to be read around it.
@@ -189,6 +217,175 @@ enum ReasonerPromptContract {
         }
         lines.append(contextFenceEnd)
         return lines.joined(separator: "\n")
+    }
+
+    /// Stable JSON for an open-schema argument object. Sorted keys make identical MCP
+    /// calls produce identical prompts and bench inputs regardless of dictionary order.
+    /// Invalid non-JSON values (for example a hand-constructed non-finite number) are
+    /// omitted rather than replaced with invented arguments; wire-decoded inputs cannot
+    /// contain those values in the first place.
+    static func encodedToolInput(_ input: [String: JSONValue]) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(input) else { return nil }
+        guard let json = String(data: data, encoding: .utf8) else { return nil }
+        return promptSafeASCIIJSON(json)
+    }
+
+    /// Returns complete canonical JSON when it fits, otherwise a bounded, key-balanced
+    /// set of top-level JSON-value excerpts. Keeping both the start and end of each value
+    /// makes late destination/publish fields visible even when an earlier payload is huge.
+    static func renderedToolInput(_ input: [String: JSONValue]) -> String? {
+        guard let complete = encodedToolInput(input) else { return nil }
+        guard complete.count > toolInputCharacterLimit
+                || complete.utf8.count > toolInputByteLimit else {
+            return complete
+        }
+
+        let sortedKeys = input.keys.sorted()
+        let keyLimit = 24
+        let headCount = min(sortedKeys.count, keyLimit / 2)
+        let tailCount = min(sortedKeys.count - headCount, keyLimit - headCount)
+        let selectedKeys = Array(sortedKeys.prefix(headCount))
+            + Array(sortedKeys.suffix(tailCount))
+        let omittedCount = sortedKeys.count - selectedKeys.count
+        let header = "[tool_input truncated; key-balanced top-level JSON excerpts; "
+            + "original=\(complete.count) characters]"
+        let omitted = omittedCount > 0
+            ? "[... \(omittedCount) top-level keys omitted ...]"
+            : nil
+
+        let encodedPairs: [(key: String, value: String)] = selectedKeys.compactMap { key in
+            guard let value = input[key],
+                  let encodedKey = encodedJSONValue(.string(key)),
+                  let encodedValue = encodedJSONValue(value) else { return nil }
+            return (
+                balancedASCIIExcerpt(encodedKey, limit: 80),
+                encodedValue
+            )
+        }
+
+        var fixedCount = header.count
+        fixedCount += omitted.map { $0.count + 1 } ?? 0
+        fixedCount += encodedPairs.reduce(0) { $0 + $1.key.count + 3 }
+        fixedCount += max(0, encodedPairs.count - 1)
+        var remaining = max(0, toolInputCharacterLimit - fixedCount)
+        var lines = [header]
+        for (index, pair) in encodedPairs.enumerated() {
+            if let omitted, omittedCount > 0, index == headCount {
+                lines.append(omitted)
+            }
+            let remainingValues = encodedPairs.count - index
+            let share = remainingValues > 0 ? remaining / remainingValues : 0
+            let excerpt = balancedASCIIExcerpt(pair.value, limit: share)
+            remaining -= excerpt.count
+            lines.append("\(pair.key): \(excerpt)")
+        }
+        if let omitted, omittedCount > 0, headCount == encodedPairs.count {
+            lines.append(omitted)
+        }
+
+        // All non-ASCII scalars were escaped before budgeting, so the result is ASCII:
+        // the character cap also keeps it far below the independent UTF-8 ceiling.
+        return lines.joined(separator: "\n")
+    }
+
+    /// Applies the character and UTF-8 caps compositionally. The marker is included in
+    /// each limit, and scalar-bound byte cutting preserves valid Swift text.
+    static func boundedToolInput(_ text: String) -> String {
+        let characterBounded = boundedIncludingMarker(
+            text,
+            limit: toolInputCharacterLimit,
+            unit: "characters"
+        )
+        return byteBoundedIncludingMarker(characterBounded, limit: toolInputByteLimit)
+    }
+
+    private static func encodedJSONValue(_ value: JSONValue) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(value),
+              let json = String(data: data, encoding: .utf8) else { return nil }
+        return promptSafeASCIIJSON(json)
+    }
+
+    /// JSONEncoder may emit Unicode line/paragraph separators literally. Escaping every
+    /// non-ASCII scalar makes those separators inert and makes prompt-size accounting
+    /// deterministic: one rendered character is one UTF-8 byte.
+    private static func promptSafeASCIIJSON(_ json: String) -> String {
+        var result = ""
+        result.reserveCapacity(json.utf8.count)
+        for scalar in json.unicodeScalars {
+            let value = scalar.value
+            if value < 0x80 {
+                result.unicodeScalars.append(scalar)
+            } else if value <= 0xFFFF {
+                result += String(format: "\\u%04X", value)
+            } else {
+                let adjusted = value - 0x1_0000
+                let high = 0xD800 + (adjusted >> 10)
+                let low = 0xDC00 + (adjusted & 0x3FF)
+                result += String(format: "\\u%04X\\u%04X", high, low)
+            }
+        }
+        return result
+    }
+
+    private static func balancedASCIIExcerpt(_ text: String, limit: Int) -> String {
+        guard limit > 0 else { return "" }
+        guard text.count > limit else { return text }
+        let marker = "...[truncated]"
+        guard limit > marker.count else { return String(text.prefix(limit)) }
+        let content = limit - marker.count
+        let head = (content + 1) / 2
+        let tail = content / 2
+        return String(text.prefix(head)) + marker + String(text.suffix(tail))
+    }
+
+    private static func boundedIncludingMarker(
+        _ text: String,
+        limit: Int,
+        unit: String
+    ) -> String {
+        guard text.count > limit else { return text }
+        var marker = ""
+        var contentLimit = limit
+        for _ in 0..<3 {
+            contentLimit = max(0, limit - marker.count)
+            marker = "…[truncated \(text.count - contentLimit) \(unit)]"
+        }
+        contentLimit = max(0, limit - marker.count)
+        return String(text.prefix(contentLimit)) + marker
+    }
+
+    private static func byteBoundedIncludingMarker(_ text: String, limit: Int) -> String {
+        guard text.utf8.count > limit else { return text }
+        var marker = ""
+        var prefix = ""
+        for _ in 0..<3 {
+            let byteBudget = max(0, limit - marker.utf8.count)
+            var scalars = String.UnicodeScalarView()
+            var bytes = 0
+            for scalar in text.unicodeScalars {
+                let width = scalar.utf8.count
+                guard bytes + width <= byteBudget else { break }
+                bytes += width
+                scalars.append(scalar)
+            }
+            prefix = String(scalars)
+            marker = "…[truncated \(text.utf8.count - bytes) UTF-8 bytes]"
+        }
+        let byteBudget = max(0, limit - marker.utf8.count)
+        var scalars = String.UnicodeScalarView()
+        var bytes = 0
+        for scalar in text.unicodeScalars {
+            let width = scalar.utf8.count
+            guard bytes + width <= byteBudget else { break }
+            bytes += width
+            scalars.append(scalar)
+        }
+        prefix = String(scalars)
+        return prefix + marker
     }
 
     /// Renders the choices a question offered, one per line, capped in both directions.

--- a/Sources/TapQContextBaseline/ReasonerRequestContext.swift
+++ b/Sources/TapQContextBaseline/ReasonerRequestContext.swift
@@ -2,7 +2,7 @@ import Foundation
 import TapQContracts
 
 /// Maps the two things a user is made to answer — a broker approval and a question the
-/// agent asked — onto the flat context a stage-2 reasoner reads.
+/// agent asked — onto the portable context a stage-2 reasoner reads.
 ///
 /// `ReasonerContext` is deliberately decoupled from `ApprovalRequest` — a corpus builds
 /// contexts with no broker in sight — so this is the one place the two meet. It lives
@@ -29,6 +29,10 @@ public extension ReasonerContext {
         self.init(
             toolName: request.toolName,
             commandText: ReasonerContext.commandText(
+                toolName: request.toolName,
+                toolInput: request.toolInput
+            ),
+            toolInput: ReasonerContext.openSchemaToolInput(
                 toolName: request.toolName,
                 toolInput: request.toolInput
             ),
@@ -122,6 +126,33 @@ public extension ReasonerContext {
             if let value = nonblank(toolInput[key]?.stringValue) { return value }
         }
         return nil
+    }
+
+    /// Preserves arguments for tools whose schema TapQ does not own.
+    ///
+    /// Codex identifies connector calls with `mcp__<server>__<tool>`. Their arguments
+    /// are defined by the MCP server and can encode the actual consequence in any field:
+    /// a recipient, repository, record identifier, message body, delete flag, or an
+    /// application-specific nested object. Reducing that object to a guessed "primary"
+    /// string would give the reasoner a misleadingly incomplete action, so the exact
+    /// object is carried instead. The prompt renderer applies the size bound at the
+    /// model boundary; keeping the contract lossless here also makes that truncation
+    /// explicit rather than silently dropping fields during mapping.
+    ///
+    /// Other tools continue to use the pinned `commandText` convention above. This keeps
+    /// the established corpus stable and avoids sending file bodies merely because a
+    /// closed-schema editor tool happened to include them alongside its primary path.
+    static func openSchemaToolInput(
+        toolName: String,
+        toolInput: [String: JSONValue]?
+    ) -> [String: JSONValue]? {
+        let prefix = "mcp__"
+        guard toolName.hasPrefix(prefix) else { return nil }
+        let remainder = toolName.dropFirst(prefix.count)
+        guard let separator = remainder.range(of: "__"),
+              !remainder[..<separator.lowerBound].isEmpty,
+              !remainder[separator.upperBound...].isEmpty else { return nil }
+        return toolInput
     }
 
     /// Blank-to-`nil` normalization. Whitespace-only text is absence with extra

--- a/Sources/TapQContextBaseline/ReasonerReviewDisclosure.swift
+++ b/Sources/TapQContextBaseline/ReasonerReviewDisclosure.swift
@@ -1,0 +1,25 @@
+/// Privacy policy for the free-text rationale persisted by the local shadow-review log.
+///
+/// Closed-schema contexts may retain the model's bounded note. Open-schema MCP contexts
+/// may contain arbitrary connector values, and a model instruction not to repeat them is
+/// not a redaction boundary, so their free-text note is always discarded. Confidence is
+/// also model-generated numeric output with enough precision to echo an argument value,
+/// so MCP rows discard it too. The review log still records the decision's tier, closed
+/// rationale code, and outcome.
+package enum ReasonerReviewDisclosure {
+    package static func persistedNote(
+        from decision: ReasonerDecision?,
+        context: ReasonerContext
+    ) -> String? {
+        guard context.toolInput == nil else { return nil }
+        return decision?.rationale.note
+    }
+
+    package static func persistedConfidence(
+        from decision: ReasonerDecision?,
+        context: ReasonerContext
+    ) -> Double? {
+        guard context.toolInput == nil else { return nil }
+        return decision?.confidence
+    }
+}

--- a/Sources/TapQPOSIXBridgeClient/BrokerDiscovery.swift
+++ b/Sources/TapQPOSIXBridgeClient/BrokerDiscovery.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 /// Read-only discovery for a server-owned local broker record.
 ///
@@ -67,6 +72,49 @@ public struct BrokerDiscovery {
         protocolVersion: Int?,
         steeringEnabled: Bool
     ) {
+        let record = try readRecord()
+        return (record.socket, record.token, record.protocolVersion,
+                record.steeringEnabled ?? false)
+    }
+
+    /// Reads discovery only when its publishing runtime process is still alive.
+    ///
+    /// Steering is intentionally gated on this stronger view. A runtime terminated by
+    /// SIGKILL cannot remove its discovery file, so treating file presence as liveness
+    /// would leave advisory prompt injection enabled indefinitely. Older records without
+    /// a publisher PID fail closed for steering while remaining readable for the normal
+    /// broker connection path.
+    public func readLiveDiscovery() throws -> (
+        socket: String,
+        token: String,
+        protocolVersion: Int?,
+        steeringEnabled: Bool
+    ) {
+        try readLiveDiscovery(socketIsReachable: {
+            UnixSocketClient.canConnect(socketPath: $0)
+        })
+    }
+
+    func readLiveDiscovery(
+        socketIsReachable: (String) -> Bool
+    ) throws -> (
+        socket: String,
+        token: String,
+        protocolVersion: Int?,
+        steeringEnabled: Bool
+    ) {
+        let record = try readRecord()
+        guard let processID = record.processID,
+              processID > 0,
+              Self.processIsAlive(processID),
+              socketIsReachable(record.socket) else {
+            throw CocoaError(.fileReadNoSuchFile)
+        }
+        return (record.socket, record.token, record.protocolVersion,
+                record.steeringEnabled ?? false)
+    }
+
+    private func readRecord() throws -> DiscoveryRecord {
         let candidates = [discoveryURL] + fallbackDiscoveryURLs
         guard let url = candidates.first(where: {
             FileManager.default.fileExists(atPath: $0.path)
@@ -78,8 +126,17 @@ public struct BrokerDiscovery {
         guard !record.socket.isEmpty, !record.token.isEmpty else {
             throw CocoaError(.fileReadCorruptFile)
         }
-        return (record.socket, record.token, record.protocolVersion,
-                record.steeringEnabled ?? false)
+        return record
+    }
+
+    private static func processIsAlive(_ processID: Int32) -> Bool {
+        if kill(pid_t(processID), 0) == 0 {
+            return true
+        }
+        // A process owned by another user may reject the signal probe even though it is
+        // alive. Discovery is private to this user, but accepting EPERM keeps the helper
+        // correct if ownership rules differ on a supported POSIX platform.
+        return errno == EPERM
     }
 
     private static func nonempty(_ value: String?) -> String? {
@@ -92,11 +149,13 @@ public struct BrokerDiscovery {
         let token: String
         let protocolVersion: Int?
         let steeringEnabled: Bool?
+        let processID: Int32?
 
         enum CodingKeys: String, CodingKey {
             case socket, token
             case protocolVersion = "protocol_version"
             case steeringEnabled = "steering_enabled"
+            case processID = "process_id"
         }
     }
 }

--- a/Sources/TapQPOSIXBridgeClient/UnixSocketClient.swift
+++ b/Sources/TapQPOSIXBridgeClient/UnixSocketClient.swift
@@ -10,6 +10,62 @@ import Glibc
 /// A one-shot POSIX Unix-domain-socket client: connect, write one request line, read one
 /// response line, and close. It is shared by the macOS and Linux hook executables.
 public enum UnixSocketClient {
+    /// Opens and closes a Unix-domain socket without sending application data.
+    ///
+    /// Hook steering uses this as a liveness probe: a stale discovery file and a reused
+    /// process identifier are insufficient unless the recorded broker socket also accepts
+    /// a connection. The broker treats an EOF-only connection as a no-op.
+    public static func canConnect(
+        socketPath: String,
+        timeoutMilliseconds: Int32 = 100
+    ) -> Bool {
+        let fd = socket(AF_UNIX, streamSocketType, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        let flags = fcntl(fd, F_GETFL, 0)
+        guard flags >= 0,
+              fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0 else { return false }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard socketPath.utf8.count < capacity else { return false }
+        socketPath.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                    _ = strncpy($0, source, capacity - 1)
+                }
+            }
+        }
+
+        let result = withUnsafePointer(to: &address) { rawAddress in
+            rawAddress.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.stride))
+            }
+        }
+        if result == 0 { return true }
+        guard errno == EINPROGRESS else { return false }
+
+        var descriptor = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+        let boundedTimeout = max(0, timeoutMilliseconds)
+        // An interrupted probe fails through immediately instead of restarting a full
+        // timeout window; the hook must have a hard internal latency bound.
+        let pollResult = poll(&descriptor, 1, boundedTimeout)
+        guard pollResult > 0 else { return false }
+
+        var socketError: Int32 = 0
+        var socketErrorSize = socklen_t(MemoryLayout<Int32>.size)
+        guard getsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_ERROR,
+            &socketError,
+            &socketErrorSize
+        ) == 0 else { return false }
+        return socketError == 0
+    }
+
     public static func request(_ payload: Data, socketPath: String,
                                timeout: TimeInterval = 5) throws -> Data {
         let fd = socket(AF_UNIX, streamSocketType, 0)

--- a/Sources/TapQPOSIXSupport/POSIXNonblockingIO.swift
+++ b/Sources/TapQPOSIXSupport/POSIXNonblockingIO.swift
@@ -16,10 +16,17 @@ package enum POSIXNonblockingIO {
     }
 
     package static func configure(_ descriptor: Int32) -> Bool {
-        let flags = fcntl(descriptor, F_GETFL, 0)
+        var flags: Int32
+        repeat {
+            flags = fcntl(descriptor, F_GETFL, 0)
+        } while flags < 0 && errno == EINTR
         guard flags >= 0 else { return false }
         if flags & O_NONBLOCK != 0 { return true }
-        return fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0
+        var result: Int32
+        repeat {
+            result = fcntl(descriptor, F_SETFL, flags | O_NONBLOCK)
+        } while result < 0 && errno == EINTR
+        return result == 0
     }
 
     package static func read(

--- a/Sources/TapQPOSIXSupport/POSIXNonblockingIO.swift
+++ b/Sources/TapQPOSIXSupport/POSIXNonblockingIO.swift
@@ -1,0 +1,45 @@
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#else
+#error("TapQPOSIXSupport requires a POSIX platform")
+#endif
+
+/// Minimal nonblocking descriptor operations kept behind TapQ's POSIX boundary.
+package enum POSIXNonblockingIO {
+    package enum ReadResult: Sendable {
+        case bytes(Int)
+        case endOfFile
+        case wouldBlock
+        case failed
+    }
+
+    package static func configure(_ descriptor: Int32) -> Bool {
+        let flags = fcntl(descriptor, F_GETFL, 0)
+        guard flags >= 0 else { return false }
+        if flags & O_NONBLOCK != 0 { return true }
+        return fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0
+    }
+
+    package static func read(
+        _ descriptor: Int32,
+        into buffer: UnsafeMutableRawBufferPointer
+    ) -> ReadResult {
+        guard let baseAddress = buffer.baseAddress, !buffer.isEmpty else {
+            return .wouldBlock
+        }
+        while true {
+            #if canImport(Darwin)
+            let count = Darwin.read(descriptor, baseAddress, buffer.count)
+            #else
+            let count = Glibc.read(descriptor, baseAddress, buffer.count)
+            #endif
+            if count > 0 { return .bytes(count) }
+            if count == 0 { return .endOfFile }
+            if errno == EINTR { continue }
+            if errno == EAGAIN || errno == EWOULDBLOCK { return .wouldBlock }
+            return .failed
+        }
+    }
+}

--- a/Sources/TapQPOSIXSupport/POSIXProcessControl.swift
+++ b/Sources/TapQPOSIXSupport/POSIXProcessControl.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Small process-control operations kept behind the POSIX support boundary so portable
+/// clients do not import platform C modules directly.
+package enum POSIXProcessControl {
+    /// Sends an unconditional termination signal to one known child process.
+    ///
+    /// The caller must first resolve the exact process identifier and exhaust graceful
+    /// termination. This deliberately accepts no names, globs, process groups, or other
+    /// broad targets.
+    package static func forceTerminate(processIdentifier: Int32) {
+        guard processIdentifier > 0 else { return }
+        #if canImport(Darwin)
+        _ = Darwin.kill(processIdentifier, SIGKILL)
+        #elseif canImport(Glibc)
+        _ = Glibc.kill(processIdentifier, SIGKILL)
+        #endif
+    }
+}

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -147,21 +147,44 @@ tapq integration codex install
 ```
 
 A configured status does not mean Codex trusts the command. Open an interactive Codex
-session, run `/hooks`, review the TapQ `PreToolUse`, `PermissionRequest`, and `Stop`
-entries, and trust their exact current definitions. Codex deliberately skips new or
-changed non-managed hooks until this step is complete. Also confirm that hooks have not
+session, run `/hooks`, review the four current TapQ registrations at the selected path
+(`PreToolUse`, `PermissionRequest`, `Stop`, and `UserPromptSubmit`), and trust their exact
+definitions. Unrecognized custom-path hooks may remain as unrelated data. Codex
+deliberately skips new or changed non-managed hooks until this step is complete. TapQ
+cannot inspect trust state, so `/hooks` is authoritative. Also confirm that hooks have not
 been disabled by local or managed Codex configuration.
 
 The current adapter handles one root-agent, single-choice `request_user_input` call and
-native `PermissionRequest` prompts for `Bash` and `apply_patch`. Multiple or
-auto-resolving questions, unsupported option shapes, secret questions, subagent calls,
-read-only commands, allow rules, permission modes, and sandboxed operations can
-legitimately bypass TapQ. There is no broad Codex strict `PreToolUse` policy or generic
-notification-hook parity. Codex CLI `0.142.5` is the lifecycle contract floor;
-structured-question coverage is tested against `0.146.0`.
+native `PermissionRequest` prompts for `Bash`, `apply_patch`, and canonical MCP tools.
+Multiple or auto-resolving questions, unsupported option shapes, secret questions,
+subagent calls, read-only commands, allow rules, permission modes, and sandboxed
+operations can legitimately bypass TapQ. In Codex CLI `0.146.0`, Plan mode is the
+reliable `request_user_input` surface; availability in default mode depends on
+`default_mode_request_user_input`. Status reports the discovered Codex executable,
+version, and relevant feature values on a best-effort basis. It resolves and executes
+`codex` from the caller's `PATH` using fixed diagnostic arguments and a reduced
+environment allowlist, so run status with a trusted `PATH`. “Not found on PATH” means resolution
+failed; “executable found, but diagnostics failed or timed out” means resolution
+succeeded but the bounded probe did not. Neither result changes hooks-file status. A
+version below the tested `0.142.5` floor emits a compatibility warning.
 
-If status is incomplete, run uninstall and install again. TapQ preserves unrelated hook
-groups, but do not edit `hooks.json` while the installer is running.
+If `--steering` is enabled, the matcherless `UserPromptSubmit` hook adds its fixed
+`request_user_input` “when available” hint only for root turns while the TapQ discovery
+record is live and wire-compatible. It opens an EOF-only Unix-socket connection to verify
+liveness but sends no request bytes or application data and performs no broker
+request/response round-trip. Disabled steering, subagents, missing discovery, or an
+incompatible runtime silently preserve native prompt submission. There is no broad Codex
+strict `PreToolUse` policy or generic notification hook parity. Codex CLI `0.142.5` is the
+lifecycle contract floor; structured-question and MCP coverage is tested against
+`0.146.0`.
+
+If status is incomplete, run `tapq integration codex install` again; direct reinstall
+repairs registrations at the current hook, the bare `tapq-codex-hook` command, and
+recognized TapQ app/build paths while preserving unfamiliar custom executable paths as
+unrelated hooks.
+There is normally no need to uninstall first. Upgrading from the previous three-hook
+layout requires this rerun to add `UserPromptSubmit`, followed by review in `/hooks`. Do
+not edit `hooks.json` while the installer is running.
 
 ## A final-response question stays on screen
 

--- a/Tests/TapQBrokerRuntimeTests/BrokerRuntimeDiscoveryTests.swift
+++ b/Tests/TapQBrokerRuntimeTests/BrokerRuntimeDiscoveryTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import TapQBrokerRuntime
-import TapQPOSIXBridgeClient
+@testable import TapQPOSIXBridgeClient
 import TapQWireProtocol
 
 final class BrokerRuntimeDiscoveryTests: XCTestCase {
@@ -28,6 +28,10 @@ final class BrokerRuntimeDiscoveryTests: XCTestCase {
         XCTAssertEqual(record.token, "tok")
         XCTAssertEqual(record.protocolVersion, WireProtocol.version)
         XCTAssertTrue(record.steeringEnabled)
+        XCTAssertTrue(
+            try client.readLiveDiscovery(socketIsReachable: { $0 == runtime.socketPath })
+                .steeringEnabled
+        )
 
         let directoryMode = try XCTUnwrap(
             FileManager.default.attributesOfItem(atPath: directory.path)[.posixPermissions]

--- a/Tests/TapQCLITests/CodexCLIProbeTests.swift
+++ b/Tests/TapQCLITests/CodexCLIProbeTests.swift
@@ -189,26 +189,28 @@ final class CodexCLIProbeTests: XCTestCase {
         try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: yes.path))
         try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: head.path))
         let generatedByteCount = CodexCLIProcessRunner.maximumCapturedOutputBytes + 262_144
-        let result = CodexCLIProcessRunner.run(
-            executableURL: shell,
-            arguments: [
-                "-c",
-                "yes O | head -c \(generatedByteCount); "
-                    + "yes E | head -c \(generatedByteCount) >&2",
-            ],
-            environment: ["PATH": "/usr/bin:/bin"],
-            currentDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
-            timeout: 3
-        )
+        for _ in 0..<3 {
+            let result = CodexCLIProcessRunner.run(
+                executableURL: shell,
+                arguments: [
+                    "-c",
+                    "yes O | head -c \(generatedByteCount); "
+                        + "yes E | head -c \(generatedByteCount) >&2",
+                ],
+                environment: ["PATH": "/usr/bin:/bin"],
+                currentDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+                timeout: 3
+            )
 
-        guard case .completed(let status, let output, let error) = result else {
-            return XCTFail("Expected oversized stdout and stderr to be fully drained")
+            guard case .completed(let status, let output, let error) = result else {
+                return XCTFail("Expected oversized stdout and stderr to be fully drained")
+            }
+            XCTAssertEqual(status, 0)
+            XCTAssertEqual(output.utf8.count, CodexCLIProcessRunner.maximumCapturedOutputBytes)
+            XCTAssertEqual(error.utf8.count, CodexCLIProcessRunner.maximumCapturedOutputBytes)
+            XCTAssertTrue(output.allSatisfy { $0 == "O" || $0 == "\n" })
+            XCTAssertTrue(error.allSatisfy { $0 == "E" || $0 == "\n" })
         }
-        XCTAssertEqual(status, 0)
-        XCTAssertEqual(output.utf8.count, CodexCLIProcessRunner.maximumCapturedOutputBytes)
-        XCTAssertEqual(error.utf8.count, CodexCLIProcessRunner.maximumCapturedOutputBytes)
-        XCTAssertTrue(output.allSatisfy { $0 == "O" || $0 == "\n" })
-        XCTAssertTrue(error.allSatisfy { $0 == "E" || $0 == "\n" })
     }
 
     func testProcessRunnerClosesPipesRetainedByAnExitedParentsDescendant() throws {
@@ -230,8 +232,8 @@ final class CodexCLIProbeTests: XCTestCase {
             executableURL: shell,
             arguments: [
                 "-c",
-                "exec 9>&1; (sleep 1; "
-                    + "printf retained > \"$TAPQ_PIPE_MARKER\"; exec 9>&-) & exit 0",
+                "exec 9>&1; (sleep 2; "
+                    + "printf retained > \"$TAPQ_PIPE_MARKER\"; exec 9>&-) & kill -9 $$",
             ],
             environment: [
                 "PATH": "/usr/bin:/bin",

--- a/Tests/TapQCLITests/CodexCLIProbeTests.swift
+++ b/Tests/TapQCLITests/CodexCLIProbeTests.swift
@@ -227,13 +227,22 @@ final class CodexCLIProbeTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
         let markerURL = temporaryDirectory.appendingPathComponent("pipe-state")
+        // swift-corelibs-foundation gives the child a private process-tracking socket. Close
+        // unrelated inherited descriptors in the descendant so this test isolates stdout/stderr
+        // pipe retention instead of waiting for Foundation's private socket to reach EOF.
+        let closeUnrelatedDescriptors = "descriptor_root=/proc/self/fd; "
+            + "[ -d \"$descriptor_root\" ] || descriptor_root=/dev/fd; "
+            + "for descriptor_path in \"$descriptor_root\"/*; "
+            + "do descriptor=${descriptor_path##*/}; "
+            + "case \"$descriptor\" in 0|1|2|*[!0-9]*) ;; "
+            + "*) eval \"exec ${descriptor}>&-\" ;; esac; done"
         let start = Date()
         let result = CodexCLIProcessRunner.run(
             executableURL: shell,
             arguments: [
                 "-c",
-                "exec 9>&1; (sleep 2; "
-                    + "printf retained > \"$TAPQ_PIPE_MARKER\"; exec 9>&-) & kill -9 $$",
+                "(\(closeUnrelatedDescriptors); sleep 2; "
+                    + "printf retained > \"$TAPQ_PIPE_MARKER\") & kill -9 $$",
             ],
             environment: [
                 "PATH": "/usr/bin:/bin",

--- a/Tests/TapQCLITests/CodexCLIProbeTests.swift
+++ b/Tests/TapQCLITests/CodexCLIProbeTests.swift
@@ -257,17 +257,19 @@ final class CodexCLIProbeTests: XCTestCase {
     func testProcessRunnerBoundsAWedgedCommand() throws {
         let shell = URL(fileURLWithPath: "/bin/sh")
         try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: shell.path))
-        let start = Date()
-        let result = CodexCLIProcessRunner.run(
-            executableURL: shell,
-            arguments: ["-c", "trap '' TERM; while :; do :; done"],
-            environment: ["PATH": "/usr/bin:/bin"],
-            currentDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
-            timeout: 0.05
-        )
+        for _ in 0..<3 {
+            let start = Date()
+            let result = CodexCLIProcessRunner.run(
+                executableURL: shell,
+                arguments: ["-c", "trap '' TERM; while :; do :; done"],
+                environment: ["PATH": "/usr/bin:/bin"],
+                currentDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+                timeout: 0.05
+            )
 
-        XCTAssertEqual(result, .unavailable)
-        XCTAssertLessThan(Date().timeIntervalSince(start), 1.5)
+            XCTAssertEqual(result, .unavailable)
+            XCTAssertLessThan(Date().timeIntervalSince(start), 1.5)
+        }
     }
 
     func testResolvedProcessRunnerPassesOnlyTheMinimalDiagnosticEnvironment() throws {

--- a/Tests/TapQCLITests/CodexCLIProbeTests.swift
+++ b/Tests/TapQCLITests/CodexCLIProbeTests.swift
@@ -214,7 +214,9 @@ final class CodexCLIProbeTests: XCTestCase {
     }
 
     func testProcessRunnerClosesPipesRetainedByAnExitedParentsDescendant() throws {
-        let shell = URL(fileURLWithPath: "/bin/sh")
+        // Bash accepts multi-digit descriptor redirections; Ubuntu's /bin/sh (dash)
+        // treats `exec 10>&-` as an attempt to run a command named `10`.
+        let shell = URL(fileURLWithPath: "/bin/bash")
         try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: shell.path))
         let descriptorCountBeforeRun = try openFileDescriptorCount()
         let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/Tests/TapQCLITests/CodexCLIProbeTests.swift
+++ b/Tests/TapQCLITests/CodexCLIProbeTests.swift
@@ -1,0 +1,333 @@
+import XCTest
+@testable import TapQCLI
+
+final class CodexCLIProbeTests: XCTestCase {
+    func testProbeParsesVersionAndRequestedFeatures() {
+        let status = CodexCLIProbe.probe { arguments -> CodexCLICommandResult in
+            switch arguments {
+            case ["--version"]:
+                return .completed(
+                    status: 0,
+                    standardOutput: "codex-cli 0.146.0\n",
+                    standardError: ""
+                )
+            case ["features", "list"]:
+                return .completed(
+                    status: 0,
+                    standardOutput: """
+                    hooks                                 stable             true
+                    default_mode_request_user_input       under development  false
+                    """,
+                    standardError: ""
+                )
+            default:
+                XCTFail("Unexpected Codex arguments: \(arguments)")
+                return .unavailable
+            }
+        }
+
+        XCTAssertEqual(status.version, "0.146.0")
+        XCTAssertTrue(status.isAvailable)
+        XCTAssertEqual(status.hooks, .enabled(stage: "stable"))
+        XCTAssertEqual(
+            status.defaultModeRequestUserInput,
+            .disabled(stage: "under development")
+        )
+    }
+
+    func testResolvedCodexWhoseVersionProbeFailsIsNotReportedAsMissing() {
+        var calls: [[String]] = []
+
+        let status = CodexCLIProbe.probe(executablePath: "/opt/codex/bin/codex") { arguments in
+            calls.append(arguments)
+            return .unavailable
+        }
+
+        XCTAssertEqual(calls, [["--version"]])
+        XCTAssertEqual(status.availability, .probeFailed)
+        XCTAssertEqual(status.executablePath, "/opt/codex/bin/codex")
+        XCTAssertFalse(status.isAvailable)
+    }
+
+    func testMissingCodexDoesNotAttemptAnyProbe() {
+        var callCount = 0
+
+        let status = CodexCLIProbe.probe(executableWasResolved: false) { _ in
+            callCount += 1
+            return .unavailable
+        }
+
+        XCTAssertEqual(callCount, 0)
+        XCTAssertEqual(status, .notFound)
+    }
+
+    func testMalformedSuccessfulOutputProducesUnknownDiagnostics() {
+        let status = CodexCLIProbe.probe { arguments in
+            if arguments == ["--version"] {
+                return .completed(
+                    status: 0,
+                    standardOutput: "unexpected version output",
+                    standardError: ""
+                )
+            }
+            return .completed(
+                status: 0,
+                standardOutput: "hooks stable perhaps\ndefault_mode_request_user_input ???",
+                standardError: ""
+            )
+        }
+
+        XCTAssertTrue(status.isAvailable)
+        XCTAssertNil(status.version)
+        XCTAssertEqual(status.hooks, .unknown)
+        XCTAssertEqual(status.defaultModeRequestUserInput, .unknown)
+    }
+
+    func testFeatureParserRejectsUnrecognizedUnboundedAndControlBearingStages() {
+        let oversizedStage = String(repeating: "stage", count: 10_000)
+
+        XCTAssertEqual(
+            CodexCLIProbe.parseFeature(named: "hooks", from: "hooks \(oversizedStage) true"),
+            .unknown
+        )
+        XCTAssertEqual(
+            CodexCLIProbe.parseFeature(
+                named: "hooks",
+                from: "hooks stable\u{001B}[2J true"
+            ),
+            .unknown
+        )
+        XCTAssertEqual(
+            CodexCLIProbe.parseFeature(named: "hooks", from: "hooks experimental false"),
+            .disabled(stage: "experimental")
+        )
+        XCTAssertEqual(
+            CodexCLIProbe.parseFeature(named: "hooks", from: "hooks removed false"),
+            .disabled(stage: "removed")
+        )
+        XCTAssertEqual(
+            CodexCLIProbe.parseFeature(named: "hooks", from: "hooks deprecated false"),
+            .disabled(stage: "deprecated")
+        )
+    }
+
+    func testVersionParserAcceptsOnlyBoundedASCIIPreReleaseAndBuildMetadata() {
+        XCTAssertEqual(
+            CodexCLIProbe.parseVersion(from: "codex-cli 0.146.0-beta.1+build-7"),
+            "0.146.0-beta.1+build-7"
+        )
+        XCTAssertNil(
+            CodexCLIProbe.parseVersion(from: "codex-cli 0.146.0+\u{001B}[2J")
+        )
+        XCTAssertNil(
+            CodexCLIProbe.parseVersion(from: "codex-cli 0.146.0-beta\u{202E}txt")
+        )
+        XCTAssertNil(
+            CodexCLIProbe.parseVersion(
+                from: "codex-cli 0.146.0+\(String(repeating: "a", count: 256))"
+            )
+        )
+        XCTAssertNil(
+            CodexCLIProbe.parseVersion(from: "codex-cli 0.146.0+build/unsafe")
+        )
+    }
+
+    func testFailedFeatureCommandKeepsDetectedVersionAndUnknownFeatures() {
+        let status = CodexCLIProbe.probe { arguments in
+            if arguments == ["--version"] {
+                return .completed(
+                    status: 0,
+                    standardOutput: "codex 1.2.3-beta.1",
+                    standardError: ""
+                )
+            }
+            return .completed(status: 64, standardOutput: "", standardError: "unsupported")
+        }
+
+        XCTAssertEqual(status.version, "1.2.3-beta.1")
+        XCTAssertEqual(status.hooks, .unknown)
+        XCTAssertEqual(status.defaultModeRequestUserInput, .unknown)
+    }
+
+    func testTestedLifecycleFloorComparisonBoundaries() {
+        XCTAssertEqual(CodexCLIProbe.isBelowTestedLifecycleFloor("0.142.4"), true)
+        XCTAssertEqual(CodexCLIProbe.isBelowTestedLifecycleFloor("0.142.5-beta.1"), true)
+        XCTAssertEqual(CodexCLIProbe.isBelowTestedLifecycleFloor("0.142.5"), false)
+        XCTAssertEqual(CodexCLIProbe.isBelowTestedLifecycleFloor("0.146.0"), false)
+        XCTAssertNil(CodexCLIProbe.isBelowTestedLifecycleFloor("development"))
+        XCTAssertNil(CodexCLIProbe.isBelowTestedLifecycleFloor(""))
+        XCTAssertNil(CodexCLIProbe.isBelowTestedLifecycleFloor("0.142.5-"))
+    }
+
+    func testProcessRunnerDrainsOutputLargerThanAPipeBuffer() throws {
+        let shell = URL(fileURLWithPath: "/bin/sh")
+        try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: shell.path))
+        let result = CodexCLIProcessRunner.run(
+            executableURL: shell,
+            arguments: [
+                "-c",
+                "i=0; while [ \"$i\" -lt 20000 ]; do printf 0123456789; i=$((i+1)); done",
+            ],
+            environment: ["PATH": "/usr/bin:/bin"],
+            currentDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+            timeout: 3
+        )
+
+        guard case .completed(let status, let output, let error) = result else {
+            return XCTFail("Expected the bounded process to complete")
+        }
+        XCTAssertEqual(status, 0)
+        XCTAssertEqual(output.utf8.count, 200_000)
+        XCTAssertEqual(error, "")
+    }
+
+    func testProcessRunnerRetainsAtMostTheOutputLimitWhileContinuingToDrain() throws {
+        let shell = URL(fileURLWithPath: "/bin/sh")
+        let yes = URL(fileURLWithPath: "/usr/bin/yes")
+        let head = URL(fileURLWithPath: "/usr/bin/head")
+        try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: shell.path))
+        try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: yes.path))
+        try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: head.path))
+        let generatedByteCount = CodexCLIProcessRunner.maximumCapturedOutputBytes + 262_144
+        let result = CodexCLIProcessRunner.run(
+            executableURL: shell,
+            arguments: [
+                "-c",
+                "yes O | head -c \(generatedByteCount); "
+                    + "yes E | head -c \(generatedByteCount) >&2",
+            ],
+            environment: ["PATH": "/usr/bin:/bin"],
+            currentDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+            timeout: 3
+        )
+
+        guard case .completed(let status, let output, let error) = result else {
+            return XCTFail("Expected oversized stdout and stderr to be fully drained")
+        }
+        XCTAssertEqual(status, 0)
+        XCTAssertEqual(output.utf8.count, CodexCLIProcessRunner.maximumCapturedOutputBytes)
+        XCTAssertEqual(error.utf8.count, CodexCLIProcessRunner.maximumCapturedOutputBytes)
+        XCTAssertTrue(output.allSatisfy { $0 == "O" || $0 == "\n" })
+        XCTAssertTrue(error.allSatisfy { $0 == "E" || $0 == "\n" })
+    }
+
+    func testProcessRunnerClosesPipesRetainedByAnExitedParentsDescendant() throws {
+        let shell = URL(fileURLWithPath: "/bin/sh")
+        try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: shell.path))
+        let descriptorCountBeforeRun = try openFileDescriptorCount()
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "tapq-codex-probe-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+        let markerURL = temporaryDirectory.appendingPathComponent("pipe-state")
+        let start = Date()
+        let result = CodexCLIProcessRunner.run(
+            executableURL: shell,
+            arguments: [
+                "-c",
+                "exec 9>&1; (sleep 1; "
+                    + "printf retained > \"$TAPQ_PIPE_MARKER\"; exec 9>&-) & exit 0",
+            ],
+            environment: [
+                "PATH": "/usr/bin:/bin",
+                "TAPQ_PIPE_MARKER": markerURL.path,
+            ],
+            currentDirectory: temporaryDirectory,
+            timeout: 3
+        )
+
+        XCTAssertEqual(result, .unavailable)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 1.5)
+        XCTAssertLessThanOrEqual(try openFileDescriptorCount(), descriptorCountBeforeRun)
+
+        let deadline = Date().addingTimeInterval(3)
+        var marker: String?
+        while Date() < deadline, marker == nil {
+            marker = try? String(contentsOf: markerURL, encoding: .utf8)
+            if marker == nil { Thread.sleep(forTimeInterval: 0.02) }
+        }
+        XCTAssertEqual(marker, "retained")
+    }
+
+    func testProcessRunnerBoundsAWedgedCommand() throws {
+        let shell = URL(fileURLWithPath: "/bin/sh")
+        try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: shell.path))
+        let start = Date()
+        let result = CodexCLIProcessRunner.run(
+            executableURL: shell,
+            arguments: ["-c", "trap '' TERM; while :; do :; done"],
+            environment: ["PATH": "/usr/bin:/bin"],
+            currentDirectory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+            timeout: 0.05
+        )
+
+        XCTAssertEqual(result, .unavailable)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 1.5)
+    }
+
+    func testResolvedProcessRunnerPassesOnlyTheMinimalDiagnosticEnvironment() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "tapq-codex-environment-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+        let executableURL = temporaryDirectory.appendingPathComponent("codex")
+        let script = """
+        #!/bin/sh
+        printf '%s|%s|%s|%s|%s' "${OPENAI_API_KEY-unset}" "${AWS_SECRET_ACCESS_KEY-unset}" "$NO_COLOR" "$TERM" "$CODEX_HOME"
+        """
+        try Data(script.utf8).write(to: executableURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executableURL.path
+        )
+        let path = temporaryDirectory.path + ":/usr/bin:/bin"
+        let codexHome = temporaryDirectory.appendingPathComponent("codex-home").path
+        let runner = try XCTUnwrap(CodexCLIProcessRunner.resolve(
+            environment: [
+                "PATH": path,
+                "HOME": temporaryDirectory.path,
+                "CODEX_HOME": codexHome,
+                "LANG": "C",
+                "OPENAI_API_KEY": "must-not-reach-child",
+                "AWS_SECRET_ACCESS_KEY": "must-not-reach-child",
+                "SSH_AUTH_SOCK": "/tmp/private-agent",
+                "TAPQ_INTERNAL_SECRET": "must-not-reach-child",
+                "NO_COLOR": "host-value-is-overridden",
+                "TERM": "xterm-secret-capability",
+            ],
+            currentDirectory: temporaryDirectory
+        ))
+
+        XCTAssertEqual(runner.executableURL.path, executableURL.path)
+        XCTAssertEqual(
+            Set(runner.environment.keys),
+            Set(["PATH", "HOME", "CODEX_HOME", "LANG", "NO_COLOR", "TERM"])
+        )
+        guard case .completed(let status, let output, let error) =
+                runner.run(arguments: ["--version"]) else {
+            return XCTFail("Expected the resolved probe executable to run")
+        }
+        XCTAssertEqual(status, 0)
+        XCTAssertEqual(output, "unset|unset|1|dumb|\(codexHome)")
+        XCTAssertEqual(error, "")
+    }
+
+    private func openFileDescriptorCount() throws -> Int {
+        #if os(Linux)
+        let descriptorDirectory = "/proc/self/fd"
+        #else
+        let descriptorDirectory = "/dev/fd"
+        #endif
+        return try FileManager.default.contentsOfDirectory(atPath: descriptorDirectory).count
+    }
+}

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -414,6 +414,24 @@ final class TapQCLIApplicationTests: XCTestCase {
     }
 
     @MainActor
+    func testIntegrationHelpDescribesTheFullCodexHookAndProbeContract() async {
+        let buffer = Buffer()
+        let app = application(io: buffer.io)
+
+        let status = await app.run(arguments: ["integration", "--help"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("four managed lifecycle definitions"))
+        XCTAssertTrue(buffer.output.contains("structured `request_user_input`"))
+        XCTAssertTrue(buffer.output.contains("canonical MCP tools"))
+        XCTAssertTrue(buffer.output.contains("matcherless UserPromptSubmit"))
+        XCTAssertTrue(buffer.output.contains("codex --version"))
+        XCTAssertTrue(buffer.output.contains("codex features list"))
+        XCTAssertTrue(buffer.output.contains("with a minimal"))
+        XCTAssertTrue(buffer.output.contains("environment. It reports"))
+    }
+
+    @MainActor
     func testCodexIntegrationLifecycle() async throws {
         let buffer = Buffer()
         let app = application(io: buffer.io)
@@ -444,6 +462,168 @@ final class TapQCLIApplicationTests: XCTestCase {
         let removedStatus = await app.run(arguments: ["integration", "codex", "status"] + options)
         XCTAssertEqual(removedStatus, 0)
         XCTAssertTrue(buffer.output.contains("not installed"))
+    }
+
+    @MainActor
+    func testCodexStatusReportsCLIActivationAndPreservesCustomPaths() async throws {
+        let buffer = Buffer()
+        let hook = directory.appendingPathComponent("custom/tapq-codex-hook")
+        let hooks = directory.appendingPathComponent("custom-codex/hooks.json")
+        try FileManager.default.createDirectory(
+            at: hook.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: hook.path, contents: Data("hook".utf8)))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hook.path)
+        let app = application(
+            io: buffer.io,
+            codexCLICommandRunner: { arguments in
+                if arguments == ["--version"] {
+                    return .completed(
+                        status: 0,
+                        standardOutput: "codex-cli 0.146.0\n",
+                        standardError: ""
+                    )
+                }
+                return .completed(
+                    status: 0,
+                    standardOutput: """
+                    hooks                                 stable             false
+                    default_mode_request_user_input       under development  false
+                    """,
+                    standardError: ""
+                )
+            },
+            codexCLIResolvedExecutableURL: URL(fileURLWithPath: "/opt/codex/bin/codex")
+        )
+        let options = ["--hooks", hooks.path, "--hook", hook.path]
+        let installStatus = await app.run(
+            arguments: ["integration", "codex", "install"] + options
+        )
+        XCTAssertEqual(installStatus, 0)
+
+        buffer.output = ""
+        let status = await app.run(arguments: ["integration", "codex", "status"] + options)
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("Codex integration: configured"))
+        XCTAssertTrue(buffer.output.contains("Hooks: \(hooks.path)"))
+        XCTAssertTrue(buffer.output.contains("Hook: \(hook.path)"))
+        XCTAssertTrue(buffer.output.contains("Codex CLI: 0.146.0"))
+        XCTAssertTrue(buffer.output.contains("Codex CLI executable: /opt/codex/bin/codex"))
+        XCTAssertTrue(buffer.output.contains("Codex feature `hooks`: disabled (stable)"))
+        XCTAssertTrue(buffer.output.contains(
+            "Codex feature `default_mode_request_user_input`: disabled (under development)"
+        ))
+        XCTAssertTrue(buffer.output.contains("use Plan mode for `request_user_input`"))
+        XCTAssertTrue(buffer.output.contains("Hook activation: disabled in Codex"))
+        XCTAssertTrue(buffer.output.contains("Trust: owned by Codex"))
+        XCTAssertTrue(buffer.output.contains("TapQ cannot inspect or grant it"))
+    }
+
+    @MainActor
+    func testCodexStatusSurvivesMissingCLI() async {
+        let buffer = Buffer()
+        let app = application(io: buffer.io)
+
+        let status = await app.run(arguments: ["integration", "codex", "status"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("Codex integration: not installed"))
+        XCTAssertTrue(buffer.output.contains("Codex CLI: not found on PATH"))
+        XCTAssertTrue(buffer.output.contains("Codex feature `hooks`: unknown"))
+        XCTAssertTrue(buffer.output.contains("Default-mode availability is unknown"))
+        XCTAssertTrue(buffer.output.contains("Trust: owned by Codex"))
+    }
+
+    @MainActor
+    func testCodexStatusDistinguishesResolvedExecutableWhoseProbeFailed() async {
+        let buffer = Buffer()
+        let executableURL = URL(fileURLWithPath: "/opt/codex/bin/codex")
+        let app = application(
+            io: buffer.io,
+            codexCLICommandRunner: { _ in .unavailable },
+            codexCLIResolvedExecutableURL: executableURL
+        )
+
+        let status = await app.run(arguments: ["integration", "codex", "status"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains(
+            "Codex CLI: executable found, but diagnostics failed or timed out"
+        ))
+        XCTAssertTrue(buffer.output.contains("Codex CLI executable: \(executableURL.path)"))
+        XCTAssertFalse(buffer.output.contains("Codex CLI: not found on PATH"))
+        XCTAssertTrue(buffer.output.contains("Codex feature `hooks`: unknown"))
+    }
+
+    @MainActor
+    func testCodexStatusSurvivesMalformedCLIOutputAndUnknownFeatures() async {
+        let buffer = Buffer()
+        let app = application(
+            io: buffer.io,
+            codexCLICommandRunner: { _ in
+                .completed(
+                    status: 0,
+                    standardOutput: "not a recognized Codex diagnostic",
+                    standardError: ""
+                )
+            }
+        )
+
+        let status = await app.run(arguments: ["integration", "codex", "status"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("Codex CLI: detected; version unknown"))
+        XCTAssertTrue(buffer.output.contains("Codex feature `hooks`: unknown"))
+        XCTAssertTrue(buffer.output.contains(
+            "Codex feature `default_mode_request_user_input`: unknown"
+        ))
+    }
+
+    @MainActor
+    func testCodexStatusWarnsOnlyBelowTestedLifecycleFloor() async {
+        for (version, expectsWarning) in [
+            ("0.142.4", true),
+            ("0.142.5", false),
+            ("0.146.0", false),
+        ] {
+            let buffer = Buffer()
+            let app = application(
+                io: buffer.io,
+                codexCLICommandRunner: { arguments in
+                    if arguments == ["--version"] {
+                        return .completed(
+                            status: 0,
+                            standardOutput: "codex-cli \(version)",
+                            standardError: ""
+                        )
+                    }
+                    return .completed(
+                        status: 0,
+                        standardOutput: """
+                        hooks                                 stable             true
+                        default_mode_request_user_input       under development  false
+                        """,
+                        standardError: ""
+                    )
+                }
+            )
+
+            let status = await app.run(arguments: ["integration", "codex", "status"])
+
+            XCTAssertEqual(status, 0, "version \(version)")
+            XCTAssertEqual(
+                buffer.output.contains("Compatibility warning:"),
+                expectsWarning,
+                "version \(version)"
+            )
+            if expectsWarning {
+                XCTAssertTrue(buffer.output.contains("tested lifecycle-hook floor 0.142.5"))
+            } else {
+                XCTAssertFalse(buffer.output.contains("validated"))
+            }
+        }
     }
 
     @MainActor
@@ -753,7 +933,9 @@ final class TapQCLIApplicationTests: XCTestCase {
         environment: [String: String]? = nil,
         monotonicNow: @escaping () -> TimeInterval = {
             ProcessInfo.processInfo.systemUptime
-        }
+        },
+        codexCLICommandRunner: (([String]) -> CodexCLICommandResult)? = nil,
+        codexCLIResolvedExecutableURL: URL? = nil
     ) -> TapQCLIApplication {
         TapQCLIApplication(
             io: io,
@@ -765,7 +947,9 @@ final class TapQCLIApplicationTests: XCTestCase {
             homeDirectory: directory,
             executableURL: directory.appendingPathComponent("tapq"),
             currentDirectory: directory,
-            monotonicNow: monotonicNow
+            monotonicNow: monotonicNow,
+            codexCLICommandRunner: codexCLICommandRunner,
+            codexCLIResolvedExecutableURL: codexCLIResolvedExecutableURL
         )
     }
 

--- a/Tests/TapQCodexAdapterTests/CodexHookInstallerTests.swift
+++ b/Tests/TapQCodexAdapterTests/CodexHookInstallerTests.swift
@@ -101,7 +101,7 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertEqual(CodexHookInstaller.trustCommand, "/hooks")
     }
 
-    func testInstallCreatesStableQuestionPermissionAndStopHooks() throws {
+    func testInstallCreatesStableQuestionPermissionStopAndSteeringHooks() throws {
         let report = try installer().install()
         let root = try read()
         let hooks = try XCTUnwrap(root["hooks"]?.objectValue)
@@ -139,6 +139,17 @@ final class CodexHookInstallerTests: XCTestCase {
             XCTAssertEqual(timeout, InteractionBudget.hookTimeout)
         } else {
             XCTFail("Stop timeout is missing")
+        }
+
+        let userPromptSubmit = try XCTUnwrap(hooks["UserPromptSubmit"]?.arrayValue?.first)
+        XCTAssertNil(userPromptSubmit["matcher"])
+        let steeringHook = try XCTUnwrap(userPromptSubmit["hooks"]?.arrayValue?.first)
+        XCTAssertEqual(steeringHook["type"]?.stringValue, "command")
+        XCTAssertEqual(steeringHook["command"]?.stringValue, quotedCommand)
+        if case .number(let timeout)? = steeringHook["timeout"] {
+            XCTAssertEqual(timeout, 5)
+        } else {
+            XCTFail("UserPromptSubmit timeout is missing")
         }
 
         XCTAssertEqual(report.status, .installed)
@@ -179,6 +190,9 @@ final class CodexHookInstallerTests: XCTestCase {
             ]}],
             "Stop":[{"hooks":[
               {"type":"command","command":"/usr/bin/user-stop","timeout":10}
+            ]}],
+            "UserPromptSubmit":[{"hooks":[
+              {"type":"command","command":"/usr/bin/user-steering","timeout":5}
             ]}]
           }
         }
@@ -210,6 +224,11 @@ final class CodexHookInstallerTests: XCTestCase {
         }
         XCTAssertTrue(stopCommands.contains("/usr/bin/user-stop"))
         XCTAssertTrue(stopCommands.contains(quotedCommand))
+        let steeringCommands = (hooks["UserPromptSubmit"]?.arrayValue ?? []).flatMap {
+            ($0["hooks"]?.arrayValue ?? []).compactMap { $0["command"]?.stringValue }
+        }
+        XCTAssertTrue(steeringCommands.contains("/usr/bin/user-steering"))
+        XCTAssertTrue(steeringCommands.contains(quotedCommand))
     }
 
     func testRepeatedInstallDoesNotRewriteOrDuplicateHooks() throws {
@@ -227,6 +246,7 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertEqual(tapQHandlers(event: "PreToolUse", in: hooks).count, 1)
         XCTAssertEqual(tapQHandlers(event: "PermissionRequest", in: hooks).count, 1)
         XCTAssertEqual(tapQHandlers(event: "Stop", in: hooks).count, 1)
+        XCTAssertEqual(tapQHandlers(event: "UserPromptSubmit", in: hooks).count, 1)
     }
 
     func testStatusDetectsIncompleteStaleAndMalformedLayouts() throws {
@@ -316,6 +336,7 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertEqual(tapQHandlers(event: "PreToolUse", in: hooks).count, 1)
         XCTAssertEqual(tapQHandlers(event: "PermissionRequest", in: hooks).count, 1)
         XCTAssertEqual(tapQHandlers(event: "Stop", in: hooks).count, 1)
+        XCTAssertEqual(tapQHandlers(event: "UserPromptSubmit", in: hooks).count, 1)
         let allCommands = hooks.values.flatMap { event in
             (event.arrayValue ?? []).flatMap { group in
                 (group["hooks"]?.arrayValue ?? []).compactMap { $0["command"]?.stringValue }
@@ -348,6 +369,10 @@ final class CodexHookInstallerTests: XCTestCase {
             "Stop":[{"hooks":[
               {"type":"command","command":"\(quotedCommand)","timeout":120}
             ]}],
+            "UserPromptSubmit":[{"hooks":[
+              {"type":"command","command":"\(quotedCommand)","timeout":5},
+              {"type":"command","command":"/usr/bin/user-prompt-audit","timeout":5}
+            ]}],
             "PostToolUse":[{"matcher":"Bash","hooks":[
               {"type":"command","command":"/usr/bin/post","timeout":5}
             ]}]
@@ -369,6 +394,10 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertEqual(
             hooks["PermissionRequest"]?.arrayValue?.first?["hooks"]?.arrayValue?.first?["command"]?.stringValue,
             "/usr/bin/user-audit"
+        )
+        XCTAssertEqual(
+            hooks["UserPromptSubmit"]?.arrayValue?.first?["hooks"]?.arrayValue?.first?["command"]?.stringValue,
+            "/usr/bin/user-prompt-audit"
         )
         XCTAssertEqual(
             hooks["PostToolUse"]?.arrayValue?.first?["hooks"]?.arrayValue?.first?["command"]?.stringValue,

--- a/Tests/TapQCodexAdapterTests/CodexHookShimTests.swift
+++ b/Tests/TapQCodexAdapterTests/CodexHookShimTests.swift
@@ -124,6 +124,23 @@ final class CodexHookShimTests: XCTestCase {
         try! JSONEncoder().encode(stopObject(message: message, active: active))
     }
 
+    private func userPromptSubmitObject() -> [String: JSONValue] {
+        [
+            "hook_event_name": .string("UserPromptSubmit"),
+            "session_id": .string("session-1"),
+            "turn_id": .string("turn-1"),
+            "transcript_path": .null,
+            "cwd": .string("/tmp/project"),
+            "model": .string("gpt-5.6"),
+            "permission_mode": .string("default"),
+            "prompt": .string("Plan the deployment."),
+        ]
+    }
+
+    private func userPromptSubmitInput() -> Data {
+        try! JSONEncoder().encode(userPromptSubmitObject())
+    }
+
     private func permissionOutput(
         _ stdout: String?
     ) throws -> (event: String, behavior: String, message: String?) {
@@ -136,6 +153,106 @@ final class CodexHookShimTests: XCTestCase {
             decision?["behavior"]?.stringValue ?? "",
             decision?["message"]?.stringValue
         )
+    }
+
+    // MARK: - UserPromptSubmit steering
+
+    func testUserPromptSubmitEmitsExactContextShapeWhenSteeringEnabled() throws {
+        var steeringChecks = 0
+        var reachedBroker = false
+        let result = CodexHookShim.handle(
+            stdinData: userPromptSubmitInput(),
+            steeringEnabled: {
+                steeringChecks += 1
+                return true
+            }
+        ) { _, _ in
+            reachedBroker = true
+            return Data()
+        }
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(steeringChecks, 1)
+        XCTAssertFalse(reachedBroker)
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: Data(try XCTUnwrap(result.stdout).utf8)
+        )
+        XCTAssertEqual(Set(output.keys), ["hookSpecificOutput"])
+        let inner = try XCTUnwrap(output["hookSpecificOutput"]?.objectValue)
+        XCTAssertEqual(Set(inner.keys), ["hookEventName", "additionalContext"])
+        XCTAssertEqual(inner["hookEventName"]?.stringValue, "UserPromptSubmit")
+        XCTAssertEqual(inner["additionalContext"]?.stringValue, CodexHookShim.steeringNudge)
+        XCTAssertTrue(CodexHookShim.steeringNudge.contains("request_user_input when available"))
+    }
+
+    func testUserPromptSubmitIsSilentWhenSteeringDisabledOrDefaultedOff() {
+        var reachedBroker = false
+        let disabled = CodexHookShim.handle(
+            stdinData: userPromptSubmitInput(),
+            steeringEnabled: { false }
+        ) { _, _ in
+            reachedBroker = true
+            return Data()
+        }
+        let defaulted = CodexHookShim.handle(stdinData: userPromptSubmitInput()) { _, _ in
+            reachedBroker = true
+            return Data()
+        }
+
+        XCTAssertEqual(disabled, CodexHookShim.passThrough)
+        XCTAssertEqual(defaulted, CodexHookShim.passThrough)
+        XCTAssertFalse(reachedBroker)
+    }
+
+    func testUserPromptSubmitInvalidAndSubagentInputsStaySilent() {
+        var inputs: [[String: JSONValue]] = []
+        for key in [
+            "session_id", "turn_id", "transcript_path", "cwd", "model",
+            "permission_mode", "prompt",
+        ] {
+            var missing = userPromptSubmitObject()
+            missing.removeValue(forKey: key)
+            inputs.append(missing)
+        }
+        var emptyPrompt = userPromptSubmitObject()
+        emptyPrompt["prompt"] = .string(" ")
+        inputs.append(emptyPrompt)
+        var invalidTranscript = userPromptSubmitObject()
+        invalidTranscript["transcript_path"] = .number(1)
+        inputs.append(invalidTranscript)
+        var invalidMode = userPromptSubmitObject()
+        invalidMode["permission_mode"] = .string("futureMode")
+        inputs.append(invalidMode)
+        for (key, value) in [
+            ("agent_id", JSONValue.string("agent-1")),
+            ("agent_type", JSONValue.string("worker")),
+            ("agent_id", JSONValue.null),
+            ("agent_type", JSONValue.null),
+        ] {
+            var subagent = userPromptSubmitObject()
+            subagent[key] = value
+            inputs.append(subagent)
+        }
+
+        for object in inputs {
+            var steeringChecked = false
+            var reachedBroker = false
+            let result = CodexHookShim.handle(
+                stdinData: try! JSONEncoder().encode(object),
+                steeringEnabled: {
+                    steeringChecked = true
+                    return true
+                }
+            ) { _, _ in
+                reachedBroker = true
+                return Data()
+            }
+
+            XCTAssertEqual(result, CodexHookShim.passThrough)
+            XCTAssertFalse(steeringChecked)
+            XCTAssertFalse(reachedBroker)
+        }
     }
 
     // MARK: - PreToolUse request_user_input

--- a/Tests/TapQCodexProcessTests/CodexHookProcessContractTests.swift
+++ b/Tests/TapQCodexProcessTests/CodexHookProcessContractTests.swift
@@ -108,6 +108,160 @@ final class CodexHookProcessContractTests: XCTestCase {
         XCTAssertFalse(request.multiSelect)
     }
 
+    func testCodex01460UserPromptSubmitWithLiveSteeringEmitsContextWithoutBrokerRequest() async throws {
+        let fixture = try fixtureData(named: "user-prompt-submit-root")
+        let fixtureObject = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: fixture
+        )
+        XCTAssertEqual(
+            Set(fixtureObject.keys),
+            [
+                "session_id", "turn_id", "transcript_path", "cwd",
+                "hook_event_name", "model", "permission_mode", "prompt",
+            ],
+            "the source-derived fixture must preserve the exact Codex 0.146 envelope"
+        )
+        XCTAssertNil(fixtureObject["agent_id"])
+        XCTAssertNil(fixtureObject["agent_type"])
+
+        let callbacks = BrokerCallbackRecorder()
+        let diagnostics = ProcessDiagnosticRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            discoveryOverride: .steeringEnabled,
+            diagnosticSink: diagnostics,
+            onApproval: { _ in
+                callbacks.events.append("approval")
+                return .ask
+            },
+            onNotification: { _ in callbacks.events.append("notification") },
+            onSelection: { _ in
+                callbacks.events.append("selection")
+                return .noSelection
+            },
+            onStopQuestion: { _ in
+                callbacks.events.append("stop_question")
+                return nil
+            }
+        )
+        assertCleanExit(processResult)
+
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: processResult.stdout
+        )
+        XCTAssertEqual(output, [
+            "hookSpecificOutput": .object([
+                "hookEventName": .string("UserPromptSubmit"),
+                "additionalContext": .string(
+                    "When you need the user to choose between options or confirm a decision, "
+                        + "use request_user_input when available rather than asking in plain text."
+                ),
+            ]),
+        ])
+        XCTAssertTrue(callbacks.events.isEmpty)
+        XCTAssertEqual(
+            diagnostics.events.map(\.name),
+            ["started", "stopped"],
+            "UserPromptSubmit steering must read discovery without sending a broker request"
+        )
+    }
+
+    func testCodex01460UserPromptSubmitWithSteeringDisabledFailsOpen() async throws {
+        let callbacks = BrokerCallbackRecorder()
+        let diagnostics = ProcessDiagnosticRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixtureData(named: "user-prompt-submit-root"),
+            diagnosticSink: diagnostics,
+            onApproval: { _ in
+                callbacks.events.append("approval")
+                return .ask
+            },
+            onNotification: { _ in callbacks.events.append("notification") },
+            onSelection: { _ in
+                callbacks.events.append("selection")
+                return .noSelection
+            },
+            onStopQuestion: { _ in
+                callbacks.events.append("stop_question")
+                return nil
+            }
+        )
+
+        assertFailOpen(processResult)
+        XCTAssertTrue(callbacks.events.isEmpty)
+        XCTAssertEqual(diagnostics.events.map(\.name), ["started", "stopped"])
+    }
+
+    func testCodex01460UserPromptSubmitWithMissingDiscoveryFailsOpen() async throws {
+        let hookExecutable = try hookExecutableURL()
+        let testRoot = try makeTestRoot()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+
+        let processResult = try await runHook(
+            executable: hookExecutable,
+            fixture: fixtureData(named: "user-prompt-submit-root"),
+            testRoot: testRoot
+        )
+
+        assertFailOpen(processResult)
+    }
+
+    func testCodex01460UserPromptSubmitWithStaleDiscoveryFailsOpen() async throws {
+        let callbacks = BrokerCallbackRecorder()
+        let diagnostics = ProcessDiagnosticRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixtureData(named: "user-prompt-submit-root"),
+            discoveryOverride: .staleSteering,
+            diagnosticSink: diagnostics,
+            onApproval: { _ in
+                callbacks.events.append("approval")
+                return .ask
+            },
+            onNotification: { _ in callbacks.events.append("notification") },
+            onSelection: { _ in
+                callbacks.events.append("selection")
+                return .noSelection
+            },
+            onStopQuestion: { _ in
+                callbacks.events.append("stop_question")
+                return nil
+            }
+        )
+
+        assertFailOpen(processResult)
+        XCTAssertTrue(callbacks.events.isEmpty)
+        XCTAssertEqual(diagnostics.events.map(\.name), ["started", "stopped"])
+    }
+
+    func testCodex01460UserPromptSubmitWithIncompatibleDiscoveryFailsOpen() async throws {
+        let callbacks = BrokerCallbackRecorder()
+        let diagnostics = ProcessDiagnosticRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixtureData(named: "user-prompt-submit-root"),
+            discoveryOverride: .steeringProtocolVersion(WireProtocol.version + 1),
+            diagnosticSink: diagnostics,
+            onApproval: { _ in
+                callbacks.events.append("approval")
+                return .ask
+            },
+            onNotification: { _ in callbacks.events.append("notification") },
+            onSelection: { _ in
+                callbacks.events.append("selection")
+                return .noSelection
+            },
+            onStopQuestion: { _ in
+                callbacks.events.append("stop_question")
+                return nil
+            }
+        )
+
+        assertFailOpen(processResult)
+        XCTAssertTrue(callbacks.events.isEmpty)
+        XCTAssertEqual(diagnostics.events.map(\.name), ["started", "stopped"])
+    }
+
     func testCodex01460MCPPermissionRequestReachesBrokerAndAllows() async throws {
         let hookExecutable = try hookExecutableURL()
         let testRoot = try makeTestRoot()
@@ -211,6 +365,262 @@ final class CodexHookProcessContractTests: XCTestCase {
         }
     }
 
+    func testCodex01425PermissionRequestEnvelopeReachesBrokerAndAllows() async throws {
+        let fixture = try fixtureData(
+            version: "0.142.5",
+            named: "permission-request-bash"
+        )
+        let fixtureObject = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: fixture
+        )
+        XCTAssertEqual(
+            Set(fixtureObject.keys),
+            [
+                "session_id", "turn_id", "transcript_path", "cwd",
+                "hook_event_name", "model", "permission_mode", "tool_name",
+                "tool_input",
+            ],
+            "the source-derived fixture must preserve the exact Codex 0.142.5 envelope"
+        )
+        for absentKey in [
+            "agent_id", "agent_type", "tool_use_id", "request_id", "call_id",
+            "approval_attempt", "sandbox_permissions", "additional_permissions",
+            "justification", "host", "protocol",
+        ] {
+            XCTAssertNil(fixtureObject[absentKey])
+        }
+
+        let recorder = ApprovalRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            onApproval: { request in
+                recorder.requests.append(request)
+                return .allow
+            }
+        )
+        assertCleanExit(processResult)
+
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: processResult.stdout
+        )
+        XCTAssertEqual(output, permissionRequestOutput(behavior: "allow"))
+
+        let request = try XCTUnwrap(recorder.requests.only)
+        XCTAssertEqual(request.sessionID, "019fb425-0000-7000-8000-000000000001")
+        XCTAssertNotNil(UUID(uuidString: request.id))
+        XCTAssertEqual(request.agent, .codex)
+        XCTAssertEqual(request.toolName, "Bash")
+        XCTAssertEqual(request.toolInput, [
+            "command": .string("rm -f /tmp/tapq-codex-0.142.5-marker"),
+        ])
+        XCTAssertEqual(request.cwd, "/tmp/tapq-codex-0.142.5-fixture-workspace")
+        XCTAssertEqual(request.permissionMode, "default")
+        XCTAssertEqual(request.approvalSource, .permissionRequest)
+    }
+
+    func testCodex01460MCPPermissionRequestReachesBrokerAndDenies() async throws {
+        let fixture = try fixtureData(
+            named: "permission-request-mcp-memory-create-entities"
+        )
+        let recorder = ApprovalRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            onApproval: { request in
+                recorder.requests.append(request)
+                return .deny
+            }
+        )
+        assertCleanExit(processResult)
+
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: processResult.stdout
+        )
+        XCTAssertEqual(
+            output,
+            permissionRequestOutput(
+                behavior: "deny",
+                message: "Denied via TapQ"
+            )
+        )
+        XCTAssertEqual(recorder.requests.only?.toolName, "mcp__memory__create_entities")
+    }
+
+    func testCodex01460MCPBrokerAskFailsOpenToNativePrompt() async throws {
+        let fixture = try fixtureData(
+            named: "permission-request-mcp-memory-create-entities"
+        )
+        let recorder = ApprovalRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            onApproval: { request in
+                recorder.requests.append(request)
+                return .ask
+            }
+        )
+
+        assertFailOpen(processResult)
+        XCTAssertEqual(recorder.requests.only?.toolName, "mcp__memory__create_entities")
+    }
+
+    func testCodex01425StopQuestionReachesBrokerAndReturnsContinuation() async throws {
+        let fixture = try fixtureData(version: "0.142.5", named: "stop-question")
+        let fixtureObject = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: fixture
+        )
+        XCTAssertEqual(
+            Set(fixtureObject.keys),
+            [
+                "session_id", "turn_id", "transcript_path", "cwd",
+                "hook_event_name", "model", "permission_mode", "stop_hook_active",
+                "last_assistant_message",
+            ],
+            "the source-derived fixture must preserve the exact Codex 0.142.5 Stop envelope"
+        )
+        XCTAssertNil(fixtureObject["agent_id"])
+        XCTAssertNil(fixtureObject["agent_type"])
+
+        let stopRecorder = StopQuestionRecorder()
+        let notificationRecorder = NotificationRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            onNotification: { notificationRecorder.notifications.append($0) },
+            onStopQuestion: { question in
+                stopRecorder.questions.append(question)
+                return "Yes. Run the migration."
+            }
+        )
+        assertCleanExit(processResult)
+
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: processResult.stdout
+        )
+        XCTAssertEqual(output, [
+            "decision": .string("block"),
+            "reason": .string("Yes. Run the migration."),
+        ])
+        XCTAssertTrue(notificationRecorder.notifications.isEmpty)
+
+        let question = try XCTUnwrap(stopRecorder.questions.only)
+        XCTAssertEqual(question.sessionID, "019fb425-0000-7000-8000-000000000003")
+        XCTAssertEqual(question.agent, .codex)
+        XCTAssertEqual(question.text, "Would you like me to run the migration?")
+    }
+
+    func testCodex01425StopWithoutQuestionNotifiesCompletionAndFailsThrough() async throws {
+        let fixture = try fixtureReplacing(
+            version: "0.142.5",
+            named: "stop-question",
+            values: ["last_assistant_message": .string("Migration is complete.")]
+        )
+        let stopRecorder = StopQuestionRecorder()
+        let notificationRecorder = NotificationRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            onNotification: { notificationRecorder.notifications.append($0) },
+            onStopQuestion: { question in
+                stopRecorder.questions.append(question)
+                return "unexpected"
+            }
+        )
+
+        assertFailOpen(processResult)
+        XCTAssertTrue(stopRecorder.questions.isEmpty)
+        let notification = try XCTUnwrap(notificationRecorder.notifications.only)
+        XCTAssertEqual(notification.sessionID, "019fb425-0000-7000-8000-000000000003")
+        XCTAssertEqual(notification.agent, .codex)
+        XCTAssertEqual(notification.kind, .finished)
+        XCTAssertNil(notification.summary)
+    }
+
+    func testCodex01425ActiveStopDoesNotRepeatQuestionAndFailsThrough() async throws {
+        let fixture = try fixtureReplacing(
+            version: "0.142.5",
+            named: "stop-question",
+            values: ["stop_hook_active": .bool(true)]
+        )
+        let stopRecorder = StopQuestionRecorder()
+        let notificationRecorder = NotificationRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            onNotification: { notificationRecorder.notifications.append($0) },
+            onStopQuestion: { question in
+                stopRecorder.questions.append(question)
+                return "unexpected"
+            }
+        )
+
+        assertFailOpen(processResult)
+        XCTAssertTrue(stopRecorder.questions.isEmpty)
+        XCTAssertEqual(notificationRecorder.notifications.only?.kind, .finished)
+    }
+
+    func testPermissionRequestWithMissingDiscoveryFailsOpen() async throws {
+        let hookExecutable = try hookExecutableURL()
+        let testRoot = try makeTestRoot()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+
+        let fixture = try fixtureData(
+            version: "0.142.5",
+            named: "permission-request-bash"
+        )
+        let processResult = try await runHook(
+            executable: hookExecutable,
+            fixture: fixture,
+            testRoot: testRoot
+        )
+
+        assertFailOpen(processResult)
+    }
+
+    func testPermissionRequestWithIncompatibleDiscoveredWireVersionFailsOpen() async throws {
+        let fixture = try fixtureData(
+            version: "0.142.5",
+            named: "permission-request-bash"
+        )
+        let recorder = ApprovalRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            discoveryOverride: .protocolVersion(WireProtocol.version + 1),
+            onApproval: { request in
+                recorder.requests.append(request)
+                return .allow
+            }
+        )
+
+        assertFailOpen(processResult)
+        XCTAssertTrue(
+            recorder.requests.isEmpty,
+            "the hook must reject an incompatible discovery record before broker policy runs"
+        )
+    }
+
+    func testPermissionRequestWithUnauthorizedDiscoveryTokenFailsOpen() async throws {
+        let fixture = try fixtureData(
+            version: "0.142.5",
+            named: "permission-request-bash"
+        )
+        let recorder = ApprovalRecorder()
+        let processResult = try await runHookAgainstBroker(
+            fixture: fixture,
+            discoveryOverride: .wrongToken,
+            onApproval: { request in
+                recorder.requests.append(request)
+                return .allow
+            }
+        )
+
+        assertFailOpen(processResult)
+        XCTAssertTrue(
+            recorder.requests.isEmpty,
+            "the broker must reject the request before approval policy runs"
+        )
+    }
+
     private func makeTestRoot() throws -> URL {
         let testRoot = URL(
             fileURLWithPath: "/tmp/tapq-codex-contract-\(UUID().uuidString.prefix(12))",
@@ -223,13 +633,167 @@ final class CodexHookProcessContractTests: XCTestCase {
         return testRoot
     }
 
-    private func fixtureData(named name: String) throws -> Data {
+    private func fixtureData(
+        version: String = "0.146.0",
+        named name: String
+    ) throws -> Data {
         let fixtureURL = try XCTUnwrap(Bundle.module.url(
             forResource: name,
             withExtension: "json",
-            subdirectory: "Fixtures/codex-cli-0.146.0"
+            subdirectory: "Fixtures/codex-cli-\(version)"
         ))
         return try Data(contentsOf: fixtureURL)
+    }
+
+    private func fixtureReplacing(
+        version: String,
+        named name: String,
+        values: [String: JSONValue]
+    ) throws -> Data {
+        var fixture = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: fixtureData(version: version, named: name)
+        )
+        for (key, value) in values {
+            fixture[key] = value
+        }
+        return try JSONEncoder().encode(fixture)
+    }
+
+    private func runHookAgainstBroker(
+        fixture: Data,
+        discoveryOverride: DiscoveryOverride = .standard,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
+        onApproval: @escaping @MainActor (ApprovalRequest) async -> Decision = { _ in .ask },
+        onNotification: @escaping @MainActor (AgentNotification) -> Void = { _ in },
+        onSelection: @escaping @MainActor (SelectionRequest) async -> SelectionResult = {
+            _ in .noSelection
+        },
+        onStopQuestion: @escaping @MainActor (StopQuestion) async -> String? = { _ in nil }
+    ) async throws -> HookProcessResult {
+        let hookExecutable = try hookExecutableURL()
+        let testRoot = try makeTestRoot()
+        let discovery = BrokerRuntimeDiscovery(supportDirectory: testRoot)
+        try discovery.prepareDirectory()
+        let serverToken = BrokerRuntimeDiscovery.generateToken()
+        let server = BrokerServer(
+            transport: UnixSocketTransport(path: discovery.socketPath),
+            token: serverToken,
+            diagnosticSink: diagnosticSink,
+            onApproval: onApproval,
+            onNotification: onNotification,
+            onSelection: onSelection,
+            onStopQuestion: onStopQuestion
+        )
+        try server.start()
+        switch discoveryOverride {
+        case .standard:
+            try discovery.publish(token: serverToken)
+        case .steeringEnabled:
+            try discovery.publish(token: serverToken, steeringEnabled: true)
+        case .wrongToken:
+            try discovery.publish(token: "wrong-\(serverToken)")
+        case .protocolVersion(let version):
+            try publishDiscovery(
+                discovery,
+                token: serverToken,
+                protocolVersion: version
+            )
+        case .steeringProtocolVersion(let version):
+            try publishDiscovery(
+                discovery,
+                token: serverToken,
+                protocolVersion: version,
+                steeringEnabled: true
+            )
+        case .staleSteering:
+            try publishDiscovery(
+                discovery,
+                token: serverToken,
+                protocolVersion: WireProtocol.version,
+                steeringEnabled: true,
+                processID: Int32.max
+            )
+        }
+        defer {
+            server.stop()
+            discovery.remove()
+            try? FileManager.default.removeItem(at: testRoot)
+        }
+
+        return try await runHook(
+            executable: hookExecutable,
+            fixture: fixture,
+            testRoot: testRoot
+        )
+    }
+
+    private func publishDiscovery(
+        _ discovery: BrokerRuntimeDiscovery,
+        token: String,
+        protocolVersion: Int,
+        steeringEnabled: Bool = false,
+        processID: Int32 = ProcessInfo.processInfo.processIdentifier
+    ) throws {
+        let record: [String: JSONValue] = [
+            "socket": .string(discovery.socketPath),
+            "token": .string(token),
+            "protocol_version": .number(Double(protocolVersion)),
+            "steering_enabled": .bool(steeringEnabled),
+            "process_id": .number(Double(processID)),
+        ]
+        var data = try JSONEncoder().encode(record)
+        data.append(0x0A)
+        try data.write(to: discovery.discoveryURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: discovery.discoveryURL.path
+        )
+    }
+
+    private func permissionRequestOutput(
+        behavior: String,
+        message: String? = nil
+    ) -> [String: JSONValue] {
+        var decision: [String: JSONValue] = ["behavior": .string(behavior)]
+        if let message {
+            decision["message"] = .string(message)
+        }
+        return [
+            "hookSpecificOutput": .object([
+                "hookEventName": .string("PermissionRequest"),
+                "decision": .object(decision),
+            ]),
+        ]
+    }
+
+    private func assertCleanExit(
+        _ result: HookProcessResult,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(result.terminationStatus, 0, file: file, line: line)
+        XCTAssertTrue(
+            result.stderr.isEmpty,
+            "unexpected hook stderr: " + String(decoding: result.stderr, as: UTF8.self),
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertFailOpen(
+        _ result: HookProcessResult,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        assertCleanExit(result, file: file, line: line)
+        XCTAssertTrue(
+            result.stdout.isEmpty,
+            "fail-open must emit no stdout; got: "
+                + String(decoding: result.stdout, as: UTF8.self),
+            file: file,
+            line: line
+        )
     }
 
     private func runHook(
@@ -325,6 +889,47 @@ private final class SelectionRecorder {
 @MainActor
 private final class ApprovalRecorder {
     var requests: [ApprovalRequest] = []
+}
+
+@MainActor
+private final class StopQuestionRecorder {
+    var questions: [StopQuestion] = []
+}
+
+@MainActor
+private final class NotificationRecorder {
+    var notifications: [AgentNotification] = []
+}
+
+@MainActor
+private final class BrokerCallbackRecorder {
+    var events: [String] = []
+}
+
+private final class ProcessDiagnosticRecorder: TapQDiagnosticSink, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedEvents: [TapQDiagnosticEvent] = []
+
+    func record(_ event: TapQDiagnosticEvent) {
+        lock.lock()
+        recordedEvents.append(event)
+        lock.unlock()
+    }
+
+    var events: [TapQDiagnosticEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedEvents
+    }
+}
+
+private enum DiscoveryOverride {
+    case standard
+    case steeringEnabled
+    case wrongToken
+    case protocolVersion(Int)
+    case steeringProtocolVersion(Int)
+    case staleSteering
 }
 
 private struct HookProcessResult {

--- a/Tests/TapQCodexProcessTests/Fixtures/README.md
+++ b/Tests/TapQCodexProcessTests/Fixtures/README.md
@@ -1,0 +1,18 @@
+# Codex hook process-contract fixtures
+
+These fixtures drive `tapq-codex-hook` as a real child process and, for
+broker-backed cases, send its authenticated request through the real Unix-socket
+transport to `BrokerServer`. The tests assert the Codex hook JSON written by the
+executable as well as the normalized request observed by the broker.
+
+This is an **executable-to-broker process contract**, not a model-level or Codex
+CLI end-to-end test. It does not start Codex, require a Codex login, contact a
+model, prove that a particular Codex build consumes the hook stdout, or prove
+that a model follows TapQ's continuation/selection feedback. Those boundaries
+remain covered by upstream source/schema provenance and manual compatibility
+testing.
+
+Each `codex-cli-<version>` directory documents whether its inputs are sanitized
+captures or official-source-derived fixtures. Add a new version directory when
+Codex changes a hook envelope; do not silently rewrite an older release's
+fixture.

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.142.5/README.md
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.142.5/README.md
@@ -1,0 +1,47 @@
+# Codex CLI 0.142.5 hook fixtures
+
+These are **official-source-derived fixtures**, not runtime captures. They pin
+TapQ's advertised lifecycle-hook compatibility floor to the annotated Codex tag
+`rust-v0.142.5`:
+
+- tag object: `1b30ea33f13533474db7c3ad6313ef280769e432`
+- commit: `26de83050b20f7e0ee211b9739e52ae00ce8032a`
+
+`permission-request-bash.json` derives its complete envelope from:
+
+- `codex-rs/hooks/src/events/permission_request.rs` (`build_command_input`)
+- `codex-rs/hooks/src/schema.rs` (`PermissionRequestCommandInput`)
+- `codex-rs/hooks/schema/generated/permission-request.command.input.schema.json`
+- `codex-rs/hooks/schema/generated/permission-request.command.output.schema.json`
+- `codex-rs/hooks/src/events/permission_request.rs` (`parse_completed`, which calls
+  `output_parser::parse_permission_request`)
+- `codex-rs/core/src/hook_runtime.rs` (the core approval path that executes and applies
+  the parsed hook decision)
+- `codex-rs/core/tests/suite/hooks.rs`
+  (`permission_request_hook_allows_shell_command_without_user_approval` and
+  `assert_permission_request_hook_input`)
+
+The upstream test pins `Bash`, a `{ "command": ... }` tool input, and the absence
+of `tool_use_id` and approval-attempt metadata. Dynamic identifiers, paths,
+model, and the temporary command path were normalized to stable test values.
+
+`stop-question.json` derives its complete envelope from:
+
+- `codex-rs/hooks/src/events/stop.rs` (`StopCommandInput` construction)
+- `codex-rs/hooks/src/schema.rs` (`StopCommandInput`)
+- `codex-rs/hooks/schema/generated/stop.command.input.schema.json`
+- `codex-rs/hooks/schema/generated/stop.command.output.schema.json`
+- `codex-rs/hooks/src/events/stop.rs` (`parse_completed`, which calls
+  `output_parser::parse_stop` and creates continuation fragments)
+- `codex-rs/core/src/hook_runtime.rs` (the core lifecycle path that executes Stop hooks
+  and applies their continuation result)
+- `codex-rs/core/tests/suite/hooks.rs`
+  (`stop_hook_can_block_multiple_times_in_same_turn`)
+
+That upstream contract pins `stop_hook_active` as `false` on the first Stop and
+`true` on continuation callbacks. Dynamic identifiers, paths, model, and final
+assistant text were normalized to stable values. The representative question
+lets TapQ exercise the continuation response without starting Codex or a model.
+
+See the parent fixture README for the exact boundary these process contracts do
+and do not cover.

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.142.5/permission-request-bash.json
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.142.5/permission-request-bash.json
@@ -1,0 +1,13 @@
+{
+  "session_id": "019fb425-0000-7000-8000-000000000001",
+  "turn_id": "019fb425-0000-7000-8000-000000000002",
+  "transcript_path": "/tmp/codex-0.142.5-session.jsonl",
+  "cwd": "/tmp/tapq-codex-0.142.5-fixture-workspace",
+  "hook_event_name": "PermissionRequest",
+  "model": "gpt-5.4",
+  "permission_mode": "default",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "rm -f /tmp/tapq-codex-0.142.5-marker"
+  }
+}

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.142.5/stop-question.json
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.142.5/stop-question.json
@@ -1,0 +1,11 @@
+{
+  "session_id": "019fb425-0000-7000-8000-000000000003",
+  "turn_id": "019fb425-0000-7000-8000-000000000004",
+  "transcript_path": "/tmp/codex-0.142.5-session.jsonl",
+  "cwd": "/tmp/tapq-codex-0.142.5-fixture-workspace",
+  "hook_event_name": "Stop",
+  "model": "gpt-5.4",
+  "permission_mode": "default",
+  "stop_hook_active": false,
+  "last_assistant_message": "Would you like me to run the migration?"
+}

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/README.md
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/README.md
@@ -31,5 +31,25 @@ fixture. Its envelope and response contract were also verified against:
 - `codex-rs/hooks/schema/generated/permission-request.command.output.schema.json`
 - `codex-rs/core/src/hook_runtime.rs`
 
+`user-prompt-submit-root.json` is also an **official-source-derived fixture**,
+not a runtime capture. Its complete root-thread envelope comes from the same
+`rust-v0.146.0` tag and commit above, specifically:
+
+- `codex-rs/hooks/src/events/user_prompt_submit.rs`
+- `codex-rs/hooks/src/schema.rs` (`UserPromptSubmitCommandInput`)
+- `codex-rs/hooks/schema/generated/user-prompt-submit.command.input.schema.json`
+- `codex-rs/hooks/schema/generated/user-prompt-submit.command.output.schema.json`
+- `codex-rs/core/tests/suite/hooks.rs`
+  (`session_start_runs_before_user_prompt_submit_on_first_turn` and the
+  user-prompt blocking/acceptance tests)
+
+The fixture deliberately omits `agent_id` and `agent_type`, as the upstream
+serializer does for a root turn. Dynamic identifiers, paths, model, and prompt
+text were normalized to stable test values. TapQ uses it to test the local
+steering hook process; it is not presented as a capture of model behavior.
+
 Keep fixtures versioned by Codex CLI release. A contract change should add a new
 version directory instead of silently rewriting this fixture.
+
+See the parent fixture README for the executable-to-broker boundary these tests
+cover and the model/Codex-consumption boundary they intentionally do not claim.

--- a/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/user-prompt-submit-root.json
+++ b/Tests/TapQCodexProcessTests/Fixtures/codex-cli-0.146.0/user-prompt-submit-root.json
@@ -1,0 +1,10 @@
+{
+  "session_id": "019fb3cc-0000-7000-8000-000000000005",
+  "turn_id": "019fb3cc-0000-7000-8000-000000000006",
+  "transcript_path": "/tmp/codex-session.jsonl",
+  "cwd": "/tmp/tapq-codex-fixture-workspace",
+  "hook_event_name": "UserPromptSubmit",
+  "model": "gpt-5.6-luna",
+  "permission_mode": "default",
+  "prompt": "Plan the deployment."
+}

--- a/Tests/TapQContextBaselineTests/ReasonerContractTests.swift
+++ b/Tests/TapQContextBaselineTests/ReasonerContractTests.swift
@@ -271,6 +271,7 @@ final class ReasonerContractTests: XCTestCase {
     func testContextDefaultsOptionalsAndRoundTrips() throws {
         let minimal = ReasonerContext(toolName: "Read", summary: "Read a file")
         XCTAssertNil(minimal.commandText)
+        XCTAssertNil(minimal.toolInput)
         XCTAssertNil(minimal.cwd)
         XCTAssertNil(minimal.agentName)
         XCTAssertNil(minimal.detail)
@@ -286,6 +287,69 @@ final class ReasonerContractTests: XCTestCase {
             try JSONDecoder().decode(ReasonerContext.self, from: data),
             minimal
         )
+    }
+
+    func testMCPToolInputUsesPinnedSnakeCaseKeyAndRoundTripsLosslessly() throws {
+        let input: [String: JSONValue] = [
+            "recipient": .string("ops@example.com"),
+            "payload": .object([
+                "count": .number(3),
+                "confirmed": .bool(false),
+            ]),
+        ]
+        let original = ReasonerContext(
+            toolName: "mcp__mail__send",
+            toolInput: input,
+            agentName: "Codex",
+            summary: "use send from mail"
+        )
+        let data = try JSONEncoder().encode(original)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        XCTAssertEqual(
+            Set(object.keys),
+            ["tool_name", "tool_input", "agent_name", "summary"]
+        )
+        XCTAssertNotNil(object["tool_input"] as? [String: Any])
+        XCTAssertEqual(try JSONDecoder().decode(ReasonerContext.self, from: data), original)
+    }
+
+    func testMCPReviewRowsCannotPersistAModelGeneratedEcho() {
+        let decision = ReasonerDecision(
+            riskTier: .sensitive,
+            requiredConfirmation: .doubleGesture,
+            rationale: ReasonerRationale(
+                code: .externalPublication,
+                note: "Publishes tapq-secret-connector-value."
+            ),
+            confidence: 0.9
+        )
+        let ordinary = ReasonerContext(toolName: "Bash", summary: "run a command")
+        let mcp = ReasonerContext(
+            toolName: "mcp__service__publish",
+            toolInput: ["payload": .string("tapq-secret-connector-value")],
+            summary: "use publish from service"
+        )
+
+        XCTAssertEqual(
+            ReasonerReviewDisclosure.persistedNote(from: decision, context: ordinary),
+            "Publishes tapq-secret-connector-value."
+        )
+        XCTAssertNil(
+            ReasonerReviewDisclosure.persistedNote(from: decision, context: mcp),
+            "an MCP model note is an untrusted echo channel, not sanitized metadata"
+        )
+        XCTAssertEqual(
+            ReasonerReviewDisclosure.persistedConfidence(from: decision, context: ordinary),
+            0.9
+        )
+        XCTAssertNil(
+            ReasonerReviewDisclosure.persistedConfidence(from: decision, context: mcp),
+            "MCP confidence cannot become a numeric echo channel"
+        )
+        XCTAssertNil(ReasonerReviewDisclosure.persistedNote(from: nil, context: ordinary))
     }
 
     /// The fusion fields are additive, which is a claim about *old* data: a context

--- a/Tests/TapQContextBaselineTests/ReasonerPromptTests.swift
+++ b/Tests/TapQContextBaselineTests/ReasonerPromptTests.swift
@@ -131,6 +131,148 @@ final class ReasonerPromptTests: XCTestCase {
         XCTAssertTrue(body.contains("command_text:\ngit push --force origin main"))
     }
 
+    func testRenderedMCPContextIncludesCanonicalCompleteInputInsideTheFence() throws {
+        let input: [String: JSONValue] = [
+            "z_destination": .string("external-channel"),
+            "a_payload": .object([
+                "publish": .bool(true),
+                "items": .array([.number(2), .null]),
+            ]),
+        ]
+        let rendered = ReasonerPromptContract.renderContext(ReasonerContext(
+            toolName: "mcp__messaging__publish",
+            toolInput: input,
+            agentName: "Codex",
+            summary: "use publish from messaging"
+        ))
+        let body = try fencedBody(of: rendered)
+        let encoded = try XCTUnwrap(ReasonerPromptContract.encodedToolInput(input))
+
+        XCTAssertEqual(
+            encoded,
+            #"{"a_payload":{"items":[2,null],"publish":true},"z_destination":"external-channel"}"#,
+            "dictionary order must not change the prompt"
+        )
+        XCTAssertTrue(body.contains("tool_input:\n\(encoded)"))
+        XCTAssertFalse(rendered[..<rendered.range(
+            of: ReasonerPromptContract.contextFenceBegin
+        )!.lowerBound].contains("external-channel"))
+    }
+
+    func testRenderedMCPInputIsCappedAndReportsTruncation() throws {
+        let limit = ReasonerPromptContract.toolInputCharacterLimit
+        XCTAssertEqual(limit, ReasonerPromptContract.commandTextCharacterLimit)
+        let secret = String(repeating: "s", count: limit + 1_000)
+        let rendered = ReasonerPromptContract.renderContext(ReasonerContext(
+            toolName: "mcp__server__operation",
+            toolInput: ["payload": .string(secret)],
+            summary: "use operation from server"
+        ))
+        let full = try XCTUnwrap(ReasonerPromptContract.encodedToolInput([
+            "payload": .string(secret),
+        ]))
+        XCTAssertTrue(rendered.contains("[tool_input truncated; key-balanced"))
+        XCTAssertFalse(rendered.contains(full))
+        XCTAssertLessThan(rendered.count, limit + 500)
+        _ = try fencedBody(of: rendered)
+    }
+
+    func testRenderedMCPInputHasAnAbsoluteUTF8Bound() throws {
+        let cluster = "x" + String(repeating: "\u{0301}", count: 40_000)
+        XCTAssertEqual(cluster.count, 1, "the fixture defeats a character-only cap")
+        let bounded = ReasonerPromptContract.boundedToolInput(cluster)
+
+        XCTAssertTrue(bounded.contains("UTF-8 bytes]"))
+        XCTAssertLessThanOrEqual(
+            bounded.utf8.count,
+            ReasonerPromptContract.toolInputByteLimit,
+            "the marker must fit inside the absolute byte cap"
+        )
+        XCTAssertLessThanOrEqual(
+            bounded.count,
+            ReasonerPromptContract.toolInputCharacterLimit
+        )
+        XCTAssertFalse(bounded.contains(String(repeating: "\u{0301}", count: 40_000)))
+    }
+
+    func testOversizedASCIIInputComposesCharacterAndByteCaps() {
+        let bounded = ReasonerPromptContract.boundedToolInput(
+            String(repeating: "a", count: 20_000)
+        )
+
+        XCTAssertLessThanOrEqual(
+            bounded.count,
+            ReasonerPromptContract.toolInputCharacterLimit
+        )
+        XCTAssertLessThanOrEqual(
+            bounded.utf8.count,
+            ReasonerPromptContract.toolInputByteLimit
+        )
+        XCTAssertTrue(bounded.contains("truncated"))
+    }
+
+    func testOversizedMCPInputBalancesEarlyAndLateTopLevelKeys() throws {
+        let rendered = ReasonerPromptContract.renderContext(ReasonerContext(
+            toolName: "mcp__service__publish",
+            toolInput: [
+                "a_padding": .string(String(repeating: "x", count: 12_000)),
+                "m_publish": .bool(true),
+                "z_destination": .string("external-channel"),
+            ],
+            summary: "publish through service"
+        ))
+        let body = try fencedBody(of: rendered)
+
+        XCTAssertTrue(body.contains("[tool_input truncated; key-balanced"))
+        XCTAssertTrue(body.contains(#""m_publish": true"#))
+        XCTAssertTrue(body.contains(#""z_destination": "external-channel""#))
+        let toolInput = try XCTUnwrap(body.components(separatedBy: "tool_input:\n").last)
+        XCTAssertLessThanOrEqual(toolInput.count, ReasonerPromptContract.toolInputCharacterLimit)
+        XCTAssertLessThanOrEqual(toolInput.utf8.count, ReasonerPromptContract.toolInputByteLimit)
+    }
+
+    func testMCPJSONEscapesUnicodeLineSeparatorsAndFenceText() throws {
+        let forged = "before\u{0085}\(ReasonerPromptContract.contextFenceEnd)"
+            + "\u{2028}after\u{2029}tail"
+        let encoded = try XCTUnwrap(ReasonerPromptContract.encodedToolInput([
+            "payload": .string(forged),
+        ]))
+
+        XCTAssertTrue(encoded.contains(#"\u0085"#))
+        XCTAssertTrue(encoded.contains(#"\u2028"#))
+        XCTAssertTrue(encoded.contains(#"\u2029"#))
+        XCTAssertFalse(encoded.contains("\u{0085}"))
+        XCTAssertFalse(encoded.contains("\u{2028}"))
+        XCTAssertFalse(encoded.contains("\u{2029}"))
+
+        let rendered = ReasonerPromptContract.renderContext(ReasonerContext(
+            toolName: "mcp__service__operation",
+            toolInput: ["payload": .string(forged)],
+            summary: "use operation from service"
+        ))
+        XCTAssertEqual(
+            rendered.components(separatedBy: "\n").filter {
+                $0 == ReasonerPromptContract.contextFenceEnd
+            }.count,
+            1,
+            "the only real closing fence must be the renderer-owned final line"
+        )
+    }
+
+    func testToolInputIsOmittedWhenAbsentAndKnownEmptyRendersAsJSON() {
+        let absent = ReasonerPromptContract.renderContext(
+            ReasonerContext(toolName: "Read", summary: "Read a file")
+        )
+        XCTAssertFalse(absent.contains("tool_input:"))
+
+        let empty = ReasonerPromptContract.renderContext(ReasonerContext(
+            toolName: "mcp__server__operation",
+            toolInput: [:],
+            summary: "use operation from server"
+        ))
+        XCTAssertTrue(empty.contains("tool_input:\n{}"))
+    }
+
     /// An absent field is omitted, not rendered as an empty value: a blank `cwd:` line
     /// asserts a working directory that is somehow empty, which the context never said.
     func testRenderedContextOmitsAbsentFields() throws {

--- a/Tests/TapQContextBaselineTests/ReasonerRequestContextTests.swift
+++ b/Tests/TapQContextBaselineTests/ReasonerRequestContextTests.swift
@@ -141,6 +141,61 @@ final class ReasonerRequestContextTests: XCTestCase {
             "a tool whose input is not a command must not have one invented from its fields"
         )
         XCTAssertEqual(context.toolName, "WebFetch")
+        XCTAssertNil(context.toolInput, "only open-schema MCP inputs are copied wholesale")
+    }
+
+    func testCodexMCPCallCarriesTheCompleteOpenSchemaInput() {
+        let input: [String: JSONValue] = [
+            "channel": .string("release-room"),
+            "message": .string("Deploy completed"),
+            "metadata": .object([
+                "notify": .bool(true),
+                "labels": .array([.string("production"), .string("urgent")]),
+            ]),
+        ]
+        let context = ReasonerContext(approvalRequest: request(
+            toolName: "mcp__slack__send_message",
+            toolInput: input,
+            agent: .codex,
+            summary: "use send message from slack",
+            detail: "Use send message from the slack MCP server"
+        ))
+
+        XCTAssertNil(context.commandText, "an MCP schema has no guessed primary argument")
+        XCTAssertEqual(context.toolInput, input, "the reasoner receives the exact local input")
+    }
+
+    func testCodexMCPDistinguishesAbsentAndKnownEmptyInput() {
+        XCTAssertNil(
+            ReasonerContext(approvalRequest: request(
+                toolName: "mcp__server__operation",
+                toolInput: nil,
+                agent: .codex
+            )).toolInput
+        )
+        XCTAssertEqual(
+            ReasonerContext(approvalRequest: request(
+                toolName: "mcp__server__operation",
+                toolInput: [:],
+                agent: .codex
+            )).toolInput,
+            [:],
+            "a known argument object with no fields is not the same as missing input"
+        )
+    }
+
+    func testMalformedMCPNamesDoNotWidenTheReasonerContext() {
+        let toolInput: [String: JSONValue] = ["secret": .string("value")]
+
+        for toolName in ["mcp__", "mcp__server", "mcp____tool", "mcp__server__"] {
+            XCTAssertNil(
+                ReasonerContext.openSchemaToolInput(
+                    toolName: toolName,
+                    toolInput: toolInput
+                ),
+                "only canonical mcp__<server>__<tool> names carry open-schema input"
+            )
+        }
     }
 
     // MARK: - Question requests

--- a/Tests/TapQPOSIXBridgeClientTests/BrokerDiscoveryTests.swift
+++ b/Tests/TapQPOSIXBridgeClientTests/BrokerDiscoveryTests.swift
@@ -20,13 +20,20 @@ final class BrokerDiscoveryTests: XCTestCase {
     }
 
     func testReadsServerOwnedRecordIncludingProtocolVersion() throws {
-        let record = #"{"socket":"/tmp/tapq.sock","token":"tok","protocol_version":3,"steering_enabled":true}"#
+        let record = """
+        {"socket":"/tmp/tapq.sock","token":"tok","protocol_version":3,\
+        "steering_enabled":true,"process_id":\(ProcessInfo.processInfo.processIdentifier)}
+        """
         try Data(record.utf8).write(to: discovery.discoveryURL)
         let read = try discovery.readDiscovery()
         XCTAssertEqual(read.socket, "/tmp/tapq.sock")
         XCTAssertEqual(read.token, "tok")
         XCTAssertEqual(read.protocolVersion, WireProtocol.version)
         XCTAssertTrue(read.steeringEnabled)
+        XCTAssertTrue(
+            try discovery.readLiveDiscovery(socketIsReachable: { $0 == "/tmp/tapq.sock" })
+                .steeringEnabled
+        )
     }
 
     func testLegacyDiscoveryWithoutVersionReadsAsNil() throws {
@@ -41,6 +48,33 @@ final class BrokerDiscoveryTests: XCTestCase {
         let legacy = #"{"socket":"/tmp/x.sock","token":"tok"}"#
         try Data(legacy.utf8).write(to: discovery.discoveryURL)
         XCTAssertFalse(try discovery.readDiscovery().steeringEnabled)
+    }
+
+    func testLiveDiscoveryRejectsLegacyRecordWithoutPublisherPID() throws {
+        let legacy = #"{"socket":"/tmp/x.sock","token":"tok","steering_enabled":true}"#
+        try Data(legacy.utf8).write(to: discovery.discoveryURL)
+
+        XCTAssertTrue(try discovery.readDiscovery().steeringEnabled)
+        XCTAssertThrowsError(try discovery.readLiveDiscovery())
+    }
+
+    func testLiveDiscoveryRejectsDeadPublisherPID() throws {
+        let stale = #"{"socket":"/tmp/x.sock","token":"tok","steering_enabled":true,"process_id":2147483647}"#
+        try Data(stale.utf8).write(to: discovery.discoveryURL)
+
+        XCTAssertThrowsError(try discovery.readLiveDiscovery())
+    }
+
+    func testLiveDiscoveryRejectsUnreachableBrokerSocket() throws {
+        let record = """
+        {"socket":"/tmp/not-listening.sock","token":"tok","steering_enabled":true,\
+        "process_id":\(ProcessInfo.processInfo.processIdentifier)}
+        """
+        try Data(record.utf8).write(to: discovery.discoveryURL)
+
+        XCTAssertThrowsError(
+            try discovery.readLiveDiscovery(socketIsReachable: { _ in false })
+        )
     }
 
     func testMissingRequiredFieldsAreRejected() throws {

--- a/Tests/TapQPOSIXBridgeClientTests/UnixSocketClientTests.swift
+++ b/Tests/TapQPOSIXBridgeClientTests/UnixSocketClientTests.swift
@@ -35,6 +35,39 @@ final class UnixSocketClientTests: XCTestCase {
         }
     }
 
+    func testLivenessProbeAcceptsReachableSocketAndRejectsMissingSocket() throws {
+        let path = "/tmp/tapq-probe-\(UUID().uuidString.prefix(12)).sock"
+        let listenFD = socket(AF_UNIX, streamSocketType, 0)
+        XCTAssertGreaterThanOrEqual(listenFD, 0)
+        defer {
+            close(listenFD)
+            unlink(path)
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                    _ = strncpy($0, source, capacity - 1)
+                }
+            }
+        }
+        let bound = withUnsafePointer(to: &address) { rawAddress in
+            rawAddress.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                systemBind(listenFD, $0, socklen_t(MemoryLayout<sockaddr_un>.stride))
+            }
+        }
+        XCTAssertEqual(bound, 0)
+        XCTAssertEqual(listen(listenFD, 1), 0)
+
+        XCTAssertTrue(UnixSocketClient.canConnect(socketPath: path))
+        XCTAssertFalse(
+            UnixSocketClient.canConnect(socketPath: path + ".missing")
+        )
+    }
+
     func testWritesOneLineAndReadsOneLine() throws {
         let path = "/tmp/tapq-client-\(UUID().uuidString.prefix(12)).sock"
         let listenFD = socket(AF_UNIX, streamSocketType, 0)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -71,7 +71,7 @@ The underlying command syntax is `tapq serve [options]`.
 | `--no-voice` | Do not request microphone/Speech access or start voice input |
 | `--speech-voice VOICE` | Voice used for spoken output: a language tag (`en-US`, `zh-CN`) or a macOS voice identifier. Default `en-US`; also settable with `TAPQ_SPEECH_VOICE`. Unrelated to `--no-voice`, which gates the microphone |
 | `--no-announcements` | Suppress non-blocking waiting and completion announcements |
-| `--steering` | Enable opt-in structured-question guidance for adapters that support it (currently Claude Code) |
+| `--steering` | Enable opt-in structured-question guidance for Claude Code and root Codex turns |
 | `--encoder-model PATH` | Load a TapQ-1 encoder model (`.mlpackage` or `.mlmodelc`) exported by `ml/tapq1/export.py` |
 | `--encoder-mode shadow\|primary` | `shadow` (default) records encoder detections as diagnostics while heuristics drive events; `primary` lets the encoder drive events with heuristic detections logged for comparison. Requires `--encoder-model`; a model that fails to load degrades to heuristics and reports it |
 | `--reasoner PROVIDER` | Stage-2 risk reasoner backend: `off` (default) or `apple`, Apple's on-device Foundation Model |
@@ -80,8 +80,8 @@ The underlying command syntax is `tapq serve [options]`.
 
 Selecting a reasoner also starts a local decision log at
 `<broker-dir>/reasoner-log.jsonl` — one JSON line per reasoner-observed approval,
-recording the tier, rationale code, confidence or abstention reason, latency, the
-confirmation the decision implied, and what the user then decided. It is the
+recording the tier, rationale code, disclosure-permitted confidence or abstention reason,
+latency, the confirmation the decision implied, and what the user then decided. It is the
 shadow-review artifact: comparing what a decision asked for against what the user
 actually did is the only way to answer whether `primary` would have been safe.
 The file is created `0600` inside the `0700` runtime directory, is capped at
@@ -89,9 +89,11 @@ roughly 5 MB with a single rotation to `reasoner-log.1.jsonl`, never leaves the
 machine, and is never read back by TapQ. Deleting either file at any time is safe
 and costs only review history.
 
-Be aware of what a line can contain: the full command line, the working directory,
-and the adapter's `detail` are deliberately absent, but the recorded `summary` is
-the same text TapQ speaks aloud, and for a `Bash` request that summary is the
+Be aware of what a line can contain: the full command line, working directory,
+adapter `detail`, and MCP argument values are deliberately absent. MCP rows additionally
+omit the model's free-text note and confidence because either could echo an argument
+value; they retain the interaction outcome and, for a decided row, constrained tier/code. The recorded
+`summary` is the same text TapQ speaks aloud, and for a `Bash` request that summary is the
 *front* of the command line (its first six words, capped at 64 characters). That
 prefix can carry a real secret — a connection string, a header fragment, a token
 passed as an early argument. Treat the log as the same class of local state as
@@ -480,7 +482,12 @@ By default, the installer merges TapQ-managed hook groups into
 `$CODEX_HOME/hooks.json`. It preserves unrelated top-level data, events, matcher groups,
 and handlers; snapshots an existing file to a restrictive timestamped backup; and
 atomically replaces the original. Do not edit the file concurrently with installation.
-Reinstall after moving TapQ because the hook command is an absolute path.
+Reinstall after moving TapQ because the hook command is an absolute path. A direct
+`install` repairs registrations at the current hook, the bare `tapq-codex-hook` command,
+or recognized TapQ app/build paths; unfamiliar custom executable paths are preserved as
+unrelated hooks. Users upgrading from the previous three-hook layout must rerun `install`
+to add the fourth `UserPromptSubmit` registration, then review all changed definitions in
+`/hooks`.
 
 The installed executable is named `tapq-codex-hook` and is expected beside `tapq`.
 Development and custom installations can pass `--hook PATH`; isolated setups and tests
@@ -488,20 +495,32 @@ can pass `--hooks PATH`.
 
 Installation is not activation. Codex requires users to review and trust the exact
 definition of every non-managed command hook. After installation, open an interactive
-Codex session, run `/hooks`, inspect all three TapQ entries, and trust their current
-definitions. Changed definitions receive a new hash and must be reviewed again. The
-`status` command validates only TapQ’s file layout; it cannot read or change Codex’s
-trust decision.
+Codex session, run `/hooks`, inspect the four current TapQ registrations at the selected
+hook path, and trust their definitions. Unrecognized custom-path hooks may remain as
+unrelated data. Changed definitions receive a new hash and must be reviewed again. The
+`status` command validates TapQ’s file layout and reports best-effort diagnostics for the
+local Codex executable, version, and relevant feature values when available. It resolves
+`codex` from the caller's `PATH`, then executes only `--version` and `features list` with
+a minimal allowlisted environment containing process/configuration lookup,
+temporary-directory, and locale values. A missing executable is reported as
+`not found on PATH`; a resolved one
+that cannot launch, complete, or drain within the probe bounds is reported as
+`executable found, but diagnostics failed or timed out`. Neither condition changes status
+exit semantics. Since the resolved path is executed with the user's authority, invoke
+status with a trusted `PATH`. TapQ cannot inspect or change Codex’s trust decision;
+`/hooks` remains authoritative. A parsed version below `0.142.5` produces a compatibility
+warning.
 
 ### Supported Codex event slice
 
-TapQ installs three lifecycle hooks:
+TapQ installs four lifecycle hooks:
 
 | Event | Matcher | Current behavior |
 |---|---|---|
 | `PreToolUse` | `request_user_input` | Answers one supported root-agent single-choice question before Codex opens its native selector |
 | `PermissionRequest` | `Bash`, `apply_patch`, `mcp__<server>__<tool>` | Answers only native approval prompts Codex was already going to show |
 | `Stop` | All root turns | Sends completion and optionally routes an explicit final-response question |
+| `UserPromptSubmit` | None | Adds a fixed root-turn `request_user_input` hint only while live compatible discovery advertises steering |
 
 For `request_user_input`, TapQ supports exactly one question with two or three valid,
 uniquely labelled options. A hands-free selection is delivered to the model through
@@ -511,6 +530,11 @@ secret questions, subagent calls, unanswered interactions, broker failures, and 
 runtimes emit no hook output; Codex then retains its native behavior, including its
 free-form `Other` choice.
 
+In Codex CLI `0.146.0`, Plan mode is the reliable surface for
+`request_user_input`. Default-mode exposure depends on Codex's
+`default_mode_request_user_input` feature. Status reports the observed feature value when
+Codex exposes it, but it cannot force the feature on or make an unavailable tool callable.
+
 For `PermissionRequest`, an allow or deny becomes Codex’s documented event-specific
 decision. A broker timeout, `.ask`, invalid reply, incompatible wire version, or missing
 runtime emits no hook output, so Codex retains its native approval prompt. Existing
@@ -518,9 +542,25 @@ Codex rules, sandbox policy, and permission modes remain authoritative; an opera
 that does not produce a native `PermissionRequest` does not reach TapQ. For MCP tools,
 TapQ speaks a humanized server and operation name but never renders argument values in
 the summary or detail. The original `tool_input` remains in the local broker request
-context and is not spoken or logged. A hook allow applies to that call only; persistent
+context. If the on-device stage-2 reasoner is selected, complete inputs are rendered as
+sorted JSON. Oversized inputs become key-balanced top-level excerpts spanning early and
+late keys, with balanced head/tail excerpts of selected values. Non-ASCII scalars and
+Unicode line separators are escaped before accounting, and all rendered input including
+markers is at most 4,000 characters. MCP values are not spoken, diagnosed, or sent to a
+cloud provider. MCP review rows omit the argument object, model note, and confidence but
+retain outcome and, for a decided row, tier/code. A hook allow applies to that call only; persistent
 connector rules, connector authentication, and MCP-generated elicitation remain in
 Codex's native flow.
+
+`UserPromptSubmit` steering is advisory rather than an approval path. The matcherless
+hook applies only to root turns and returns the exact fixed additional context “When you
+need the user to choose between options or confirm a decision, use request_user_input
+when available rather than asking in plain text.” only when a live, wire-compatible TapQ
+runtime advertises `--steering`. It reads discovery, then makes a bounded, EOF-only
+Unix-socket connection to verify liveness, but sends no broker request or application data
+and performs no request/response round-trip. Invalid input, subagent turns, missing or
+incompatible discovery, and disabled steering emit no output, preserving Codex's native
+prompt submission.
 
 For `Stop`, Codex supplies the final text through `last_assistant_message`; TapQ does not
 parse Codex transcript files. Replies without `?`, inconclusive classifications, and
@@ -536,15 +576,20 @@ output falls through to the deterministic local heuristic and then Codex's norma
 Because provider selection is runtime-wide, any Claude Code adapter connected to the
 same instance also uses Luna in this mode.
 
-The Codex adapter has no broad strict `PreToolUse` mode, `UserPromptSubmit` steering, or
-generic notification-hook equivalent. Completion notification is derived from `Stop`;
-these limitations are intentional rather than installation errors.
+The Codex adapter has no broad strict `PreToolUse` mode or generic notification-hook
+equivalent. Completion notification is derived from `Stop`; these limitations are
+intentional rather than installation errors.
 
-Codex CLI `0.142.5` is TapQ’s tested lifecycle-hook contract floor. Structured
-`request_user_input` and MCP `PermissionRequest` use versioned Codex CLI `0.146.0`
-fixtures and real hook-executable-to-broker tests. Older hook contracts are unsupported.
-This adapter targets local Codex clients that load user lifecycle hooks; it does not
-attach to hosted Codex Cloud tasks.
+Codex CLI `0.142.5` is TapQ’s tested lifecycle-hook contract floor. Versioned
+`PermissionRequest` and `Stop` fixtures cover that floor; structured
+`request_user_input`, MCP `PermissionRequest`, and `UserPromptSubmit` use versioned Codex
+CLI `0.146.0` fixtures. Real hook-process-to-broker contracts cover supported decisions,
+denial, and native fail-through for missing discovery and incompatible versions. They do
+not launch Codex, authenticate, prove Codex consumes hook stdout, or prove a model follows
+the returned decision/feedback. Those boundaries remain live manual release tests. Older
+hook contracts are unsupported. This adapter targets local
+Codex clients that load user lifecycle hooks; it does not attach to hosted Codex Cloud
+tasks.
 
 ## Environment variables and local data
 

--- a/docs/CODEX_ADAPTER_MANUAL_TEST_PLAN.md
+++ b/docs/CODEX_ADAPTER_MANUAL_TEST_PLAN.md
@@ -5,16 +5,30 @@
 Use this plan to validate the TapQ Codex adapter as one tester on one Mac. It covers:
 
 - Codex hook installation, status, repair, idempotence, backup, and removal.
-- Codex hook review and trust.
+- Best-effort Codex executable, version, and feature diagnostics plus hook review/trust.
 - Root-agent `request_user_input` handling for one single-choice question.
 - Native `PermissionRequest` handling for `Bash`, `apply_patch`, and MCP connector tools.
 - `Stop` completion announcements and final-response question continuation.
+- Opt-in root-turn `UserPromptSubmit` steering with native fail-through.
+- On-device MCP reasoner context and its spoken, diagnostic, cloud, and review-log
+  boundaries.
 - Fail-open behavior when TapQ is unavailable.
 - Preservation of unrelated Codex hook configuration.
 
-The lifecycle-hook floor tested by this plan is Codex CLI `0.142.5`. Structured
-`request_user_input` and MCP `PermissionRequest` coverage use the Codex CLI `0.146.0`
-contract. Hosted Codex Cloud tasks are out of scope.
+The lifecycle-hook floor tested by this plan is Codex CLI `0.142.5`. Versioned
+`PermissionRequest` and `Stop` process contracts cover that floor; structured
+`request_user_input`, MCP `PermissionRequest`, and `UserPromptSubmit` coverage use the
+Codex CLI `0.146.0` contract. Those automated contracts run the real hook process
+against a broker but do not launch an authenticated model-level Codex session. Required
+live cases cover applicable approval, structured-question, and Stop consumption
+boundaries. `UserPromptSubmit` model behavior remains an optional observation: its
+deterministic assertion is the exact hook output, not proof that a particular model will
+follow the nudge. Hosted Codex Cloud tasks are out of scope.
+
+Passing a fixture-driven or direct-hook case proves TapQ's process boundary only. It does
+not prove that Codex consumed the hook output or that a model followed selection,
+continuation, or steering feedback. Never mark a required live-Codex case as passed from
+process-contract evidence alone.
 
 ## Supported and unsupported behavior
 
@@ -26,13 +40,13 @@ contract. Hosted Codex Cloud tasks are out of scope.
 | `PermissionRequest` for `mcp__<server>__<tool>` | TapQ may answer a native connector prompt without speaking its argument values. |
 | `Stop` without a supported question | Announce `Codex finished.` and let the turn finish normally. |
 | `Stop` with a supported final question | Return one hands-free answer as a Codex continuation, then prevent a re-ask loop. |
+| Root `UserPromptSubmit` with live compatible `--steering` discovery | Add the fixed `request_user_input` “when available” nudge after a connection-only liveness probe, without a broker request or application data. |
 | Missing runtime, timeout, invalid reply, or unsupported input | Emit no decision and leave Codex's native flow in control. |
 | Other tools or operations that Codex does not prompt for | Do not intercept. |
 
 Multiple or auto-resolving questions, unsupported option shapes, and subagent
 `request_user_input` calls intentionally stay in Codex’s native flow. Broad strict
-`PreToolUse`, `UserPromptSubmit`, generic notification hooks, and hosted Cloud tasks are
-unsupported.
+`PreToolUse`, generic notification hooks, and hosted Cloud tasks are unsupported.
 
 ## Test environment
 
@@ -156,14 +170,26 @@ stat -f 'hooks mode: %OLp' "$CODEX_ADAPTER_ISOLATED_HOOKS"
 Expected:
 
 - Initial status is `not installed`; final status is `configured`.
+- Status reports the detected Codex version, `hooks` state,
+  `default_mode_request_user_input` state, Plan/default-mode guidance, and the reminder
+  that only Codex can report trust.
 - Install output says `Permission policy: native Codex prompts` and tells the tester to
   review the definitions with `/hooks`.
 - The JSON has exactly one TapQ group for each of these events:
   - `PreToolUse`, matcher `^request_user_input$`.
   - `PermissionRequest`, matcher `^(Bash|apply_patch|mcp__.+__.+)$`.
   - `Stop`, with no matcher.
-- Each handler is a command pointing to the quoted absolute hook path, with timeout `260`.
+  - `UserPromptSubmit`, with no matcher.
+- Each handler points to the quoted absolute hook path. Broker-backed handlers have
+  timeout `260`; `UserPromptSubmit` has timeout `5` because it performs only bounded
+  discovery and connection-only liveness checks, not a hands-free interaction.
 - File mode is `600`.
+
+“Exactly one” is asserted here because the disposable file has no prior TapQ custom path.
+On a real existing file, repair removes only the current command, the bare command, and
+recognized TapQ app/build paths; an unfamiliar custom executable path is preserved as an
+unrelated hook. Users upgrading from the three-hook layout must rerun `install` to add
+`UserPromptSubmit` and then retrust the changed definitions.
 
 ### CX-003 — Repeated install is idempotent — P0
 
@@ -215,7 +241,7 @@ Expected:
 
 - Top-level `marker: keep-me` remains.
 - The unrelated `SessionStart` group and `/usr/bin/true` handler remain unchanged.
-- The three TapQ groups are added.
+- The four TapQ groups are added.
 - The active hooks file and new backup both have mode `600`.
 - The newest backup contains the exact pre-install JSON.
 
@@ -231,7 +257,9 @@ Steps:
 Expected:
 
 - Status first reports `incomplete`.
-- Reinstall restores one current `PreToolUse`, `PermissionRequest`, and `Stop` group.
+- Direct reinstall restores one current `PreToolUse`, `PermissionRequest`, `Stop`, and
+  `UserPromptSubmit` group because this fixture uses the current recognized hook path;
+  uninstalling first is not required.
 - Unrelated JSON remains intact.
 - The changed definition requires review in `/hooks`.
 
@@ -255,7 +283,8 @@ Expected:
 
 - Status is `not installed`.
 - The `marker` and unrelated `SessionStart` hook still exist.
-- No TapQ hook remains in `PreToolUse`, `PermissionRequest`, or `Stop`.
+- No TapQ hook remains in `PreToolUse`, `PermissionRequest`, `Stop`, or
+  `UserPromptSubmit`.
 - The CLI tells the tester to confirm removal in Codex.
 
 ## Phase 2: install and trust in the active Codex client
@@ -278,16 +307,17 @@ Steps:
 
 3. Start an interactive local Codex session.
 4. Run `/hooks`.
-5. Inspect all three TapQ entries before trusting them. Confirm the command is exactly the
-   current absolute `tapq-codex-hook` path and that the events/matcher match CX-002.
-6. Trust all three current definitions.
+5. Inspect the four current TapQ registrations before trusting them. Confirm the command
+   is exactly the current absolute `tapq-codex-hook` path and that the events/matcher
+   match CX-002. Treat any unrecognized custom-path hook as unrelated evidence.
+6. Trust the four current definitions.
 7. Run `/hooks` again.
 
 Expected:
 
 - CLI status is `configured`, but does not claim to know the trust state.
 - Before approval, Codex shows the TapQ definitions as needing review or untrusted.
-- After approval, Codex shows all three exact definitions as trusted.
+- After approval, Codex shows all four exact current-path definitions as trusted.
 - No unrelated hook trust or hook definition changes.
 
 Record the active hooks-file backup name before continuing. If the checkout or runtime
@@ -406,16 +436,21 @@ Expected:
 
 ## Phase 5: structured tool questions
 
-Codex CLI `0.146.0` exposes `request_user_input` in default mode behind a feature flag.
-For these cases, start a fresh session with:
+In Codex CLI `0.146.0`, Plan mode is the reliable `request_user_input` surface. Start a
+fresh session, then use Codex's mode control to switch the root turn to Plan mode and
+confirm the UI reports Plan before submitting each prompt:
 
 ```bash
 codex -C "$CODEX_ADAPTER_WORKSPACE" \
-  --enable default_mode_request_user_input \
   --sandbox read-only \
   --ask-for-approval never \
   --no-alt-screen
 ```
+
+Default-mode coverage is optional and must follow the value reported by
+`codex features list` or `tapq integration codex status`. To exercise it on `0.146.0`,
+start a separate session with `--enable default_mode_request_user_input`; do not mistake
+the absence of that feature for a hook failure.
 
 ### CX-013 — Select a `request_user_input` option through TapQ — P0
 
@@ -626,6 +661,142 @@ Expected:
 - Runtime absence, deferral, or a malformed broker response leaves Codex's native
   connector approval prompt usable.
 
+## Phase 9: activation diagnostics and prompt steering
+
+### CX-025 — Status explains local Codex activation limits — P1
+
+With the isolated hooks file configured, run:
+
+```bash
+"$CODEX_ADAPTER_TAPQ" integration codex status \
+  --hooks "$CODEX_ADAPTER_ISOLATED_HOOKS" \
+  --hook "$CODEX_ADAPTER_HOOK"
+
+/usr/bin/env PATH=/nonexistent \
+  "$CODEX_ADAPTER_TAPQ" integration codex status \
+  --hooks "$CODEX_ADAPTER_ISOLATED_HOOKS" \
+  --hook "$CODEX_ADAPTER_HOOK"
+```
+
+Expected:
+
+- With Codex on `PATH`, status reports its parsed version plus the observed `hooks` and
+  `default_mode_request_user_input` stage/value. On the stock `0.146.0` configuration,
+  `hooks` is stable/enabled and `default_mode_request_user_input` is under
+  development/disabled. It also prints the terminal-safe resolved executable path.
+- Guidance says Plan mode has `request_user_input`; Default-mode availability follows
+  `default_mode_request_user_input`.
+- The trust line says only Codex can report or grant trust and directs the tester to
+  `/hooks`.
+- With Codex hidden from `PATH`, status says `not found on PATH` and feature diagnostics
+  become unknown without changing the configured file-level result or crashing.
+- If `codex` resolves but cannot launch, complete, or drain within the probe bounds,
+  status instead says `executable found, but diagnostics failed or timed out` and prints
+  the resolved path. This is distinct from a missing executable and still does not change
+  file-level status.
+- Status executes resolved `codex --version` and `codex features list` commands with a
+  minimal allowlisted environment. Run this diagnostic only with a trusted `PATH`; the
+  environment filter is not a sandbox for an unexpected executable.
+- A parsed version below `0.142.5` prints a compatibility warning.
+- Automated probe tests separately cover malformed version and feature output, which
+  must likewise remain best-effort.
+
+### CX-026 — Matcherless root-only `UserPromptSubmit` steering — P1
+
+Use this valid root payload for the direct hook checks:
+
+```json
+{"hook_event_name":"UserPromptSubmit","session_id":"manual-session","turn_id":"manual-turn","transcript_path":null,"cwd":"/tmp/project","model":"gpt-5.6","permission_mode":"default","prompt":"Plan the deployment."}
+```
+
+For example, keep the compact payload in a task-specific shell variable:
+
+```bash
+CODEX_ADAPTER_USER_PROMPT='{"hook_event_name":"UserPromptSubmit","session_id":"manual-session","turn_id":"manual-turn","transcript_path":null,"cwd":"/tmp/project","model":"gpt-5.6","permission_mode":"default","prompt":"Plan the deployment."}'
+printf '%s\n' "$CODEX_ADAPTER_USER_PROMPT" | "$CODEX_ADAPTER_HOOK"
+```
+
+1. With a live runtime started **without** `--steering`, pipe the compact JSON above to
+   `"$CODEX_ADAPTER_HOOK"`. Confirm stdout is empty.
+2. Stop that runtime and restart it with:
+
+   ```bash
+   TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 30 --steering
+   ```
+
+3. Pipe the same payload to `"$CODEX_ADAPTER_HOOK"` again and format its stdout with
+   `python3 -m json.tool`.
+4. Add `"agent_id":"subagent-1"` to the payload and repeat.
+5. Stop the runtime and repeat the original root payload once more.
+
+Expected:
+
+- Only step 3 emits JSON. Its sole top-level field is `hookSpecificOutput`; the nested
+  event is `UserPromptSubmit` and `additionalContext` is exactly: `When you need the user
+  to choose between options or confirm a decision, use request_user_input when available
+  rather than asking in plain text.`
+- The installed `UserPromptSubmit` group has no matcher. Root/subagent filtering is done
+  by the shim, not by a matcher that Codex could interpret differently.
+- No broker approval, selection, or notification appears in runtime diagnostics. The
+  path reads discovery and opens/closes one bounded EOF-only Unix-socket liveness
+  connection, but sends no broker request bytes or application data and performs no
+  request/response round-trip.
+- Disabled steering, subagent input, and missing discovery all emit nothing and exit
+  successfully, preserving Codex's native prompt submission.
+
+An optional authenticated smoke test can now submit a choice/confirmation prompt in a
+root Codex turn and observe whether the model chooses `request_user_input`. Record model
+behavior, but do not use one model choice as the contract assertion; the exact hook output
+above is deterministic.
+
+## Phase 10: on-device MCP reasoner boundary
+
+### CX-027 — MCP arguments inform the reasoner without leaking to other surfaces — P1
+
+This case requires macOS 26 or newer, an available Apple Foundation Model, and the
+disposable MCP server from CX-024. If any prerequisite is absent, record `Blocked`.
+Configure the harmless fixture operation so its canonical name is neutral but its
+arguments include non-sensitive markers such as `action: "publish"`,
+`destination: "public"`, and `sentinel: "tapq-mcp-value-must-not-leak"`. The fixture
+must remain a no-op even if approved.
+
+Restart TapQ with an isolated runtime directory and no cloud classifier:
+
+```bash
+TAPQ_BROKER_DIR="$CODEX_ADAPTER_RUN_DIR/reasoner-runtime" \
+TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve \
+  --timeout 30 \
+  --reasoner apple \
+  --reasoner-mode shadow \
+  --question-classifier local
+```
+
+Invoke the fixture once through a native Codex MCP `PermissionRequest`, then approve or
+deny through TapQ. Inspect the spoken interaction, sanitized runtime diagnostics, and:
+
+```bash
+rg -n 'tapq-mcp-value-must-not-leak|"destination":"public"' \
+  "$CODEX_ADAPTER_RUN_DIR/reasoner-runtime/reasoner-log.jsonl"
+```
+
+Expected:
+
+- The reasoner records an assessment for the MCP approval. Its decision may identify the
+  public/publication risk even though the fixture's tool name is neutral; record the
+  exact tier/code as model evidence, not a deterministic assertion.
+- Neither speech nor `details` contains any MCP argument value.
+- Debug diagnostics and `reasoner-log.jsonl` contain no sentinel or destination value;
+  the `rg` command returns no match. Nothing is cloud-sent because the reasoner is
+  on-device and the question classifier is explicitly local.
+- The MCP review row omits both `note` and `confidence`, while retaining constrained
+  `risk_tier`/`code` when the model decided, and the interaction `outcome` plus ordinary
+  bookkeeping fields on every row.
+- Automated reasoner prompt tests remain the deterministic assertion that a fitting
+  canonical argument object is complete sorted JSON; oversized objects use key-balanced
+  early/late top-level excerpts with balanced value heads/tails. Non-ASCII scalars and
+  line separators are escaped, and all rendered content including truncation markers is
+  within 4,000 characters.
+
 ## Input-modality extension
 
 After all P0 adapter cases pass with one reliable modality, repeat CX-008, CX-009,
@@ -653,8 +824,9 @@ output says voice is unavailable while the chosen AirPods input still resolves t
    "$CODEX_ADAPTER_TAPQ" integration codex status
    ```
 
-3. Open Codex, run `/hooks`, and verify that none of the three TapQ entries remain while
-   unrelated hooks remain.
+3. Open Codex, run `/hooks`, and verify that none of the four current registrations for
+   the selected recognized TapQ path remain while unrelated hooks, including unrecognized
+   custom paths, remain.
 4. Keep the disposable directory until evidence and defects are filed. When it is no
    longer needed, reveal it in Finder and move that exact directory to Trash:
 
@@ -674,6 +846,14 @@ The adapter is ready for the tested environment when:
 - A supported `request_user_input` choice reaches Codex exactly once, while deferral or
   runtime absence leaves the native selector usable.
 - `Bash`, `apply_patch`, and a configured MCP connector each honor both allow and deny.
+- Root-turn steering emits only with compatible live `--steering` discovery. Its bounded
+  EOF-only liveness connection sends no broker request or application data and performs
+  no request/response round-trip; subagents and unavailable runtimes remain silent.
+- Status reports useful local Codex compatibility guidance without claiming hook trust.
+- When reasoner prerequisites are available, MCP values reach only the bounded on-device
+  reasoner prompt and remain absent from speech, diagnostics, cloud processing, and the
+  review log; MCP review rows also omit model note and confidence while retaining
+  outcome and, for decided rows, constrained tier/code.
 - Supported final questions continue exactly once and never loop.
 - Runtime absence leaves Codex's native permission and final-response flow usable.
 - Active uninstall removes only TapQ-managed hooks.


### PR DESCRIPTION
## Summary

- add root-only UserPromptSubmit steering with live-runtime fail-through
- add bounded Codex CLI activation diagnostics for version, hooks, mode availability, executable path, and trust guidance
- add versioned 0.142.5 and 0.146.0 real hook-process-to-broker contracts
- preserve canonical MCP tool input for the local reasoner with bounded key-balanced rendering and hardened review-log privacy
- update CLI help, security guidance, troubleshooting, changelog, and the manual test plan

Codex strict mode is intentionally not added.

## Validation

- exact macOS CI test command: 835 tests passed
- release hook process contracts: 16 tests passed
- release build and signed runtime app packaging passed
- public and portability boundary checks passed
- two independent final reviews found no remaining issues