### PR TITLE
Fix flaky descriptor-count assertion in CodexCLIProbeTests

### DIFF
--- a/Tests/TapQCLITests/CodexCLIProbeTests.swift
+++ b/Tests/TapQCLITests/CodexCLIProbeTests.swift
@@ -256,7 +256,16 @@ final class CodexCLIProbeTests: XCTestCase {
 
         XCTAssertEqual(result, .unavailable)
         XCTAssertLessThan(Date().timeIntervalSince(start), 1.5)
-        XCTAssertLessThanOrEqual(try openFileDescriptorCount(), descriptorCountBeforeRun)
+        // Descriptor teardown after the killed shell is reaped is asynchronous (Foundation
+        // closes its process-tracking descriptors off the calling thread), so poll briefly
+        // instead of asserting the instantaneous count.
+        let descriptorDeadline = Date().addingTimeInterval(2)
+        var openDescriptorCount = try openFileDescriptorCount()
+        while openDescriptorCount > descriptorCountBeforeRun, Date() < descriptorDeadline {
+            Thread.sleep(forTimeInterval: 0.02)
+            openDescriptorCount = try openFileDescriptorCount()
+        }
+        XCTAssertLessThanOrEqual(openDescriptorCount, descriptorCountBeforeRun)
 
         let deadline = Date().addingTimeInterval(3)
         var marker: String?


### PR DESCRIPTION
`testProcessRunnerClosesPipesRetainedByAnExitedParentsDescendant` asserts the process-wide open-descriptor count is back at its baseline immediately after the runner returns, but descriptor teardown after the `kill -9`'d shell is reaped is asynchronous — Foundation closes its process-tracking descriptors off the calling thread. On Linux CI the instantaneous count intermittently comes up one or two high (3 failures in the last 5 linux jobs: `58 > 57`, `26 > 24`, blocking #13 among others).

This polls the count for up to 2 seconds (20 ms interval) before asserting, mirroring the marker-file poll at the end of the same test and the approach from 430a428. A genuine descriptor leak still fails after the deadline — the assertion is unchanged, only its timing tolerance is.

Verified locally: all 13 `CodexCLIProbeTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)