### PR TITLE
Finalize v0.4.0-beta.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
-## [0.4.0-beta.1] - 2026-08-02
+## [0.4.0-beta.1] - 2026-08-03
 
 ### Added
 
@@ -65,6 +65,8 @@ All notable changes to TapQ will be recorded in this file. The project uses
 - The broker wire protocol remains at version 3. Hooks and brokers built against version
   0.3.0 remain wire-compatible, but existing Codex installations must reinstall and trust
   the expanded hook definitions to activate the new event coverage.
+- Project documentation now leads with the user workflow, with detailed integration and
+  roadmap material moved into dedicated guides for easier navigation.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ add calibrated AirPods gesture input — double-nod, shake, tilt, and tap events
 plus a raw motion tier for custom detection — to a Swift project with no agent
 machinery attached, and build your own hands-free interactions or gesture-driven
 agent frontends on top. It is in active development and will be available soon;
-watch this repository for the first release.
+watch this repository for the first SDK release.
 
 ## Roadmap
 
@@ -173,6 +173,8 @@ roadmap — agent integrations, wearables, and interaction capabilities — live
 - [Troubleshooting](TROUBLESHOOTING.md)
 - [Contributing](CONTRIBUTING.md) — includes the build/test/boundary checks to run
   before submitting a change
+- [Release process](RELEASING.md) — signed source tags, qualification gates, and
+  source-only GitHub publication
 - [Changelog](CHANGELOG.md)
 
 ## License


### PR DESCRIPTION
## Summary

- set the beta changelog date to the actual publication date
- record the README and documentation restructuring that landed before the release-prep merge
- restore the release-process link and clarify that the upcoming first release mentioned in the SDK section is the first SDK release

## Verification

- [x] scripts/check-release-version.sh v0.4.0-beta.1
- [x] scripts/check-public-boundary.sh
- [x] git diff --check

This is the final documentation-only correction before creating the protected signed tag.