### PR TITLE
Stop a spoken refusal from approving an agent action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
+### Fixed
+
+- A spoken refusal can no longer approve. The voice grammar matched `do it` as raw text,
+  so "don't do it" and "do not do it" contained an affirmative and were answered before
+  the denial rule ran; typographic apostrophes ("don’t", as recognizers actually emit
+  them) matched no denial at all, and "not okay" approved on `okay`. Approval is now
+  guarded on the whole transcript: any negator — the "no" family, bare "not", "cannot",
+  and the contracted forms in any apostrophe spelling — makes `yes` unreachable however
+  the words are arranged. Clear refusals answer no; a negated transcript with no outright
+  denial ("not okay", "sure, why not") matches nothing and falls back to the agent's
+  on-screen prompt. Every rule now matches whole words or runs of adjacent words, so
+  "undo items" no longer reads as "do it".
+
 ## [0.4.0-beta.1] - 2026-08-03
 
 ### Added

--- a/Sources/TapQDetectionBaseline/VoiceCommandMatcher.swift
+++ b/Sources/TapQDetectionBaseline/VoiceCommandMatcher.swift
@@ -2,12 +2,35 @@ import TapQContracts
 
 /// Deterministic, hardware-independent keyword grammar for short voice commands.
 /// Speech-to-text acquisition remains the responsibility of a platform adapter.
