### PR TITLE
Add concise issue templates and Discussions contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,24 @@
+name: Bug report
+description: Something doesn't work as expected
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what happened instead.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: macOS version · TapQ version or commit · device · agent and version
+      placeholder: macOS 15.5 · TapQ 0.4.0-beta.1 · AirPods Pro 2 · Claude Code 2.1
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output (optional)
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and ideas
+    url: https://github.com/spaceamoeba-t/tapq/discussions
+    about: Ask questions or discuss TapQ in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,11 @@
+name: Feature request
+description: Suggest an improvement or new capability
+labels: [enhancement]
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What and why
+      description: The capability you want and the problem it solves.
+    validations:
+      required: true


### PR DESCRIPTION
Two minimal GitHub issue forms — bug report (what happened, one-line environment, optional logs) and feature request (what and why) — plus a `config.yml` contact link routing questions to the newly enabled Discussions. Blank issues stay enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)