+///
+/// Every rule matches at word granularity: the transcript is split into letter-only
+/// words and a rule matches either one word or a run of adjacent words. Raw substring
+/// containment is deliberately absent — it is what let "don't do it" approve (the text
+/// contains "do it"), and the same leak reads "undo items" as "do it", "cannot" as
+/// "not", and "notify" as "not".
+///
+/// The two answers are not symmetric. A missed `.no` costs the user one repeat; a wrong
+/// `.yes` runs an agent action nobody authorized. Approval therefore carries a structural
+/// guard rather than an ordering assumption: `.yes` is unreachable for any transcript
+/// containing a negator — `negationWords`, which covers the "no" family, bare "not", and
+/// the contracted forms — however the words are arranged around it. Ordering the `.no`
+/// branch first would fix the reported phrases and leave "not okay" approving; the guard
+/// closes the class instead of the instances.
+///
+/// A transcript that is negated but carries no outright denial ("not okay", "sure, why
+/// not") resolves to `nil` rather than guess a side. TapQ fails open: an unmatched
+/// transcript leaves the request to the agent's on-screen prompt, which the user can
+/// still answer, so silence is recoverable in a way a wrong approval is not.
 public enum VoiceCommandMatcher {
     public static func match(_ raw: String) -> VoiceCommand? {
-        let text = raw.lowercased()
-        let tokens = Set(text.split { !$0.isLetter }.map(String.init))
-        func token(_ words: String...) -> Bool { words.contains { tokens.contains($0) } }
-        func phrase(_ phrases: String...) -> Bool { phrases.contains { text.contains($0) } }
+        let words = Self.words(in: raw)
+        let vocabulary = Set(words)
+        func token(_ candidates: String...) -> Bool {
+            candidates.contains { vocabulary.contains($0) }
+        }
+        func phrase(_ phrases: String...) -> Bool {
+            phrases.contains { Self.contains(run: $0, in: words) }
+        }
 
         if token("repeat", "again") || phrase("say again", "one more time") { return .repeatRequest }
         if token("details", "detail", "explain") || phrase("more info", "tell me more") { return .details }
@@ -19,10 +42,71 @@ public enum VoiceCommandMatcher {
         if token("two", "second") { return .number(2) }
         if token("three", "third") { return .number(3) }
         if token("four", "fourth") { return .number(4) }
-        if token("yes", "yeah", "yep", "yup", "approve", "approved", "sure", "okay", "ok", "confirm")
+        // Negation is read from the whole transcript rather than from the words adjacent
+        // to the affirmative: this grammar sees partial transcriptions in arbitrary states
+        // of completeness, so a negator can land on either side of the word it governs,
+        // and no reading of a negated sentence is worth approving on.
+        if vocabulary.isDisjoint(with: Self.negationWords),
+           token("yes", "yeah", "yep", "yup", "approve", "approved", "sure", "okay", "ok", "confirm")
             || phrase("do it", "go ahead", "go for it") { return .yes }
-        if token("no", "nope", "nah", "deny", "denied", "cancel", "stop", "reject")
-            || phrase("don't", "do not") { return .no }
+        if !vocabulary.isDisjoint(with: Self.denialWords) || phrase("do not") { return .no }
         return nil
+    }
+
+    /// Words that deny on their own, so reaching one is an answer and not merely a doubt.
+    /// "dont" covers every apostrophe spelling of "don't" once `words(in:)` has run.
+    private static let denialWords: Set<String> = [
+        "no", "nope", "nah", "deny", "denied", "cancel", "stop", "reject", "dont",
+    ]
+
+    /// Words that forbid an approval. Every denial word negates; the rest negate without
+    /// deciding anything, because a grammar this small cannot separate "not okay" (a
+    /// refusal) from "sure, why not" (an approval). Both stop short of `.yes` and fall
+    /// through to `nil` unless a denial word is present too.
+    ///
+    /// Contractions appear in their apostrophe-stripped form for the same reason as
+    /// "dont", and "cannot" is listed explicitly because word-level matching — correctly —
+    /// does not see the "not" inside it.
+    private static let negationWords: Set<String> = denialWords.union([
+        "not", "never", "cannot", "cant", "wont", "isnt", "arent", "wasnt",
+        "doesnt", "didnt", "couldnt", "wouldnt", "shouldnt", "aint",
+    ])
+
+    /// The apostrophe spellings a transcript can carry. Recognizers emit the typographic
+    /// U+2019 far more often than the ASCII U+0027 this grammar is written with, so a
+    /// literal-only comparison would never see a spoken "don't" at all.
+    private static let apostrophes: Set<Character> = [
+        "\u{0027}", // ' apostrophe
+        "\u{2019}", // ’ right single quotation mark
+        "\u{02BC}", // ʼ modifier letter apostrophe
+        "\u{2018}", // ‘ left single quotation mark, from pair-matching engines
+        "\u{FF07}", // ＇ fullwidth apostrophe
+    ]
+
+    /// Lowercased words in spoken order, apostrophes removed.
+    ///
+    /// Apostrophes are elided instead of separating words, so every spelling of "don't"
+    /// — ASCII, typographic, or the apostrophe-free "dont" a recognizer also produces —
+    /// yields the single word "dont". Splitting on them instead yields "don" and "t",
+    /// neither of which is a negator, which is how a curly-quoted denial used to reach
+    /// the affirmative branch.
+    ///
+    /// The elision is by explicit apostrophe set, not by keeping letters: U+02BC is a
+    /// Unicode letter (modifier letter, category Lm), so a letters-only filter would
+    /// leave it inside the word and "donʼt" would again miss "dont".
+    private static func words(in raw: String) -> [String] {
+        raw.lowercased()
+            .split { !$0.isLetter && !apostrophes.contains($0) }
+            .map { String($0.filter { !apostrophes.contains($0) }) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Whether `words` holds the space-separated `run` as consecutive whole words.
+    private static func contains(run: String, in words: [String]) -> Bool {
+        let needle = run.split(separator: " ").map(String.init)
+        guard !needle.isEmpty, words.count >= needle.count else { return false }
+        return (0...(words.count - needle.count)).contains { start in
+            words[start ..< (start + needle.count)].elementsEqual(needle)
+        }
     }
 }

--- a/Tests/TapQDetectionBaselineTests/VoiceCommandMatcherTests.swift
+++ b/Tests/TapQDetectionBaselineTests/VoiceCommandMatcherTests.swift
@@ -8,6 +8,12 @@ final class VoiceCommandMatcherTests: XCTestCase {
         XCTAssertEqual(VoiceCommandMatcher.match("Okay"), .yes)
         XCTAssertEqual(VoiceCommandMatcher.match("go ahead"), .yes)
         XCTAssertEqual(VoiceCommandMatcher.match("approve that"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("yes"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("do it"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("okay"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("sure, go ahead"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("go for it"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("confirm"), .yes)
     }
 
     func testNoVariants() {
@@ -15,6 +21,8 @@ final class VoiceCommandMatcherTests: XCTestCase {
         XCTAssertEqual(VoiceCommandMatcher.match("nope"), .no)
         XCTAssertEqual(VoiceCommandMatcher.match("cancel it"), .no)
         XCTAssertEqual(VoiceCommandMatcher.match("stop"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("cancel"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("reject that"), .no)
     }
 
     func testControlCommands() {
@@ -36,5 +44,139 @@ final class VoiceCommandMatcherTests: XCTestCase {
     func testTokenBoundariesPreventFalseNoMatch() {
         XCTAssertNil(VoiceCommandMatcher.match("the weather is nice"))
         XCTAssertNil(VoiceCommandMatcher.match("now we know"))
+    }
+
+    // MARK: - Negation must never approve
+
+    /// The reported defect: "do it" survives inside "don't do it" as a substring, and the
+    /// affirmative branch ran before the denial branch, so a refusal approved the action.
+    func testNegatedImperativeDeniesInsteadOfApproving() {
+        XCTAssertEqual(VoiceCommandMatcher.match("don't do it"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("do not do it"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("dont do it"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("no don't"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("don't"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("please don't go ahead"), .no)
+    }
+
+    /// Recognizers emit typographic apostrophes, so the curly spellings are the ones a
+    /// live denial actually arrives in.
+    func testCurlyApostropheDenialsMatchTheAsciiSpelling() {
+        XCTAssertEqual(VoiceCommandMatcher.match("don\u{2019}t do it"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("don\u{02BC}t do it"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("don\u{2018}t do it"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("don\u{FF07}t do it"), .no)
+        XCTAssertEqual(
+            VoiceCommandMatcher.match("don\u{2019}t"),
+            VoiceCommandMatcher.match("don't")
+        )
+        XCTAssertEqual(
+            VoiceCommandMatcher.match("don\u{2019}t approve"),
+            VoiceCommandMatcher.match("dont approve")
+        )
+    }
+
+    /// A negated affirmative is not an approval. It is also not a reliable denial
+    /// ("sure, why not"), so the grammar declines to answer and TapQ falls back to the
+    /// agent's on-screen prompt.
+    func testNegatedAffirmativesResolveToNothingRatherThanYes() {
+        XCTAssertNil(VoiceCommandMatcher.match("not okay"))
+        XCTAssertNil(VoiceCommandMatcher.match("that is not okay"))
+        XCTAssertNil(VoiceCommandMatcher.match("I cannot approve that"))
+        XCTAssertNil(VoiceCommandMatcher.match("I can't approve that"))
+        XCTAssertNil(VoiceCommandMatcher.match("I can\u{2019}t approve that"))
+        XCTAssertNil(VoiceCommandMatcher.match("never approve that"))
+        XCTAssertNil(VoiceCommandMatcher.match("that doesn't confirm anything"))
+        XCTAssertNil(VoiceCommandMatcher.match("sure, why not"))
+    }
+
+    /// An outright denial anywhere in the transcript decides it, whichever side of the
+    /// affirmative it lands on — partial transcriptions arrive in arbitrary states of
+    /// completeness, so the answer must not depend on word order.
+    func testDenialBeatsAnAffirmativeInTheSameUtterance() {
+        XCTAssertEqual(VoiceCommandMatcher.match("no, go ahead"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("yes, cancel that"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("approve, no wait"), .no)
+        XCTAssertEqual(VoiceCommandMatcher.match("okay, stop"), .no)
+    }
+
+    /// The exhaustive safety net: no arrangement of a negator and an affirmative may
+    /// produce an approval. This is the property the fix exists to hold, so it is
+    /// asserted over the cross product rather than over sampled phrases.
+    func testNoNegatedUtteranceEverApproves() {
+        let negators = [
+            "no", "not", "don't", "don\u{2019}t", "dont", "do not", "cannot", "can't",
+            "won't", "never", "nope", "nah", "deny", "cancel", "stop", "reject",
+            "isn't", "doesn't", "didn't", "couldn't", "wouldn't", "shouldn't", "ain't",
+        ]
+        let affirmatives = [
+            "yes", "yeah", "yep", "yup", "approve", "approved", "sure", "okay", "ok",
+            "confirm", "do it", "go ahead", "go for it",
+        ]
+        for negator in negators {
+            for affirmative in affirmatives {
+                for utterance in ["\(negator) \(affirmative)", "\(affirmative) \(negator)"] {
+                    XCTAssertNotEqual(
+                        VoiceCommandMatcher.match(utterance), .yes,
+                        "negated utterance approved: \(utterance)"
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Word-level matching
+
+    /// Negation is matched as whole words, so a word that merely contains a negator's
+    /// letters must not deny, and must not block an approval either.
+    func testNegatorsMatchWholeWordsOnly() {
+        XCTAssertEqual(VoiceCommandMatcher.match("notify me, okay"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("note that, go ahead"), .yes)
+        XCTAssertNil(VoiceCommandMatcher.match("cannot decide"))
+        XCTAssertNil(VoiceCommandMatcher.match("notify me"))
+        XCTAssertNil(VoiceCommandMatcher.match("nothing"))
+    }
+
+    /// Multi-word rules match runs of whole words, so an affirmative may not be spliced
+    /// out of the middle of longer words.
+    func testPhrasesMatchWordRunsNotSubstrings() {
+        XCTAssertNil(VoiceCommandMatcher.match("undo items"))
+        XCTAssertNil(VoiceCommandMatcher.match("undo notes"))
+        XCTAssertEqual(VoiceCommandMatcher.match("one more time"), .repeatRequest)
+        XCTAssertEqual(VoiceCommandMatcher.match("this one"), .select)
+    }
+
+    /// Apostrophe elision must not disturb ordinary contractions that carry no negation.
+    func testContractionsWithoutNegationStillMatch() {
+        XCTAssertEqual(VoiceCommandMatcher.match("that's okay"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("let's do it"), .yes)
+        XCTAssertEqual(VoiceCommandMatcher.match("I\u{2019}m sure"), .yes)
+    }
+
+    // MARK: - Branches that precede the answer branches
+
+    /// The navigation and deferral rules run before yes/no and keep their own readings,
+    /// including the "not sure" deferral that contains a negator.
+    func testEarlierBranchesAreUnchangedByNegationHandling() {
+        XCTAssertEqual(VoiceCommandMatcher.match("not sure"), .skip)
+        XCTAssertEqual(VoiceCommandMatcher.match("I'm not sure"), .skip)
+        XCTAssertEqual(VoiceCommandMatcher.match("I\u{2019}m not sure"), .skip)
+        XCTAssertEqual(VoiceCommandMatcher.match("next"), .next)
+        XCTAssertEqual(VoiceCommandMatcher.match("go back"), .previous)
+        XCTAssertEqual(VoiceCommandMatcher.match("this one"), .select)
+        XCTAssertEqual(VoiceCommandMatcher.match("two"), .number(2))
+        XCTAssertEqual(VoiceCommandMatcher.match("say again"), .repeatRequest)
+        XCTAssertEqual(VoiceCommandMatcher.match("tell me more"), .details)
+        XCTAssertEqual(VoiceCommandMatcher.match("ask later"), .skip)
+        XCTAssertEqual(VoiceCommandMatcher.match("move on"), .next)
+        XCTAssertEqual(VoiceCommandMatcher.match("last one"), .previous)
+        XCTAssertEqual(VoiceCommandMatcher.match("go with this"), .select)
+    }
+
+    func testEmptyAndPunctuationOnlyTranscriptsMatchNothing() {
+        XCTAssertNil(VoiceCommandMatcher.match(""))
+        XCTAssertNil(VoiceCommandMatcher.match("   "))
+        XCTAssertNil(VoiceCommandMatcher.match("\u{2019}\u{2019}"))
+        XCTAssertNil(VoiceCommandMatcher.match("..."))
     }
 }


### PR DESCRIPTION
## Summary

`VoiceCommandMatcher` decided the affirmative before the denial and matched multi-word rules by raw substring containment, so refusals that contain an affirmative substring returned `.yes`: "don't do it", "do not do it", curly-apostrophe "don’t do it", "not okay", "I cannot approve that", "never approve that", and contradictions like "no, go ahead" all false-approved. The ASCII `don't` denial phrase also never matched real speech-to-text output, which emits U+2019.

The fix makes approval structurally impossible in the presence of negation instead of reordering branches:

- All matching is word-level. Apostrophes (`'` `’` `ʼ` `‘` `＇`) are elided before tokenizing, so every spelling of "don't" yields the word `dont`; phrases now match runs of adjacent words rather than substrings ("undo items" no longer approves).
- `.yes` requires the transcript to contain no negator word (`dont`, `not`, `cannot`, `never`, `wont`, `couldnt`, …). A denial word beats a co-occurring affirmative regardless of order. Negated-but-not-denying utterances ("not okay", "sure, why not") return `nil` and fail open to the on-screen prompt — never to approval.
- Earlier branches (repeat, details, skip, navigation, numbers) are unchanged and pinned by tests; "not sure" still maps to skip.

Regression tests include a sweep asserting no combination of 23 negators × 13 affirmatives in either word order can approve (598 assertions), plus whole-word negator matching, word-run phrase matching, curly-apostrophe equivalence, and unrelated-contraction controls. CHANGELOG gains an Unreleased → Fixed entry.

Known limitation, deliberately out of scope: the negation guard covers only the yes/no branch, so in multi-choice selection a negated navigation phrase ("don't pick this one") still selects; flagged for a separate decision.

## Verification

- [x] `swift build`
- [x] `swift test` — 845 tests, 0 failures
- [x] `scripts/check-release-version.sh`
- [x] `scripts/check-public-boundary.sh`
- [x] Relevant macOS runtime or packaging checks, if applicable — none applicable (pure portable-core change)

## Checklist

- [x] The change is scoped to the smallest owning target.
- [x] Behavior changes include tests.
- [x] Portable-logic targets do not import Apple-only or direct POSIX APIs.
- [x] Documentation reflects user-visible changes.
- [x] No secrets, private fixtures, raw captures, or unauthorized proprietary assets are included.
- [x] Any brand asset change has prior written approval and separate contribution terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)