### PR TITLE
Milestone 2: live voice loop (playback, mic pump, IMU turn control, free-form answers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - "worktree-**"
     tags:
       - "v*"
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
+### Added
+
+- Wearer-speech detection from head motion. A portable analyzer turns the 25 Hz IMU stream
+  into a speaking/quiet signal from the jaw- and skull-borne vibration the earbud picks up
+  while its wearer talks, using a differenced-acceleration envelope with hysteresis, a
+  hangover hold, a rotation-quiet gate that separates speech from nods and shakes, and a
+  minimum duration that separates it from taps. Every threshold lives in a calibration
+  profile, so retuning after the capture study is a data change rather than a code change.
+- A third calibration profile, `wearer-speech`, alongside gesture and tap. `calibration
+  run|show|reset` accept the `wearer-speech` target, `--wearer-speech-profile PATH`, and
+  `--speak-seconds N`; a read-aloud phase is appended to the `all` timeline, which now
+  covers all three profiles. The document is `wearer-speech-calibration.json`. Each usable
+  profile is saved as its phase is assessed, so a failed speak phase keeps a good gesture
+  or tap profile, and resetting one target never touches the other two.
+- `tapq capture --mic-envelope PATH` co-records a microphone loudness envelope sidecar
+  time-aligned to the motion track's own boot clock. It is capture-study tooling for
+  labeling wearer speech: no audio is retained, only per-block RMS and peak, written as
+  line-delimited JSON behind a `tapq-mic-envelope-v1` header. Unlike TapQ's runtime paths
+  this one is fail-closed — a microphone that cannot start aborts before any motion is
+  recorded, and a mid-capture route change finishes and writes the motion track, reports
+  the truncated sidecar, and exits nonzero.
+- `tapq replay` scores wearer-speech detection as an interval rather than an event.
+  Ground truth comes from `wearer_speech` label segments or from a `--mic-envelope`
+  sidecar, with labels winning when both are present; `--wearer-speech-profile PATH`
+  replays a calibrated profile. The report adds frame-level precision, recall, and F1 at
+  the capture's sample rate, mean onset latency, and false activations per minute, as a
+  text section and as a `wearer_speech` object under `--json`. Existing label files parse
+  unchanged and a replay without the new flags produces exactly its previous output.
+- `WearerGatedVoice`, a composition wrapper that attributes a matched voice command to the
+  wearer using the motion speech signal, passing a command through when the wearer spoke
+  within a trailing attribution window. It fails open in every degraded state: no signal,
+  a magnitude-only stream, or a wedged analyzer reproduces today's shipped behavior
+  verbatim. Not wired into the live runtime yet — live promotion awaits the capture study.
+- A `VoiceBackend` contract in `TapQContracts` covering both half- and full-duplex speech
+  pipes, with turn arbitration held permanently on TapQ's side: a backend is a speech pipe
+  and never ends a turn, an invariant enforced mechanically by a pure turn state machine
+  that adapters run internally. Ships with `VoiceBackendCommandProvider`, which adapts any
+  backend into the existing `VoiceCommandProviding` composition.
+- `tapq serve --voice-backend apple|openai-realtime`. `apple` is the default and is
+  byte-for-byte today's composition. `openai-realtime` requires `OPENAI_API_KEY` and
+  refuses to start without it, runs the Realtime API in manual-turn mode with server-side
+  voice activity detection disabled, and is always composed with the Apple stack beneath
+  it — a session that cannot open or that drops mid-window continues on-device instead of
+  leaving the window without voice. The ready block reports the composition.
+
 ## [0.4.0-beta.1] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,70 @@ All notable changes to TapQ will be recorded in this file. The project uses
   voice activity detection disabled, and is always composed with the Apple stack beneath
   it — a session that cannot open or that drops mid-window continues on-device instead of
   leaving the window without voice. The ready block reports the composition.
+- Conversation-scoped sessions for the `openai-realtime` backend. The WebSocket session
+  outlives individual response windows, eliminating the per-window reconnect churn caused
+  by `SpeechGatedVoice` stopping and restarting the voice provider on every TTS transition.
+  An idle timer (60 seconds with no window open) closes the session; the next window
+  reopens from scratch. Fail-through to the Apple backend is sticky per conversation: once
+  the primary fails, subsequent windows skip the primary until the conversation resets on
+  idle-close reopen, preventing a 5-second handshake timeout at every mic reopen when the
+  network is down.
+- Response-audio playback for `openai-realtime`. Cloud voice output is played through
+  `AVAudioEngine` on macOS. The engine starts lazily on the first chunk of each response,
+  stops when drained, and fails open on any playback error — the transcript and the window
+  are unaffected. A combined speech activity signal merges TTS and backend playback so the
+  microphone is held closed while either source is active, maintaining the strict
+  half-duplex guarantee without acoustic echo cancellation.
+- Microphone pump for `openai-realtime`. The pipe backend now actually hears the wearer:
+  `MicrophonePumpVoiceBackend` opens the Mac's audio input on each user turn, converts
+  captured buffers to the pipe's wire format (mono 24 kHz PCM16), and streams them via
+  `sendAudio`. The microphone is opened only inside a user turn and never between windows.
+  A mid-turn audio route change triggers fail-through to the Apple backend. This closes the
+  milestone-one gap where the `openai-realtime` flag transmitted no audio and voice could
+  only resolve through fail-through.
+- `tapq serve --wearer-gate`. Filters voice commands through IMU-based wearer-speech
+  attribution: a command is passed through when the wearer spoke within a trailing
+  attribution window. Commands from bystanders or other audio sources are rejected. Default
+  off. Fails open in every degraded state — no signal, a magnitude-only stream, or a stale
+  analyzer reproduces today's behavior verbatim. Uses `wearer-speech-calibration.json` when
+  present, provisional thresholds otherwise.
+- `tapq serve --imu-turn-control`. Endpointing: when the wearer stops speaking, the user
+  turn is committed after a short delay (0.4 seconds on top of the detector's 0.6-second
+  hangover), making voice resolution possible on the `openai-realtime` path before the
+  window timeout. Barge-in: when the wearer starts speaking during response audio, playback
+  is stopped immediately so the wearer can speak their answer on the next turn. Both are
+  additive — gesture, tap, timeout, and command-match resolution continue to work as
+  fallback. A dead or absent signal means neither feature fires (fail-open). Default off.
+- `tapq serve --voice-freeform`. Free-form spoken answers for selections and multi-option
+  stop questions. Requires `--voice-backend openai-realtime`. An unmatched final transcript
+  is offered as a free-text reply with mandatory read-back confirmation: the wearer hears
+  their answer spoken back and nods to send or shakes to discard. The confirmed text reaches
+  Claude Code as a deny reason and Codex as a `request_user_input` answer. Tool approvals
+  and yes/no stop questions stay binary — a spoken free-text answer can never authorize an
+  agent action.
+- Live wearer-speech signal producer. The headphone motion stream feeds a
+  `WearerSpeechMonitor` through a fan-out hook on the gesture detector, producing a
+  speaking/quiet signal for the attribution gate and the turn coordinator. The signal flows
+  only while a response window is open; between windows it goes stale and both consumers
+  fail open by design. Multiple consumers get independent handles through a multicast child
+  pattern.
+
+### Changed
+
+- The broker wire protocol is now version 4. The `selection` response gains an optional
+  `free_text` field for free-form voice answers. The broker accepts both v4 and v3
+  requests — request shapes are identical and the only change is the additive response
+  field. Shims built against v3 continue to work and simply never see the `free_text`
+  field. The v2 legacy bridge is unchanged.
+- `VoiceCommand` and `InputIntent` gain a `.freeform(String)` case for free-form voice
+  answers. This is the one contract-shape change of the milestone; every consumer switch
+  is compiler-audited. Existing composition paths never produce it, so default behavior is
+  unchanged.
+- The `openai-realtime` composition now uses conversation-scoped sessions with sticky
+  fail-through, a microphone pump, and response-audio playback. The default `apple` path
+  is unchanged. Without the new flags, `tapq serve --voice-backend openai-realtime`
+  resolves windows by gesture, tap, or timeout exactly as before — the only behavioral
+  difference is that the pipe actually transmits audio and the cloud voice is audible.
 
 ## [0.4.0-beta.1] - 2026-08-03
 

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -560,6 +560,11 @@ import Darwin
         defer {
             finishShutdownWait()
             turnCoordinator?.stop()
+            // Prevent ARC from releasing the wearer-speech source at the
+            // waitForShutdown suspension. HeadGestureDetector and every ChildSignal hold
+            // it weakly; without this reference, optimized builds can deallocate it
+            // mid-serve, silently disabling --wearer-gate and --imu-turn-control.
+            _ = wearerSpeechSource
             approvalArbiter.cancel()
             selectionArbiter.cancel()
             gestures.stop()

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -31,9 +31,6 @@ import Darwin
         reasonerLoader: TapQReasonerLoading?,
         onReady: @escaping @MainActor (TapQRuntimeEndpoint) -> Void
     ) async throws {
-        // The runtime reads only the two profiles it acts on. The wearer-speech profile is
-        // calibrated and replayed this milestone but not yet consumed live, so the store
-        // points at its default location purely to satisfy the initializer.
         let store = CalibrationStore(
             gestureProfileURL: configuration.gestureProfileURL,
             tapProfileURL: configuration.tapProfileURL,
@@ -124,11 +121,40 @@ import Darwin
                     + " (\(error.localizedDescription))"
             }
         }
+        // -- Wearer-speech signal source (WP5/WP6) --
+        // When --wearer-gate is enabled, the motion sample stream feeds a
+        // WearerSpeechSignalSource whose children provide WearerSpeechSignaling to
+        // WearerGatedVoice (and later WearerTurnCoordinator in WP7).
+        var wearerSpeechSource: WearerSpeechSignalSource?
+        var wearerSpeechStatus: String?
+        if configuration.wearerGateEnabled {
+            let wearerSpeechConfig: WearerSpeechConfig
+            if store.exists(.wearerSpeech) {
+                do {
+                    wearerSpeechConfig = try store.loadWearerSpeech().config
+                } catch {
+                    // Match the loadGestureIfPresent / loadTapIfPresent semantics: a
+                    // malformed profile throws and aborts serve, exactly as gesture/tap do.
+                    throw error
+                }
+            } else {
+                wearerSpeechConfig = WearerSpeechConfig()
+            }
+            let source = WearerSpeechSignalSource(config: wearerSpeechConfig)
+            gestures.setMotionSampleObserver(source)
+            source.isAttached = true
+            wearerSpeechSource = source
+            wearerSpeechStatus = "gate"
+        }
+
+        // -- Voice composition --
         // `apple` is the shipped path and stays literally the shipped path: the same
         // `VoiceListener` instance, wrapped by the same `SpeechGatedVoice`, with nothing
         // between them. Any other provider swaps only what sits inside that gate — the
         // arbiter, the controllers, and the mic-lifecycle rules above are untouched.
         let rawVoice: any VoiceCommandProviding
+        var backendProvider: VoiceBackendCommandProvider?
+        var playback: BackendAudioPlayback?
         switch configuration.voiceBackend {
         case .apple:
             rawVoice = VoiceListener(diagnosticSink: diagnostics)
@@ -147,23 +173,65 @@ import Darwin
                         diagnosticSink: diagnostics
                     )
                 },
+                // Conversation mode uses sticky fail-through: once the primary fails, the
+                // fallback handles every subsequent open until resetStickiness() on the
+                // next conversation (idle-close reopen). Decision 3.
+                failThroughStickiness: .stickyAfterFailure,
                 diagnosticSink: diagnostics,
                 // Shares the one `SpeechEngine`, so the fallback speaks through the same
                 // activity signal `SpeechGatedVoice` gates the microphone on.
                 makeAppleBackend: { AppleVoiceBackend(speech: speech, diagnosticSink: diagnostics) }
             )
-            rawVoice = VoiceBackendCommandProvider(
+            let player = BackendAudioPlayback(diagnosticSink: diagnostics)
+            playback = player
+            let provider = VoiceBackendCommandProvider(
                 backend: selection.backend,
                 match: { VoiceCommandMatcher.match($0) },
+                sessionPolicy: .conversation(idleClose: 60),
+                supportsBargeIn: true,
+                responseAudio: player,
                 diagnosticSink: diagnostics
             )
+            // Wire the conversation-reopened seam so sticky fail-through resets on a new
+            // conversation. The backend is a FailThroughVoiceBackend (created by the
+            // factory above); we call resetStickiness() on idle-close reopen.
+            if let failThrough = selection.backend as? FailThroughVoiceBackend {
+                provider.onConversationReopened = { [weak failThrough] in
+                    failThrough?.resetStickiness()
+                }
+            }
+            backendProvider = provider
+            rawVoice = provider
         }
         let voiceAuthorized = configuration.voiceEnabled
             ? await VoiceListener.requestAuthorization()
             : false
+
+        // -- Gate composition --
+        // Stacking order: SpeechGatedVoice(WearerGatedVoice(rawVoice)). The outer gate
+        // owns the mic lifecycle (TTS + playback); the inner gate filters what survives.
+        let gatedInner: any VoiceCommandProviding
+        if let wearerSpeechSource {
+            gatedInner = WearerGatedVoice(
+                wrapping: rawVoice,
+                signal: wearerSpeechSource.makeSignal(),
+                diagnosticSink: diagnostics
+            )
+        } else {
+            gatedInner = rawVoice
+        }
+        // When a backend audio player exists, the speech gate must watch both TTS and
+        // playback: CombinedSpeechActivity merges the two signals. Without a player the
+        // speech engine is the sole activity source, byte-identical to M1.
+        let activitySignal: SpeechActivitySignaling
+        if let playback {
+            activitySignal = CombinedSpeechActivity(tts: speech, playback: playback)
+        } else {
+            activitySignal = speech
+        }
         let gatedVoice = SpeechGatedVoice(
-            wrapping: rawVoice,
-            activity: speech,
+            wrapping: gatedInner,
+            activity: activitySignal,
             diagnosticSink: diagnostics
         )
         let voice: (any VoiceCommandProviding)? = voiceAuthorized ? gatedVoice : nil
@@ -414,7 +482,8 @@ import Darwin
             voiceAvailable: voiceAuthorized,
             voiceBackendStatus: configuration.voiceBackend.statusDescription,
             encoderStatus: encoderStatus,
-            reasonerStatus: reasonerStatus
+            reasonerStatus: reasonerStatus,
+            wearerSpeechStatus: wearerSpeechStatus
         ))
 
         defer {
@@ -422,7 +491,13 @@ import Darwin
             approvalArbiter.cancel()
             selectionArbiter.cancel()
             gestures.stop()
-            rawVoice.stop()
+            // In conversation mode, shutdown() tears down the backend session cleanly.
+            // In per-window mode (or for VoiceListener), stop() is the correct teardown.
+            if let backendProvider {
+                backendProvider.shutdown()
+            } else {
+                rawVoice.stop()
+            }
             speech.stopAll()
             server.stop()
             discovery.remove()

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -138,6 +138,15 @@ import Darwin
             let selection = try VoiceBackendFactory.select(
                 provider: configuration.voiceBackend,
                 openAIAPIKey: ProcessInfo.processInfo.environment["OPENAI_API_KEY"],
+                // The microphone pump wraps the realtime primary so the pipe actually
+                // hears the wearer. The decorator keeps AVFoundation out of the portable
+                // factory: only this executable — already macOS-only — constructs one.
+                decorateRealtimePrimary: { primary in
+                    MicrophonePumpVoiceBackend(
+                        inner: primary,
+                        diagnosticSink: diagnostics
+                    )
+                },
                 diagnosticSink: diagnostics,
                 // Shares the one `SpeechEngine`, so the fallback speaks through the same
                 // activity signal `SpeechGatedVoice` gates the microphone on.

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -198,6 +198,7 @@ import Darwin
                 sessionPolicy: .conversation(idleClose: 60),
                 supportsBargeIn: true,
                 responseAudio: player,
+                freeformEnabled: configuration.voiceFreeformEnabled,
                 diagnosticSink: diagnostics
             )
             // Wire the conversation-reopened seam so sticky fail-through resets on a new

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -219,8 +219,11 @@ import Darwin
         // -- Gate composition --
         // Stacking order: SpeechGatedVoice(WearerGatedVoice(rawVoice)). The outer gate
         // owns the mic lifecycle (TTS + playback); the inner gate filters what survives.
+        // The attribution gate is composed ONLY when --wearer-gate is set. --imu-turn-control
+        // alone shares the signal source (for the coordinator) but must not alter command
+        // delivery — its help text promises only endpointing and barge-in.
         let gatedInner: any VoiceCommandProviding
-        if let wearerSpeechSource {
+        if configuration.wearerGateEnabled, let wearerSpeechSource {
             gatedInner = WearerGatedVoice(
                 wrapping: rawVoice,
                 signal: wearerSpeechSource.makeSignal(),

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -121,13 +121,16 @@ import Darwin
                     + " (\(error.localizedDescription))"
             }
         }
-        // -- Wearer-speech signal source (WP5/WP6) --
-        // When --wearer-gate is enabled, the motion sample stream feeds a
-        // WearerSpeechSignalSource whose children provide WearerSpeechSignaling to
-        // WearerGatedVoice (and later WearerTurnCoordinator in WP7).
+        // -- Wearer-speech signal source (WP5/WP6/WP7) --
+        // When --wearer-gate or --imu-turn-control is enabled, the motion sample stream
+        // feeds a WearerSpeechSignalSource whose children provide WearerSpeechSignaling
+        // to WearerGatedVoice (gate) and WearerTurnCoordinator (turn control). Both
+        // flags share one source.
+        let needsWearerSpeechSource = configuration.wearerGateEnabled
+            || configuration.imuTurnControlEnabled
         var wearerSpeechSource: WearerSpeechSignalSource?
         var wearerSpeechStatus: String?
-        if configuration.wearerGateEnabled {
+        if needsWearerSpeechSource {
             let wearerSpeechConfig: WearerSpeechConfig
             if store.exists(.wearerSpeech) {
                 do {
@@ -144,7 +147,12 @@ import Darwin
             gestures.setMotionSampleObserver(source)
             source.isAttached = true
             wearerSpeechSource = source
-            wearerSpeechStatus = "gate"
+            switch (configuration.wearerGateEnabled, configuration.imuTurnControlEnabled) {
+            case (true, true): wearerSpeechStatus = "gate+turn-control"
+            case (true, false): wearerSpeechStatus = "gate"
+            case (false, true): wearerSpeechStatus = "turn-control"
+            case (false, false): break
+            }
         }
 
         // -- Voice composition --
@@ -235,6 +243,65 @@ import Darwin
             diagnosticSink: diagnostics
         )
         let voice: (any VoiceCommandProviding)? = voiceAuthorized ? gatedVoice : nil
+
+        // -- IMU turn coordinator (WP7) --
+        // When --imu-turn-control is enabled, the coordinator watches the wearer-speech
+        // signal and calls endActiveTurn (endpointing) or interrupts playback (barge-in).
+        // Both are additive; a dead signal means neither fires.
+        //
+        // On the .apple/VoiceListener path the coordinator composes with
+        // interruptPlayback = speech.stopAll() and no endpoint (VoiceListener has no
+        // turn API) — barge-in-only there. On the backend-provider path both
+        // endpointing and barge-in are available.
+        var turnCoordinator: WearerTurnCoordinator?
+        if configuration.imuTurnControlEnabled, let wearerSpeechSource {
+            switch configuration.voiceBackend {
+            case .openaiRealtime:
+                let coordinator = WearerTurnCoordinator(
+                    signal: wearerSpeechSource.makeSignal(),
+                    endpoint: { [weak backendProvider] in
+                        backendProvider?.endActiveTurn()
+                    },
+                    interruptPlayback: { [weak playback, weak backendProvider] in
+                        playback?.stopAndFlush()
+                        backendProvider?.cancelActiveResponse()
+                        speech.stopAll()
+                    },
+                    isResponsePlaying: { [weak playback] in
+                        (playback?.isPlaying ?? false) || speech.isSpeaking
+                    },
+                    isUserTurnActive: { [weak backendProvider] in
+                        backendProvider?.isUserTurnActiveForCoordination ?? false
+                    }
+                )
+                // The coordinator is armed once for the serve lifetime. Between windows
+                // no motion samples flow (the detector stops on InputArbiter.finish),
+                // so the signal goes stale and isSignalAvailable returns false, which
+                // makes the coordinator ignore all transitions. The isUserTurnActive
+                // guard is the second line of defense: no endpoint fires unless a turn
+                // is actually open. No explicit stop() is needed at teardown because the
+                // coordinator only adds calls, never blocks them, and the serve defer
+                // block tears down everything below it.
+                coordinator.start()
+                turnCoordinator = coordinator
+            case .apple:
+                // VoiceListener has no turn API, so only barge-in is meaningful:
+                // interrupt TTS when the wearer starts speaking during a prompt.
+                let coordinator = WearerTurnCoordinator(
+                    signal: wearerSpeechSource.makeSignal(),
+                    endpoint: { /* no-op: VoiceListener has no turn API */ },
+                    interruptPlayback: {
+                        speech.stopAll()
+                    },
+                    isResponsePlaying: {
+                        speech.isSpeaking
+                    },
+                    isUserTurnActive: { false /* no explicit turns on the Apple path */ }
+                )
+                coordinator.start()
+                turnCoordinator = coordinator
+            }
+        }
 
         let approvalArbiter = InputArbiter(
             gestures: gestures,
@@ -488,6 +555,7 @@ import Darwin
 
         defer {
             finishShutdownWait()
+            turnCoordinator?.stop()
             approvalArbiter.cancel()
             selectionArbiter.cancel()
             gestures.stop()

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -7,6 +7,7 @@ import TapQContextBaseline
 import TapQContracts
 import TapQDetectionBaseline
 import TapQInteractionBaseline
+import TapQVoiceBackends
 #if canImport(Darwin)
 import Darwin
 #endif
@@ -123,7 +124,31 @@ import Darwin
                     + " (\(error.localizedDescription))"
             }
         }
-        let rawVoice = VoiceListener(diagnosticSink: diagnostics)
+        // `apple` is the shipped path and stays literally the shipped path: the same
+        // `VoiceListener` instance, wrapped by the same `SpeechGatedVoice`, with nothing
+        // between them. Any other provider swaps only what sits inside that gate — the
+        // arbiter, the controllers, and the mic-lifecycle rules above are untouched.
+        let rawVoice: any VoiceCommandProviding
+        switch configuration.voiceBackend {
+        case .apple:
+            rawVoice = VoiceListener(diagnosticSink: diagnostics)
+        case .openaiRealtime:
+            // Throwing aborts serve, like a misconfigured question classifier: the operator
+            // asked for a specific pipe and must not be given a different one in silence.
+            let selection = try VoiceBackendFactory.select(
+                provider: configuration.voiceBackend,
+                openAIAPIKey: ProcessInfo.processInfo.environment["OPENAI_API_KEY"],
+                diagnosticSink: diagnostics,
+                // Shares the one `SpeechEngine`, so the fallback speaks through the same
+                // activity signal `SpeechGatedVoice` gates the microphone on.
+                makeAppleBackend: { AppleVoiceBackend(speech: speech, diagnosticSink: diagnostics) }
+            )
+            rawVoice = VoiceBackendCommandProvider(
+                backend: selection.backend,
+                match: { VoiceCommandMatcher.match($0) },
+                diagnosticSink: diagnostics
+            )
+        }
         let voiceAuthorized = configuration.voiceEnabled
             ? await VoiceListener.requestAuthorization()
             : false
@@ -378,6 +403,7 @@ import Darwin
             tapProfileLoaded: tapProfile != nil,
             motionAvailable: HeadGestureDetector.isAvailable,
             voiceAvailable: voiceAuthorized,
+            voiceBackendStatus: configuration.voiceBackend.statusDescription,
             encoderStatus: encoderStatus,
             reasonerStatus: reasonerStatus
         ))

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -30,9 +30,13 @@ import Darwin
         reasonerLoader: TapQReasonerLoading?,
         onReady: @escaping @MainActor (TapQRuntimeEndpoint) -> Void
     ) async throws {
+        // The runtime reads only the two profiles it acts on. The wearer-speech profile is
+        // calibrated and replayed this milestone but not yet consumed live, so the store
+        // points at its default location purely to satisfy the initializer.
         let store = CalibrationStore(
             gestureProfileURL: configuration.gestureProfileURL,
-            tapProfileURL: configuration.tapProfileURL
+            tapProfileURL: configuration.tapProfileURL,
+            wearerSpeechProfileURL: CalibrationStore.defaultStore().wearerSpeechProfileURL
         )
         let gestureProfile = try loadGestureIfPresent(store)
         let tapProfile = try loadTapIfPresent(store)

--- a/Executables/tapq/Info.plist
+++ b/Executables/tapq/Info.plist
@@ -21,7 +21,7 @@
     <key>LSUIElement</key>
     <true/>
     <key>NSMicrophoneUsageDescription</key>
-    <string>TapQ opens the microphone only during an active hands-free response window.</string>
+    <string>TapQ opens the microphone during an active hands-free response window, and during a capture run that was explicitly asked for a microphone envelope track.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>TapQ recognizes short spoken commands such as yes, no, repeat, details, and option numbers.</string>
     <key>NSMotionUsageDescription</key>

--- a/Executables/tapq/TapQMain.swift
+++ b/Executables/tapq/TapQMain.swift
@@ -28,12 +28,15 @@ struct TapQMain {
 
         #if canImport(TapQAppleAdapters)
         let capture: (any TapQMotionCapturing)? = AppleHeadphoneMotionCapture()
+        let envelopeCapture: (any TapQAudioEnvelopeCapturing)? =
+            AppleMicrophoneEnvelopeCapture()
         let runtime: (any TapQRuntimeServing)? = AppleTapQRuntimeService()
         let scorerLoader: ((URL) async throws -> any MotionWindowScoring)? = { url in
             try await CoreMLMotionScorer.load(modelURL: url)
         }
         #else
         let capture: (any TapQMotionCapturing)? = nil
+        let envelopeCapture: (any TapQAudioEnvelopeCapturing)? = nil
         let runtime: (any TapQRuntimeServing)? = nil
         let scorerLoader: ((URL) async throws -> any MotionWindowScoring)? = nil
         #endif
@@ -62,6 +65,7 @@ struct TapQMain {
 
         let application = TapQCLIApplication(
             motionCapture: capture,
+            envelopeCapture: envelopeCapture,
             runtimeService: runtime,
             motionScorerLoader: scorerLoader,
             reasonerLoader: reasonerLoader,
@@ -121,6 +125,41 @@ private final class AppleHeadphoneMotionCapture: TapQMotionCapturing {
 
         try await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
         if let failure = health.failure { throw failure }
+    }
+}
+
+/// Translates the Apple envelope source into the CLI's portable capture contract. It
+/// holds no logic of its own — everything testable lives on either side of this seam.
+@MainActor
+private final class AppleMicrophoneEnvelopeCapture: TapQAudioEnvelopeCapturing {
+    private let source = MicrophoneEnvelopeSource()
+
+    func start(
+        onTrack: @escaping @MainActor (MicEnvelopeTrackMeta) -> Void,
+        onSample: @escaping @MainActor (MicEnvelopeSample) -> Void,
+        onInvalidation: @escaping @MainActor (TapQEnvelopeCaptureError) -> Void
+    ) throws {
+        do {
+            try source.start(
+                onTrack: { track in
+                    onTrack(MicEnvelopeTrackMeta(
+                        sampleRate: track.sampleRate, blockFrames: track.blockFrames))
+                },
+                onBlock: { block in
+                    onSample(MicEnvelopeSample(
+                        timestamp: block.timestamp, rms: block.rms, peak: block.peak))
+                },
+                onInvalidation: { failure in
+                    onInvalidation(.invalidated(failure.description))
+                }
+            )
+        } catch let failure as MicrophoneEnvelopeFailure {
+            throw TapQEnvelopeCaptureError.startFailed(failure.description)
+        }
+    }
+
+    func stop() {
+        source.stop()
     }
 }
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ var products: [Product] = [
     .library(name: "TapQPOSIXBridgeClient", targets: ["TapQPOSIXBridgeClient"]),
     .library(name: "TapQClaudeAdapter", targets: ["TapQClaudeAdapter"]),
     .library(name: "TapQCodexAdapter", targets: ["TapQCodexAdapter"]),
+    .library(name: "TapQVoiceBackends", targets: ["TapQVoiceBackends"]),
     .executable(name: "tapq", targets: ["tapq"]),
     .executable(name: "tapq-hook", targets: ["tapq-hook"]),
     .executable(name: "tapq-codex-hook", targets: ["tapq-codex-hook"]),
@@ -65,6 +66,13 @@ var targets: [Target] = [
         dependencies: ["TapQContracts", "TapQPOSIXSupport", "TapQWireProtocol"],
         swiftSettings: swiftSettings
     ),
+    // Portable: the OpenAI Realtime adapter reaches the network only through an injected
+    // transport seam, so the target itself imports nothing beyond Foundation and contracts.
+    .target(
+        name: "TapQVoiceBackends",
+        dependencies: ["TapQContracts"],
+        swiftSettings: swiftSettings
+    ),
     .target(
         name: "TapQCLI",
         dependencies: [
@@ -74,6 +82,7 @@ var targets: [Target] = [
             "TapQContracts",
             "TapQDetectionBaseline",
             "TapQPOSIXSupport",
+            "TapQVoiceBackends",
             "TapQWireProtocol",
         ],
         swiftSettings: swiftSettings
@@ -161,6 +170,11 @@ var targets: [Target] = [
         swiftSettings: swiftSettings
     ),
     .testTarget(
+        name: "TapQVoiceBackendsTests",
+        dependencies: ["TapQContracts", "TapQVoiceBackends"],
+        swiftSettings: swiftSettings
+    ),
+    .testTarget(
         name: "TapQCLITests",
         dependencies: ["TapQCLI", "TapQDetectionBaseline", "TapQWireProtocol"],
         swiftSettings: swiftSettings
@@ -228,6 +242,7 @@ var tapqExecutableDependencies: [Target.Dependency] = [
     "TapQContracts",
     "TapQDetectionBaseline",
     "TapQInteractionBaseline",
+    "TapQVoiceBackends",
 ]
 
 #if os(macOS)

--- a/Package.swift
+++ b/Package.swift
@@ -169,9 +169,12 @@ var targets: [Target] = [
         resources: [.copy("Fixtures")],
         swiftSettings: swiftSettings
     ),
+    // `TapQInteractionBaseline` is a test-only dependency: the fail-through guarantee is
+    // only meaningful one layer up, where a dying realtime session still has to resolve a
+    // window through `VoiceBackendCommandProvider`, so that composition is proven here.
     .testTarget(
         name: "TapQVoiceBackendsTests",
-        dependencies: ["TapQContracts", "TapQVoiceBackends"],
+        dependencies: ["TapQContracts", "TapQInteractionBaseline", "TapQVoiceBackends"],
         swiftSettings: swiftSettings
     ),
     .testTarget(

--- a/Sources/TapQAppleAdapters/AppleVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/AppleVoiceBackend.swift
@@ -192,18 +192,24 @@ import AVFoundation
         #endif
     }
 
-    public func endUserTurn() {
+    @discardableResult
+    public func endUserTurn(expectingResponse: Bool) -> Bool {
         #if canImport(Speech) && canImport(AVFoundation)
         do {
             try turns.endUserTurn()
         } catch {
-            return violated(error)
+            violated(error)
+            return false
         }
         // The microphone closes the instant the turn commits; the recognition task stays
         // alive just long enough to deliver the settled transcript for what it already heard.
         audioSource.stop()
         request?.endAudio()
         diagnostics.record("turn.committed")
+        // Apple's on-device recognizer never creates a spoken response from endUserTurn.
+        return false
+        #else
+        return false
         #endif
     }
 

--- a/Sources/TapQAppleAdapters/AppleVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/AppleVoiceBackend.swift
@@ -1,0 +1,357 @@
+import Foundation
+import TapQContracts
+#if canImport(Speech)
+import Speech
+#endif
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+
+/// The default `VoiceBackend`: on-device Apple speech recognition, one microphone window
+/// per user turn, no audio produced.
+///
+/// It is deliberately a sibling of `VoiceListener` rather than a refactor of it. The
+/// shipped voice path is the one thing in this milestone that must not move, so the ~40
+/// lines of recognition-window setup are duplicated here instead of being hoisted into a
+/// shared helper that both paths would then depend on.
+///
+/// Two invariants this class exists to hold:
+///
+/// - **The microphone opens in `beginUserTurn` and closes in `endUserTurn`**, never in
+///   `open`. A session can sit open for the length of an interaction without the mic being
+///   live, which is the "never always-on" guarantee `VoiceListener` documents.
+/// - **The backend never ends a turn.** `SFSpeechRecognizer` marks a result final on its
+///   own silence heuristic; that is a transcript, not a turn boundary, and it is forwarded
+///   as `transcriptFinal` while the turn stays exactly as open as TapQ left it. Everything
+///   else routes through `VoiceTurnStateMachine`, so a turn-protocol mistake surfaces as
+///   `sessionFailed(.protocolViolation)` rather than as a window that resolves itself.
+///
+/// The microphone plus recognizer pair is this backend's transport, so route changes,
+/// engine-start failures, and recognizer errors all arrive as `VoiceBackendFailure.network`
+/// — the same case a socket-backed adapter reports a dropped connection with, which is what
+/// lets a fail-through wrapper treat them alike.
+@MainActor public final class AppleVoiceBackend: VoiceBackend {
+    public let capabilities = VoiceBackendCapabilities.transcriptOnly
+
+    #if canImport(Speech)
+    private let recognizer: any VoiceSpeechRecognizing
+    private var task: (any VoiceRecognitionTasking)?
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    #endif
+    #if canImport(AVFoundation)
+    private let audioSource: VoiceAudioSourceController
+    #endif
+
+    private let speech: any SpeechPresenting
+    private let diagnostics: TapQDiagnosticEmitter
+    private var onEvent: (@MainActor (VoiceBackendEvent) -> Void)?
+    private var turns = VoiceTurnStateMachine(capabilities: .transcriptOnly)
+    /// Invalidates delayed recognition, route, and synthesizer callbacks from a prior
+    /// session or turn. Bumped on every open and every teardown.
+    private var sessionGeneration: UInt64 = 0
+
+    /// Mirrors `VoiceListener.preferOnDevice`: on-device recognition when the recognizer
+    /// offers it, so a voice window never leaves the machine.
+    public var preferOnDevice = true
+    /// Priority for `requestResponse(text:)`. An agent answer is a notification, not an
+    /// approval prompt, so it must not preempt one.
+    public var responsePriority: SpeechPriority = .notification
+
+    /// - Parameter speech: the host's single `SpeechEngine`. A backend that produced its
+    ///   own `AVSpeechSynthesizer` would speak outside the engine's activity signal, and
+    ///   `SpeechGatedVoice` would open the microphone straight into it.
+    public init(speech: any SpeechPresenting,
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        #if canImport(Speech)
+        self.recognizer = AppleVoiceSpeechRecognizer(locale: VoiceListener.grammarLocale)
+        #endif
+        #if canImport(AVFoundation)
+        self.audioSource = VoiceAudioSourceController {
+            AVAudioEngineVoiceAudioSource()
+        }
+        #endif
+        self.speech = speech
+        self.diagnostics = TapQDiagnosticEmitter(category: "AppleVoiceBackend",
+                                                 sink: diagnosticSink)
+    }
+
+    #if canImport(Speech) && canImport(AVFoundation)
+    /// Test seam: fakes exercise the session and turn lifecycle without touching Speech,
+    /// AVFAudio, or the synthesizer.
+    init(recognizer: any VoiceSpeechRecognizing,
+         makeAudioSource: @escaping @MainActor () -> any VoiceAudioSource,
+         speech: any SpeechPresenting,
+         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        self.recognizer = recognizer
+        self.audioSource = VoiceAudioSourceController(makeSource: makeAudioSource)
+        self.speech = speech
+        self.diagnostics = TapQDiagnosticEmitter(category: "AppleVoiceBackend",
+                                                 sink: diagnosticSink)
+    }
+    #endif
+
+    var turnStateForTesting: VoiceTurnStateMachine.State { turns.state }
+    var sessionGenerationForTesting: UInt64 { sessionGeneration }
+
+    #if canImport(Speech) && canImport(AVFoundation)
+    /// Test seam: `SFSpeechRecognitionResult` has no initializer a test can use, so the
+    /// recognition callback is driven directly — including with a deliberately stale
+    /// generation, which is the callback class this file most needs to prove it drops.
+    func deliverRecognitionForTesting(transcript: String? = nil, isFinal: Bool = false,
+                                      error: (any Error)? = nil,
+                                      generation: UInt64? = nil) {
+        handleRecognition(transcript: transcript, isFinal: isFinal, error: error,
+                          generation: generation ?? sessionGeneration)
+    }
+    #endif
+
+    public func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+        #if canImport(Speech) && canImport(AVFoundation)
+        do {
+            try turns.open()
+        } catch {
+            throw VoiceBackendFailure.protocolViolation(Self.describe(error))
+        }
+        guard recognizer.isAvailable else {
+            turns.close()
+            diagnostics.record("open.failed", level: .warning,
+                               fields: ["reason": "recognizer_unavailable"])
+            // Unavailability is almost always a permission or download state the user has
+            // to resolve; retrying the same session would spin.
+            throw VoiceBackendFailure.authorization(
+                "speech recognition is unavailable for \(VoiceListener.grammarLocale.identifier)")
+        }
+        sessionGeneration &+= 1
+        self.onEvent = onEvent
+        diagnostics.record("session.opened",
+                           fields: ["locale": VoiceListener.grammarLocale.identifier])
+        #else
+        _ = onEvent
+        throw VoiceBackendFailure.closed("speech recognition is unavailable on this platform")
+        #endif
+    }
+
+    public func close() {
+        teardown()
+        diagnostics.record("session.closed")
+    }
+
+    public func beginUserTurn() {
+        #if canImport(Speech) && canImport(AVFoundation)
+        do {
+            try turns.beginUserTurn()
+        } catch {
+            return violated(error)
+        }
+        let generation = sessionGeneration
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        if preferOnDevice, recognizer.supportsOnDeviceRecognition {
+            request.requiresOnDeviceRecognition = true
+        }
+        self.request = request
+
+        let audioResult = audioSource.start(
+            onBuffer: { buffer, _ in
+                request.append(buffer)
+            },
+            onInvalidation: { [weak self] failure in
+                self?.audioSourceInvalidated(failure, generation: generation)
+            }
+        )
+        switch audioResult {
+        case .started:
+            break
+        case .alreadyRunning:
+            return failSession(.network("a microphone window is already open"),
+                               generation: generation)
+        case .failed(let error):
+            return failSession(Self.failure(from: error), generation: generation)
+        }
+
+        guard sessionGeneration == generation else { return }
+
+        let recognitionTask = recognizer.recognitionTask(with: request) {
+            [weak self] result, error in
+            Task { @MainActor in
+                self?.handleRecognition(
+                    transcript: result?.bestTranscription.formattedString,
+                    isFinal: result?.isFinal ?? false,
+                    error: error,
+                    generation: generation
+                )
+            }
+        }
+        guard let recognitionTask else {
+            return failSession(.network("the speech recognizer returned no task"),
+                               generation: generation)
+        }
+        task = recognitionTask
+        diagnostics.record("turn.began")
+        #endif
+    }
+
+    public func endUserTurn() {
+        #if canImport(Speech) && canImport(AVFoundation)
+        do {
+            try turns.endUserTurn()
+        } catch {
+            return violated(error)
+        }
+        // The microphone closes the instant the turn commits; the recognition task stays
+        // alive just long enough to deliver the settled transcript for what it already heard.
+        audioSource.stop()
+        request?.endAudio()
+        diagnostics.record("turn.committed")
+        #endif
+    }
+
+    /// Accepted and discarded: this backend records its own microphone, so pushed audio has
+    /// no destination. The requirement exists for pipe-style backends that are handed bytes.
+    public func sendAudio(_ chunk: VoiceAudioChunk) {
+        diagnostics.record("audio.ignored",
+                           fields: ["reason": "backend_owns_microphone",
+                                    "bytes": "\(chunk.data.count)"])
+    }
+
+    public func requestResponse(text: String) {
+        do {
+            try turns.requestResponse()
+        } catch {
+            return violated(error)
+        }
+        let generation = sessionGeneration
+        diagnostics.record("response.requested", fields: ["length": "\(text.count)"])
+        speech.speak(text, priority: responsePriority) { [weak self] in
+            Task { @MainActor in
+                self?.responseFinished(generation: generation)
+            }
+        }
+    }
+
+    /// Always a violation here: `capabilities.supportsBargeIn` is false, and the contract
+    /// requires that be surfaced rather than swallowed, so no caller can believe a response
+    /// was abandoned when it was not.
+    public func cancelResponse() {
+        do {
+            try turns.cancelResponse()
+        } catch {
+            return violated(error)
+        }
+    }
+
+    #if canImport(Speech) && canImport(AVFoundation)
+    private func handleRecognition(transcript: String?, isFinal: Bool,
+                                   error: (any Error)?, generation: UInt64) {
+        guard sessionGeneration == generation, onEvent != nil else { return }
+
+        if let transcript, !transcript.isEmpty {
+            diagnostics.record("transcript.received", fields: ["final": "\(isFinal)"])
+            emit(isFinal ? .transcriptFinal(transcript) : .transcriptPartial(transcript))
+            // A consumer may resolve its window and close us from inside that event.
+            guard sessionGeneration == generation, onEvent != nil else { return }
+        }
+
+        if let error {
+            return failSession(.network("recognition failed: \(Self.describe(error))"),
+                               generation: generation)
+        }
+        guard isFinal else { return }
+
+        if turns.isUserTurnActive {
+            // The recognizer decided the utterance was over. Only TapQ decides that, so the
+            // transcript is forwarded above and the turn is left untouched.
+            diagnostics.record("transcript.final_during_turn",
+                               fields: ["reason": "recognizer_vad_ignored"])
+            return
+        }
+
+        do {
+            try turns.responseCompleted()
+        } catch {
+            return
+        }
+        finishTurnResources()
+        emit(.responseCompleted)
+    }
+
+    private func audioSourceInvalidated(_ failure: VoiceAudioSourceFailure,
+                                        generation: UInt64) {
+        guard sessionGeneration == generation, onEvent != nil else { return }
+        failSession(Self.failure(from: failure), generation: generation)
+    }
+
+    private func finishTurnResources() {
+        request?.endAudio()
+        task?.cancel()
+        request = nil
+        task = nil
+    }
+    #endif
+
+    private func responseFinished(generation: UInt64) {
+        guard sessionGeneration == generation, onEvent != nil else { return }
+        do {
+            try turns.responseCompleted()
+        } catch {
+            return
+        }
+        emit(.responseCompleted)
+    }
+
+    private func violated(_ error: any Error) {
+        failSession(.protocolViolation(Self.describe(error)), generation: sessionGeneration)
+    }
+
+    /// Ends the session and reports it. Teardown happens before the event is delivered, so
+    /// a consumer that reacts by opening a fresh session never races this one's cleanup.
+    private func failSession(_ failure: VoiceBackendFailure, generation: UInt64) {
+        guard sessionGeneration == generation else { return }
+        diagnostics.record("session.failed", level: .warning,
+                           fields: ["detail": failure.localizedDescription])
+        let callback = onEvent
+        turns.sessionFailed()
+        teardown(expectedGeneration: generation)
+        callback?(.sessionFailed(failure))
+    }
+
+    private func emit(_ event: VoiceBackendEvent) {
+        onEvent?(event)
+    }
+
+    private func teardown(expectedGeneration: UInt64? = nil) {
+        if let expectedGeneration, expectedGeneration != sessionGeneration { return }
+        sessionGeneration &+= 1
+        onEvent = nil
+        turns.close()
+        #if canImport(AVFoundation)
+        audioSource.stop()
+        #endif
+        #if canImport(Speech)
+        request?.endAudio()
+        task?.cancel()
+        request = nil
+        task = nil
+        #endif
+    }
+
+    private static func describe(_ error: any Error) -> String {
+        if let violation = error as? VoiceTurnViolation {
+            return violation.localizedDescription
+        }
+        if let failure = error as? VoiceBackendFailure {
+            return failure.localizedDescription
+        }
+        return String(describing: error)
+    }
+
+    #if canImport(AVFoundation)
+    private static func failure(from error: any Error) -> VoiceBackendFailure {
+        guard let failure = error as? VoiceAudioSourceFailure else {
+            return .network(String(describing: error))
+        }
+        return .network("\(failure.stage.rawValue): \(failure.detail)")
+    }
+    #endif
+}

--- a/Sources/TapQAppleAdapters/BackendAudioPlayback.swift
+++ b/Sources/TapQAppleAdapters/BackendAudioPlayback.swift
@@ -1,0 +1,351 @@
+import Foundation
+import TapQContracts
+#if canImport(AVFoundation)
+import AVFoundation
+import TapQAudioCaptureBridge
+#endif
+
+#if canImport(AVFoundation)
+/// Internal protocol wrapping the three ObjC bridge functions for the playback engine.
+///
+/// Production uses `LiveAudioPlaybackScheduler`, which calls through to the
+/// `TapQAudioPlaybackEngine*` ObjC boundary. Tests inject a `FakeScheduler` that records
+/// calls and fires completions synchronously on the main actor, so no test emits audible
+/// audio or touches real audio hardware.
+///
+/// The pattern mirrors `VoiceAudioSource` / `AVAudioEngineVoiceAudioSource`: the thin live
+/// layer is untested (one line per method); all behavioral logic lives in `BackendAudioPlayback`
+/// and is exercised through the fake.
+@MainActor protocol AudioPlaybackScheduling: AnyObject {
+    /// Starts the playback engine for the given PCM format.
+    /// Returns false and describes the failure in `detail` on error.
+    func start(sampleRate: Double, channels: Int) -> Result<Void, AudioPlaybackSchedulerFailure>
+
+    /// Schedules a buffer for playback with a completion handler.
+    ///
+    /// The scheduler is responsible for delivering the completion on the MainActor. In
+    /// production (`LiveAudioPlaybackScheduler`) this means hopping from AVAudioEngine's
+    /// internal thread via `Task { @MainActor }`. In tests (`FakeScheduler`) the completion
+    /// fires synchronously on the main actor, so the state machine can be driven without
+    /// async yields.
+    func schedule(_ buffer: AVAudioPCMBuffer, completion: @escaping @MainActor () -> Void) -> Result<Void, AudioPlaybackSchedulerFailure>
+
+    /// Stops and resets the engine. Best-effort and idempotent.
+    func stop() -> Result<Void, AudioPlaybackSchedulerFailure>
+}
+
+struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible {
+    enum Stage: String {
+        case playbackSetup = "playback_setup"
+        case playbackEngineStart = "playback_engine_start"
+        case playbackSchedule = "playback_schedule"
+        case playbackTeardown = "playback_teardown"
+    }
+
+    let stage: Stage
+    let detail: String
+
+    var description: String {
+        "\(stage.rawValue): \(detail)"
+    }
+}
+
+/// Production scheduler that calls through to the ObjC exception-boundary functions.
+@MainActor final class LiveAudioPlaybackScheduler: AudioPlaybackScheduling {
+    private var engine: TapQAudioPlaybackEngine?
+
+    func start(sampleRate: Double, channels: Int) -> Result<Void, AudioPlaybackSchedulerFailure> {
+        let playback = TapQAudioPlaybackEngine()
+        var error: NSError?
+        guard TapQAudioPlaybackEngineStart(playback, sampleRate, AVAudioChannelCount(channels), &error) else {
+            return .failure(Self.failure(from: error, defaultStage: .playbackEngineStart))
+        }
+        self.engine = playback
+        return .success(())
+    }
+
+    func schedule(_ buffer: AVAudioPCMBuffer, completion: @escaping @MainActor () -> Void) -> Result<Void, AudioPlaybackSchedulerFailure> {
+        guard let engine else {
+            return .failure(AudioPlaybackSchedulerFailure(
+                stage: .playbackSchedule,
+                detail: "engine not started"
+            ))
+        }
+        var error: NSError?
+        // The ObjC bridge fires the block on an internal AVAudioEngine thread. Hop to the
+        // MainActor here so BackendAudioPlayback never needs to think about threading.
+        guard TapQAudioPlaybackEngineSchedule(engine, buffer, {
+            Task { @MainActor in completion() }
+        }, &error) else {
+            return .failure(Self.failure(from: error, defaultStage: .playbackSchedule))
+        }
+        return .success(())
+    }
+
+    func stop() -> Result<Void, AudioPlaybackSchedulerFailure> {
+        guard let engine else { return .success(()) }
+        self.engine = nil
+        var error: NSError?
+        guard TapQAudioPlaybackEngineStop(engine, &error) else {
+            return .failure(Self.failure(from: error, defaultStage: .playbackTeardown))
+        }
+        return .success(())
+    }
+
+    private static func failure(from error: NSError?, defaultStage: AudioPlaybackSchedulerFailure.Stage) -> AudioPlaybackSchedulerFailure {
+        let stageName = error?.userInfo[TapQAudioPlaybackFailureStageKey] as? String
+        let stage = AudioPlaybackSchedulerFailure.Stage(rawValue: stageName ?? "")
+            ?? defaultStage
+        return AudioPlaybackSchedulerFailure(
+            stage: stage,
+            detail: error?.localizedDescription ?? "audio playback failed"
+        )
+    }
+}
+
+/// The macOS implementation of `VoiceResponseAudioPlaying`: converts backend PCM16 audio
+/// chunks into `AVAudioPCMBuffer`s and schedules them through an `AVAudioEngine` +
+/// `AVAudioPlayerNode`.
+///
+/// ## Lifecycle
+///
+/// The engine is lazily started on the first `enqueue` of a response and stopped when the
+/// response drains (no idle audio unit). Each response gets a fresh engine start — the cost
+/// is negligible compared to the audio latency budget, and it avoids holding an output device
+/// open between responses.
+///
+/// ## isPlaying invariant
+///
+/// `isPlaying` becomes `true` synchronously within the first `enqueue` call, before that
+/// call returns. The mic gate (`CombinedSpeechActivity` -> `SpeechGatedVoice`) reads
+/// `isPlaying` on every activity-change edge; making the flag rise inside `enqueue` closes
+/// the race window to zero.
+///
+/// ## Fail-open
+///
+/// Any start/schedule failure or engine configuration change: drop audio for the rest of
+/// the response, emit a `playback.unavailable` diagnostic, transition `isPlaying` -> `false`.
+/// Transcripts and the window are unaffected (the provider keeps consuming events;
+/// `CombinedSpeechActivity` just never sees busy). The next response attempts a fresh engine.
+///
+/// ## Generation-counted completions
+///
+/// Completions from `AVAudioPlayerNode` arrive on an internal queue. The Swift side hops to
+/// `@MainActor` and checks a generation counter before touching shared state. A `stopAndFlush`
+/// bumps the generation, so completions from flushed buffers are silently ignored — they
+/// never produce a spurious `isPlaying` edge.
+@MainActor public final class BackendAudioPlayback: VoiceResponseAudioPlaying {
+    private let scheduler: AudioPlaybackScheduling
+    private let diagnostics: TapQDiagnosticEmitter
+
+    /// Number of scheduled buffers whose completion has not yet fired.
+    private var outstandingBuffers: Int = 0
+    /// True after `finishStream()` has been called for the current response.
+    private var streamFinished = false
+    /// Bumped on every `stopAndFlush` and on each fresh response start; completions from
+    /// a prior generation are silently dropped.
+    private var generation: UInt64 = 0
+    /// True when the engine is running for the current response.
+    private var engineRunning = false
+    /// True when the current response has encountered a failure and all subsequent chunks
+    /// should be dropped (fail-open: the response is silent, the window proceeds).
+    private var failedForCurrentResponse = false
+
+    public private(set) var isPlaying: Bool = false
+    public var onPlayingChange: (@MainActor (Bool) -> Void)?
+
+    /// Production initializer: uses the live ObjC bridge through `LiveAudioPlaybackScheduler`.
+    public init(diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        self.scheduler = LiveAudioPlaybackScheduler()
+        self.diagnostics = TapQDiagnosticEmitter(category: "Playback", sink: diagnosticSink)
+    }
+
+    /// Test seam: injects a fake scheduler so tests exercise the full state machine without
+    /// touching audio hardware.
+    init(scheduler: AudioPlaybackScheduling,
+         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        self.scheduler = scheduler
+        self.diagnostics = TapQDiagnosticEmitter(category: "Playback", sink: diagnosticSink)
+    }
+
+    // MARK: - VoiceResponseAudioPlaying
+
+    public func enqueue(_ chunk: VoiceAudioChunk) {
+        guard !failedForCurrentResponse else { return }
+
+        // Synchronous isPlaying invariant: rise BEFORE any audio reaches the hardware.
+        if !isPlaying {
+            // New response starting.
+            streamFinished = false
+            setPlaying(true)
+        }
+
+        // Lazily start the engine on the first chunk.
+        if !engineRunning {
+            let result = startEngine(for: chunk)
+            guard case .success = result else {
+                enterFailedState()
+                return
+            }
+        }
+
+        // Convert PCM16 data to an AVAudioPCMBuffer.
+        guard let buffer = makeBuffer(from: chunk) else {
+            diagnostics.record("playback.buffer_conversion_failed", level: .warning,
+                               fields: ["dataSize": "\(chunk.data.count)",
+                                         "sampleRate": "\(chunk.format.sampleRate)",
+                                         "channels": "\(chunk.format.channels)"])
+            // A single bad buffer does not fail the whole response; just skip it.
+            return
+        }
+
+        // Schedule the buffer with a generation-guarded completion.
+        let gen = generation
+        outstandingBuffers += 1
+
+        let result = scheduler.schedule(buffer) { [weak self] in
+            // The scheduler delivers this on the MainActor (production: Task hop in
+            // LiveAudioPlaybackScheduler; tests: synchronous call from FakeScheduler).
+            self?.bufferCompleted(generation: gen)
+        }
+
+        if case .failure(let failure) = result {
+            outstandingBuffers -= 1
+            diagnostics.record("playback.schedule_failed", level: .warning,
+                               fields: ["error": failure.description])
+            enterFailedState()
+        }
+    }
+
+    public func finishStream() {
+        streamFinished = true
+        checkDrain()
+    }
+
+    public func stopAndFlush() {
+        generation &+= 1
+        outstandingBuffers = 0
+        streamFinished = false
+        failedForCurrentResponse = false
+
+        if engineRunning {
+            let result = scheduler.stop()
+            if case .failure(let failure) = result {
+                diagnostics.record("playback.stop_failed", level: .warning,
+                                   fields: ["error": failure.description])
+            }
+            engineRunning = false
+        }
+
+        // Exactly one falling edge, or none if already idle.
+        setPlaying(false)
+    }
+
+    // MARK: - Engine lifecycle
+
+    private func startEngine(for chunk: VoiceAudioChunk) -> Result<Void, AudioPlaybackSchedulerFailure> {
+        let result = scheduler.start(
+            sampleRate: chunk.format.sampleRate,
+            channels: chunk.format.channels
+        )
+        switch result {
+        case .success:
+            engineRunning = true
+            diagnostics.record("playback.engine_started",
+                               fields: ["sampleRate": "\(chunk.format.sampleRate)",
+                                         "channels": "\(chunk.format.channels)"])
+        case .failure(let failure):
+            diagnostics.record("playback.engine_start_failed", level: .warning,
+                               fields: ["error": failure.description])
+        }
+        return result
+    }
+
+    // MARK: - Buffer completion
+
+    private func bufferCompleted(generation gen: UInt64) {
+        guard gen == generation else { return }
+        guard outstandingBuffers > 0 else { return }
+        outstandingBuffers -= 1
+        checkDrain()
+    }
+
+    /// Transitions to idle if the stream is finished and all buffers have drained.
+    private func checkDrain() {
+        guard streamFinished, outstandingBuffers == 0 else { return }
+        // Response fully drained: stop the engine (no idle audio unit).
+        if engineRunning {
+            let result = scheduler.stop()
+            if case .failure(let failure) = result {
+                diagnostics.record("playback.stop_failed", level: .warning,
+                                   fields: ["error": failure.description])
+            }
+            engineRunning = false
+        }
+        setPlaying(false)
+    }
+
+    // MARK: - Fail-open
+
+    /// Enters the failed state for the current response: drops all future audio for this
+    /// response, stops the engine, and transitions to idle.
+    private func enterFailedState() {
+        failedForCurrentResponse = true
+        outstandingBuffers = 0
+        diagnostics.record("playback.unavailable", level: .warning)
+        if engineRunning {
+            _ = scheduler.stop()
+            engineRunning = false
+        }
+        setPlaying(false)
+    }
+
+    // MARK: - Activity transitions
+
+    private func setPlaying(_ value: Bool) {
+        guard value != isPlaying else { return }
+        isPlaying = value
+        onPlayingChange?(value)
+    }
+
+    // MARK: - PCM16 -> AVAudioPCMBuffer conversion
+
+    /// Converts a `VoiceAudioChunk` (PCM16 data) into an `AVAudioPCMBuffer` in int16 format.
+    ///
+    /// The engine's mixer will resample if the chunk's sample rate differs from the output
+    /// device rate. We create the buffer in the same format as the engine was started with
+    /// (int16, matching the chunk's declared rate and channels), so no Swift-side resampling
+    /// is needed.
+    private func makeBuffer(from chunk: VoiceAudioChunk) -> AVAudioPCMBuffer? {
+        guard chunk.format.pcm16 else { return nil }
+        let channels = AVAudioChannelCount(chunk.format.channels)
+        let bytesPerSample = MemoryLayout<Int16>.size
+        let bytesPerFrame = Int(channels) * bytesPerSample
+        guard bytesPerFrame > 0 else { return nil }
+        let frameCount = chunk.data.count / bytesPerFrame
+        guard frameCount > 0 else { return nil }
+
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: chunk.format.sampleRate,
+            channels: channels,
+            interleaved: true
+        ) else { return nil }
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount)) else {
+            return nil
+        }
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+
+        // Copy PCM16 bytes directly into the buffer's int16 channel data.
+        guard let int16Ptr = buffer.int16ChannelData else { return nil }
+        let destCount = frameCount * Int(channels)
+        chunk.data.withUnsafeBytes { rawPtr in
+            guard let src = rawPtr.baseAddress?.assumingMemoryBound(to: Int16.self) else { return }
+            int16Ptr[0].update(from: src, count: destCount)
+        }
+
+        return buffer
+    }
+}
+#endif

--- a/Sources/TapQAppleAdapters/BackendAudioPlayback.swift
+++ b/Sources/TapQAppleAdapters/BackendAudioPlayback.swift
@@ -264,6 +264,11 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
     }
 
     public func finishStream() {
+        // A finished stream ends the current response. Clear the per-response
+        // failure flag so the *next* response can attempt a fresh engine. After
+        // enterFailedState(), outstandingBuffers is 0 and the engine is already
+        // stopped, so checkDrain is a no-op and the reset is safe.
+        failedForCurrentResponse = false
         streamFinished = true
         checkDrain()
     }

--- a/Sources/TapQAppleAdapters/BackendAudioPlayback.swift
+++ b/Sources/TapQAppleAdapters/BackendAudioPlayback.swift
@@ -32,6 +32,12 @@ import TapQAudioCaptureBridge
 
     /// Stops and resets the engine. Best-effort and idempotent.
     func stop() -> Result<Void, AudioPlaybackSchedulerFailure>
+
+    /// Called when the engine reports `AVAudioEngineConfigurationChange` (e.g. output route
+    /// change). The scheduler observes the notification on the engine it owns and fires this
+    /// callback on the MainActor. The callback is set by `BackendAudioPlayback` after
+    /// `start` succeeds and cleared on `stop`.
+    var onConfigurationChange: (@MainActor () -> Void)? { get set }
 }
 
 struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible {
@@ -53,6 +59,10 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
 /// Production scheduler that calls through to the ObjC exception-boundary functions.
 @MainActor final class LiveAudioPlaybackScheduler: AudioPlaybackScheduling {
     private var engine: TapQAudioPlaybackEngine?
+    private var configurationObserver: NSObjectProtocol?
+    private var observerGeneration: UInt64 = 0
+
+    var onConfigurationChange: (@MainActor () -> Void)?
 
     func start(sampleRate: Double, channels: Int) -> Result<Void, AudioPlaybackSchedulerFailure> {
         let playback = TapQAudioPlaybackEngine()
@@ -61,6 +71,7 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
             return .failure(Self.failure(from: error, defaultStage: .playbackEngineStart))
         }
         self.engine = playback
+        observeConfigurationChanges(for: playback)
         return .success(())
     }
 
@@ -83,6 +94,7 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
     }
 
     func stop() -> Result<Void, AudioPlaybackSchedulerFailure> {
+        removeConfigurationObserver()
         guard let engine else { return .success(()) }
         self.engine = nil
         var error: NSError?
@@ -90,6 +102,40 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
             return .failure(Self.failure(from: error, defaultStage: .playbackTeardown))
         }
         return .success(())
+    }
+
+    // MARK: - Configuration change observation
+
+    /// Observes `AVAudioEngineConfigurationChange` on the playback engine, generation-
+    /// guarded so a stale notification after `stop()` is silently dropped. Copied from the
+    /// capture-side pattern in `AVAudioEngineVoiceAudioSource.observeConfigurationChanges`
+    /// including the yield-before-teardown note.
+    private func observeConfigurationChanges(for playback: TapQAudioPlaybackEngine) {
+        observerGeneration &+= 1
+        let generation = observerGeneration
+        configurationObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: playback.engine,
+            queue: .main
+        ) { [weak self] _ in
+            // Apple warns against releasing the engine from inside its configuration
+            // notification. Yield first, then let BackendAudioPlayback fail open.
+            Task { @MainActor [weak self] in
+                await Task.yield()
+                guard let self,
+                      self.observerGeneration == generation,
+                      self.engine != nil else { return }
+                self.onConfigurationChange?()
+            }
+        }
+    }
+
+    private func removeConfigurationObserver() {
+        observerGeneration &+= 1
+        if let configurationObserver {
+            NotificationCenter.default.removeObserver(configurationObserver)
+            self.configurationObserver = nil
+        }
     }
 
     private static func failure(from error: NSError?, defaultStage: AudioPlaybackSchedulerFailure.Stage) -> AudioPlaybackSchedulerFailure {
@@ -227,6 +273,7 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
         outstandingBuffers = 0
         streamFinished = false
         failedForCurrentResponse = false
+        scheduler.onConfigurationChange = nil
 
         if engineRunning {
             let result = scheduler.stop()
@@ -244,6 +291,12 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
     // MARK: - Engine lifecycle
 
     private func startEngine(for chunk: VoiceAudioChunk) -> Result<Void, AudioPlaybackSchedulerFailure> {
+        let gen = generation
+        scheduler.onConfigurationChange = { [weak self] in
+            guard let self, self.generation == gen, self.engineRunning else { return }
+            self.diagnostics.record("playback.configuration_changed", level: .warning)
+            self.enterFailedState()
+        }
         let result = scheduler.start(
             sampleRate: chunk.format.sampleRate,
             channels: chunk.format.channels
@@ -255,6 +308,7 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
                                fields: ["sampleRate": "\(chunk.format.sampleRate)",
                                          "channels": "\(chunk.format.channels)"])
         case .failure(let failure):
+            scheduler.onConfigurationChange = nil
             diagnostics.record("playback.engine_start_failed", level: .warning,
                                fields: ["error": failure.description])
         }
@@ -274,6 +328,7 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
     private func checkDrain() {
         guard streamFinished, outstandingBuffers == 0 else { return }
         // Response fully drained: stop the engine (no idle audio unit).
+        scheduler.onConfigurationChange = nil
         if engineRunning {
             let result = scheduler.stop()
             if case .failure(let failure) = result {
@@ -292,6 +347,7 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
     private func enterFailedState() {
         failedForCurrentResponse = true
         outstandingBuffers = 0
+        scheduler.onConfigurationChange = nil
         diagnostics.record("playback.unavailable", level: .warning)
         if engineRunning {
             _ = scheduler.stop()

--- a/Sources/TapQAppleAdapters/HeadGestureDetector.swift
+++ b/Sources/TapQAppleAdapters/HeadGestureDetector.swift
@@ -2,6 +2,15 @@ import Foundation
 import TapQContracts
 import TapQDetectionBaseline
 
+/// A secondary consumer of the motion sample stream inside `HeadGestureDetector`.
+/// The observer receives every sample after recovery handling and before pipeline
+/// dispatch, and is notified on stream interruptions (teardown, motion loss, session
+/// reset). When no observer is attached, the detector's behavior is unchanged.
+@MainActor public protocol MotionSampleObserving: AnyObject {
+    func ingest(_ sample: HeadMotionSample)
+    func streamInterrupted()
+}
+
 /// Adapts the Apple headphone motion source to the portable `MotionGesturePipeline`.
 /// One subscription feeds gestures, taps, and tilts so competing CoreMotion managers
 /// never contend for the same headphones.
@@ -45,6 +54,12 @@ import TapQDetectionBaseline
     /// Fired once per contiguous motion outage. A later valid sample rearms the callback
     /// so a genuinely new outage is reported as well.
     public var onMotionLost: (@MainActor () -> Void)?
+
+    /// A secondary consumer of the raw motion sample stream (e.g. wearer-speech
+    /// detection). Receives samples after recovery handling, before pipeline dispatch.
+    /// Notified of stream interruptions on teardown, session reset, and confirmed motion
+    /// loss. Setting `nil` detaches the observer with zero behavior change.
+    private weak var motionSampleObserver: (any MotionSampleObserving)?
 
     /// How a configured TapQ-1 encoder backend participates. `.off` until
     /// `configureEncoder` succeeds; the heuristic pipeline always keeps running so a
@@ -119,6 +134,13 @@ import TapQDetectionBaseline
         encoderPipeline = mode == .off ? nil : EncoderMotionPipeline(
             scorer: scorer, config: config, diagnosticSink: diagnosticSink)
         diagnostics.record("encoder.configured", fields: ["mode": mode.rawValue])
+    }
+
+    /// Attaches a secondary consumer of the raw motion sample stream. The observer
+    /// receives every sample the gesture pipeline ingests and is notified of stream
+    /// interruptions. Pass `nil` to detach. The observer is held weakly.
+    public func setMotionSampleObserver(_ observer: (any MotionSampleObserving)?) {
+        motionSampleObserver = observer
     }
 
     public convenience init(config: HeadGestureConfig = .init(),
@@ -315,6 +337,7 @@ import TapQDetectionBaseline
         firstSampleStartedAt = nil
         if motionUpdatesActive { source.stopUpdates() }
         motionUpdatesActive = false
+        motionSampleObserver?.streamInterrupted()
         onGesture = nil
         onTap = nil
         onTilt = nil
@@ -332,6 +355,7 @@ import TapQDetectionBaseline
         subscriptionEpoch &+= 1
         awaitingFirstSampleEpoch = nil
         firstSampleStartedAt = nil
+        motionSampleObserver?.streamInterrupted()
         pipeline.reset()
         encoderPipeline?.reset()
         motionLossSignaled = false
@@ -348,6 +372,7 @@ import TapQDetectionBaseline
 
     private func ingest(_ sample: HeadMotionSample) {
         handleMotionRecoveryIfNeeded()
+        motionSampleObserver?.ingest(sample)
         // Heuristics run in every mode: they are the fallback and, in primary mode,
         // the comparison shadow — the cost is trivial next to a model inference.
         let heuristic = pipeline.ingest(sample)
@@ -508,6 +533,7 @@ import TapQDetectionBaseline
         firstSampleStartedAt = nil
         guard running, !motionLossSignaled else { return }
         motionLossSignaled = true
+        motionSampleObserver?.streamInterrupted()
         diagnostics.record(
             "motion.lost",
             level: .error,

--- a/Sources/TapQAppleAdapters/MicrophoneEnvelopeSource.swift
+++ b/Sources/TapQAppleAdapters/MicrophoneEnvelopeSource.swift
@@ -1,0 +1,294 @@
+import Foundation
+import TapQContracts
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+#if canImport(Darwin)
+import Darwin
+#endif
+
+#if canImport(AVFoundation)
+/// Converts audio host times to the seconds-since-boot clock CoreMotion stamps head
+/// motion with. Both clocks derive from `mach_absolute_time`, so one anchor pair captured
+/// at the start of a recording — the host tick and the uptime read back to back — pins
+/// them together for the whole session.
+///
+/// Pure and constant-injected on purpose: clock alignment is the failure mode that makes
+/// a capture study quietly worthless, so it must be checkable without audio hardware.
+public struct AudioClockAnchor: Equatable, Sendable {
+    public let hostTime: UInt64
+    public let uptime: TimeInterval
+    public let timebaseNumerator: UInt32
+    public let timebaseDenominator: UInt32
+
+    public init(
+        hostTime: UInt64,
+        uptime: TimeInterval,
+        timebaseNumerator: UInt32,
+        timebaseDenominator: UInt32
+    ) {
+        self.hostTime = hostTime
+        self.uptime = uptime
+        self.timebaseNumerator = timebaseNumerator
+        self.timebaseDenominator = max(timebaseDenominator, 1)
+    }
+
+    /// Reads the current host tick, uptime, and timebase as one anchor.
+    public static func current() -> AudioClockAnchor {
+        var timebase = mach_timebase_info_data_t()
+        mach_timebase_info(&timebase)
+        // Host tick first: the pair is read back to back, and the residual skew between
+        // the two reads is smaller than one audio block either way.
+        let hostTime = mach_absolute_time()
+        let uptime = ProcessInfo.processInfo.systemUptime
+        return AudioClockAnchor(
+            hostTime: hostTime,
+            uptime: uptime,
+            timebaseNumerator: timebase.numer == 0 ? 1 : timebase.numer,
+            timebaseDenominator: timebase.denom == 0 ? 1 : timebase.denom
+        )
+    }
+
+    /// Host ticks before the anchor are legitimate — a block can be timestamped at the
+    /// moment its first frame was sampled, slightly ahead of the anchor read — so the
+    /// difference is taken in signed arithmetic rather than on `UInt64`.
+    public func uptime(forHostTime hostTime: UInt64) -> TimeInterval {
+        let ticks = Double(hostTime) - Double(self.hostTime)
+        let nanoseconds = ticks * Double(timebaseNumerator) / Double(timebaseDenominator)
+        return uptime + nanoseconds / 1_000_000_000
+    }
+}
+
+/// The hardware input format, learned from the first block the tap delivers rather than
+/// asked of the engine: the tap installs with a nil format and follows the live route, so
+/// the block itself is the only honest description of what is being recorded.
+public struct MicrophoneEnvelopeTrack: Equatable, Sendable {
+    public let sampleRate: Double
+    public let blockFrames: Int
+}
+
+/// One audio block's loudness, already on the motion clock. No audio is retained.
+public struct MicrophoneEnvelopeBlock: Equatable, Sendable {
+    public let timestamp: TimeInterval
+    public let rms: Double
+    public let peak: Double
+}
+
+public struct MicrophoneEnvelopeFailure: Error, Equatable, CustomStringConvertible {
+    public enum Stage: String, Sendable {
+        case inputFormat = "input_format"
+        case audioSetup = "audio_setup"
+        case engineStart = "engine_start"
+        case audioTeardown = "audio_teardown"
+        case configurationChanged = "configuration_changed"
+        case alreadyRunning = "already_running"
+    }
+
+    public let stage: Stage
+    public let detail: String
+
+    public var description: String {
+        "\(stage.rawValue): \(detail)"
+    }
+}
+
+/// Microphone arm of the capture study: opens one input window and reduces every audio
+/// block to an RMS/peak pair stamped on the motion stream's clock.
+///
+/// It reuses `VoiceAudioSourceController` rather than opening a second `AVAudioEngine`
+/// path, so route-change invalidation, NSException conversion, and generation-counted
+/// teardown all behave exactly as they do for a voice window.
+///
+/// Blocks cross from the realtime audio thread to the main actor through one buffering
+/// `AsyncStream`. A `Task { @MainActor }` per block would be simpler and wrong: task
+/// scheduling makes no ordering promise, and an envelope delivered out of order is worse
+/// than no envelope at all. The reduction to two doubles happens inside the tap so
+/// nothing is allocated or retained on the audio thread.
+@MainActor public final class MicrophoneEnvelopeSource {
+    private let controller: VoiceAudioSourceController
+    private let anchorProvider: @Sendable () -> AudioClockAnchor
+    private let diagnostics: TapQDiagnosticEmitter
+
+    private var continuation: AsyncStream<RawBlock>.Continuation?
+    private var consumer: Task<Void, Never>?
+    private var running = false
+    /// Invalidates blocks and route callbacks left over from an earlier window.
+    private var sessionGeneration: UInt64 = 0
+
+    private struct RawBlock: Sendable {
+        let hostTime: UInt64
+        let sampleRate: Double
+        let frames: Int
+        let rms: Double
+        let peak: Double
+    }
+
+    public init(diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        let diagnostics = TapQDiagnosticEmitter(
+            category: "MicEnvelope", sink: diagnosticSink)
+        self.diagnostics = diagnostics
+        self.anchorProvider = { AudioClockAnchor.current() }
+        self.controller = VoiceAudioSourceController {
+            let source = AVAudioEngineVoiceAudioSource()
+            // Teardown errors are dropped on the voice path, where the window is over
+            // regardless. A study session wants them: a failed engine stop is the first
+            // sign that the next recording will start on a wedged route.
+            source.onTeardownFailure = { failure in
+                diagnostics.record(
+                    "capture.teardown_failed",
+                    level: .warning,
+                    fields: ["stage": failure.stage.rawValue, "error": failure.detail]
+                )
+            }
+            return source
+        }
+    }
+
+    /// Test seam: fakes exercise the envelope pipeline without touching audio hardware.
+    init(
+        makeAudioSource: @escaping @MainActor () -> any VoiceAudioSource,
+        anchorProvider: @escaping @Sendable () -> AudioClockAnchor,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.controller = VoiceAudioSourceController(makeSource: makeAudioSource)
+        self.anchorProvider = anchorProvider
+        self.diagnostics = TapQDiagnosticEmitter(
+            category: "MicEnvelope", sink: diagnosticSink)
+    }
+
+    public var isRunning: Bool { running }
+
+    /// Opens the microphone. `onTrack` fires once, with the first block, before any
+    /// `onBlock`. Throws `MicrophoneEnvelopeFailure` if the input never opened.
+    public func start(
+        onTrack: @escaping @MainActor (MicrophoneEnvelopeTrack) -> Void,
+        onBlock: @escaping @MainActor (MicrophoneEnvelopeBlock) -> Void,
+        onInvalidation: @escaping @MainActor (MicrophoneEnvelopeFailure) -> Void
+    ) throws {
+        guard !running else {
+            throw MicrophoneEnvelopeFailure(
+                stage: .alreadyRunning, detail: "an envelope capture is already open")
+        }
+
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
+        let anchor = anchorProvider()
+        let (stream, continuation) = AsyncStream<RawBlock>.makeStream(
+            bufferingPolicy: .unbounded)
+        self.continuation = continuation
+
+        let result = controller.start(
+            onBuffer: { buffer, time in
+                guard let envelope = Self.envelope(of: buffer) else { return }
+                let hostTime = time.isHostTimeValid ? time.hostTime : mach_absolute_time()
+                continuation.yield(RawBlock(
+                    hostTime: hostTime,
+                    sampleRate: buffer.format.sampleRate,
+                    frames: Int(buffer.frameLength),
+                    rms: envelope.rms,
+                    peak: envelope.peak
+                ))
+            },
+            onInvalidation: { [weak self] failure in
+                self?.invalidated(failure, generation: generation, handler: onInvalidation)
+            }
+        )
+
+        switch result {
+        case .started:
+            break
+        case .alreadyRunning:
+            teardown(expectedGeneration: generation)
+            throw MicrophoneEnvelopeFailure(
+                stage: .alreadyRunning, detail: "the audio source is already open")
+        case .failed(let error):
+            teardown(expectedGeneration: generation)
+            throw Self.failure(from: error)
+        }
+
+        running = true
+        consumer = Task { @MainActor [weak self] in
+            var reportedTrack = false
+            for await block in stream {
+                guard let self, self.sessionGeneration == generation else { return }
+                if !reportedTrack {
+                    reportedTrack = true
+                    onTrack(MicrophoneEnvelopeTrack(
+                        sampleRate: block.sampleRate, blockFrames: block.frames))
+                }
+                onBlock(MicrophoneEnvelopeBlock(
+                    timestamp: anchor.uptime(forHostTime: block.hostTime),
+                    rms: block.rms,
+                    peak: block.peak
+                ))
+            }
+        }
+        diagnostics.record("capture.started")
+    }
+
+    public func stop() {
+        guard running else { return }
+        teardown(expectedGeneration: sessionGeneration)
+    }
+
+    /// Sum-of-squares and peak over every channel of one block. Returns nil for a format
+    /// the tap cannot reduce (non-float or empty), which the caller drops silently rather
+    /// than guessing a loudness for.
+    static func envelope(of buffer: AVAudioPCMBuffer) -> (rms: Double, peak: Double)? {
+        let frames = Int(buffer.frameLength)
+        let channels = Int(buffer.format.channelCount)
+        guard let data = buffer.floatChannelData, frames > 0, channels > 0 else {
+            return nil
+        }
+        let stride = buffer.stride
+        var sumOfSquares = 0.0
+        var peak = 0.0
+        for channel in 0..<channels {
+            let samples = data[channel]
+            for frame in 0..<frames {
+                let value = Double(samples[frame * stride])
+                sumOfSquares += value * value
+                peak = max(peak, abs(value))
+            }
+        }
+        return ((sumOfSquares / Double(frames * channels)).squareRoot(), peak)
+    }
+
+    private func invalidated(
+        _ failure: VoiceAudioSourceFailure,
+        generation: UInt64,
+        handler: @MainActor (MicrophoneEnvelopeFailure) -> Void
+    ) {
+        guard running, sessionGeneration == generation else { return }
+        let mapped = Self.failure(from: failure)
+        diagnostics.record(
+            "capture.invalidated",
+            level: .warning,
+            fields: ["stage": mapped.stage.rawValue, "error": mapped.detail]
+        )
+        teardown(expectedGeneration: generation)
+        handler(mapped)
+    }
+
+    private func teardown(expectedGeneration: UInt64) {
+        guard expectedGeneration == sessionGeneration else { return }
+        sessionGeneration &+= 1
+        running = false
+        continuation?.finish()
+        continuation = nil
+        consumer?.cancel()
+        consumer = nil
+        controller.stop()
+    }
+
+    private static func failure(from error: any Error) -> MicrophoneEnvelopeFailure {
+        guard let failure = error as? VoiceAudioSourceFailure else {
+            return MicrophoneEnvelopeFailure(
+                stage: .audioSetup, detail: String(describing: error))
+        }
+        let stage = MicrophoneEnvelopeFailure.Stage(rawValue: failure.stage.rawValue)
+            ?? .audioSetup
+        return MicrophoneEnvelopeFailure(stage: stage, detail: failure.detail)
+    }
+}
+#endif

--- a/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
@@ -235,7 +235,17 @@ import AVFoundation
                 ) else { return }
 
                 var error: NSError?
+                // One-shot: AVAudioConverter may call the input block more than
+                // once per convert() call (SRC priming pulls twice on the first
+                // buffer after converter creation). Returning .haveData every
+                // time duplicates the tap buffer into the output stream.
+                var inputConsumed = false
                 let status = converter.convert(to: outputBuffer, error: &error) { _, status in
+                    if inputConsumed {
+                        status.pointee = .noDataNow
+                        return nil
+                    }
+                    inputConsumed = true
                     status.pointee = .haveData
                     return buffer
                 }

--- a/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
@@ -130,12 +130,13 @@ import AVFoundation
         openMicrophone()
     }
 
-    public func endUserTurn() {
+    @discardableResult
+    public func endUserTurn(expectingResponse: Bool) -> Bool {
         // The mic closes before the inner commit, matching AppleVoiceBackend ordering:
         // hardware is silenced before the transcript is finalized.
         stopMicrophone()
         turnActive = false
-        inner.endUserTurn()
+        return inner.endUserTurn(expectingResponse: expectingResponse)
     }
 
     public func sendAudio(_ chunk: VoiceAudioChunk) {

--- a/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
@@ -1,0 +1,362 @@
+import Foundation
+import TapQContracts
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+
+#if canImport(AVFoundation)
+/// A `VoiceBackend` wrapper that owns the microphone for a pipe backend.
+///
+/// The gap this fills: `OpenAIRealtimeVoiceBackend` is a pure pipe — it has no mic of its
+/// own, and nothing in the M1 composition called `sendAudio`. Consequently, a user turn
+/// opened on the OpenAI path produced zero audio and no transcript could ever arrive.
+///
+/// The pump opens the microphone on `beginUserTurn`, converts buffers from the hardware's
+/// native format (typically 48 kHz float stereo) to the pipe's wire format (24 kHz PCM16
+/// mono by default), and streams them through `inner.sendAudio`. The mic closes on
+/// `endUserTurn`, before the inner commit — matching `AppleVoiceBackend.swift:195-207`
+/// ordering, where the hardware is silenced before the transcript is finalized.
+///
+/// Route-change invalidation mid-turn closes the mic and relays a synthetic session failure
+/// through the pump's own event path, so `FailThroughVoiceBackend` fails over to Apple
+/// exactly as for any network death.
+///
+/// Audio crosses from the realtime tap thread to the main actor through one ordered
+/// buffering `AsyncStream` — the pattern `MicrophoneEnvelopeSource` already proves safe.
+/// A `Task { @MainActor }` per buffer would be simpler and wrong: task scheduling makes
+/// no ordering promise, and interleaved audio is worse than no audio.
+///
+/// Two invariants:
+///
+/// - **The microphone opens in `beginUserTurn` and closes in `endUserTurn`**, never in
+///   `open`. A session can sit open between windows without the mic being live — the
+///   "never always-on" guarantee.
+/// - **The pump never ends a turn.** It delivers audio; only TapQ decides when the turn
+///   is over.
+@MainActor public final class MicrophonePumpVoiceBackend: VoiceBackend {
+    public var capabilities: VoiceBackendCapabilities { inner.capabilities }
+
+    private let inner: any VoiceBackend
+    private let wireFormat: VoiceAudioFormat
+    private let makeAudioSource: @MainActor () -> any VoiceAudioSource
+    private let diagnostics: TapQDiagnosticEmitter
+
+    private var audioController: VoiceAudioSourceController?
+    private var callerOnEvent: (@MainActor (VoiceBackendEvent) -> Void)?
+
+    private var continuation: AsyncStream<RawAudioBlock>.Continuation?
+    private var consumer: Task<Void, Never>?
+
+    /// Invalidates stale tap-thread blocks and route callbacks from a prior turn.
+    private var turnGeneration: UInt64 = 0
+    /// Guards the session-level relay: events from the inner backend are valid only while
+    /// the session identity matches.
+    private var sessionGeneration: UInt64 = 0
+    private var turnActive = false
+
+    /// Per-buffer RMS, computed on the tap thread where the samples are already hot.
+    /// Inert hook for a possible acoustic-silence endpoint fallback; costs a few lines now,
+    /// avoids reopening the realtime-thread code later.
+    public var onInputLevel: ((Double) -> Void)?
+
+    /// Audio block reduced on the tap thread: raw PCM bytes already converted, plus the
+    /// RMS for the input-level hook.
+    private struct RawAudioBlock: Sendable {
+        let data: Data
+        let timestamp: TimeInterval
+        let rms: Double
+    }
+
+    /// - Parameters:
+    ///   - inner: the pipe backend (e.g. `OpenAIRealtimeVoiceBackend`) that receives audio.
+    ///   - format: the wire format the inner backend speaks. Default `.pcm16Mono24k`.
+    ///   - makeAudioSource: factory for the microphone source. Production: `AVAudioEngineVoiceAudioSource`.
+    ///   - diagnosticSink: the runtime's shared diagnostic sink.
+    public init(
+        inner: any VoiceBackend,
+        format: VoiceAudioFormat = .pcm16Mono24k,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.inner = inner
+        self.wireFormat = format
+        self.makeAudioSource = { AVAudioEngineVoiceAudioSource() }
+        self.diagnostics = TapQDiagnosticEmitter(category: "MicPump", sink: diagnosticSink)
+    }
+
+    /// Test seam: fakes exercise the pump pipeline without touching audio hardware.
+    init(
+        inner: any VoiceBackend,
+        format: VoiceAudioFormat = .pcm16Mono24k,
+        makeAudioSource: @escaping @MainActor () -> any VoiceAudioSource,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.inner = inner
+        self.wireFormat = format
+        self.makeAudioSource = makeAudioSource
+        self.diagnostics = TapQDiagnosticEmitter(category: "MicPump", sink: diagnosticSink)
+    }
+
+    var isTurnActiveForTesting: Bool { turnActive }
+
+    // MARK: - VoiceBackend forwarding
+
+    public func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+        sessionGeneration &+= 1
+        let sessGen = sessionGeneration
+        callerOnEvent = onEvent
+        try await inner.open { [weak self] event in
+            self?.relayEvent(event, sessionGeneration: sessGen)
+        }
+    }
+
+    public func close() {
+        stopMicrophone()
+        sessionGeneration &+= 1
+        callerOnEvent = nil
+        inner.close()
+    }
+
+    public func beginUserTurn() {
+        inner.beginUserTurn()
+        turnActive = true
+        openMicrophone()
+    }
+
+    public func endUserTurn() {
+        // The mic closes before the inner commit, matching AppleVoiceBackend ordering:
+        // hardware is silenced before the transcript is finalized.
+        stopMicrophone()
+        turnActive = false
+        inner.endUserTurn()
+    }
+
+    public func sendAudio(_ chunk: VoiceAudioChunk) {
+        // The pump owns the mic for this backend; externally pushed audio is unexpected but
+        // forwarded to the inner backend in case a composition above also feeds audio.
+        inner.sendAudio(chunk)
+    }
+
+    public func requestResponse(text: String) {
+        inner.requestResponse(text: text)
+    }
+
+    public func cancelResponse() {
+        inner.cancelResponse()
+    }
+
+    // MARK: - Event relay
+
+    private func relayEvent(_ event: VoiceBackendEvent, sessionGeneration sessGen: UInt64) {
+        guard self.sessionGeneration == sessGen else { return }
+        if case .sessionFailed = event {
+            // The inner backend died: stop the mic immediately so we do not pump into a
+            // dead pipe, then forward the failure.
+            stopMicrophone()
+            turnActive = false
+        }
+        callerOnEvent?(event)
+    }
+
+    // MARK: - Microphone lifecycle
+
+    private func openMicrophone() {
+        turnGeneration &+= 1
+        let generation = turnGeneration
+        let sessGen = sessionGeneration
+
+        let controller = VoiceAudioSourceController(makeSource: makeAudioSource)
+        audioController = controller
+
+        // The converter is created lazily from the first buffer's format, since the tap
+        // installs with a nil format and follows the live route.
+        var converter: AVAudioConverter?
+        var converterInputFormat: AVAudioFormat?
+
+        let targetFormat = avAudioFormat(for: wireFormat)
+
+        let (stream, continuation) = AsyncStream<RawAudioBlock>.makeStream(
+            bufferingPolicy: .unbounded)
+        self.continuation = continuation
+
+        let result = controller.start(
+            onBuffer: { [wireFormat] buffer, time in
+                // Realtime audio thread: no allocations beyond what AVAudioConverter needs,
+                // no main-actor hops, no locks on shared state.
+                let inputFormat = buffer.format
+                let frames = Int(buffer.frameLength)
+                guard frames > 0 else { return }
+
+                // Recreate the converter if the input format changed (route sample-rate
+                // change). The comparison is by pointer identity first (cheap), then by
+                // value if the pointer differs.
+                if converter == nil || inputFormat != converterInputFormat {
+                    if let target = targetFormat {
+                        converter = AVAudioConverter(from: inputFormat, to: target)
+                    }
+                    converterInputFormat = inputFormat
+                }
+
+                // Compute RMS on the tap thread where the samples are already hot.
+                let rms = Self.computeRMS(buffer)
+                let timestamp = time.isHostTimeValid
+                    ? TimeInterval(time.hostTime) / 1_000_000_000
+                    : ProcessInfo.processInfo.systemUptime
+
+                // Convert to the wire format.
+                guard let converter, let target = targetFormat else {
+                    // No usable converter: drop the block silently. This can happen if the
+                    // hardware format is truly incompatible.
+                    return
+                }
+
+                let outputFrameCount = AVAudioFrameCount(
+                    Double(frames) * wireFormat.sampleRate / inputFormat.sampleRate
+                )
+                guard outputFrameCount > 0 else { return }
+                guard let outputBuffer = AVAudioPCMBuffer(
+                    pcmFormat: target,
+                    frameCapacity: outputFrameCount
+                ) else { return }
+
+                var error: NSError?
+                let status = converter.convert(to: outputBuffer, error: &error) { _, status in
+                    status.pointee = .haveData
+                    return buffer
+                }
+                guard status != .error, outputBuffer.frameLength > 0 else { return }
+
+                let data = Self.extractPCM16Data(from: outputBuffer)
+                guard !data.isEmpty else { return }
+
+                continuation.yield(RawAudioBlock(
+                    data: data,
+                    timestamp: timestamp,
+                    rms: rms
+                ))
+            },
+            onInvalidation: { [weak self] failure in
+                self?.microphoneInvalidated(failure, generation: generation,
+                                            sessionGeneration: sessGen)
+            }
+        )
+
+        switch result {
+        case .started:
+            diagnostics.record("mic.opened")
+        case .alreadyRunning:
+            diagnostics.record("mic.open_skipped", fields: ["reason": "already_running"])
+            return
+        case .failed(let error):
+            diagnostics.record("mic.open_failed", level: .warning,
+                               fields: ["error": String(describing: error)])
+            // Mic failure mid-turn: relay a session failure so FailThrough can fail over.
+            micFailedSession(sessionGeneration: sessGen)
+            return
+        }
+
+        // Consumer task: reads converted blocks in order and delivers to the inner backend.
+        consumer = Task { @MainActor [weak self] in
+            for await block in stream {
+                guard let self,
+                      self.turnGeneration == generation,
+                      self.turnActive else { return }
+                self.onInputLevel?(block.rms)
+                let chunk = VoiceAudioChunk(
+                    data: block.data,
+                    format: self.wireFormat,
+                    timestamp: block.timestamp
+                )
+                self.inner.sendAudio(chunk)
+            }
+        }
+    }
+
+    private func stopMicrophone() {
+        turnGeneration &+= 1
+        continuation?.finish()
+        continuation = nil
+        consumer?.cancel()
+        consumer = nil
+        audioController?.stop()
+        audioController = nil
+    }
+
+    private func microphoneInvalidated(
+        _ failure: VoiceAudioSourceFailure,
+        generation: UInt64,
+        sessionGeneration sessGen: UInt64
+    ) {
+        guard turnGeneration == generation else { return }
+        diagnostics.record("mic.invalidated", level: .warning,
+                           fields: ["stage": failure.stage.rawValue,
+                                    "error": failure.detail])
+        stopMicrophone()
+        turnActive = false
+        micFailedSession(sessionGeneration: sessGen)
+    }
+
+    /// Route change or mic failure: close the inner backend and emit sessionFailed through
+    /// the pump's own event relay, so FailThroughVoiceBackend fails over to Apple.
+    private func micFailedSession(sessionGeneration sessGen: UInt64) {
+        guard self.sessionGeneration == sessGen else { return }
+        let callback = callerOnEvent
+        inner.close()
+        sessionGeneration &+= 1
+        callerOnEvent = nil
+        callback?(.sessionFailed(.network("microphone route changed or unavailable")))
+    }
+
+    // MARK: - Audio conversion helpers
+
+    /// Creates an `AVAudioFormat` matching the wire format for use as the converter's output.
+    private func avAudioFormat(for format: VoiceAudioFormat) -> AVAudioFormat? {
+        guard format.pcm16 else { return nil }
+        return AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: format.sampleRate,
+            channels: AVAudioChannelCount(format.channels),
+            interleaved: true
+        )
+    }
+
+    /// Extracts raw PCM16 bytes from a converted buffer.
+    static func extractPCM16Data(from buffer: AVAudioPCMBuffer) -> Data {
+        let frames = Int(buffer.frameLength)
+        let channels = Int(buffer.format.channelCount)
+        guard let int16Data = buffer.int16ChannelData, frames > 0, channels > 0 else {
+            return Data()
+        }
+        // For interleaved int16, the data is contiguous.
+        if buffer.format.isInterleaved {
+            let byteCount = frames * channels * MemoryLayout<Int16>.size
+            return Data(bytes: int16Data[0], count: byteCount)
+        }
+        // Non-interleaved: interleave manually.
+        var result = Data(capacity: frames * channels * MemoryLayout<Int16>.size)
+        for frame in 0..<frames {
+            for channel in 0..<channels {
+                var sample = int16Data[channel][frame]
+                withUnsafeBytes(of: &sample) { result.append(contentsOf: $0) }
+            }
+        }
+        return result
+    }
+
+    /// RMS over all channels of one float buffer. Returns 0 for non-float or empty buffers.
+    static func computeRMS(_ buffer: AVAudioPCMBuffer) -> Double {
+        let frames = Int(buffer.frameLength)
+        let channels = Int(buffer.format.channelCount)
+        guard let data = buffer.floatChannelData, frames > 0, channels > 0 else { return 0 }
+        let stride = buffer.stride
+        var sumOfSquares = 0.0
+        for channel in 0..<channels {
+            let samples = data[channel]
+            for frame in 0..<frames {
+                let value = Double(samples[frame * stride])
+                sumOfSquares += value * value
+            }
+        }
+        return (sumOfSquares / Double(frames * channels)).squareRoot()
+    }
+}
+#endif

--- a/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
@@ -117,7 +117,15 @@ import AVFoundation
     }
 
     public func beginUserTurn() {
+        let sessGen = sessionGeneration
         inner.beginUserTurn()
+        // If the inner backend synchronously failed the session (e.g. a state-machine
+        // violation that triggers failSession -> relayEvent(.sessionFailed) -> pump.close()),
+        // the session generation has changed and callerOnEvent is nil. Opening the
+        // microphone here would leave it dangling: teardown would skip the primary because
+        // the FailThrough wrapper already closed it, and the real mic stays open until
+        // process exit.
+        guard sessionGeneration == sessGen, callerOnEvent != nil else { return }
         turnActive = true
         openMicrophone()
     }
@@ -150,9 +158,17 @@ import AVFoundation
         guard self.sessionGeneration == sessGen else { return }
         if case .sessionFailed = event {
             // The inner backend died: stop the mic immediately so we do not pump into a
-            // dead pipe, then forward the failure.
+            // dead pipe, then forward the failure. Also bump the session generation and
+            // clear the callback — beginUserTurn checks this to detect a session that died
+            // synchronously during inner.beginUserTurn(), and no further events are valid
+            // after sessionFailed anyway.
             stopMicrophone()
             turnActive = false
+            let callback = callerOnEvent
+            sessionGeneration &+= 1
+            callerOnEvent = nil
+            callback?(event)
+            return
         }
         callerOnEvent?(event)
     }

--- a/Sources/TapQAppleAdapters/VoiceAudioSource.swift
+++ b/Sources/TapQAppleAdapters/VoiceAudioSource.swift
@@ -10,6 +10,7 @@ struct VoiceAudioSourceFailure: Error, Equatable, CustomStringConvertible {
         case inputFormat = "input_format"
         case audioSetup = "audio_setup"
         case engineStart = "engine_start"
+        case audioTeardown = "audio_teardown"
         case configurationChanged = "configuration_changed"
     }
 
@@ -23,9 +24,13 @@ struct VoiceAudioSourceFailure: Error, Equatable, CustomStringConvertible {
 
 /// Hardware boundary for one microphone window. A source is single-use in production:
 /// its fresh AVAudioEngine cannot retain formats from an earlier audio route.
+///
+/// `onBuffer` runs on the realtime audio thread and carries the tap's own `AVAudioTime`.
+/// Speech recognition ignores it; the capture study's envelope arm needs it to place each
+/// block on the motion stream's clock.
 @MainActor protocol VoiceAudioSource: AnyObject {
     func start(
-        onBuffer: @escaping (AVAudioPCMBuffer) -> Void,
+        onBuffer: @escaping (AVAudioPCMBuffer, AVAudioTime) -> Void,
         onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
     ) throws
     func stop()
@@ -54,7 +59,7 @@ enum VoiceAudioSourceStartResult {
     }
 
     func start(
-        onBuffer: @escaping (AVAudioPCMBuffer) -> Void,
+        onBuffer: @escaping (AVAudioPCMBuffer, AVAudioTime) -> Void,
         onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
     ) -> VoiceAudioSourceStartResult {
         guard source == nil else { return .alreadyRunning }
@@ -117,13 +122,16 @@ enum VoiceAudioSourceStartResult {
     private var configurationObserver: NSObjectProtocol?
     private var subscriptionGeneration: UInt64 = 0
     private var started = false
+    /// Teardown failures have nowhere to go in a voice window — the window is over either
+    /// way — but a study recording wants them in its diagnostics, so an owner may opt in.
+    var onTeardownFailure: (@MainActor (VoiceAudioSourceFailure) -> Void)?
 
     init(capture: TapQAudioCaptureEngine = TapQAudioCaptureEngine()) {
         self.capture = capture
     }
 
     func start(
-        onBuffer: @escaping (AVAudioPCMBuffer) -> Void,
+        onBuffer: @escaping (AVAudioPCMBuffer, AVAudioTime) -> Void,
         onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
     ) throws {
         guard !started else { return }
@@ -136,7 +144,7 @@ enum VoiceAudioSourceStartResult {
         guard TapQAudioCaptureEngineStart(
             capture,
             1024,
-            { buffer, _ in onBuffer(buffer) },
+            { buffer, time in onBuffer(buffer, time) },
             &captureError
         ) else {
             throw Self.failure(from: captureError)
@@ -153,8 +161,10 @@ enum VoiceAudioSourceStartResult {
             self.configurationObserver = nil
         }
 
-        var ignoredError: NSError?
-        _ = TapQAudioCaptureEngineStop(capture, &ignoredError)
+        var teardownError: NSError?
+        if !TapQAudioCaptureEngineStop(capture, &teardownError) {
+            onTeardownFailure?(Self.failure(from: teardownError))
+        }
     }
 
     private func observeConfigurationChanges(

--- a/Sources/TapQAppleAdapters/VoiceListener.swift
+++ b/Sources/TapQAppleAdapters/VoiceListener.swift
@@ -163,7 +163,7 @@ extension SFSpeechRecognitionTask: VoiceRecognitionTasking {}
         self.request = request
 
         let audioResult = audioSource.start(
-            onBuffer: { buffer in
+            onBuffer: { buffer, _ in
                 request.append(buffer)
             },
             onInvalidation: { [weak self] failure in

--- a/Sources/TapQAppleAdapters/WearerSpeechSignalSource.swift
+++ b/Sources/TapQAppleAdapters/WearerSpeechSignalSource.swift
@@ -1,0 +1,90 @@
+import Foundation
+import TapQContracts
+import TapQDetectionBaseline
+
+/// Owns a `WearerSpeechMonitor` and exposes it as the `WearerSpeechSignaling` contract,
+/// with multicast support for multiple independent consumers. Each child signal returned
+/// by `makeSignal()` has its own single-observer slot and reads shared state from the
+/// source -- the "add a multicast on the implementation" escape hatch that
+/// `WearerSpeech.swift:27-31` anticipates.
+///
+/// Conforms to `MotionSampleObserving` so `HeadGestureDetector.setMotionSampleObserver`
+/// can attach it as a secondary consumer of the motion sample stream.
+@MainActor public final class WearerSpeechSignalSource: MotionSampleObserving {
+    private let monitor: WearerSpeechMonitor
+
+    /// Whether the source has been attached to a motion stream via
+    /// `HeadGestureDetector.setMotionSampleObserver`. Set externally after attachment.
+    public var isAttached: Bool = false
+
+    /// All live child signals. Children are held strongly; they hold the source weakly.
+    private var children: [ChildSignal] = []
+
+    public init(config: WearerSpeechConfig = .init(),
+                monotonicNow: @escaping () -> TimeInterval = {
+                    ProcessInfo.processInfo.systemUptime
+                }) {
+        self.monitor = WearerSpeechMonitor(config: config, monotonicNow: monotonicNow)
+        self.monitor.onTransition = { [weak self] transition in
+            self?.broadcastTransition(transition)
+        }
+    }
+
+    /// Creates an independent child signal with its own single-observer callback slot.
+    /// Multiple children can coexist; each observes every transition.
+    public func makeSignal() -> any WearerSpeechSignaling {
+        let child = ChildSignal(source: self)
+        children.append(child)
+        return child
+    }
+
+    // MARK: - MotionSampleObserving
+
+    public func ingest(_ sample: HeadMotionSample) {
+        monitor.ingest(sample)
+    }
+
+    public func streamInterrupted() {
+        monitor.streamInterrupted()
+    }
+
+    // MARK: - Internal state for children
+
+    fileprivate var isWearerSpeaking: Bool {
+        monitor.state == .speaking
+    }
+
+    fileprivate var isSignalAvailable: Bool {
+        isAttached && monitor.isFresh() && (monitor.lastSampleHadPerAxisData)
+    }
+
+    // MARK: - Multicast
+
+    private func broadcastTransition(_ transition: WearerSpeechTransition) {
+        let speaking = monitor.state == .speaking
+        for child in children {
+            child.onWearerSpeakingChange?(speaking)
+        }
+    }
+}
+
+/// One child handle into a shared `WearerSpeechSignalSource`. Reads state from the
+/// source and owns its own observer callback -- the single-observer pattern the contract
+/// documents, replicated per child.
+@MainActor private final class ChildSignal: WearerSpeechSignaling {
+    private weak var source: WearerSpeechSignalSource?
+
+    var isWearerSpeaking: Bool {
+        source?.isWearerSpeaking ?? false
+    }
+
+    var isSignalAvailable: Bool {
+        source?.isSignalAvailable ?? false
+    }
+
+    var onWearerSpeakingChange: (@MainActor (Bool) -> Void)?
+
+    init(source: WearerSpeechSignalSource) {
+        self.source = source
+    }
+}

--- a/Sources/TapQAudioCaptureBridge/TapQAudioCaptureBridge.m
+++ b/Sources/TapQAudioCaptureBridge/TapQAudioCaptureBridge.m
@@ -155,3 +155,170 @@ BOOL TapQAudioCaptureEngineStop(
     }
     return firstError == nil;
 }
+
+// MARK: - Playback engine
+
+NSString * const TapQAudioPlaybackErrorDomain = @"ai.tapq.audio.playback";
+NSString * const TapQAudioPlaybackFailureStageKey = @"stage";
+
+static NSString * const TapQPlaybackSetupStage = @"playback_setup";
+static NSString * const TapQPlaybackEngineStartStage = @"playback_engine_start";
+static NSString * const TapQPlaybackScheduleStage = @"playback_schedule";
+static NSString * const TapQPlaybackTeardownStage = @"playback_teardown";
+
+@interface TapQAudioPlaybackEngine ()
+
+@property(nonatomic, strong, readwrite) AVAudioEngine *engine;
+@property(nonatomic, strong, readwrite) AVAudioPlayerNode *player;
+
+@end
+
+@implementation TapQAudioPlaybackEngine
+
+- (instancetype)init {
+    self = [super init];
+    if (self != nil) {
+        _engine = [[AVAudioEngine alloc] init];
+        _player = [[AVAudioPlayerNode alloc] init];
+        [_engine attachNode:_player];
+    }
+    return self;
+}
+
+@end
+
+static NSError *TapQPlaybackError(
+    NSString *stage,
+    NSString *description,
+    NSError * _Nullable underlyingError
+) {
+    NSMutableDictionary *userInfo = [@{
+        NSLocalizedDescriptionKey: description,
+        TapQAudioPlaybackFailureStageKey: stage,
+    } mutableCopy];
+    if (underlyingError != nil) {
+        userInfo[NSUnderlyingErrorKey] = underlyingError;
+    }
+    return [NSError errorWithDomain:TapQAudioPlaybackErrorDomain
+                               code:1
+                           userInfo:userInfo];
+}
+
+static NSError *TapQPlaybackExceptionError(NSString *stage, NSException *exception) {
+    NSString *reason = exception.reason ?: @"AVFAudio raised an exception";
+    return TapQPlaybackError(
+        stage,
+        [NSString stringWithFormat:@"%@: %@", exception.name, reason],
+        nil
+    );
+}
+
+BOOL TapQAudioPlaybackEngineStart(
+    TapQAudioPlaybackEngine *playback,
+    double sampleRate,
+    AVAudioChannelCount channels,
+    NSError * _Nullable * _Nullable error
+) {
+    @try {
+        AVAudioFormat *format = [[AVAudioFormat alloc]
+            initWithCommonFormat:AVAudioPCMFormatInt16
+                     sampleRate:sampleRate
+                       channels:channels
+                    interleaved:YES];
+        if (format == nil) {
+            if (error != NULL) {
+                *error = TapQPlaybackError(
+                    TapQPlaybackSetupStage,
+                    [NSString stringWithFormat:
+                        @"cannot create playback format (sample_rate=%g, channels=%u)",
+                        sampleRate, (unsigned int)channels],
+                    nil
+                );
+            }
+            return NO;
+        }
+
+        [playback.engine connect:playback.player
+                              to:playback.engine.mainMixerNode
+                          format:format];
+        [playback.engine prepare];
+
+        NSError *startError = nil;
+        if (![playback.engine startAndReturnError:&startError]) {
+            if (error != NULL) {
+                *error = TapQPlaybackError(
+                    TapQPlaybackEngineStartStage,
+                    startError.localizedDescription ?: @"AVAudioEngine failed to start",
+                    startError
+                );
+            }
+            return NO;
+        }
+        [playback.player play];
+        return YES;
+    } @catch (NSException *exception) {
+        if (error != NULL) {
+            *error = TapQPlaybackExceptionError(TapQPlaybackSetupStage, exception);
+        }
+        return NO;
+    }
+}
+
+BOOL TapQAudioPlaybackEngineSchedule(
+    TapQAudioPlaybackEngine *playback,
+    AVAudioPCMBuffer *buffer,
+    void (^_Nullable completion)(void),
+    NSError * _Nullable * _Nullable error
+) {
+    @try {
+        if (completion != nil) {
+            [playback.player scheduleBuffer:buffer completionHandler:completion];
+        } else {
+            [playback.player scheduleBuffer:buffer completionHandler:nil];
+        }
+        return YES;
+    } @catch (NSException *exception) {
+        if (error != NULL) {
+            *error = TapQPlaybackExceptionError(TapQPlaybackScheduleStage, exception);
+        }
+        return NO;
+    }
+}
+
+BOOL TapQAudioPlaybackEngineStop(
+    TapQAudioPlaybackEngine *playback,
+    NSError * _Nullable * _Nullable error
+) {
+    NSError *firstError = nil;
+
+    @try {
+        if (playback.player.isPlaying) {
+            [playback.player stop];
+        }
+    } @catch (NSException *exception) {
+        firstError = TapQPlaybackExceptionError(TapQPlaybackTeardownStage, exception);
+    }
+
+    @try {
+        [playback.player reset];
+    } @catch (NSException *exception) {
+        if (firstError == nil) {
+            firstError = TapQPlaybackExceptionError(TapQPlaybackTeardownStage, exception);
+        }
+    }
+
+    @try {
+        if (playback.engine.running) {
+            [playback.engine stop];
+        }
+    } @catch (NSException *exception) {
+        if (firstError == nil) {
+            firstError = TapQPlaybackExceptionError(TapQPlaybackTeardownStage, exception);
+        }
+    }
+
+    if (error != NULL) {
+        *error = firstError;
+    }
+    return firstError == nil;
+}

--- a/Sources/TapQAudioCaptureBridge/include/TapQAudioCaptureBridge.h
+++ b/Sources/TapQAudioCaptureBridge/include/TapQAudioCaptureBridge.h
@@ -39,6 +39,54 @@ FOUNDATION_EXPORT BOOL TapQAudioCaptureEngineStop(
     NSError * _Nullable * _Nullable error
 );
 
+// MARK: - Playback engine
+
+FOUNDATION_EXPORT NSString * const TapQAudioPlaybackErrorDomain;
+FOUNDATION_EXPORT NSString * const TapQAudioPlaybackFailureStageKey;
+
+/// Owns one `AVAudioEngine` + `AVAudioPlayerNode` for backend response playback. All
+/// operations that may raise an AVFAudio NSException are performed by the typed Objective-C
+/// functions below, so an exception never unwinds through a Swift frame.
+@interface TapQAudioPlaybackEngine : NSObject
+
+@property(nonatomic, strong, readonly) AVAudioEngine *engine;
+@property(nonatomic, strong, readonly) AVAudioPlayerNode *player;
+
+- (instancetype)init;
+
+@end
+
+/// Starts the engine and prepares the player node for the given PCM format.
+///
+/// The engine connects the player node to the main mixer in the declared format.
+/// Returns NO and sets `*error` on failure (both NSError from `startAndReturnError:`
+/// and NSException from any AVFAudio call).
+FOUNDATION_EXPORT BOOL TapQAudioPlaybackEngineStart(
+    TapQAudioPlaybackEngine *playback,
+    double sampleRate,
+    AVAudioChannelCount channels,
+    NSError * _Nullable * _Nullable error
+);
+
+/// Schedules an `AVAudioPCMBuffer` on the player node with a completion handler.
+///
+/// The completion fires on an internal AVAudioEngine thread; the Swift caller must hop
+/// to @MainActor before touching shared state.
+FOUNDATION_EXPORT BOOL TapQAudioPlaybackEngineSchedule(
+    TapQAudioPlaybackEngine *playback,
+    AVAudioPCMBuffer *buffer,
+    void (^_Nullable completion)(void),
+    NSError * _Nullable * _Nullable error
+);
+
+/// Stops the player node and the engine. Best-effort and idempotent: stop, reset, and
+/// engine stop each have an independent exception boundary so cleanup continues if one
+/// operation fails.
+FOUNDATION_EXPORT BOOL TapQAudioPlaybackEngineStop(
+    TapQAudioPlaybackEngine *playback,
+    NSError * _Nullable * _Nullable error
+);
+
 NS_ASSUME_NONNULL_END
 
 #endif

--- a/Sources/TapQBrokerRuntime/BrokerServer.swift
+++ b/Sources/TapQBrokerRuntime/BrokerServer.swift
@@ -154,7 +154,8 @@ import TapQWireProtocol
             if result.timedOut { return BrokerResponse.error("timeout").encoded() }
             return BrokerResponse.selection(
                 indices: result.choices.map(\.index),
-                labels: result.choices.map(\.label)
+                labels: result.choices.map(\.label),
+                freeText: result.freeText
             ).encoded()
 
         case .stopQuestion(let message):

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -2,6 +2,7 @@ import Foundation
 import TapQClaudeAdapter
 import TapQContextBaseline
 import TapQDetectionBaseline
+import TapQVoiceBackends
 
 enum CLIHelpTopic: Equatable {
     case root
@@ -41,6 +42,9 @@ struct ServeOptions: Equatable {
     var announcementsEnabled = true
     var steeringEnabled = false
     var questionClassifier: QuestionClassifierProvider = .auto
+    /// Speech pipe for voice commands. `apple` is the shipped on-device path; the realtime
+    /// provider is always composed with that same path underneath it as a fallback.
+    var voiceBackend: VoiceBackendProvider = .apple
     var encoderModelPath: String?
     /// Meaningful only alongside `encoderModelPath`; shadow is the safe default —
     /// the encoder is observed, never trusted, until promoted explicitly.
@@ -294,6 +298,14 @@ enum CLICommandParser {
                     )
                 }
                 options.questionClassifier = provider
+            case "--voice-backend":
+                let value = try cursor.requireValue(for: argument)
+                guard let provider = VoiceBackendProvider(rawValue: value) else {
+                    throw CLIUsageError(
+                        message: "--voice-backend must be 'apple' or 'openai-realtime'."
+                    )
+                }
+                options.voiceBackend = provider
             case "--encoder-model":
                 options.encoderModelPath = try cursor.requireValue(for: argument)
             case "--encoder-mode":

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -61,6 +61,10 @@ struct ReplayOptions: Equatable {
     var encoderModelPath: String?
     var gestureProfilePath: String?
     var tapProfilePath: String?
+    var wearerSpeechProfilePath: String?
+    /// Envelope sidecar from `tapq capture --mic-envelope`, used as wearer-speech ground
+    /// truth when the label file carries no `wearer_speech` segments.
+    var micEnvelopePath: String?
 }
 
 /// Options for `tapq bench reasoner`.
@@ -353,6 +357,10 @@ enum CLICommandParser {
                 options.gestureProfilePath = try cursor.requireValue(for: argument)
             case "--tap-profile":
                 options.tapProfilePath = try cursor.requireValue(for: argument)
+            case "--wearer-speech-profile":
+                options.wearerSpeechProfilePath = try cursor.requireValue(for: argument)
+            case "--mic-envelope":
+                options.micEnvelopePath = try cursor.requireValue(for: argument)
             default:
                 throw CLIUsageError(message: "Unknown replay option '\(argument)'.")
             }

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -65,6 +65,11 @@ struct ServeOptions: Equatable {
     /// when both are active). Always fail-open: a dead signal means match/timeout
     /// fallback, exactly as without the flag.
     var imuTurnControlEnabled = false
+    /// Free-form voice answers for selection/multi-option stop questions. Default off;
+    /// requires a voice backend that produces transcripts (i.e. not `.apple` alone).
+    /// When enabled, an unmatched final transcript is offered as a free-text reply
+    /// with mandatory read-back confirmation (nod to send, shake to discard).
+    var voiceFreeformEnabled = false
 }
 
 struct ReplayOptions: Equatable {
@@ -343,6 +348,8 @@ enum CLICommandParser {
                 options.wearerGateEnabled = true
             case "--imu-turn-control":
                 options.imuTurnControlEnabled = true
+            case "--voice-freeform":
+                options.voiceFreeformEnabled = true
             default:
                 throw CLIUsageError(message: "Unknown serve option '\(argument)'.")
             }

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -23,6 +23,9 @@ struct CaptureOptions: Equatable {
     var outputPath = "-"
     var format: CaptureFormat = .jsonl
     var force = false
+    /// Sidecar path for the capture study's microphone ground-truth track. nil keeps the
+    /// command microphone-free, which is what every non-study capture wants.
+    var micEnvelopePath: String?
 }
 
 struct ServeOptions: Equatable {
@@ -246,6 +249,8 @@ enum CLICommandParser {
                 options.format = format
             case "--force", "-f":
                 options.force = true
+            case "--mic-envelope":
+                options.micEnvelopePath = try cursor.requireValue(for: argument)
             default:
                 throw CLIUsageError(message: "Unknown capture option '\(argument)'.")
             }

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -54,6 +54,11 @@ struct ServeOptions: Equatable {
     /// Meaningful only alongside a `reasonerProvider` other than `off`; shadow is the
     /// safe default — the reasoner is observed, never trusted, until promoted explicitly.
     var reasonerMode: ReasonerMode = .shadow
+    /// IMU-based wearer-speech attribution gate. Default off; needs AirPods motion.
+    /// Uses `wearer-speech-calibration.json` when present, provisional thresholds
+    /// otherwise. Always fail-open: a degraded or absent signal reproduces today's
+    /// shipped behavior verbatim.
+    var wearerGateEnabled = false
 }
 
 struct ReplayOptions: Equatable {
@@ -328,6 +333,8 @@ enum CLICommandParser {
                 }
                 options.reasonerMode = mode
                 reasonerModeSpecified = true
+            case "--wearer-gate":
+                options.wearerGateEnabled = true
             default:
                 throw CLIUsageError(message: "Unknown serve option '\(argument)'.")
             }

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -59,6 +59,12 @@ struct ServeOptions: Equatable {
     /// otherwise. Always fail-open: a degraded or absent signal reproduces today's
     /// shipped behavior verbatim.
     var wearerGateEnabled = false
+    /// IMU-based turn control: endpointing (wearer speech-end commits the user turn)
+    /// and barge-in (wearer speech-onset during response playback interrupts audio).
+    /// Default off; implies a wearer-speech signal source (shared with --wearer-gate
+    /// when both are active). Always fail-open: a dead signal means match/timeout
+    /// fallback, exactly as without the flag.
+    var imuTurnControlEnabled = false
 }
 
 struct ReplayOptions: Equatable {
@@ -335,6 +341,8 @@ enum CLICommandParser {
                 reasonerModeSpecified = true
             case "--wearer-gate":
                 options.wearerGateEnabled = true
+            case "--imu-turn-control":
+                options.imuTurnControlEnabled = true
             default:
                 throw CLIUsageError(message: "Unknown serve option '\(argument)'.")
             }

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -77,13 +77,19 @@ enum CalibrationTarget: String, Equatable {
     case all
     case gesture
     case tap
+    case wearerSpeech = "wearer-speech"
 
     var profileKinds: [CalibrationProfileKind] {
         switch self {
-        case .all: [.gesture, .tap]
+        case .all: [.gesture, .tap, .wearerSpeech]
         case .gesture: [.gesture]
         case .tap: [.tap]
+        case .wearerSpeech: [.wearerSpeech]
         }
+    }
+
+    func includes(_ kind: CalibrationProfileKind) -> Bool {
+        profileKinds.contains(kind)
     }
 }
 
@@ -93,8 +99,13 @@ struct CalibrationRunOptions: Equatable {
     var nodDuration: TimeInterval = 4
     var shakeDuration: TimeInterval = 4
     var tapDuration: TimeInterval = 4
+    /// Read-aloud phase. Longer than the others by default: the wearer-speech statistic is
+    /// a median over a sustained tremor, not a peak, so it needs continuous speech to
+    /// summarise rather than a handful of discrete events.
+    var speakDuration: TimeInterval = 6
     var gestureProfilePath: String?
     var tapProfilePath: String?
+    var wearerSpeechProfilePath: String?
     var nonInteractive = false
 }
 
@@ -102,6 +113,7 @@ struct CalibrationShowOptions: Equatable {
     var target: CalibrationTarget = .all
     var gestureProfilePath: String?
     var tapProfilePath: String?
+    var wearerSpeechProfilePath: String?
     var json = false
 }
 
@@ -109,6 +121,7 @@ struct CalibrationResetOptions: Equatable {
     var target: CalibrationTarget = .all
     var gestureProfilePath: String?
     var tapProfilePath: String?
+    var wearerSpeechProfilePath: String?
     var confirmed = false
 }
 
@@ -430,12 +443,16 @@ enum CLICommandParser {
                 options.shakeDuration = try duration(cursor.requireValue(for: argument), flag: argument)
             case "--tap-seconds":
                 options.tapDuration = try duration(cursor.requireValue(for: argument), flag: argument)
+            case "--speak-seconds":
+                options.speakDuration = try duration(cursor.requireValue(for: argument), flag: argument)
             case "--profile":
                 selectedProfilePath = try cursor.requireValue(for: argument)
             case "--gesture-profile":
                 options.gestureProfilePath = try cursor.requireValue(for: argument)
             case "--tap-profile":
                 options.tapProfilePath = try cursor.requireValue(for: argument)
+            case "--wearer-speech-profile":
+                options.wearerSpeechProfilePath = try cursor.requireValue(for: argument)
             case "--non-interactive":
                 options.nonInteractive = true
             default:
@@ -447,7 +464,7 @@ enum CLICommandParser {
     }
 
     private static func parseCalibrationShow(_ arguments: [String]) throws -> CalibrationShowOptions {
-        if isHelp(arguments) { throw CLIUsageError(message: "Usage: tapq calibration show [all|gesture|tap] [--json]") }
+        if isHelp(arguments) { throw CLIUsageError(message: "Usage: tapq calibration show [all|gesture|tap|wearer-speech] [--json]") }
         let (target, remaining) = try calibrationTarget(from: arguments)
         var options = CalibrationShowOptions(target: target)
         var selectedProfilePath: String?
@@ -457,6 +474,7 @@ enum CLICommandParser {
             case "--profile": selectedProfilePath = try cursor.requireValue(for: argument)
             case "--gesture-profile": options.gestureProfilePath = try cursor.requireValue(for: argument)
             case "--tap-profile": options.tapProfilePath = try cursor.requireValue(for: argument)
+            case "--wearer-speech-profile": options.wearerSpeechProfilePath = try cursor.requireValue(for: argument)
             case "--json": options.json = true
             default: throw CLIUsageError(message: "Unknown calibration show option '\(argument)'.")
             }
@@ -466,7 +484,7 @@ enum CLICommandParser {
     }
 
     private static func parseCalibrationReset(_ arguments: [String]) throws -> CalibrationResetOptions {
-        if isHelp(arguments) { throw CLIUsageError(message: "Usage: tapq calibration reset [all|gesture|tap] [--yes]") }
+        if isHelp(arguments) { throw CLIUsageError(message: "Usage: tapq calibration reset [all|gesture|tap|wearer-speech] [--yes]") }
         let (target, remaining) = try calibrationTarget(from: arguments)
         var options = CalibrationResetOptions(target: target)
         var selectedProfilePath: String?
@@ -476,6 +494,7 @@ enum CLICommandParser {
             case "--profile": selectedProfilePath = try cursor.requireValue(for: argument)
             case "--gesture-profile": options.gestureProfilePath = try cursor.requireValue(for: argument)
             case "--tap-profile": options.tapProfilePath = try cursor.requireValue(for: argument)
+            case "--wearer-speech-profile": options.wearerSpeechProfilePath = try cursor.requireValue(for: argument)
             case "--yes", "-y": options.confirmed = true
             default: throw CLIUsageError(message: "Unknown calibration reset option '\(argument)'.")
             }
@@ -491,10 +510,15 @@ enum CLICommandParser {
             return (.all, arguments)
         }
         guard let target = CalibrationTarget(rawValue: first) else {
-            throw CLIUsageError(message: "Calibration target must be 'all', 'gesture', or 'tap'.")
+            throw CLIUsageError(message: "Calibration target must be 'all', 'gesture', 'tap', or 'wearer-speech'.")
         }
         return (target, Array(arguments.dropFirst()))
     }
+
+    /// `--profile` names the one document a single-target command touches, so it has no
+    /// meaning under `all`, where three documents are in play.
+    private static let combinedProfilePathMessage =
+        "--profile requires the gesture, tap, or wearer-speech target; use --gesture-profile, --tap-profile, and --wearer-speech-profile when targeting all."
 
     private static func applySelectedProfilePath(
         _ path: String?,
@@ -505,8 +529,8 @@ enum CLICommandParser {
         switch target {
         case .gesture: options.gestureProfilePath = path
         case .tap: options.tapProfilePath = path
-        case .all:
-            throw CLIUsageError(message: "--profile requires the gesture or tap target; use --gesture-profile and --tap-profile when targeting all.")
+        case .wearerSpeech: options.wearerSpeechProfilePath = path
+        case .all: throw CLIUsageError(message: combinedProfilePathMessage)
         }
     }
 
@@ -519,8 +543,8 @@ enum CLICommandParser {
         switch target {
         case .gesture: options.gestureProfilePath = path
         case .tap: options.tapProfilePath = path
-        case .all:
-            throw CLIUsageError(message: "--profile requires the gesture or tap target; use --gesture-profile and --tap-profile when targeting all.")
+        case .wearerSpeech: options.wearerSpeechProfilePath = path
+        case .all: throw CLIUsageError(message: combinedProfilePathMessage)
         }
     }
 
@@ -533,8 +557,8 @@ enum CLICommandParser {
         switch target {
         case .gesture: options.gestureProfilePath = path
         case .tap: options.tapProfilePath = path
-        case .all:
-            throw CLIUsageError(message: "--profile requires the gesture or tap target; use --gesture-profile and --tap-profile when targeting all.")
+        case .wearerSpeech: options.wearerSpeechProfilePath = path
+        case .all: throw CLIUsageError(message: combinedProfilePathMessage)
         }
     }
 

--- a/Sources/TapQCLI/CalibrationProfile.swift
+++ b/Sources/TapQCLI/CalibrationProfile.swift
@@ -1,9 +1,20 @@
 import Foundation
 import TapQDetectionBaseline
 
-public enum CalibrationProfileKind: String, Sendable, Equatable {
+public enum CalibrationProfileKind: String, Sendable, Equatable, CaseIterable {
     case gesture
     case tap
+    case wearerSpeech = "wearer_speech"
+
+    /// Human-readable name for CLI output. The raw value is the on-disk and JSON spelling
+    /// and stays snake_case; `wearer_speech.capitalized` would print as "Wearer_speech".
+    public var displayName: String {
+        switch self {
+        case .gesture: "Gesture"
+        case .tap: "Tap"
+        case .wearerSpeech: "Wearer speech"
+        }
+    }
 }
 
 public enum CalibrationStoreError: Error, LocalizedError, Equatable {
@@ -12,20 +23,26 @@ public enum CalibrationStoreError: Error, LocalizedError, Equatable {
     public var errorDescription: String? {
         switch self {
         case .unsupportedSchema(let kind, let version):
-            return "The \(kind.rawValue) calibration profile schema \(version) is not supported by this TapQ version."
+            return "The \(kind.displayName.lowercased()) calibration profile schema \(version) is not supported by this TapQ version."
         }
     }
 }
 
-/// Stores gesture and tap calibration as independent documents. A failed or reset tap
-/// calibration can therefore never discard a valid nod/shake profile, and vice versa.
+/// Stores gesture, tap and wearer-speech calibration as independent documents. A failed or
+/// reset calibration of one input can therefore never discard another's valid profile.
 public struct CalibrationStore {
     public let gestureProfileURL: URL
     public let tapProfileURL: URL
+    public let wearerSpeechProfileURL: URL
 
-    public init(gestureProfileURL: URL, tapProfileURL: URL) {
+    public init(
+        gestureProfileURL: URL,
+        tapProfileURL: URL,
+        wearerSpeechProfileURL: URL
+    ) {
         self.gestureProfileURL = gestureProfileURL
         self.tapProfileURL = tapProfileURL
+        self.wearerSpeechProfileURL = wearerSpeechProfileURL
     }
 
     public static func defaultProfileDirectory(
@@ -60,7 +77,9 @@ public struct CalibrationStore {
         )
         return CalibrationStore(
             gestureProfileURL: directory.appendingPathComponent("gesture-calibration.json"),
-            tapProfileURL: directory.appendingPathComponent("tap-calibration.json")
+            tapProfileURL: directory.appendingPathComponent("tap-calibration.json"),
+            wearerSpeechProfileURL: directory
+                .appendingPathComponent("wearer-speech-calibration.json")
         )
     }
 
@@ -80,6 +99,17 @@ public struct CalibrationStore {
         return profile
     }
 
+    public func loadWearerSpeech() throws -> TapQWearerSpeechCalibrationProfile {
+        let profile: TapQWearerSpeechCalibrationProfile = try decode(
+            from: wearerSpeechProfileURL)
+        guard profile.schemaVersion
+            == TapQWearerSpeechCalibrationProfile.currentSchemaVersion else {
+            throw CalibrationStoreError.unsupportedSchema(
+                .wearerSpeech, profile.schemaVersion)
+        }
+        return profile
+    }
+
     public func save(_ profile: TapQGestureCalibrationProfile) throws {
         guard profile.schemaVersion == TapQGestureCalibrationProfile.currentSchemaVersion else {
             throw CalibrationStoreError.unsupportedSchema(.gesture, profile.schemaVersion)
@@ -92,6 +122,15 @@ public struct CalibrationStore {
             throw CalibrationStoreError.unsupportedSchema(.tap, profile.schemaVersion)
         }
         try encode(profile, to: tapProfileURL)
+    }
+
+    public func save(_ profile: TapQWearerSpeechCalibrationProfile) throws {
+        guard profile.schemaVersion
+            == TapQWearerSpeechCalibrationProfile.currentSchemaVersion else {
+            throw CalibrationStoreError.unsupportedSchema(
+                .wearerSpeech, profile.schemaVersion)
+        }
+        try encode(profile, to: wearerSpeechProfileURL)
     }
 
     public func exists(_ kind: CalibrationProfileKind) -> Bool {
@@ -110,6 +149,7 @@ public struct CalibrationStore {
         switch kind {
         case .gesture: gestureProfileURL
         case .tap: tapProfileURL
+        case .wearerSpeech: wearerSpeechProfileURL
         }
     }
 

--- a/Sources/TapQCLI/CalibrationTimeline.swift
+++ b/Sources/TapQCLI/CalibrationTimeline.swift
@@ -5,6 +5,7 @@ enum CalibrationPhase: Equatable {
     case nod
     case shake
     case tap
+    case speak
 }
 
 struct CalibrationStage: Equatable {
@@ -39,7 +40,7 @@ struct CalibrationTimeline: Equatable {
             ),
         ]
 
-        if options.target != .tap {
+        if options.target.includes(.gesture) {
             result += [Self.transition(to: "nod"), CalibrationStage(
                 phase: .nod,
                 title: "Nod",
@@ -53,12 +54,24 @@ struct CalibrationTimeline: Equatable {
             )]
         }
 
-        if options.target != .gesture {
+        if options.target.includes(.tap) {
             result += [Self.transition(to: "tap"), CalibrationStage(
                 phase: .tap,
                 title: "Tap",
                 instruction: "Keep your head still and give the outside of an earbud several quick fingertip taps. Do not squeeze or press the stem.",
                 duration: options.tapDuration
+            )]
+        }
+
+        // Last, and after the tap phase: the wearer-speech envelope is the same
+        // acceleration channel a tap saturates, so a lingering fingertip on the earbud
+        // would read as speech. The transition stage discards that overlap.
+        if options.target.includes(.wearerSpeech) {
+            result += [Self.transition(to: "speak"), CalibrationStage(
+                phase: .speak,
+                title: "Speak",
+                instruction: "Read something aloud at a normal pace, keeping your head still and your hands away from the earbuds.",
+                duration: options.speakDuration
             )]
         }
 

--- a/Sources/TapQCLI/EnvelopeCapture.swift
+++ b/Sources/TapQCLI/EnvelopeCapture.swift
@@ -1,0 +1,233 @@
+import Foundation
+
+/// Hardware boundary for the capture study's microphone arm, sibling to
+/// `TapQMotionCapturing`. The envelope track is *ground truth for a study recording*,
+/// never a runtime input: it exists so a wearer-speech detector trained on the IMU can be
+/// scored against something that actually heard the room.
+///
+/// Lifecycle brackets the motion capture — `start` before the IMU stream opens, `stop`
+/// after it closes — so both tracks cover the same wall-clock span. `start` is
+/// synchronous and throws: a study session whose label track never opened must fail
+/// before any motion is recorded, not halfway through.
+///
+/// Implementations must call `onTrack` exactly once, before the first `onSample`. The
+/// audio format is only known once the hardware hands over its first block, so the
+/// sidecar's header line is written from that block rather than from `start`.
+/// `stop` is idempotent: the capture command stops explicitly on the success path and
+/// again from a `defer` that covers the throwing one.
+@MainActor public protocol TapQAudioEnvelopeCapturing: AnyObject {
+    func start(
+        onTrack: @escaping @MainActor (MicEnvelopeTrackMeta) -> Void,
+        onSample: @escaping @MainActor (MicEnvelopeSample) -> Void,
+        onInvalidation: @escaping @MainActor (TapQEnvelopeCaptureError) -> Void
+    ) throws
+    func stop()
+}
+
+/// One audio block reduced to its loudness envelope. Raw audio is deliberately not
+/// retained: the study needs to know *when* the wearer spoke, and an RMS/peak pair
+/// answers that without recording what was said.
+public struct MicEnvelopeSample: Equatable, Sendable {
+    /// Seconds on the same boot clock as `HeadMotionSample.timestamp`, so the two tracks
+    /// overlay directly without a second alignment step at analysis time.
+    public let timestamp: TimeInterval
+    public let rms: Double
+    public let peak: Double
+
+    public init(timestamp: TimeInterval, rms: Double, peak: Double) {
+        self.timestamp = timestamp
+        self.rms = rms
+        self.peak = peak
+    }
+}
+
+/// Header record for an envelope sidecar. Written as the file's first line so a reader
+/// can reject a track from a future schema instead of misinterpreting its samples.
+public struct MicEnvelopeTrackMeta: Equatable, Sendable {
+    public static let schema = "tapq-mic-envelope-v1"
+    /// Names the clock `MicEnvelopeSample.timestamp` is expressed in — the same
+    /// seconds-since-boot clock CoreMotion stamps motion samples with.
+    public static let clock = "boottime"
+
+    public let sampleRate: Double
+    /// Frames in the hardware's audio block, which is what sets the envelope's own
+    /// sample rate (`sampleRate / blockFrames` envelope points per second).
+    public let blockFrames: Int
+
+    public init(sampleRate: Double, blockFrames: Int) {
+        self.sampleRate = sampleRate
+        self.blockFrames = blockFrames
+    }
+}
+
+public enum TapQEnvelopeCaptureError: Error, LocalizedError, Equatable {
+    case unavailable
+    case startFailed(String)
+    case invalidated(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Microphone envelope co-recording is unavailable. On macOS, allow Microphone access for tapq. Linux does not yet include an audio acquisition adapter."
+        case .startFailed(let detail):
+            return "Could not start microphone envelope capture: \(detail). Nothing was recorded — a study session without its label track is not worth keeping."
+        case .invalidated(let detail):
+            return "The microphone envelope track ended early (\(detail)). The motion capture finished and was written, but its envelope sidecar is truncated and covers only part of the session."
+        }
+    }
+}
+
+enum EnvelopeSampleFormatter {
+    static func metaLine(for meta: MicEnvelopeTrackMeta) -> String {
+        encode(MetaRecord(
+            schema: MicEnvelopeTrackMeta.schema,
+            clock: MicEnvelopeTrackMeta.clock,
+            sampleRate: meta.sampleRate,
+            blockFrames: meta.blockFrames
+        ))
+    }
+
+    static func line(for sample: MicEnvelopeSample) -> String {
+        encode(SampleRecord(timestamp: sample.timestamp, rms: sample.rms, peak: sample.peak))
+    }
+
+    private static func encode(_ value: some Encodable) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(value),
+              let text = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return text
+    }
+
+    fileprivate struct MetaRecord: Codable {
+        let schema: String
+        let clock: String
+        let sampleRate: Double
+        let blockFrames: Int
+
+        enum CodingKeys: String, CodingKey {
+            case schema, clock
+            case sampleRate = "sample_rate"
+            case blockFrames = "block_frames"
+        }
+    }
+
+    fileprivate struct SampleRecord: Codable {
+        let timestamp: TimeInterval
+        let rms: Double
+        let peak: Double
+    }
+}
+
+struct MicEnvelopeTrack: Equatable {
+    let meta: MicEnvelopeTrackMeta
+    let samples: [MicEnvelopeSample]
+}
+
+enum EnvelopeTrackReadError: Error, LocalizedError, Equatable {
+    case unreadable(String)
+    case missingMeta(String)
+    case unsupportedSchema(String)
+    case badLine(Int, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unreadable(let path):
+            return "Could not read the microphone envelope track at \(path)."
+        case .missingMeta(let path):
+            return "The microphone envelope track at \(path) is missing its \(MicEnvelopeTrackMeta.schema) header line."
+        case .unsupportedSchema(let found):
+            return "Unsupported microphone envelope schema '\(found)'; this build reads \(MicEnvelopeTrackMeta.schema)."
+        case .badLine(let line, let details):
+            return "Could not parse microphone envelope line \(line): \(details)"
+        }
+    }
+}
+
+/// Reads an envelope sidecar back into portable values. Consumed by replay tooling; kept
+/// free of AVFoundation so the portable graph still builds on Linux.
+enum EnvelopeTrackReader {
+    static func track(fromFileAt url: URL) throws -> MicEnvelopeTrack {
+        guard let data = FileManager.default.contents(atPath: url.path),
+              let text = String(data: data, encoding: .utf8) else {
+            throw EnvelopeTrackReadError.unreadable(url.path)
+        }
+        return try track(fromText: text, path: url.path)
+    }
+
+    static func track(fromText text: String, path: String = "<text>") throws -> MicEnvelopeTrack {
+        let decoder = JSONDecoder()
+        var meta: MicEnvelopeTrackMeta?
+        var samples: [MicEnvelopeSample] = []
+
+        for (index, line) in text.split(separator: "\n").enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            let payload = Data(trimmed.utf8)
+
+            if meta == nil {
+                guard let record = try? decoder.decode(
+                    EnvelopeSampleFormatter.MetaRecord.self, from: payload
+                ) else {
+                    throw EnvelopeTrackReadError.missingMeta(path)
+                }
+                guard record.schema == MicEnvelopeTrackMeta.schema else {
+                    throw EnvelopeTrackReadError.unsupportedSchema(record.schema)
+                }
+                meta = MicEnvelopeTrackMeta(
+                    sampleRate: record.sampleRate,
+                    blockFrames: record.blockFrames
+                )
+                continue
+            }
+
+            do {
+                let record = try decoder.decode(
+                    EnvelopeSampleFormatter.SampleRecord.self, from: payload)
+                samples.append(MicEnvelopeSample(
+                    timestamp: record.timestamp, rms: record.rms, peak: record.peak))
+            } catch {
+                throw EnvelopeTrackReadError.badLine(index + 1, String(describing: error))
+            }
+        }
+
+        guard let meta else { throw EnvelopeTrackReadError.missingMeta(path) }
+        return MicEnvelopeTrack(meta: meta, samples: samples)
+    }
+}
+
+/// Owns the sidecar file for one capture. Writes lines in the order the capture source
+/// delivers them — the source contract puts the header first — and stops accepting them
+/// once closed, so a block that lands after teardown cannot reach a closed descriptor.
+@MainActor final class EnvelopeSidecarRecorder {
+    let url: URL
+    private let writer: CaptureFileWriter
+    private(set) var sampleCount = 0
+    private var closed = false
+
+    init(url: URL, force: Bool) throws {
+        self.url = url
+        // jsonl: the sidecar is line-delimited JSON regardless of the motion track's
+        // format, because its header line has no CSV equivalent.
+        self.writer = try CaptureFileWriter(url: url, format: .jsonl, force: force)
+    }
+
+    func writeTrack(_ meta: MicEnvelopeTrackMeta) {
+        guard !closed else { return }
+        writer.write(EnvelopeSampleFormatter.metaLine(for: meta))
+    }
+
+    func append(_ sample: MicEnvelopeSample) {
+        guard !closed else { return }
+        writer.write(EnvelopeSampleFormatter.line(for: sample))
+        sampleCount += 1
+    }
+
+    func close() {
+        guard !closed else { return }
+        closed = true
+        try? writer.close()
+    }
+}

--- a/Sources/TapQCLI/RuntimeService.swift
+++ b/Sources/TapQCLI/RuntimeService.swift
@@ -2,6 +2,7 @@ import Foundation
 import TapQContextBaseline
 import TapQContracts
 import TapQDetectionBaseline
+import TapQVoiceBackends
 
 /// Builds the stage-2 reasoner a host should run, or throws when this build or this
 /// device cannot supply one.
@@ -61,6 +62,10 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
     public let announcementsEnabled: Bool
     public let steeringEnabled: Bool
     public let questionClassifier: QuestionClassifierProvider
+    /// Speech pipe the host composes the voice channel from. `apple` — the default — must
+    /// leave the shipped composition untouched; any other provider is composed with the
+    /// Apple stack as its fallback, so a cloud outage costs latency, never the channel.
+    public let voiceBackend: VoiceBackendProvider
     /// TapQ-1 encoder model to load, if any. A load failure must degrade to the
     /// heuristic backend, never abort serving.
     public let encoderModelURL: URL?
@@ -85,6 +90,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         announcementsEnabled: Bool = true,
         steeringEnabled: Bool = false,
         questionClassifier: QuestionClassifierProvider = .auto,
+        voiceBackend: VoiceBackendProvider = .apple,
         encoderModelURL: URL? = nil,
         encoderMode: EncoderMode = .off,
         reasonerProvider: ReasonerProvider = .off,
@@ -100,6 +106,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         self.announcementsEnabled = announcementsEnabled
         self.steeringEnabled = steeringEnabled
         self.questionClassifier = questionClassifier
+        self.voiceBackend = voiceBackend
         self.encoderModelURL = encoderModelURL
         self.encoderMode = encoderMode
         self.reasonerProvider = reasonerProvider
@@ -115,6 +122,9 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
     public let tapProfileLoaded: Bool
     public let motionAvailable: Bool
     public let voiceAvailable: Bool
+    /// Human-readable voice-backend state; nil for the default Apple path, whose behavior
+    /// is what every operator already expects and so is worth no line at all.
+    public let voiceBackendStatus: String?
     /// Human-readable TapQ-1 encoder state; nil when no encoder was requested.
     public let encoderStatus: String?
     /// Human-readable stage-2 reasoner state; nil when no reasoner was requested.
@@ -127,6 +137,7 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         tapProfileLoaded: Bool,
         motionAvailable: Bool,
         voiceAvailable: Bool,
+        voiceBackendStatus: String? = nil,
         encoderStatus: String? = nil,
         reasonerStatus: String? = nil
     ) {
@@ -136,6 +147,7 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         self.tapProfileLoaded = tapProfileLoaded
         self.motionAvailable = motionAvailable
         self.voiceAvailable = voiceAvailable
+        self.voiceBackendStatus = voiceBackendStatus
         self.encoderStatus = encoderStatus
         self.reasonerStatus = reasonerStatus
     }

--- a/Sources/TapQCLI/RuntimeService.swift
+++ b/Sources/TapQCLI/RuntimeService.swift
@@ -83,6 +83,11 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
     /// When on, TapQ rejects voice commands that cannot be attributed to the wearer's
     /// own jaw vibration, unless the signal is unavailable (fail-open).
     public let wearerGateEnabled: Bool
+    /// Whether IMU-based turn control is active. Default off.
+    /// Endpointing: wearer speech-end commits the user turn.
+    /// Barge-in: wearer speech-onset during response playback interrupts audio.
+    /// Implies a wearer-speech signal source (shared with `wearerGateEnabled`).
+    public let imuTurnControlEnabled: Bool
 
     public init(
         brokerDirectory: URL? = nil,
@@ -100,7 +105,8 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         reasonerProvider: ReasonerProvider = .off,
         reasonerMode: ReasonerMode = .shadow,
         reasonerConfig: ReasonerConfig = ReasonerConfig(),
-        wearerGateEnabled: Bool = false
+        wearerGateEnabled: Bool = false,
+        imuTurnControlEnabled: Bool = false
     ) {
         self.brokerDirectory = brokerDirectory
         self.gestureProfileURL = gestureProfileURL
@@ -118,6 +124,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         self.reasonerMode = reasonerMode
         self.reasonerConfig = reasonerConfig
         self.wearerGateEnabled = wearerGateEnabled
+        self.imuTurnControlEnabled = imuTurnControlEnabled
     }
 }
 

--- a/Sources/TapQCLI/RuntimeService.swift
+++ b/Sources/TapQCLI/RuntimeService.swift
@@ -79,6 +79,10 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
     /// Thresholds the reasoner is built with. Defaulted rather than flag-driven: these
     /// are policy knobs, and no CLI flag exposes them yet.
     public let reasonerConfig: ReasonerConfig
+    /// Whether the IMU-based wearer-speech attribution gate is active. Default off.
+    /// When on, TapQ rejects voice commands that cannot be attributed to the wearer's
+    /// own jaw vibration, unless the signal is unavailable (fail-open).
+    public let wearerGateEnabled: Bool
 
     public init(
         brokerDirectory: URL? = nil,
@@ -95,7 +99,8 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         encoderMode: EncoderMode = .off,
         reasonerProvider: ReasonerProvider = .off,
         reasonerMode: ReasonerMode = .shadow,
-        reasonerConfig: ReasonerConfig = ReasonerConfig()
+        reasonerConfig: ReasonerConfig = ReasonerConfig(),
+        wearerGateEnabled: Bool = false
     ) {
         self.brokerDirectory = brokerDirectory
         self.gestureProfileURL = gestureProfileURL
@@ -112,6 +117,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         self.reasonerProvider = reasonerProvider
         self.reasonerMode = reasonerMode
         self.reasonerConfig = reasonerConfig
+        self.wearerGateEnabled = wearerGateEnabled
     }
 }
 
@@ -129,6 +135,8 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
     public let encoderStatus: String?
     /// Human-readable stage-2 reasoner state; nil when no reasoner was requested.
     public let reasonerStatus: String?
+    /// Human-readable wearer-speech gate state; nil when the gate was not requested.
+    public let wearerSpeechStatus: String?
 
     public init(
         socketPath: String,
@@ -139,7 +147,8 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         voiceAvailable: Bool,
         voiceBackendStatus: String? = nil,
         encoderStatus: String? = nil,
-        reasonerStatus: String? = nil
+        reasonerStatus: String? = nil,
+        wearerSpeechStatus: String? = nil
     ) {
         self.socketPath = socketPath
         self.discoveryPath = discoveryPath
@@ -150,6 +159,7 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         self.voiceBackendStatus = voiceBackendStatus
         self.encoderStatus = encoderStatus
         self.reasonerStatus = reasonerStatus
+        self.wearerSpeechStatus = wearerSpeechStatus
     }
 }
 

--- a/Sources/TapQCLI/RuntimeService.swift
+++ b/Sources/TapQCLI/RuntimeService.swift
@@ -88,6 +88,10 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
     /// Barge-in: wearer speech-onset during response playback interrupts audio.
     /// Implies a wearer-speech signal source (shared with `wearerGateEnabled`).
     public let imuTurnControlEnabled: Bool
+    /// Whether free-form voice answers are enabled for selection/multi-option stop
+    /// questions. Default off. When on, an unmatched final transcript is offered as a
+    /// free-text reply with mandatory read-back confirmation.
+    public let voiceFreeformEnabled: Bool
 
     public init(
         brokerDirectory: URL? = nil,
@@ -106,7 +110,8 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         reasonerMode: ReasonerMode = .shadow,
         reasonerConfig: ReasonerConfig = ReasonerConfig(),
         wearerGateEnabled: Bool = false,
-        imuTurnControlEnabled: Bool = false
+        imuTurnControlEnabled: Bool = false,
+        voiceFreeformEnabled: Bool = false
     ) {
         self.brokerDirectory = brokerDirectory
         self.gestureProfileURL = gestureProfileURL
@@ -125,6 +130,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         self.reasonerConfig = reasonerConfig
         self.wearerGateEnabled = wearerGateEnabled
         self.imuTurnControlEnabled = imuTurnControlEnabled
+        self.voiceFreeformEnabled = voiceFreeformEnabled
     }
 }
 

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -190,6 +190,7 @@ public struct TapQCLIIO {
             announcementsEnabled: options.announcementsEnabled,
             steeringEnabled: options.steeringEnabled,
             questionClassifier: options.questionClassifier,
+            voiceBackend: options.voiceBackend,
             encoderModelURL: options.encoderModelPath.map(resolvedURL(for:)),
             encoderMode: options.encoderModelPath == nil ? .off : options.encoderMode,
             reasonerProvider: options.reasonerProvider,
@@ -206,6 +207,9 @@ public struct TapQCLIIO {
             io.writeOutput("Tap profile: \(endpoint.tapProfileLoaded ? "loaded" : "default")\n")
             io.writeOutput("AirPods motion: \(endpoint.motionAvailable ? "available" : "unavailable")\n")
             io.writeOutput("Voice input: \(endpoint.voiceAvailable ? "available" : "unavailable")\n")
+            if let voiceBackendStatus = endpoint.voiceBackendStatus {
+                io.writeOutput("Voice backend: \(voiceBackendStatus)\n")
+            }
             if let encoderStatus = endpoint.encoderStatus {
                 io.writeOutput("TapQ-1 encoder: \(encoderStatus)\n")
             }
@@ -1522,6 +1526,14 @@ public struct TapQCLIIO {
       --no-announcements       Disable non-blocking agent status announcements
       --steering               Ask supported adapters to prefer structured questions
       --question-classifier P  Use auto, apple, anthropic, openai, or local (default: auto)
+      --voice-backend B        Speech pipe for voice commands: apple (default), Apple's
+                               on-device recognizer, or openai-realtime. The realtime
+                               backend requires OPENAI_API_KEY in the environment and
+                               serving refuses to start without it. It is always composed
+                               with the Apple stack underneath: if the session cannot be
+                               opened, or drops mid-window, voice continues on-device
+                               without the wearer noticing. TapQ commits every turn
+                               itself — no backend ever ends one.
       --encoder-model PATH     Load a TapQ-1 encoder model (.mlpackage or .mlmodelc)
       --encoder-mode MODE      shadow (default) records encoder detections as
                                diagnostics only; primary lets the encoder drive events.

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -779,6 +779,7 @@ public struct TapQCLIIO {
         var nod: [HeadMotionSample] = []
         var shake: [HeadMotionSample] = []
         var tap: [HeadMotionSample] = []
+        var speak: [HeadMotionSample] = []
         let timeline = CalibrationTimeline(options: options)
 
         errorLine("\(calibrationName(options.target)) calibration will use one continuous \(display(timeline.totalDuration))-second motion session and advance through each phase automatically.")
@@ -799,6 +800,7 @@ public struct TapQCLIIO {
             case .nod: nod.append(sample)
             case .shake: shake.append(sample)
             case .tap: tap.append(sample)
+            case .speak: speak.append(sample)
             case nil: break
             }
         }
@@ -813,11 +815,12 @@ public struct TapQCLIIO {
         )
         let store = calibrationStore(
             gesturePath: options.gestureProfilePath,
-            tapPath: options.tapProfilePath
+            tapPath: options.tapProfilePath,
+            wearerSpeechPath: options.wearerSpeechProfilePath
         )
         var failures: [String] = []
 
-        if options.target != .tap {
+        if options.target.includes(.gesture) {
             let base = (try? store.loadGesture().config) ?? HeadGestureConfig()
             let config = GestureCalibrator.suggestedConfig(from: samples, base: base)
             outputLine("Gesture threshold: \(display(config.amplitudeThreshold)) rad")
@@ -837,7 +840,7 @@ public struct TapQCLIIO {
             }
         }
 
-        if options.target != .gesture {
+        if options.target.includes(.tap) {
             let assessment = TapCalibrator.assessment(of: samples)
             outputLine("Tap signal peak: \(display(assessment.tapPeak)) g (resting peak \(display(assessment.restingPeak)) g; required \(display(assessment.requiredPeak)) g)")
             if assessment.isUsable {
@@ -860,9 +863,48 @@ public struct TapQCLIIO {
             }
         }
 
+        if options.target.includes(.wearerSpeech) {
+            let speechSamples = WearerSpeechCalibrationSamples(
+                resting: resting, speaking: speak)
+            let assessment = WearerSpeechCalibrator.assessment(of: speechSamples)
+            outputLine("Wearer speech envelope: \(display(assessment.speakingEnvelopeLevel)) g sustained (resting peak \(display(assessment.restingEnvelopePeak)) g; required \(display(assessment.requiredLevel)) g)")
+            if assessment.isUsable {
+                let base = (try? store.loadWearerSpeech().config) ?? WearerSpeechConfig()
+                let config = WearerSpeechCalibrator.suggestedConfig(
+                    from: speechSamples, base: base)
+                outputLine("Wearer speech thresholds: enter \(display(config.envelopeEnterThreshold)) g, exit \(display(config.envelopeExitThreshold)) g")
+                let profile = TapQWearerSpeechCalibrationProfile(
+                    config: config,
+                    quality: WearerSpeechCalibrationQuality(
+                        restingSampleCount: assessment.restingSampleCount,
+                        speakingSampleCount: assessment.speakingSampleCount,
+                        restingEnvelopePeak: assessment.restingEnvelopePeak,
+                        speakingEnvelopeLevel: assessment.speakingEnvelopeLevel
+                    )
+                )
+                try store.save(profile)
+                outputLine("Wearer speech calibration saved to \(store.wearerSpeechProfileURL.path)")
+            } else {
+                failures.append(wearerSpeechFailure(assessment))
+            }
+        }
+
         if !failures.isEmpty {
             throw CLIExecutionError(failures.joined(separator: " "))
         }
+    }
+
+    /// Separates the two ways a speak phase fails, because the remedies are unrelated: too
+    /// few samples means the motion stream did not deliver, while too little separation
+    /// means it did and the speech was not distinguishable from rest.
+    private func wearerSpeechFailure(
+        _ assessment: WearerSpeechCalibrator.Assessment
+    ) -> String {
+        let retry = "Any valid gesture or tap profile was kept; retry only wearer speech with `tapq calibration run wearer-speech`."
+        guard assessment.hasEnoughSamples else {
+            return "Wearer speech calibration captured too few motion samples (rest \(assessment.restingSampleCount), speak \(assessment.speakingSampleCount); \(assessment.requiredSampleCount) needed in each). Check that the AirPods are connected and lengthen the phases with --rest-seconds and --speak-seconds. \(retry)"
+        }
+        return "Wearer speech calibration did not observe a vibration envelope sufficiently separated from resting motion. Read aloud continuously at a normal speaking volume, keep your head still, and quit other headphone-motion apps first. \(retry)"
     }
 
     private func calibrationAnnouncements(for timeline: CalibrationTimeline) -> Task<Void, Never> {
@@ -883,15 +925,16 @@ public struct TapQCLIIO {
     private func showCalibration(_ options: CalibrationShowOptions) throws {
         let store = calibrationStore(
             gesturePath: options.gestureProfilePath,
-            tapPath: options.tapProfilePath
+            tapPath: options.tapProfilePath,
+            wearerSpeechPath: options.wearerSpeechProfilePath
         )
-        let gesture = options.target == .tap || !store.exists(.gesture)
-            ? nil
-            : try store.loadGesture()
-        let tap = options.target == .gesture || !store.exists(.tap)
-            ? nil
-            : try store.loadTap()
-        guard gesture != nil || tap != nil else {
+        func selected(_ kind: CalibrationProfileKind) -> Bool {
+            options.target.includes(kind) && store.exists(kind)
+        }
+        let gesture = selected(.gesture) ? try store.loadGesture() : nil
+        let tap = selected(.tap) ? try store.loadTap() : nil
+        let wearerSpeech = selected(.wearerSpeech) ? try store.loadWearerSpeech() : nil
+        guard gesture != nil || tap != nil || wearerSpeech != nil else {
             let paths = options.target.profileKinds.map { store.url(for: $0).path }
                 .joined(separator: ", ")
             throw CLIExecutionError("No \(calibrationName(options.target).lowercased()) calibration profile exists at \(paths).")
@@ -905,10 +948,12 @@ public struct TapQCLIIO {
             switch options.target {
             case .gesture: data = try encoder.encode(gesture)
             case .tap: data = try encoder.encode(tap)
+            case .wearerSpeech: data = try encoder.encode(wearerSpeech)
             case .all:
                 data = try encoder.encode(CalibrationProfileCollection(
                     gesture: gesture,
-                    tap: tap
+                    tap: tap,
+                    wearerSpeech: wearerSpeech
                 ))
             }
             guard let text = String(data: data, encoding: .utf8) else {
@@ -932,12 +977,21 @@ public struct TapQCLIIO {
             outputLine("Observed peak: \(display(tap.quality.tapAccelerationPeak)) g (resting \(display(tap.quality.restingAccelerationPeak)) g)")
             outputLine("Samples: rest \(tap.quality.restingSampleCount), tap \(tap.quality.tapSampleCount)")
         }
+        if gesture != nil || tap != nil, wearerSpeech != nil { outputLine("") }
+        if let wearerSpeech {
+            outputLine("Wearer speech calibration: \(store.wearerSpeechProfileURL.path)")
+            outputLine("Calibrated: \(ISO8601DateFormatter().string(from: wearerSpeech.calibratedAt))")
+            outputLine("Wearer speech thresholds: enter \(display(wearerSpeech.config.envelopeEnterThreshold)) g, exit \(display(wearerSpeech.config.envelopeExitThreshold)) g")
+            outputLine("Observed envelope: \(display(wearerSpeech.quality.speakingEnvelopeLevel)) g sustained (resting peak \(display(wearerSpeech.quality.restingEnvelopePeak)) g)")
+            outputLine("Samples: rest \(wearerSpeech.quality.restingSampleCount), speak \(wearerSpeech.quality.speakingSampleCount)")
+        }
     }
 
     private func resetCalibration(_ options: CalibrationResetOptions) throws {
         let store = calibrationStore(
             gesturePath: options.gestureProfilePath,
-            tapPath: options.tapProfilePath
+            tapPath: options.tapProfilePath,
+            wearerSpeechPath: options.wearerSpeechProfilePath
         )
         let existingKinds = options.target.profileKinds.filter(store.exists)
         guard !existingKinds.isEmpty else {
@@ -955,7 +1009,7 @@ public struct TapQCLIIO {
         }
         for kind in existingKinds {
             _ = try store.reset(kind)
-            outputLine("\(kind.rawValue.capitalized) calibration profile removed from \(store.url(for: kind).path).")
+            outputLine("\(kind.displayName) calibration profile removed from \(store.url(for: kind).path).")
         }
     }
 
@@ -1195,7 +1249,8 @@ public struct TapQCLIIO {
 
     private func calibrationStore(
         gesturePath: String?,
-        tapPath: String?
+        tapPath: String?,
+        wearerSpeechPath: String? = nil
     ) -> CalibrationStore {
         let defaults = CalibrationStore.defaultStore(
             environment: environment,
@@ -1205,15 +1260,18 @@ public struct TapQCLIIO {
             gestureProfileURL: gesturePath.map(resolvedURL(for:))
                 ?? defaults.gestureProfileURL,
             tapProfileURL: tapPath.map(resolvedURL(for:))
-                ?? defaults.tapProfileURL
+                ?? defaults.tapProfileURL,
+            wearerSpeechProfileURL: wearerSpeechPath.map(resolvedURL(for:))
+                ?? defaults.wearerSpeechProfileURL
         )
     }
 
     private func calibrationName(_ target: CalibrationTarget) -> String {
         switch target {
-        case .all: "Gesture and tap"
+        case .all: "Gesture, tap, and wearer speech"
         case .gesture: "Gesture"
         case .tap: "Tap"
+        case .wearerSpeech: "Wearer speech"
         }
     }
 
@@ -1382,28 +1440,39 @@ public struct TapQCLIIO {
     """
 
     private static let calibrationHelp = """
-    Calibrate gesture and tap thresholds as independent profiles without retaining raw motion samples.
+    Calibrate gesture, tap, and wearer-speech thresholds as independent profiles without
+    retaining raw motion samples.
 
     USAGE
-      tapq calibration run [all|gesture|tap] [options]
-      tapq calibrate [all|gesture|tap] [options]
-      tapq calibration show [all|gesture|tap] [--json] [profile options]
-      tapq calibration reset [all|gesture|tap] [--yes] [profile options]
+      tapq calibration run [all|gesture|tap|wearer-speech] [options]
+      tapq calibrate [all|gesture|tap|wearer-speech] [options]
+      tapq calibration show [all|gesture|tap|wearer-speech] [--json] [profile options]
+      tapq calibration reset [all|gesture|tap|wearer-speech] [--yes] [profile options]
+
+    The `all` target covers all three profiles: nod/shake, tap, and the wearer-speech
+    vibration envelope.
 
     RUN OPTIONS
       --rest-seconds N     Resting phase duration (default: 3)
       --nod-seconds N      Nod phase duration (default: 4)
       --shake-seconds N    Shake phase duration (default: 4)
       --tap-seconds N      Tap phase duration (default: 4)
+      --speak-seconds N    Read-aloud phase duration (default: 6)
       --non-interactive    Start without waiting for the initial Return prompt
 
     PROFILE OPTIONS
-      --profile PATH           Override the selected gesture or tap profile path
-      --gesture-profile PATH   Override the gesture profile path
-      --tap-profile PATH       Override the tap profile path
+      --profile PATH                Override the selected single-target profile path
+      --gesture-profile PATH        Override the gesture profile path
+      --tap-profile PATH            Override the tap profile path
+      --wearer-speech-profile PATH  Override the wearer-speech profile path
 
     A full run saves each usable profile immediately. If one phase fails, rerun only that
     target; for example, `tapq calibration run tap` does not repeat nod and shake.
+
+    The wearer-speech phase asks you to read aloud with your head still. It measures the
+    jaw- and skull-borne vibration the earbud IMU picks up while you talk, which is a
+    different quantity from the microphone's audio and is only comparable to a resting
+    baseline recorded in the same session.
     """
 
     private static let integrationHelp = """
@@ -1444,6 +1513,14 @@ public struct TapQCLIIO {
 private struct CalibrationProfileCollection: Encodable {
     let gesture: TapQGestureCalibrationProfile?
     let tap: TapQTapCalibrationProfile?
+    let wearerSpeech: TapQWearerSpeechCalibrationProfile?
+
+    enum CodingKeys: String, CodingKey {
+        case gesture, tap
+        // Matches `CalibrationProfileKind.wearerSpeech`'s raw value, so the same spelling
+        // names the target, the file, and this key.
+        case wearerSpeech = "wearer_speech"
+    }
 }
 
 private struct CLIExecutionError: Error, LocalizedError {

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -194,7 +194,8 @@ public struct TapQCLIIO {
             encoderModelURL: options.encoderModelPath.map(resolvedURL(for:)),
             encoderMode: options.encoderModelPath == nil ? .off : options.encoderMode,
             reasonerProvider: options.reasonerProvider,
-            reasonerMode: options.reasonerProvider == .off ? .off : options.reasonerMode
+            reasonerMode: options.reasonerProvider == .off ? .off : options.reasonerMode,
+            wearerGateEnabled: options.wearerGateEnabled
         )
         try await runtimeService.serve(
             configuration: configuration,
@@ -215,6 +216,9 @@ public struct TapQCLIIO {
             }
             if let reasonerStatus = endpoint.reasonerStatus {
                 io.writeOutput("Stage-2 reasoner: \(reasonerStatus)\n")
+            }
+            if let wearerSpeechStatus = endpoint.wearerSpeechStatus {
+                io.writeOutput("Wearer speech: \(wearerSpeechStatus)\n")
             }
         }
     }
@@ -1547,6 +1551,14 @@ public struct TapQCLIIO {
                                approve, deny, or resolve a request. Requires --reasoner;
                                if the model is unavailable, serving continues without
                                risk escalation.
+      --wearer-gate            Filter voice commands through IMU-based wearer-speech
+                               attribution (default: off). Requires AirPods motion.
+                               Uses wearer-speech-calibration.json when present,
+                               provisional thresholds otherwise. Always fail-open: a
+                               degraded or absent signal reproduces today's shipped
+                               behavior verbatim. With provisional thresholds, the gate
+                               may pass bystander speech — the attribution window is
+                               generous by design until the capture study lands.
 
     The broker is agent-neutral. Install each agent's adapter separately with
     `tapq integration claude install` or `tapq integration codex install`.

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -168,6 +168,17 @@ public struct TapQCLIIO {
 
     private func runServe(_ options: ServeOptions) async throws {
         guard let runtimeService else { throw TapQRuntimeUnavailableError() }
+        // --voice-freeform requires a backend that produces transcripts from a pipe
+        // (i.e. not the Apple-only recognizer, which never surfaces unmatched finals
+        // through VoiceBackendCommandProvider). Reject at startup rather than silently
+        // doing nothing — the question-classifier precedent.
+        if options.voiceFreeformEnabled, options.voiceBackend == .apple {
+            throw CLIUsageError(
+                message: "--voice-freeform requires --voice-backend openai-realtime. "
+                    + "The Apple speech recognizer does not produce transcripts "
+                    + "through the backend command provider."
+            )
+        }
         let defaults = CalibrationStore.defaultStore(
             environment: environment,
             homeDirectory: homeDirectory
@@ -196,7 +207,8 @@ public struct TapQCLIIO {
             reasonerProvider: options.reasonerProvider,
             reasonerMode: options.reasonerProvider == .off ? .off : options.reasonerMode,
             wearerGateEnabled: options.wearerGateEnabled,
-            imuTurnControlEnabled: options.imuTurnControlEnabled
+            imuTurnControlEnabled: options.imuTurnControlEnabled,
+            voiceFreeformEnabled: options.voiceFreeformEnabled
         )
         try await runtimeService.serve(
             configuration: configuration,
@@ -1570,6 +1582,17 @@ public struct TapQCLIIO {
                                Shares one signal source with --wearer-gate when both
                                are active. Provisional thresholds until the capture
                                study lands.
+      --voice-freeform         Enable free-form voice answers for selections and
+                               multi-option stop questions (default: off). Requires
+                               --voice-backend openai-realtime (the Apple recognizer
+                               does not produce transcripts through the backend
+                               command provider). When enabled, an unmatched final
+                               transcript is offered as a free-text reply with
+                               mandatory read-back confirmation: the wearer hears
+                               their answer spoken back and nods to send or shakes
+                               to discard. Tool approvals and yes/no stop questions
+                               stay binary — a spoken free-text answer can never
+                               authorize an agent action.
 
     The broker is agent-neutral. Install each agent's adapter separately with
     `tapq integration claude install` or `tapq integration codex install`.

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -195,7 +195,8 @@ public struct TapQCLIIO {
             encoderMode: options.encoderModelPath == nil ? .off : options.encoderMode,
             reasonerProvider: options.reasonerProvider,
             reasonerMode: options.reasonerProvider == .off ? .off : options.reasonerMode,
-            wearerGateEnabled: options.wearerGateEnabled
+            wearerGateEnabled: options.wearerGateEnabled,
+            imuTurnControlEnabled: options.imuTurnControlEnabled
         )
         try await runtimeService.serve(
             configuration: configuration,
@@ -1559,6 +1560,16 @@ public struct TapQCLIIO {
                                behavior verbatim. With provisional thresholds, the gate
                                may pass bystander speech — the attribution window is
                                generous by design until the capture study lands.
+      --imu-turn-control       IMU-based turn control (default: off). Endpointing:
+                               wearer speech-end commits the user turn with a 0.4 s
+                               delay on top of the detector's 0.6 s hangover. Barge-in:
+                               wearer speech-onset during response audio stops playback.
+                               Both features are additive — match-on-transcript and
+                               window timeout continue to work as fallback. A dead or
+                               absent signal means neither feature fires (fail-open).
+                               Shares one signal source with --wearer-gate when both
+                               are active. Provisional thresholds until the capture
+                               study lands.
 
     The broker is agent-neutral. Install each agent's adapter separately with
     `tapq integration claude install` or `tapq integration codex install`.

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -287,7 +287,8 @@ public struct TapQCLIIO {
 
         let store = calibrationStore(
             gesturePath: options.gestureProfilePath,
-            tapPath: options.tapProfilePath
+            tapPath: options.tapProfilePath,
+            wearerSpeechPath: options.wearerSpeechProfilePath
         )
         let gestureConfig = store.exists(.gesture)
             ? (try? store.loadGesture().config) ?? HeadGestureConfig()
@@ -295,6 +296,9 @@ public struct TapQCLIIO {
         let tapConfig = store.exists(.tap)
             ? (try? store.loadTap().config) ?? TapConfig()
             : TapConfig()
+        let wearerSpeechConfig = store.exists(.wearerSpeech)
+            ? (try? store.loadWearerSpeech().config) ?? WearerSpeechConfig()
+            : WearerSpeechConfig()
 
         var backends: [(name: String, events: [ReplayEvent])] = [(
             "heuristic",
@@ -311,14 +315,24 @@ public struct TapQCLIIO {
                 ReplayBackendRunner.encoderEvents(samples: samples, scorer: scorer)
             ))
         }
-        let segments = try options.labelsPath.map {
-            try ReplayLabelReader.segments(fromFileAt: resolvedURL(for: $0))
+        let partition = try options.labelsPath.map {
+            try ReplaySpeechLabelReader.partition(fromFileAt: resolvedURL(for: $0))
         }
+        let segments = partition?.events
+        let wearerSpeech = try wearerSpeechReport(
+            samples: samples,
+            config: wearerSpeechConfig,
+            labeled: partition?.speech ?? [],
+            envelopePath: options.micEnvelopePath,
+            tolerance: options.tolerance,
+            duration: duration
+        )
 
         if options.json {
             try outputReplayJSON(
                 input: inputURL.path, sampleCount: samples.count, duration: duration,
-                backends: backends, segments: segments, tolerance: options.tolerance)
+                backends: backends, segments: segments, tolerance: options.tolerance,
+                wearerSpeech: wearerSpeech)
             return
         }
 
@@ -350,12 +364,82 @@ public struct TapQCLIIO {
                 }
             }
         }
+
+        if let wearerSpeech { outputWearerSpeechSection(wearerSpeech) }
+    }
+
+    /// Runs the wearer-speech detector over the capture and scores it, or returns nil when
+    /// the replay has no speech ground truth — in which case the report keeps exactly the
+    /// shape it had before wearer speech existed.
+    ///
+    /// Labels beat the envelope sidecar: a human marking spans is the better truth, and a
+    /// study that supplies both is nearly always re-scoring a corrected label file against
+    /// the recording it was derived from.
+    private func wearerSpeechReport(
+        samples: [HeadMotionSample],
+        config: WearerSpeechConfig,
+        labeled: [ReplaySpeechSegment],
+        envelopePath: String?,
+        tolerance: TimeInterval,
+        duration: TimeInterval
+    ) throws -> WearerSpeechReplayReport? {
+        let truth: [ReplaySpeechSegment]
+        let source: WearerSpeechTruthSource
+        if !labeled.isEmpty {
+            if envelopePath != nil {
+                errorLine("Both wearer_speech labels and --mic-envelope were supplied; scoring against the labels.")
+            }
+            truth = labeled
+            source = .labels
+        } else if let envelopePath {
+            let track = try EnvelopeTrackReader.track(
+                fromFileAt: resolvedURL(for: envelopePath))
+            truth = EnvelopeLabelDeriver.segments(from: track)
+            source = .micEnvelope
+        } else {
+            return nil
+        }
+
+        let detected = WearerSpeechReplayRunner.intervals(samples: samples, config: config)
+        return WearerSpeechReplayReport(
+            truthSource: source,
+            metrics: SpeechIntervalEvaluator.evaluate(
+                detected: detected, truth: truth,
+                frameTimes: samples.map(\.timestamp),
+                tolerance: tolerance, duration: duration
+            )
+        )
+    }
+
+    private func outputWearerSpeechSection(_ report: WearerSpeechReplayReport) {
+        let metrics = report.metrics
+        outputLine("")
+        outputLine("Wearer speech (truth: \(report.truthSource.rawValue)): "
+            + "\(metrics.detectedSegments) detected, \(metrics.truthSegments) labeled")
+        outputLine("  " + pad("frames", 8) + lpad("TP", 6) + lpad("FP", 6) + lpad("FN", 6)
+            + "  " + pad("precision", 9) + "  " + pad("recall", 9) + "  f1")
+        outputLine("  " + pad("", 8)
+            + lpad("\(metrics.framesTruePositive)", 6)
+            + lpad("\(metrics.framesFalsePositive)", 6)
+            + lpad("\(metrics.framesFalseNegative)", 6)
+            + "  " + pad(displayRatio(metrics.precision), 9)
+            + "  " + pad(displayRatio(metrics.recall), 9)
+            + "  " + displayRatio(metrics.f1))
+        outputLine("  onset latency: \(displaySeconds(metrics.onsetLatencyMeanSeconds)) s "
+            + "(mean over \(metrics.matchedSegments) matched)")
+        if let perMinute = metrics.falseActivationsPerMinute {
+            outputLine("  false activations: \(metrics.falseActivations) "
+                + "(\(display(perMinute))/min)")
+        } else {
+            outputLine("  false activations: \(metrics.falseActivations)")
+        }
     }
 
     private func outputReplayJSON(
         input: String, sampleCount: Int, duration: TimeInterval,
         backends: [(name: String, events: [ReplayEvent])],
-        segments: [ReplayLabelSegment]?, tolerance: TimeInterval
+        segments: [ReplayLabelSegment]?, tolerance: TimeInterval,
+        wearerSpeech: WearerSpeechReplayReport?
     ) throws {
         struct EventJSON: Encodable {
             let time: Double
@@ -386,14 +470,42 @@ public struct TapQCLIIO {
                 case falsePositivesPerMinute = "false_positives_per_minute"
             }
         }
+        /// Absent — not null — when the replay had no speech ground truth, so a report
+        /// without the new flags encodes exactly the keys it always did.
+        struct WearerSpeechJSON: Encodable {
+            let truthSource: String
+            let framePrecision: Double?
+            let frameRecall: Double?
+            let f1: Double?
+            let onsetLatencyMeanSeconds: Double?
+            let falseActivations: Int
+            let falseActivationsPerMinute: Double?
+            let detectedIntervals: Int
+            let truthIntervals: Int
+            let matchedIntervals: Int
+            enum CodingKeys: String, CodingKey {
+                case f1
+                case truthSource = "truth_source"
+                case framePrecision = "frame_precision"
+                case frameRecall = "frame_recall"
+                case onsetLatencyMeanSeconds = "onset_latency_mean_seconds"
+                case falseActivations = "false_activations"
+                case falseActivationsPerMinute = "false_activations_per_minute"
+                case detectedIntervals = "detected_intervals"
+                case truthIntervals = "truth_intervals"
+                case matchedIntervals = "matched_intervals"
+            }
+        }
         struct ReportJSON: Encodable {
             let input: String
             let samples: Int
             let durationSeconds: Double
             let backends: [BackendJSON]
+            let wearerSpeech: WearerSpeechJSON?
             enum CodingKeys: String, CodingKey {
                 case input, samples, backends
                 case durationSeconds = "duration_seconds"
+                case wearerSpeech = "wearer_speech"
             }
         }
 
@@ -422,6 +534,19 @@ public struct TapQCLIIO {
                         }
                     },
                     falsePositivesPerMinute: evaluation?.falsePositivesPerMinute)
+            },
+            wearerSpeech: wearerSpeech.map { report in
+                WearerSpeechJSON(
+                    truthSource: report.truthSource.rawValue,
+                    framePrecision: report.metrics.precision,
+                    frameRecall: report.metrics.recall,
+                    f1: report.metrics.f1,
+                    onsetLatencyMeanSeconds: report.metrics.onsetLatencyMeanSeconds,
+                    falseActivations: report.metrics.falseActivations,
+                    falseActivationsPerMinute: report.metrics.falseActivationsPerMinute,
+                    detectedIntervals: report.metrics.detectedSegments,
+                    truthIntervals: report.metrics.truthSegments,
+                    matchedIntervals: report.metrics.matchedSegments)
             }
         )
         let encoder = JSONEncoder()
@@ -1454,17 +1579,29 @@ public struct TapQCLIIO {
                                using the capture's own timestamps. Labels mark the full
                                command (a `nod` segment spans the complete double nod,
                                `shake` the complete double shake): nod, shake, tilt_left,
-                               tilt_right, tap, swipe_up, swipe_down
+                               tilt_right, tap, swipe_up, swipe_down. A `wearer_speech`
+                               segment marks a span the wearer was talking and is scored
+                               separately, as an interval rather than an event
       --format jsonl|csv       Override capture format auto-detection
       --tolerance SECONDS      Grace period after a segment's end in which its event may
-                               still fire (default: 1.0)
+                               still fire, and the edge slack allowed around a
+                               wearer-speech span (default: 1.0)
       --encoder-model PATH     Also replay through a TapQ-1 encoder model (macOS only)
       --gesture-profile PATH   Use a calibrated gesture profile instead of defaults
       --tap-profile PATH       Use a calibrated tap profile instead of defaults
+      --wearer-speech-profile PATH
+                               Use a calibrated wearer-speech profile instead of defaults
+      --mic-envelope PATH      Envelope sidecar from `tapq capture --mic-envelope`, used
+                               as wearer-speech ground truth. `wearer_speech` labels win
+                               when both are supplied
       --json                   Emit the report as JSON
 
     Swipe detection is enabled during replay even though it ships disabled live, so
     experimental channels can be evaluated from the same recordings.
+
+    The wearer-speech section appears only when ground truth exists — `wearer_speech`
+    labels or an envelope sidecar. It reports frame-level precision/recall/F1 at the
+    capture's own sample rate, mean onset latency, and false activations per minute.
     """
 
     private static let benchHelp = """

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -35,6 +35,10 @@ public struct TapQCLIIO {
 @MainActor public final class TapQCLIApplication {
     private let io: TapQCLIIO
     private let motionCapture: (any TapQMotionCapturing)?
+    /// Microphone arm of the capture study, used only by `capture --mic-envelope`. nil on
+    /// hosts without an audio adapter, which the flag then reports as unavailable rather
+    /// than capturing motion with a silently missing label track.
+    private let envelopeCapture: (any TapQAudioEnvelopeCapturing)?
     private let runtimeService: (any TapQRuntimeServing)?
     /// Loads a TapQ-1 model into a window scorer for `tapq replay --encoder-model`.
     /// nil on platforms without a Core ML host (the flag then reports unavailability).
@@ -60,6 +64,7 @@ public struct TapQCLIIO {
     public init(
         io: TapQCLIIO = .live,
         motionCapture: (any TapQMotionCapturing)? = nil,
+        envelopeCapture: (any TapQAudioEnvelopeCapturing)? = nil,
         runtimeService: (any TapQRuntimeServing)? = nil,
         motionScorerLoader: ((URL) async throws -> any MotionWindowScoring)? = nil,
         reasonerLoader: TapQReasonerLoading? = nil,
@@ -79,6 +84,7 @@ public struct TapQCLIIO {
     ) {
         self.io = io
         self.motionCapture = motionCapture
+        self.envelopeCapture = envelopeCapture
         self.runtimeService = runtimeService
         self.motionScorerLoader = motionScorerLoader
         self.reasonerLoader = reasonerLoader
@@ -118,6 +124,12 @@ public struct TapQCLIIO {
             return 64
         } catch TapQMotionCaptureError.unavailable {
             errorLine("error: \(TapQMotionCaptureError.unavailable.localizedDescription)")
+            return 69
+        } catch let error as TapQEnvelopeCaptureError {
+            errorLine("error: \(error.localizedDescription)")
+            // A truncated track is a failed run but not an unavailable service: the
+            // recording exists and the operator has to decide whether to keep it.
+            if case .invalidated = error { return 1 }
             return 69
         } catch let error as TapQRuntimeUnavailableError {
             errorLine("error: \(error.localizedDescription)")
@@ -214,6 +226,32 @@ public struct TapQCLIIO {
         }
         defer { try? writer?.close() }
 
+        // Fail-closed: a study recording whose label track never opened is worthless, and
+        // that has to be discovered before the wearer performs the session, not after. So
+        // the sidecar is opened and the microphone started ahead of the IMU stream, and
+        // any failure aborts with nothing captured.
+        let recorder = try options.micEnvelopePath.map { path -> EnvelopeSidecarRecorder in
+            guard envelopeCapture != nil else { throw TapQEnvelopeCaptureError.unavailable }
+            return try EnvelopeSidecarRecorder(
+                url: resolvedURL(for: path), force: options.force)
+        }
+        defer { recorder?.close() }
+
+        var envelopeFailure: TapQEnvelopeCaptureError?
+        if let recorder, let envelopeCapture {
+            try envelopeCapture.start(
+                onTrack: { recorder.writeTrack($0) },
+                onSample: { recorder.append($0) },
+                onInvalidation: { failure in
+                    // Recorded rather than thrown: the IMU capture in flight is still
+                    // worth finishing and writing, and the exit code carries the failure.
+                    envelopeFailure = envelopeFailure ?? failure
+                }
+            )
+            errorLine("Co-recording a microphone envelope to \(recorder.url.path)…")
+        }
+        defer { if recorder != nil { envelopeCapture?.stop() } }
+
         if outputURL == nil, options.format == .csv {
             outputLine(MotionSampleFormatter.csvHeader)
         }
@@ -231,6 +269,11 @@ public struct TapQCLIIO {
             sampleCount += 1
         }
         errorLine("Captured \(sampleCount) samples.")
+        if let recorder {
+            envelopeCapture?.stop()
+            errorLine("Captured \(recorder.sampleCount) microphone envelope blocks.")
+        }
+        if let envelopeFailure { throw envelopeFailure }
     }
 
     private func runReplay(_ options: ReplayOptions) async throws {
@@ -1377,12 +1420,23 @@ public struct TapQCLIIO {
 
     USAGE
       tapq capture [--duration SECONDS] [--format jsonl|csv] [--output PATH|-] [--force]
+                   [--mic-envelope PATH]
 
     OPTIONS
       --duration SECONDS   Capture duration (default: 10)
       --format FORMAT      jsonl (default) or csv
       --output, -o PATH    Output file, or - for stdout (default: -)
-      --force, -f          Replace an existing output file
+      --force, -f          Replace an existing output file (also applies to --mic-envelope)
+      --mic-envelope PATH  Co-record a microphone loudness envelope to a JSONL sidecar,
+                           time-aligned to the motion track's own clock. Study tooling for
+                           labelling wearer speech; no audio is retained, only per-block
+                           RMS and peak. If the microphone cannot start, the command fails
+                           before capturing any motion.
+
+    Select the Mac's built-in microphone as the system input before co-recording an
+    envelope. Opening the AirPods microphone switches Bluetooth into its headset mode,
+    which degrades the audio route mid-session and changes the very motion signal the
+    study is trying to measure.
     """
 
     private static let replayHelp = """

--- a/Sources/TapQCLI/WearerSpeechReplay.swift
+++ b/Sources/TapQCLI/WearerSpeechReplay.swift
@@ -1,0 +1,404 @@
+import Foundation
+import TapQDetectionBaseline
+
+/// A stretch of the capture's own timestamp clock during which the wearer was speaking —
+/// either because a human labelled it, because the co-recorded microphone envelope was
+/// loud there, or because `WearerSpeechDetector` said so.
+///
+/// Wearer speech is interval-valued, which is why it is evaluated by this file rather than
+/// by `ReplayEvaluator`: a nod either happened at a moment or it did not, but speech is a
+/// span whose edges are approximate on both sides. Folding it into `ReplayEventLabel`
+/// would have forced an interval through an event-shaped evaluator whose consumed/tolerance
+/// semantics are load-bearing for the existing gesture benchmarks.
+struct ReplaySpeechSegment: Equatable, Sendable {
+    let start: TimeInterval
+    let end: TimeInterval
+
+    var duration: TimeInterval { max(0, end - start) }
+
+    /// True when `time` falls in the segment widened by `slack` on both edges.
+    func contains(_ time: TimeInterval, slack: TimeInterval = 0) -> Bool {
+        time >= start - slack && time <= end + slack
+    }
+
+    /// True when the two segments share any instant once both are widened by `slack`.
+    func overlaps(_ other: ReplaySpeechSegment, slack: TimeInterval = 0) -> Bool {
+        start - slack <= other.end + slack && other.start - slack <= end + slack
+    }
+}
+
+/// A label file split into the two vocabularies it can carry.
+struct ReplayLabelPartition: Equatable {
+    let events: [ReplayLabelSegment]
+    let speech: [ReplaySpeechSegment]
+}
+
+/// Reads a replay label file that may mix event labels with `wearer_speech` spans.
+///
+/// The event labels keep going through `ReplayLabelReader` untouched: label files written
+/// before wearer speech existed parse byte-identically, and an unknown label that is *not*
+/// `wearer_speech` still fails as `badLabelLine` rather than being silently dropped.
+enum ReplaySpeechLabelReader {
+    /// The one interval-valued label. Spelled exactly like
+    /// `CalibrationProfileKind.wearerSpeech.rawValue`, so the on-disk vocabulary is one
+    /// word everywhere in the milestone.
+    static let speechLabel = "wearer_speech"
+
+    static func partition(fromFileAt url: URL) throws -> ReplayLabelPartition {
+        guard let data = FileManager.default.contents(atPath: url.path),
+              let text = String(data: data, encoding: .utf8) else {
+            throw CaptureReadError.unreadable(url.path)
+        }
+        return try partition(fromText: text)
+    }
+
+    static func partition(fromText text: String) throws -> ReplayLabelPartition {
+        let decoder = JSONDecoder()
+        var speech: [ReplaySpeechSegment] = []
+        // Speech lines are replaced by a blank placeholder rather than removed, so the
+        // line numbers `ReplayLabelReader` reports on a malformed event line still name the
+        // line the operator sees. A single space (not the empty string) survives the
+        // reader's `split`, which omits empty subsequences, and is then skipped by its
+        // whitespace guard.
+        var eventLines: [String] = []
+
+        for (index, line) in text.split(separator: "\n").enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else {
+                eventLines.append(String(line))
+                continue
+            }
+            let payload = Data(trimmed.utf8)
+            guard let probe = try? decoder.decode(LabelProbe.self, from: payload),
+                  probe.label == speechLabel else {
+                eventLines.append(String(line))
+                continue
+            }
+            let record: SpeechRecord
+            do {
+                record = try decoder.decode(SpeechRecord.self, from: payload)
+            } catch {
+                throw CaptureReadError.badLabelLine(index + 1, String(describing: error))
+            }
+            guard record.start <= record.end else {
+                throw CaptureReadError.badLabelLine(index + 1, "start is after end")
+            }
+            speech.append(ReplaySpeechSegment(start: record.start, end: record.end))
+            eventLines.append(" ")
+        }
+
+        let events = try ReplayLabelReader.segments(
+            fromText: eventLines.joined(separator: "\n"))
+        return ReplayLabelPartition(
+            events: events, speech: speech.sorted { $0.start < $1.start })
+    }
+
+    private struct LabelProbe: Decodable {
+        let label: String
+    }
+
+    private struct SpeechRecord: Decodable {
+        let start: TimeInterval
+        let end: TimeInterval
+    }
+}
+
+/// How a microphone envelope track is turned into speech ground truth.
+///
+/// Every value here is study tooling, not runtime policy: the thresholds are relative to
+/// the recording's own noise floor so one constant does not have to fit both a quiet room
+/// and a noisy one, and the absolute guards below keep a *silent* recording from deriving
+/// "speech" out of its own dither.
+struct EnvelopeLabelDeriverConfig: Equatable, Sendable {
+    /// Where between the noise floor and the loud reference a block starts counting as
+    /// speech, and where it stops. Two fractions, so the derivation has hysteresis for the
+    /// same reason the detector does: an envelope hovering at one threshold would otherwise
+    /// shred a single utterance into dozens of segments.
+    var enterFraction: Double
+    var exitFraction: Double
+    /// Quantiles of the track's RMS used as "the room" and "the wearer talking". Not min
+    /// and max: one clipped block or one door slam would otherwise set the whole scale.
+    var noiseFloorQuantile: Double
+    var loudQuantile: Double
+    /// A track whose loud reference is not at least this far above its noise floor is
+    /// treated as containing no speech at all.
+    var minimumContrast: Double
+    /// Absolute floor under the derived enter threshold. Below this, RMS is silence on any
+    /// normalised input, whatever the relative arithmetic says.
+    var minimumEnterRMS: Double
+    /// Segments closer together than this are merged — the pauses inside one utterance.
+    var minimumGapSeconds: TimeInterval
+    /// Merged segments shorter than this are dropped — a cough, a keystroke, a chair.
+    var minimumSegmentSeconds: TimeInterval
+
+    init(
+        enterFraction: Double = 0.5,
+        exitFraction: Double = 0.25,
+        noiseFloorQuantile: Double = 0.2,
+        loudQuantile: Double = 0.95,
+        minimumContrast: Double = 0.01,
+        minimumEnterRMS: Double = 0.01,
+        minimumGapSeconds: TimeInterval = 0.3,
+        minimumSegmentSeconds: TimeInterval = 0.2
+    ) {
+        self.enterFraction = enterFraction
+        self.exitFraction = exitFraction
+        self.noiseFloorQuantile = noiseFloorQuantile
+        self.loudQuantile = loudQuantile
+        self.minimumContrast = minimumContrast
+        self.minimumEnterRMS = minimumEnterRMS
+        self.minimumGapSeconds = minimumGapSeconds
+        self.minimumSegmentSeconds = minimumSegmentSeconds
+    }
+}
+
+/// Pure envelope-track → speech-truth derivation. Deterministic: the same track always
+/// yields the same segments, because a metric whose ground truth moved between runs would
+/// be worse than no metric.
+enum EnvelopeLabelDeriver {
+    struct Thresholds: Equatable {
+        let noiseFloor: Double
+        let loud: Double
+        let enter: Double
+        let exit: Double
+    }
+
+    /// nil when the track has no usable contrast — a silent recording has no speech in it,
+    /// and inventing a threshold inside its noise would label the whole file as speech.
+    static func thresholds(
+        for samples: [MicEnvelopeSample],
+        config: EnvelopeLabelDeriverConfig = .init()
+    ) -> Thresholds? {
+        guard !samples.isEmpty else { return nil }
+        let levels = samples.map(\.rms).sorted()
+        let noiseFloor = quantile(levels, config.noiseFloorQuantile)
+        let loud = quantile(levels, config.loudQuantile)
+        guard loud - noiseFloor >= config.minimumContrast else { return nil }
+        let span = loud - noiseFloor
+        return Thresholds(
+            noiseFloor: noiseFloor,
+            loud: loud,
+            enter: max(config.minimumEnterRMS,
+                       noiseFloor + config.enterFraction * span),
+            // The absolute floor is halved for the exit threshold for the same reason the
+            // relative one is lowered: leaving a segment must be harder than entering it.
+            exit: max(config.minimumEnterRMS / 2,
+                      noiseFloor + config.exitFraction * span)
+        )
+    }
+
+    static func segments(
+        from track: MicEnvelopeTrack,
+        config: EnvelopeLabelDeriverConfig = .init()
+    ) -> [ReplaySpeechSegment] {
+        segments(from: track.samples, config: config)
+    }
+
+    static func segments(
+        from samples: [MicEnvelopeSample],
+        config: EnvelopeLabelDeriverConfig = .init()
+    ) -> [ReplaySpeechSegment] {
+        guard let thresholds = thresholds(for: samples, config: config) else { return [] }
+        let ordered = samples.sorted { $0.timestamp < $1.timestamp }
+
+        var raw: [ReplaySpeechSegment] = []
+        var start: TimeInterval?
+        var lastLoud: TimeInterval = 0
+        for sample in ordered {
+            if start == nil {
+                if sample.rms >= thresholds.enter {
+                    start = sample.timestamp
+                    lastLoud = sample.timestamp
+                }
+            } else if sample.rms >= thresholds.exit {
+                lastLoud = sample.timestamp
+            } else {
+                raw.append(ReplaySpeechSegment(start: start!, end: lastLoud))
+                start = nil
+            }
+        }
+        if let start { raw.append(ReplaySpeechSegment(start: start, end: lastLoud)) }
+
+        return merged(raw, minimumGapSeconds: config.minimumGapSeconds)
+            .filter { $0.duration >= config.minimumSegmentSeconds }
+    }
+
+    /// Joins segments separated by less than `minimumGapSeconds`. Input must be sorted by
+    /// start, which every producer here guarantees.
+    static func merged(
+        _ segments: [ReplaySpeechSegment], minimumGapSeconds: TimeInterval
+    ) -> [ReplaySpeechSegment] {
+        var merged: [ReplaySpeechSegment] = []
+        for segment in segments {
+            if let last = merged.last, segment.start - last.end < minimumGapSeconds {
+                merged[merged.count - 1] = ReplaySpeechSegment(
+                    start: last.start, end: max(last.end, segment.end))
+            } else {
+                merged.append(segment)
+            }
+        }
+        return merged
+    }
+
+    /// Nearest-rank quantile over an already sorted array.
+    private static func quantile(_ sorted: [Double], _ fraction: Double) -> Double {
+        guard !sorted.isEmpty else { return 0 }
+        let position = (Double(sorted.count - 1) * min(max(fraction, 0), 1)).rounded()
+        return sorted[Int(position)]
+    }
+}
+
+/// Streams a capture through `WearerSpeechDetector` and collects the spans it called
+/// speech, stamped with the producing sample's capture timestamp — the same convention
+/// `ReplayBackendRunner` uses for events.
+enum WearerSpeechReplayRunner {
+    static func intervals(
+        samples: [HeadMotionSample],
+        config: WearerSpeechConfig = .init()
+    ) -> [ReplaySpeechSegment] {
+        var detector = WearerSpeechDetector(config: config)
+        var intervals: [ReplaySpeechSegment] = []
+        var start: TimeInterval?
+        for sample in samples {
+            switch detector.ingestDetailed(sample).transition {
+            case .startedSpeaking:
+                start = sample.timestamp
+            case .stoppedSpeaking:
+                if let open = start {
+                    intervals.append(
+                        ReplaySpeechSegment(start: open, end: sample.timestamp))
+                    start = nil
+                }
+            case nil:
+                break
+            }
+        }
+        // A capture that ends mid-utterance still detected that utterance; closing the
+        // interval at the last sample is the only end the recording has evidence for.
+        if let open = start, let last = samples.last {
+            intervals.append(ReplaySpeechSegment(start: open, end: last.timestamp))
+        }
+        return intervals
+    }
+}
+
+struct SpeechIntervalMetrics: Equatable {
+    let framesTruePositive: Int
+    let framesFalsePositive: Int
+    let framesFalseNegative: Int
+    let truthSegments: Int
+    let detectedSegments: Int
+    let matchedSegments: Int
+    let falseActivations: Int
+    /// Mean of (detected onset − truth onset) over matched segments; nil when nothing
+    /// matched. Positive is late, which is the normal sign: the detector must see enough
+    /// window to be sure.
+    let onsetLatencyMeanSeconds: TimeInterval?
+    let durationSeconds: TimeInterval
+
+    var precision: Double? {
+        let emitted = framesTruePositive + framesFalsePositive
+        return emitted == 0 ? nil : Double(framesTruePositive) / Double(emitted)
+    }
+
+    var recall: Double? {
+        let expected = framesTruePositive + framesFalseNegative
+        return expected == 0 ? nil : Double(framesTruePositive) / Double(expected)
+    }
+
+    var f1: Double? {
+        guard let precision, let recall, precision + recall > 0 else { return nil }
+        return 2 * precision * recall / (precision + recall)
+    }
+
+    var falseActivationsPerMinute: Double? {
+        durationSeconds > 0 ? Double(falseActivations) / (durationSeconds / 60) : nil
+    }
+}
+
+/// Frame-level scoring of detected speech spans against truth spans.
+///
+/// Frames are the capture's own samples, so precision and recall are "what fraction of the
+/// time was this right", which is the question a gating decision actually asks — a
+/// segment-counting score would rate a detector that fires for 200 ms of a 10 s utterance
+/// as perfect.
+///
+/// `tolerance` is edge slack, reusing replay's existing `--tolerance`: a frame the detector
+/// claims within `tolerance` of a true segment is neither credited nor penalised, and the
+/// same grace applies to true frames just outside a detected span. Onset latency is
+/// reported separately precisely because that edge behaviour is excused here.
+enum SpeechIntervalEvaluator {
+    static func evaluate(
+        detected: [ReplaySpeechSegment],
+        truth: [ReplaySpeechSegment],
+        frameTimes: [TimeInterval],
+        tolerance: TimeInterval,
+        duration: TimeInterval
+    ) -> SpeechIntervalMetrics {
+        var truePositive = 0
+        var falsePositive = 0
+        var falseNegative = 0
+        for time in frameTimes {
+            let claimed = detected.contains { $0.contains(time) }
+            let spoken = truth.contains { $0.contains(time) }
+            if claimed, spoken {
+                truePositive += 1
+            } else if claimed {
+                if !truth.contains(where: { $0.contains(time, slack: tolerance) }) {
+                    falsePositive += 1
+                }
+            } else if spoken {
+                if !detected.contains(where: { $0.contains(time, slack: tolerance) }) {
+                    falseNegative += 1
+                }
+            }
+        }
+
+        // One detected span may answer at most one true segment, so a detector that fires
+        // once for two adjacent utterances is not credited with both.
+        var claimed = Set<Int>()
+        var latencies: [TimeInterval] = []
+        for segment in truth.sorted(by: { $0.start < $1.start }) {
+            guard let index = detected.indices.first(where: {
+                !claimed.contains($0) && detected[$0].overlaps(segment, slack: tolerance)
+            }) else { continue }
+            claimed.insert(index)
+            latencies.append(detected[index].start - segment.start)
+        }
+
+        // A false activation is a detected span that answers no true segment at all.
+        // Fragmentation — two spans inside one utterance — is not counted here; the
+        // segment counts show it, and calling it a false activation would double-punish a
+        // detector that was right about the utterance.
+        let falseActivations = detected.filter { span in
+            !truth.contains { $0.overlaps(span, slack: tolerance) }
+        }.count
+
+        return SpeechIntervalMetrics(
+            framesTruePositive: truePositive,
+            framesFalsePositive: falsePositive,
+            framesFalseNegative: falseNegative,
+            truthSegments: truth.count,
+            detectedSegments: detected.count,
+            matchedSegments: latencies.count,
+            falseActivations: falseActivations,
+            onsetLatencyMeanSeconds: latencies.isEmpty
+                ? nil
+                : latencies.reduce(0, +) / Double(latencies.count),
+            durationSeconds: duration
+        )
+    }
+}
+
+/// Where a replay's wearer-speech ground truth came from. The value is reported verbatim
+/// as the `truth_source` JSON key so a study run's provenance survives into its metrics.
+enum WearerSpeechTruthSource: String, Equatable {
+    case labels
+    case micEnvelope = "mic_envelope"
+}
+
+/// Everything the wearer-speech section of a replay report needs.
+struct WearerSpeechReplayReport: Equatable {
+    let truthSource: WearerSpeechTruthSource
+    let metrics: SpeechIntervalMetrics
+}

--- a/Sources/TapQClaudeAdapter/HookShim.swift
+++ b/Sources/TapQClaudeAdapter/HookShim.swift
@@ -385,16 +385,24 @@ public struct HookShim {
             return passThrough
         }
 
-        guard let labels = obj["selected_labels"]?.arrayValue?.compactMap(\.stringValue),
-              !labels.isEmpty else {
-            diagnostics.record("ask_user_question.no_selection")
-            return passThrough
+        // Labels-preferred: a reply carrying both labels and free_text uses labels.
+        let labels = obj["selected_labels"]?.arrayValue?.compactMap(\.stringValue) ?? []
+        if !labels.isEmpty {
+            let selection = labels.joined(separator: ", ")
+            diagnostics.record("ask_user_question.selected", fields: ["selection": selection])
+            let reason = "User answered via TapQ hands-free interface. Selection: '\(selection)' for question: '\(questionText)'. Please proceed with this choice without re-asking."
+            return emitPreToolUse("deny", reason)
         }
 
-        let selection = labels.joined(separator: ", ")
-        diagnostics.record("ask_user_question.selected", fields: ["selection": selection])
-        let reason = "User answered via TapQ hands-free interface. Selection: '\(selection)' for question: '\(questionText)'. Please proceed with this choice without re-asking."
-        return emitPreToolUse("deny", reason)
+        // Free-text fallback: the wearer answered in their own words.
+        if let freeText = obj["free_text"]?.stringValue, !freeText.isEmpty {
+            diagnostics.record("ask_user_question.free_text", fields: ["chars": "\(freeText.count)"])
+            let reason = "User answered via TapQ hands-free interface. They answered in their own words: '\(freeText)' for question: '\(questionText)'. Please proceed accordingly without re-asking."
+            return emitPreToolUse("deny", reason)
+        }
+
+        diagnostics.record("ask_user_question.no_selection")
+        return passThrough
     }
 
     // MARK: - Helpers

--- a/Sources/TapQCodexAdapter/CodexHookShim.swift
+++ b/Sources/TapQCodexAdapter/CodexHookShim.swift
@@ -214,43 +214,67 @@ public struct CodexHookShim {
         guard let response = try? JSONDecoder().decode(
             [String: JSONValue].self,
             from: reply
-        ), response["error"] == nil,
-              let selectedIndices = response["selected_indices"]?.arrayValue,
-              selectedIndices.count == 1,
-              case .number(let selectedIndexNumber) = selectedIndices[0],
-              let selectedIndex = Int(exactly: selectedIndexNumber),
-              optionLabels.indices.contains(selectedIndex),
-              let selectedValues = response["selected_labels"]?.arrayValue,
-              selectedValues.count == 1,
-              let selection = nonempty(selectedValues.first?.stringValue),
-              selection == optionLabels[selectedIndex] else {
+        ), response["error"] == nil else {
             diagnostics.record("request_user_input.no_selection")
             return passThrough
         }
 
-        diagnostics.record(
-            "request_user_input.selected",
-            fields: ["selection": selection]
-        )
-        guard let responseJSON = requestUserInputResponseJSON(
-            questionID: questionID,
-            selection: selection
-        ) else {
-            diagnostics.record("request_user_input.response_encode_failed", level: .warning)
-            return passThrough
+        // Labels-preferred: a reply carrying both labels and free_text uses labels.
+        if let selectedIndices = response["selected_indices"]?.arrayValue,
+           selectedIndices.count == 1,
+           case .number(let selectedIndexNumber) = selectedIndices[0],
+           let selectedIndex = Int(exactly: selectedIndexNumber),
+           optionLabels.indices.contains(selectedIndex),
+           let selectedValues = response["selected_labels"]?.arrayValue,
+           selectedValues.count == 1,
+           let selection = nonempty(selectedValues.first?.stringValue),
+           selection == optionLabels[selectedIndex] {
+            diagnostics.record(
+                "request_user_input.selected",
+                fields: ["selection": selection]
+            )
+            guard let responseJSON = requestUserInputResponseJSON(
+                questionID: questionID,
+                answer: selection
+            ) else {
+                diagnostics.record("request_user_input.response_encode_failed", level: .warning)
+                return passThrough
+            }
+            let reason =
+                "User answered via TapQ hands-free interface. Treat this request_user_input "
+                + "call as successful with response JSON: \(responseJSON). Do not re-ask this question."
+            return emitPreToolUseDeny(reason)
         }
-        let reason =
-            "User answered via TapQ hands-free interface. Treat this request_user_input "
-            + "call as successful with response JSON: \(responseJSON). Do not re-ask this question."
-        return emitPreToolUseDeny(reason)
+
+        // Free-text fallback: the wearer answered in their own words.
+        if let freeText = nonempty(response["free_text"]?.stringValue) {
+            diagnostics.record(
+                "request_user_input.free_text",
+                fields: ["chars": "\(freeText.count)"]
+            )
+            guard let responseJSON = requestUserInputResponseJSON(
+                questionID: questionID,
+                answer: freeText
+            ) else {
+                diagnostics.record("request_user_input.response_encode_failed", level: .warning)
+                return passThrough
+            }
+            let reason =
+                "User answered via TapQ hands-free interface. Treat this request_user_input "
+                + "call as successful with response JSON: \(responseJSON). Do not re-ask this question."
+            return emitPreToolUseDeny(reason)
+        }
+
+        diagnostics.record("request_user_input.no_selection")
+        return passThrough
     }
 
     private static func requestUserInputResponseJSON(
         questionID: String,
-        selection: String
+        answer: String
     ) -> String? {
         let response = RequestUserInputResponse(
-            answers: [questionID: .init(answers: [selection])]
+            answers: [questionID: .init(answers: [answer])]
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]

--- a/Sources/TapQContextBaseline/StopQuestionCoordinator.swift
+++ b/Sources/TapQContextBaseline/StopQuestionCoordinator.swift
@@ -94,15 +94,25 @@ import TapQContracts
                 options: options,
                 multiSelect: false
             )
-            let labels = await runSelection(request, deadline).choices.map(\.label)
-            guard !labels.isEmpty else {
-                diagnostics.record("multi_option.unanswered.pass")
-                consecutiveAnswers[sessionID] = 0
-                return nil
+            let selectionResult = await runSelection(request, deadline)
+            // Labels take precedence over freeText when both are present (defensive).
+            let labels = selectionResult.choices.map(\.label)
+            if !labels.isEmpty {
+                recordAnswer(sessionID: sessionID, text: text)
+                diagnostics.record("multi_option.answered", fields: ["choices": "\(labels.count)"])
+                return Self.reply(question: question, answer: labels.joined(separator: ", "))
             }
-            recordAnswer(sessionID: sessionID, text: text)
-            diagnostics.record("multi_option.answered", fields: ["choices": "\(labels.count)"])
-            return Self.reply(question: question, answer: labels.joined(separator: ", "))
+            // A free-text answer is a resolution even with empty choices.
+            if let freeText = selectionResult.freeText {
+                recordAnswer(sessionID: sessionID, text: text)
+                diagnostics.record("multi_option.answered_freeform",
+                                   fields: ["length": "\(freeText.count)"])
+                return Self.reply(question: question,
+                                  answer: "they answered: '\(freeText)'")
+            }
+            diagnostics.record("multi_option.unanswered.pass")
+            consecutiveAnswers[sessionID] = 0
+            return nil
 
         case .yesNo(let question):
             diagnostics.record("yes_no.detected", fields: ["agent": agent.id])

--- a/Sources/TapQContracts/Inputs.swift
+++ b/Sources/TapQContracts/Inputs.swift
@@ -17,6 +17,9 @@ public enum VoiceCommand: Sendable {
     case previous
     case select
     case number(Int)
+    /// A spoken free-text answer that matched no keyword. Only produced when
+    /// `freeformEnabled` is true on the `VoiceBackendCommandProvider`.
+    case freeform(String)
 }
 
 extension VoiceCommand: Equatable {
@@ -27,6 +30,8 @@ extension VoiceCommand: Equatable {
              (.previous, .previous), (.select, .select):
             return true
         case (.number(let a), .number(let b)):
+            return a == b
+        case (.freeform(let a), .freeform(let b)):
             return a == b
         default:
             return false
@@ -51,6 +56,9 @@ public enum InputIntent: Sendable {
     case previous
     case select
     case selectByNumber(Int)
+    /// A spoken free-text answer that matched no keyword. Only meaningful in
+    /// selection flow; approval flow ignores it (keeps listening).
+    case freeform(String)
 }
 
 extension InputIntent: Equatable {
@@ -61,6 +69,8 @@ extension InputIntent: Equatable {
              (.previous, .previous), (.select, .select):
             return true
         case (.selectByNumber(let a), .selectByNumber(let b)):
+            return a == b
+        case (.freeform(let a), .freeform(let b)):
             return a == b
         default:
             return false
@@ -107,6 +117,7 @@ public extension VoiceCommand {
         case .previous: return .previous
         case .select: return .select
         case .number(let n): return .selectByNumber(n)
+        case .freeform(let text): return .freeform(text)
         }
     }
 }

--- a/Sources/TapQContracts/Inputs.swift
+++ b/Sources/TapQContracts/Inputs.swift
@@ -140,6 +140,21 @@ public extension TapCommand {
 @MainActor public protocol VoiceCommandProviding: AnyObject {
     func start(onCommand: @escaping @MainActor (VoiceCommand) -> Void)
     func stop()
+
+    /// Suspends command delivery without tearing down backend state.
+    ///
+    /// Called by `SpeechGatedVoice` when the activity signal rises (TTS or backend audio
+    /// starts playing). Unlike `stop()`, which is an arbiter-driven window end, this is an
+    /// activity-driven mic close: the window is still conceptually open, and a conversation-
+    /// mode backend must not flush response audio or cancel in-flight responses.
+    ///
+    /// The default implementation calls `stop()`, which is correct for providers that carry
+    /// no persistent session state across start/stop cycles (e.g. `VoiceListener`).
+    func pauseListening()
+}
+
+public extension VoiceCommandProviding {
+    func pauseListening() { stop() }
 }
 
 /// Emits an AirPod tap while listening. Implemented by `HeadGestureDetector`, which derives

--- a/Sources/TapQContracts/SelectionResult.swift
+++ b/Sources/TapQContracts/SelectionResult.swift
@@ -19,10 +19,15 @@ public struct SelectionResult: Sendable, Equatable {
 
     public let choices: [Choice]
     public let timedOut: Bool
+    /// Free-text answer from the wearer, when the selection was resolved by a spoken
+    /// free-form reply rather than choosing a listed option. A result with `freeText != nil`
+    /// and empty `choices` is a resolution, not a timeout.
+    public let freeText: String?
 
-    public init(choices: [Choice], timedOut: Bool = false) {
+    public init(choices: [Choice], timedOut: Bool = false, freeText: String? = nil) {
         self.choices = choices
         self.timedOut = timedOut
+        self.freeText = freeText
     }
 
     /// A sentinel value for "no selection" (empty choices, timed out).

--- a/Sources/TapQContracts/VoiceBackend.swift
+++ b/Sources/TapQContracts/VoiceBackend.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+/// PCM description for audio crossing the `VoiceBackend` boundary.
+///
+/// Deliberately tiny: TapQ ships one encoding (16-bit signed little-endian PCM), and a
+/// format type that can describe encodings no adapter implements would only invite
+/// negotiation logic into a contract that has no business negotiating.
+public struct VoiceAudioFormat: Sendable, Equatable {
+    public let sampleRate: Double
+    public let channels: Int
+    /// True when the payload bytes are 16-bit signed little-endian samples. The only
+    /// value any shipped adapter sets; the flag exists so a future encoding is a data
+    /// change at the boundary rather than a silent reinterpretation of old bytes.
+    public let pcm16: Bool
+
+    public init(sampleRate: Double, channels: Int = 1, pcm16: Bool = true) {
+        self.sampleRate = sampleRate
+        self.channels = channels
+        self.pcm16 = pcm16
+    }
+
+    /// Mono 24 kHz PCM16 — the format the OpenAI Realtime slice speaks.
+    public static let pcm16Mono24k = VoiceAudioFormat(sampleRate: 24_000, channels: 1)
+    /// Mono 16 kHz PCM16 — the common on-device speech-recognition rate.
+    public static let pcm16Mono16k = VoiceAudioFormat(sampleRate: 16_000, channels: 1)
+}
+
+/// One block of audio moving in either direction: microphone audio TapQ pushes into a
+/// backend, or synthesized response audio a duplex backend pushes back.
+public struct VoiceAudioChunk: Sendable, Equatable {
+    public let data: Data
+    public let format: VoiceAudioFormat
+    /// Seconds on the sender's monotonic clock, for ordering and latency accounting only.
+    /// Nothing in the contract interprets it as a shared wall clock.
+    public let timestamp: TimeInterval
+
+    public init(data: Data, format: VoiceAudioFormat, timestamp: TimeInterval) {
+        self.data = data
+        self.format = format
+        self.timestamp = timestamp
+    }
+
+    /// Wall time this chunk represents, or nil when the bytes are not PCM16 (the only
+    /// encoding whose length maps to a duration without decoding it).
+    ///
+    /// Callers use this to keep chunks small — a `sendAudio` that carries a second of
+    /// audio blocks the main actor for as long as it takes to frame and write a second
+    /// of audio.
+    public var durationSeconds: TimeInterval? {
+        guard pcm16 else { return nil }
+        let bytesPerFrame = 2 * channels
+        guard bytesPerFrame > 0, sampleRate > 0 else { return nil }
+        return Double(data.count / bytesPerFrame) / sampleRate
+    }
+
+    private var pcm16: Bool { format.pcm16 }
+    private var channels: Int { format.channels }
+    private var sampleRate: Double { format.sampleRate }
+}
+
+/// What a backend can actually do, declared once at composition time.
+///
+/// Capabilities describe the *pipe*, never the policy. A backend that reports
+/// `duplex: true` is saying it can carry audio both ways at once, not that TapQ will let
+/// it: TapQ runs half-duplex regardless, because a window that is both listening and
+/// speaking hears its own synthesizer.
+public struct VoiceBackendCapabilities: Sendable, Equatable {
+    /// The backend can abandon an in-flight response on `cancelResponse()`. When false,
+    /// calling `cancelResponse()` is a contract violation rather than a no-op — silently
+    /// swallowing it would let a caller believe barge-in works when it does not.
+    public let supportsBargeIn: Bool
+    /// The backend emits `.audio` events (it synthesizes speech itself). When false, the
+    /// spoken side of the interaction stays with TapQ's own `SpeechPresenting`.
+    public let producesAudio: Bool
+    /// The transport can carry input and output audio simultaneously.
+    public let duplex: Bool
+
+    public init(supportsBargeIn: Bool = false, producesAudio: Bool = false,
+                duplex: Bool = false) {
+        self.supportsBargeIn = supportsBargeIn
+        self.producesAudio = producesAudio
+        self.duplex = duplex
+    }
+
+    /// The shape of a recognition-only backend: transcripts in, nothing spoken back, one
+    /// direction at a time. The default because it is the least a backend can be and the
+    /// most TapQ requires.
+    public static let transcriptOnly = VoiceBackendCapabilities()
+}
+
+/// Why a session ended, or could not start.
+///
+/// Equatable and case-typed so a caller can branch (fail through to another backend on
+/// `.network`, abort startup on `.authorization`) without string matching. The associated
+/// text is for humans and diagnostics; it never carries credentials.
+public enum VoiceBackendFailure: Error, LocalizedError, Equatable, Sendable {
+    /// Transport-level: connect failed, socket dropped, request timed out.
+    case network(String)
+    /// The peer spoke something this adapter cannot make sense of, or violated the
+    /// manual-turn contract (e.g. produced a response nobody asked for).
+    case protocolViolation(String)
+    /// Missing, rejected, or expired credentials — retrying will not help.
+    case authorization(String)
+    /// The session is closed: the peer hung up, or an operation arrived after teardown.
+    case closed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .network(let detail):
+            return "Voice backend transport failed: \(detail)."
+        case .protocolViolation(let detail):
+            return "Voice backend protocol error: \(detail)."
+        case .authorization(let detail):
+            return "Voice backend rejected the credentials: \(detail)."
+        case .closed(let detail):
+            return "Voice backend session is closed: \(detail)."
+        }
+    }
+}
+
+/// Everything a backend is allowed to tell TapQ.
+///
+/// Note what is absent: there is no "user started speaking", "user stopped speaking", or
+/// "turn ended" event. Those are decisions, and decisions live on TapQ's side of this
+/// boundary. A backend that believes it detected end-of-speech has nothing in this enum
+/// to say so with, which is the point.
+public enum VoiceBackendEvent: Sendable, Equatable {
+    /// Best-guess transcript so far. Cumulative for the current turn, matching the
+    /// semantics `VoiceListener` already relies on: matchers see the whole utterance
+    /// each time, not a delta.
+    case transcriptPartial(String)
+    /// Settled transcript for the current turn.
+    case transcriptFinal(String)
+    /// Response audio from a backend whose `capabilities.producesAudio` is true.
+    case audio(VoiceAudioChunk)
+    /// The backend finished whatever the current turn asked of it. For a transcript-only
+    /// backend that is the end of recognition; for a speaking backend it is the end of
+    /// its response audio.
+    case responseCompleted
+    /// The session is over and no further events will arrive. The caller must treat the
+    /// backend as closed and, if it still needs voice, open a new one.
+    case sessionFailed(VoiceBackendFailure)
+}
+
+/// A dumb speech pipe.
+///
+/// Two non-negotiables, both load-bearing enough to be restated on the individual
+/// requirements below:
+///
+/// 1. **Turn arbitration lives on TapQ's side.** Only TapQ decides when a user turn
+///    begins and ends, via `beginUserTurn()` / `endUserTurn()`. A backend's own
+///    voice-activity detection must never end a turn, never commit a buffer, and never
+///    start a response on its own initiative. Backends that ship a VAD must be
+///    configured with it off (the OpenAI Realtime adapter sends `turn_detection: none`
+///    before anything else). This is not a preference: TapQ's windows are arbitrated
+///    against head gestures, taps, and timeouts, and a backend that ends turns behind
+///    TapQ's back resolves approvals the interaction controller never authorized.
+/// 2. **Wearer attribution lives on TapQ's side.** The microphone hears the whole room;
+///    only the in-ear IMU knows whose jaw moved. No backend is ever asked, or trusted,
+///    to say who spoke — see `WearerSpeechSignaling` and `WearerGatedVoice`.
+///
+/// Half-duplex is TapQ policy, not a transport limitation: even against a backend
+/// reporting `duplex: true`, TapQ never requests a response while a user turn is open.
+/// `VoiceTurnStateMachine` enforces that mechanically so each adapter does not have to
+/// re-derive it.
+///
+/// `@MainActor` with closure events rather than `AsyncSequence`, matching
+/// `VoiceCommandProviding` and the rest of the input surface.
+@MainActor public protocol VoiceBackend: AnyObject {
+    /// Static for the lifetime of the instance; safe to read before `open`.
+    var capabilities: VoiceBackendCapabilities { get }
+
+    /// Establishes the session and installs the single event observer.
+    ///
+    /// Throws `VoiceBackendFailure` when the session cannot be established. Calling
+    /// `open` on an already-open backend is a programming error.
+    func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws
+
+    /// Tears the session down. Idempotent, non-throwing, and safe from any state — a
+    /// teardown path that can fail is a teardown path that leaks microphones.
+    func close()
+
+    /// Opens a user turn: from here until `endUserTurn()`, `sendAudio` is accepted.
+    ///
+    /// Only TapQ calls this. See non-negotiable 1 on the protocol.
+    func beginUserTurn()
+
+    /// Commits the user turn. The backend may now finalize its transcript and, if asked,
+    /// produce a response.
+    ///
+    /// Only TapQ calls this — a backend must never end a turn from its own VAD, silence
+    /// timer, or heuristic. See non-negotiable 1 on the protocol.
+    func endUserTurn()
+
+    /// Feeds one block of microphone audio into the open user turn. Keep chunks short
+    /// (~100 ms); see `VoiceAudioChunk.durationSeconds`.
+    func sendAudio(_ chunk: VoiceAudioChunk)
+
+    /// Asks the backend to produce a spoken/agent response for `text`. Meaningful for
+    /// backends that produce audio; transcript-only backends route it to TapQ's shared
+    /// `SpeechPresenting` rather than opening a second synthesizer.
+    ///
+    /// Never called while a user turn is open — that is the half-duplex policy.
+    func requestResponse(text: String)
+
+    /// Abandons an in-flight response (barge-in). Only meaningful when
+    /// `capabilities.supportsBargeIn` is true.
+    func cancelResponse()
+}

--- a/Sources/TapQContracts/VoiceBackend.swift
+++ b/Sources/TapQContracts/VoiceBackend.swift
@@ -185,12 +185,25 @@ public enum VoiceBackendEvent: Sendable, Equatable {
     /// Only TapQ calls this. See non-negotiable 1 on the protocol.
     func beginUserTurn()
 
-    /// Commits the user turn. The backend may now finalize its transcript and, if asked,
-    /// produce a response.
+    /// Commits the user turn. The backend may now finalize its transcript and, if
+    /// `expectingResponse` is true, produce a spoken response.
+    ///
+    /// - Parameter expectingResponse: When `true`, the backend should create a response
+    ///   (e.g. OpenAI's `response.create` after `input_audio_buffer.commit`). When `false`,
+    ///   the backend commits the audio for transcription only — no response is created.
+    ///   Match-resolved windows, gesture/timeout stops, and activity-driven pauses all pass
+    ///   `false`; only an explicit coordinator endpoint (wearer finished speaking, TapQ wants
+    ///   the model to reply) passes `true`.
+    /// - Returns: `true` when the backend actually created a response from this turn end.
+    ///   `false` when `expectingResponse` was `false`, when the turn carried no audio (the
+    ///   empty-turn guard), or for transcript-only backends that never create responses.
+    ///   The caller derives its response-pending tracking exclusively from this report —
+    ///   no proxy flags.
     ///
     /// Only TapQ calls this — a backend must never end a turn from its own VAD, silence
     /// timer, or heuristic. See non-negotiable 1 on the protocol.
-    func endUserTurn()
+    @discardableResult
+    func endUserTurn(expectingResponse: Bool) -> Bool
 
     /// Feeds one block of microphone audio into the open user turn. Keep chunks short
     /// (~100 ms); see `VoiceAudioChunk.durationSeconds`.

--- a/Sources/TapQContracts/VoiceBackendSession.swift
+++ b/Sources/TapQContracts/VoiceBackendSession.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// An illegal move against `VoiceTurnStateMachine`.
+///
+/// Cases are specific rather than a single `.invalidTransition` because each one names a
+/// distinct bug: `.noUserTurn` is a caller that forgot to open a window, while
+/// `.responseDuringUserTurn` is a caller (or a backend) trying to talk over the wearer.
+/// Adapters surface these as `VoiceBackendFailure.protocolViolation`.
+public enum VoiceTurnViolation: Error, LocalizedError, Equatable, Sendable {
+    /// The operation needs an open session and there is none.
+    case notOpen
+    /// `open` on a session that is already open.
+    case alreadyOpen
+    /// `beginUserTurn` while a user turn is already open (double-begin).
+    case turnAlreadyInProgress
+    /// `endUserTurn` or `sendAudio` with no user turn open.
+    case noUserTurn
+    /// `requestResponse` while the wearer's turn is still open. Half-duplex is TapQ
+    /// policy even against a duplex-capable backend: a window that is listening and
+    /// speaking at once hears its own synthesizer.
+    case responseDuringUserTurn
+    /// `requestResponse` while a response is still being produced.
+    case responseAlreadyInFlight
+    /// `cancelResponse` or a `responseCompleted` event with nothing in flight.
+    case noResponseInFlight
+    /// `cancelResponse` against a backend whose `capabilities.supportsBargeIn` is false.
+    /// Rejected rather than ignored so a caller can never believe barge-in worked.
+    case bargeInUnsupported
+
+    public var errorDescription: String? {
+        switch self {
+        case .notOpen:
+            return "The voice backend session is not open."
+        case .alreadyOpen:
+            return "The voice backend session is already open."
+        case .turnAlreadyInProgress:
+            return "A user turn is already open; TapQ opens exactly one at a time."
+        case .noUserTurn:
+            return "No user turn is open."
+        case .responseDuringUserTurn:
+            return "A response cannot be requested while the user's turn is open; TapQ runs half-duplex."
+        case .responseAlreadyInFlight:
+            return "A response is already in flight."
+        case .noResponseInFlight:
+            return "No response is in flight."
+        case .bargeInUnsupported:
+            return "This voice backend does not support barge-in."
+        }
+    }
+}
+
+/// The turn protocol every `VoiceBackend` adapter runs internally, as a pure value type.
+///
+/// This exists so "TapQ owns turns" is enforced mechanically instead of by convention in
+/// each adapter. An adapter routes every inbound call and every backend event through
+/// this machine before touching its transport; a backend that tries to end a turn on its
+/// own — the exact hole the design rule forbids — hits `.noUserTurn` or
+/// `.noResponseInFlight` here instead of quietly resolving an approval window.
+///
+/// Legal cycle:
+///
+///     idle --open--> open --beginUserTurn--> userTurn --endUserTurn--> committed
+///       ^                ^                                                 |
+///       |                |                                  requestResponse|
+///     close/           responseCompleted <--responding<---------------------
+///     sessionFailed          (or straight from committed, for a
+///     (from anywhere)         transcript-only backend)
+///
+/// Teardown (`close`) and failure (`sessionFailed`) are legal from every state and never
+/// throw: a state machine that can refuse to shut down is a microphone leak.
+///
+/// Purely a legality checker — it holds no audio, no transcripts, and no timers, so it is
+/// exhaustively testable without a transport.
+public struct VoiceTurnStateMachine: Equatable, Sendable {
+    public enum State: String, Equatable, Sendable {
+        /// No session. The state before `open` and after `close`/`sessionFailed`.
+        case idle
+        /// Session established, no turn in progress.
+        case open
+        /// The wearer's turn: `sendAudio` is accepted here and nowhere else.
+        case userTurn
+        /// The turn is committed; the backend may finalize transcripts.
+        case committed
+        /// The backend is producing a response.
+        case responding
+    }
+
+    public private(set) var state: State
+    public let capabilities: VoiceBackendCapabilities
+
+    public init(capabilities: VoiceBackendCapabilities = .transcriptOnly) {
+        self.capabilities = capabilities
+        self.state = .idle
+    }
+
+    public var isOpen: Bool { state != .idle }
+    public var isUserTurnActive: Bool { state == .userTurn }
+    public var isResponding: Bool { state == .responding }
+
+    public mutating func open() throws {
+        guard state == .idle else { throw VoiceTurnViolation.alreadyOpen }
+        state = .open
+    }
+
+    public mutating func beginUserTurn() throws {
+        switch state {
+        case .idle: throw VoiceTurnViolation.notOpen
+        case .userTurn: throw VoiceTurnViolation.turnAlreadyInProgress
+        case .responding: throw VoiceTurnViolation.responseAlreadyInFlight
+        case .open, .committed:
+            // `.committed` is a legal starting point: a transcript-only backend that
+            // never requests a response goes straight from one committed turn into the
+            // next without an intervening `responseCompleted`.
+            state = .userTurn
+        }
+    }
+
+    public mutating func sendAudio() throws {
+        switch state {
+        case .idle: throw VoiceTurnViolation.notOpen
+        case .userTurn: break
+        case .open, .committed, .responding: throw VoiceTurnViolation.noUserTurn
+        }
+    }
+
+    public mutating func endUserTurn() throws {
+        switch state {
+        case .idle: throw VoiceTurnViolation.notOpen
+        case .userTurn: state = .committed
+        case .open, .committed, .responding: throw VoiceTurnViolation.noUserTurn
+        }
+    }
+
+    public mutating func requestResponse() throws {
+        switch state {
+        case .idle: throw VoiceTurnViolation.notOpen
+        case .userTurn: throw VoiceTurnViolation.responseDuringUserTurn
+        case .responding: throw VoiceTurnViolation.responseAlreadyInFlight
+        case .open, .committed: state = .responding
+        }
+    }
+
+    public mutating func cancelResponse() throws {
+        guard state != .idle else { throw VoiceTurnViolation.notOpen }
+        // Capability is checked before state so a caller that wired up barge-in against a
+        // backend that cannot do it learns that, rather than learning it only on the rare
+        // occasions a response happens to be in flight.
+        guard capabilities.supportsBargeIn else { throw VoiceTurnViolation.bargeInUnsupported }
+        guard state == .responding else { throw VoiceTurnViolation.noResponseInFlight }
+        state = .open
+    }
+
+    /// The backend reported `VoiceBackendEvent.responseCompleted`.
+    ///
+    /// Legal from `.responding` (a speaking backend finished its audio) and from
+    /// `.committed` (a transcript-only backend finished recognizing). Anywhere else it
+    /// means the backend completed something nobody asked for.
+    public mutating func responseCompleted() throws {
+        switch state {
+        case .responding, .committed: state = .open
+        case .idle: throw VoiceTurnViolation.notOpen
+        case .open, .userTurn: throw VoiceTurnViolation.noResponseInFlight
+        }
+    }
+
+    /// The backend reported `VoiceBackendEvent.sessionFailed`. Always legal, from any
+    /// state: failures arrive whenever they arrive.
+    public mutating func sessionFailed() {
+        state = .idle
+    }
+
+    /// Teardown. Always legal and idempotent, from any state.
+    public mutating func close() {
+        state = .idle
+    }
+}

--- a/Sources/TapQContracts/VoiceResponseAudio.swift
+++ b/Sources/TapQContracts/VoiceResponseAudio.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Plays backend response audio — the other half of the duplex pipe for backends that
+/// speak (`capabilities.producesAudio == true`).
+///
+/// Implemented by `BackendAudioPlayback` (macOS, AVAudioEngine); consumed by
+/// `VoiceBackendCommandProvider` (portable) through this protocol. The split keeps
+/// AVFoundation out of every portable target.
+///
+/// ## Synchronous `isPlaying` invariant
+///
+/// `isPlaying` **must** become `true` synchronously within the first `enqueue` call,
+/// before that call returns. The mic gate (`CombinedSpeechActivity` → `SpeechGatedVoice`)
+/// reads `isPlaying` on every activity-change edge; if the first sample could be scheduled
+/// on the audio hardware before the gate saw `isPlaying == true`, the microphone would be
+/// open for the duration of that race and would hear the first few milliseconds of the
+/// agent's own voice. Making the flag rise inside `enqueue` — before any audio reaches the
+/// output device — closes the window to zero.
+///
+/// ## Lifecycle
+///
+/// A typical response cycle:
+/// 1. Provider receives `.audio` events → `enqueue` for each chunk.
+/// 2. Provider receives `.responseCompleted` → `finishStream()`.
+/// 3. The player drains its buffer and transitions `isPlaying` → `false`.
+///
+/// Teardown / barge-in / session failure → `stopAndFlush()` at any point; the player drops
+/// outstanding audio immediately and fires exactly one `isPlaying → false` edge (or none if
+/// already idle).
+///
+/// Single-observer `onPlayingChange` follows the same ownership rule as
+/// `SpeechActivitySignaling.onSpeakingChange` — `CombinedSpeechActivity` claims it at
+/// composition time; a second assignment would silently break the self-hearing guard.
+@MainActor public protocol VoiceResponseAudioPlaying: AnyObject {
+    /// Schedules one chunk of backend audio for playback. The player may buffer, resample,
+    /// or convert as needed; the only contract is FIFO ordering and the synchronous
+    /// `isPlaying` invariant above.
+    func enqueue(_ chunk: VoiceAudioChunk)
+
+    /// Signals that no more chunks will arrive for this response. The player drains its
+    /// buffer and then transitions `isPlaying` → `false`.
+    func finishStream()
+
+    /// Drops all queued and in-flight audio immediately. Fires at most one
+    /// `isPlaying → false` edge. Idempotent.
+    func stopAndFlush()
+
+    /// True while audio is being played or is queued for playback. Becomes `true`
+    /// synchronously on the first `enqueue` of a response, and `false` only after
+    /// `finishStream()` + drain or `stopAndFlush()`.
+    var isPlaying: Bool { get }
+
+    /// Single observer, fired after each playing↔idle transition (never per-chunk).
+    /// `CombinedSpeechActivity` claims this at composition time.
+    var onPlayingChange: (@MainActor (Bool) -> Void)? { get set }
+}

--- a/Sources/TapQContracts/WearerSpeech.swift
+++ b/Sources/TapQContracts/WearerSpeech.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Read-only "is the person wearing the earbuds the one talking right now?" signal,
+/// derived from the in-ear motion stream rather than from audio.
+///
+/// The microphone cannot answer this question: a nearby colleague, a meeting on the
+/// laptop speakers, or a podcast all reach it exactly like the wearer does. Bone-conducted
+/// vibration only reaches the earbud IMU when the wearer's own jaw is moving, which is why
+/// attribution lives on the motion side. Implemented over `WearerSpeechDetector`; consumed
+/// by `WearerGatedVoice`.
+///
+/// Every consumer must treat this as advisory. `isSignalAvailable` is the honest admission
+/// that the signal is often absent — no motion stream, AirPods asleep, magnitude-only
+/// samples, or a stream that has gone stale — and when it is false, callers must behave
+/// exactly as they did before attribution existed (fail open).
+@MainActor public protocol WearerSpeechSignaling: AnyObject {
+    /// True while the detector currently believes the wearer is speaking. Meaningless
+    /// unless `isSignalAvailable` is true.
+    var isWearerSpeaking: Bool { get }
+
+    /// False when the signal cannot be trusted at all: no motion stream is running, the
+    /// samples carry no usable data, or the last sample is too old to describe *now*.
+    /// A false value is a directive to fail open, not a "wearer is silent" answer.
+    var isSignalAvailable: Bool { get }
+
+    /// Single observer, fired after each quiet↔speaking transition (never per sample).
+    /// `WearerGatedVoice` claims this at composition time — assigning it elsewhere would
+    /// silently disable voice attribution. Add a multicast on the implementation if a
+    /// second consumer (e.g. a UI indicator) ever needs the signal, exactly as
+    /// `SpeechActivitySignaling.onSpeakingChange` documents.
+    var onWearerSpeakingChange: (@MainActor (Bool) -> Void)? { get set }
+}

--- a/Sources/TapQDetectionBaseline/CalibrationProfile.swift
+++ b/Sources/TapQDetectionBaseline/CalibrationProfile.swift
@@ -80,3 +80,51 @@ public struct TapCalibrationQuality: Codable, Sendable, Equatable {
         self.tapAccelerationPeak = tapAccelerationPeak
     }
 }
+
+/// Persisted wearer-speech calibration — the third independent document, alongside gesture
+/// and tap, for the same reason those two are separate: recalibrating one input must never
+/// be able to discard another's working profile.
+public struct TapQWearerSpeechCalibrationProfile: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let calibratedAt: Date
+    public let config: WearerSpeechConfig
+    public let quality: WearerSpeechCalibrationQuality
+
+    public init(
+        schemaVersion: Int = currentSchemaVersion,
+        calibratedAt: Date = Date(),
+        config: WearerSpeechConfig,
+        quality: WearerSpeechCalibrationQuality
+    ) {
+        self.schemaVersion = schemaVersion
+        self.calibratedAt = calibratedAt
+        self.config = config
+        self.quality = quality
+    }
+}
+
+/// Aggregate envelope statistics explaining why a wearer-speech calibration was accepted,
+/// without retaining any raw motion samples.
+public struct WearerSpeechCalibrationQuality: Codable, Sendable, Equatable {
+    public let restingSampleCount: Int
+    public let speakingSampleCount: Int
+    /// Largest per-sample jerk while quiet (g).
+    public let restingEnvelopePeak: Double
+    /// Median per-sample jerk while speaking (g). A median rather than a peak because a
+    /// peak would be one syllable onset — see `WearerSpeechCalibrator`.
+    public let speakingEnvelopeLevel: Double
+
+    public init(
+        restingSampleCount: Int,
+        speakingSampleCount: Int,
+        restingEnvelopePeak: Double,
+        speakingEnvelopeLevel: Double
+    ) {
+        self.restingSampleCount = restingSampleCount
+        self.speakingSampleCount = speakingSampleCount
+        self.restingEnvelopePeak = restingEnvelopePeak
+        self.speakingEnvelopeLevel = speakingEnvelopeLevel
+    }
+}

--- a/Sources/TapQDetectionBaseline/WearerSpeechAnalyzer.swift
+++ b/Sources/TapQDetectionBaseline/WearerSpeechAnalyzer.swift
@@ -1,0 +1,360 @@
+import Foundation
+
+/// One window's worth of wearer-speech evidence, plus the reason it was rejected.
+/// Mirrors `TapAnalysis`: the decision and the numbers behind it are produced together so
+/// diagnostics never re-derive (and never drift from) the policy.
+public struct WearerSpeechAnalysis: Sendable, Equatable {
+    public enum Rejection: String, Sendable, Equatable {
+        case insufficientSamples = "insufficient_samples"
+        case belowEnvelope = "below_envelope"
+        case rotationNotQuiet = "rotation_not_quiet"
+        case tooBrief = "too_brief"
+    }
+
+    public let rejection: Rejection?
+    public let envelopeSamples: Int
+    public let rotationSamples: Int
+    /// Largest per-sample jerk in the window (g).
+    public let peakEnvelope: Double
+    /// Samples in the window at or above `threshold`.
+    public let elevatedSamples: Int
+    /// `elevatedSamples / envelopeSamples`; 0 for an empty window.
+    public let activeFraction: Double
+    public let maximumRotation: Double
+    /// The hysteresis threshold actually applied — enter while quiet, exit while speaking.
+    public let threshold: Double
+    /// How long the window has been continuously active up to this sample.
+    public let sustainedSeconds: TimeInterval
+
+    public var detected: Bool { rejection == nil }
+
+    /// Same window evidence, with the duration gate's verdict folded in.
+    fileprivate func timed(sustainedSeconds: TimeInterval,
+                           rejection: Rejection? = nil) -> WearerSpeechAnalysis {
+        WearerSpeechAnalysis(
+            rejection: rejection ?? self.rejection,
+            envelopeSamples: envelopeSamples,
+            rotationSamples: rotationSamples,
+            peakEnvelope: peakEnvelope,
+            elevatedSamples: elevatedSamples,
+            activeFraction: activeFraction,
+            maximumRotation: maximumRotation,
+            threshold: threshold,
+            sustainedSeconds: sustainedSeconds
+        )
+    }
+}
+
+/// Pure wearer-speech detector over a trailing window of jerk-envelope and rotation
+/// magnitudes. Separated from CoreMotion (and from `MotionGesturePipeline`'s windows) so
+/// the logic is unit-testable with synthetic data, mirroring `TapAnalyzer`.
+///
+/// Physical rationale: speech is transmitted to an in-ear IMU through the jaw and skull,
+/// not through the air. The bone-conducted component reaching the earbud is a continuous
+/// low-amplitude tremor for as long as the wearer is talking. The motion stream is only
+/// 25 Hz, so its Nyquist limit (~12.5 Hz) sits below the voiced fundamental — none of the
+/// speech *band* survives sampling. What does survive is its aliased residue: a sustained
+/// modest elevation of the sample-to-sample change in user acceleration. That residue,
+/// not a spectrum, is what this analyzer measures, which is why the thresholds are
+/// empirical config rather than derived constants.
+///
+/// A window counts as wearer speech when:
+///   1. it holds enough samples to judge,
+///   2. some sample clears the hysteresis threshold (something is vibrating at all),
+///   3. max `|rot|` stays under `rotationQuiet` — the head is not being nodded or shaken,
+///      whose turnarounds produce a speech-sized envelope, and
+///   4. the elevation is *broad* (`minimumActiveFraction` of the window) and has been
+///      sustained for `minimumSpeakingSeconds` — the exact inverse of `TapAnalyzer`'s
+///      brevity gate, and what rejects an impact: a tap elevates one or two samples.
+public struct WearerSpeechAnalyzer {
+    public let config: WearerSpeechConfig
+
+    public init(config: WearerSpeechConfig = .init()) {
+        self.config = config
+    }
+
+    /// The jerk envelope contributed by one sample, given its predecessor: the change in
+    /// user acceleration, in g. When both samples carry signed per-axis data the vector
+    /// difference is used (it sees direction reversals that leave the magnitude
+    /// unchanged); magnitude-only adapters fall back to the change in
+    /// `accelerationMagnitude`.
+    ///
+    /// The two paths do not share a scale — the vector difference is greater than or equal
+    /// to the scalar one — so a calibration profile is only valid for streams from the same
+    /// kind of adapter. `WearerSpeechCalibrator` computes its envelope through this same
+    /// function for exactly that reason.
+    ///
+    /// The difference is deliberately *not* divided by `dt`: at a fixed 25 Hz that only
+    /// rescales every value by the same constant, and keeping the units in g keeps the
+    /// thresholds comparable with `TapConfig.amplitudeThreshold`.
+    static func envelopeValue(from previous: HeadMotionSample,
+                              to sample: HeadMotionSample) -> Double {
+        guard previous.hasPerAxisData, sample.hasPerAxisData else {
+            return abs(sample.accelerationMagnitude - previous.accelerationMagnitude)
+        }
+        let a = sample.userAcceleration
+        let b = previous.userAcceleration
+        return MotionVector(x: a.x - b.x, y: a.y - b.y, z: a.z - b.z).magnitude
+    }
+
+    /// Envelope values for a whole recorded phase, oldest first. Yields `samples.count - 1`
+    /// values for a contiguous stream; pairs separated by more than `maximumGapSeconds`
+    /// (or out of order) are skipped rather than differenced across the discontinuity,
+    /// matching `WearerSpeechDetector`'s live gap policy.
+    static func envelopeSeries(
+        _ samples: [HeadMotionSample],
+        maximumGapSeconds: TimeInterval = WearerSpeechConfig.defaultMaximumSampleGapSeconds
+    ) -> [Double] {
+        guard samples.count > 1 else { return [] }
+        var values: [Double] = []
+        values.reserveCapacity(samples.count - 1)
+        for index in 1..<samples.count {
+            let previous = samples[index - 1]
+            let sample = samples[index]
+            let delta = sample.timestamp - previous.timestamp
+            guard delta > 0, delta <= maximumGapSeconds else { continue }
+            values.append(envelopeValue(from: previous, to: sample))
+        }
+        return values
+    }
+
+    /// Level, breadth and rotation gates over the window. Duration-independent, so the
+    /// caller can use one evaluation both to maintain its "active since" clock and to
+    /// decide. `holding` is true while the detector is already reporting speech, and
+    /// selects the lower (exit) half of the hysteresis pair.
+    func windowActivity(envelope: [Double], rotation: [Double],
+                        holding: Bool) -> WearerSpeechAnalysis {
+        let threshold = holding ? config.envelopeExitThreshold : config.envelopeEnterThreshold
+        let peak = envelope.max() ?? 0
+        let maximumRotation = rotation.max() ?? 0
+        let elevated = envelope.lazy.filter { $0 >= threshold }.count
+        let activeFraction = envelope.isEmpty ? 0 : Double(elevated) / Double(envelope.count)
+
+        let rejection: WearerSpeechAnalysis.Rejection?
+        if envelope.count < config.minSamples || rotation.count < config.minSamples {
+            rejection = .insufficientSamples
+        } else if peak < threshold {
+            rejection = .belowEnvelope
+        } else if maximumRotation >= config.rotationQuiet {
+            // Windowed rotation gate: a nod or shake carries a speech-sized envelope, and
+            // its quiet turnaround sample is flanked by high rotation.
+            rejection = .rotationNotQuiet
+        } else if activeFraction < config.minimumActiveFraction {
+            // Breadth: an impact is a transient, speech fills the window.
+            rejection = .tooBrief
+        } else {
+            rejection = nil
+        }
+
+        return WearerSpeechAnalysis(
+            rejection: rejection,
+            envelopeSamples: envelope.count,
+            rotationSamples: rotation.count,
+            peakEnvelope: peak,
+            elevatedSamples: elevated,
+            activeFraction: activeFraction,
+            maximumRotation: maximumRotation,
+            threshold: threshold,
+            sustainedSeconds: 0
+        )
+    }
+
+    /// Applies the onset-duration gate to a window that already passed `windowActivity`.
+    /// The gate is skipped while `holding`: once speech has been declared, staying in it
+    /// must not re-serve the onset delay on every sample.
+    func applyDurationGate(to activity: WearerSpeechAnalysis,
+                           sustainedSeconds: TimeInterval,
+                           holding: Bool) -> WearerSpeechAnalysis {
+        guard activity.detected, !holding,
+              sustainedSeconds < config.minimumSpeakingSeconds - Self.durationEpsilon else {
+            return activity.timed(sustainedSeconds: sustainedSeconds)
+        }
+        return activity.timed(sustainedSeconds: sustainedSeconds, rejection: .tooBrief)
+    }
+
+    /// Full window decision. `sustainedSeconds` is how long the window has been
+    /// continuously active; `WearerSpeechDetector` tracks it across samples.
+    func analyze(envelope: [Double], rotation: [Double],
+                 sustainedSeconds: TimeInterval, holding: Bool) -> WearerSpeechAnalysis {
+        applyDurationGate(
+            to: windowActivity(envelope: envelope, rotation: rotation, holding: holding),
+            sustainedSeconds: sustainedSeconds,
+            holding: holding
+        )
+    }
+
+    /// True when the window ends in wearer speech.
+    public func detect(envelope: [Double], rotation: [Double],
+                       sustainedSeconds: TimeInterval, holding: Bool) -> Bool {
+        analyze(envelope: envelope, rotation: rotation,
+                sustainedSeconds: sustainedSeconds, holding: holding).detected
+    }
+
+    /// Duration comparisons run against timestamps accumulated by repeated addition at
+    /// 25 Hz, so a sample landing exactly on the minimum must not be lost to rounding.
+    private static let durationEpsilon: TimeInterval = 1e-9
+}
+
+/// Whether the wearer is currently judged to be speaking.
+public enum WearerSpeechState: String, Sendable, Equatable {
+    case quiet
+    case speaking
+}
+
+/// State change produced by a single ingested sample.
+public enum WearerSpeechTransition: String, Sendable, Equatable {
+    case startedSpeaking = "started_speaking"
+    case stoppedSpeaking = "stopped_speaking"
+}
+
+/// Everything one ingested sample produced: the resulting state, the transition it caused
+/// (if any), the sample's own envelope contribution, and the window analysis behind the
+/// decision.
+public struct WearerSpeechUpdate: Sendable, Equatable {
+    public let state: WearerSpeechState
+    public let transition: WearerSpeechTransition?
+    /// This sample's jerk contribution (g); 0 for the first sample of a stream and for the
+    /// sample that follows a gap, neither of which has a usable predecessor.
+    public let envelope: Double
+    public let analysis: WearerSpeechAnalysis
+    /// True while `state == .speaking` only because the hangover has not yet expired.
+    public let inHangover: Bool
+
+    public var isSpeaking: Bool { state == .speaking }
+}
+
+/// Stateful, hardware-independent wearer-speech detector. It owns the trailing envelope
+/// and rotation windows, the hysteresis state, the onset clock and the hangover;
+/// `WearerSpeechAnalyzer` stays pure.
+///
+/// This is a *separate consumer* of the same `HeadMotionSample` stream as
+/// `MotionGesturePipeline` and deliberately shares no window state with it: the two answer
+/// different questions over different time scales, and coupling them would make one's
+/// window-consumption policy silently change the other's decisions.
+public struct WearerSpeechDetector {
+    public var config: WearerSpeechConfig {
+        didSet { analyzer = WearerSpeechAnalyzer(config: config) }
+    }
+
+    /// The current decision. Also readable between ingests, for signal adapters.
+    public private(set) var state: WearerSpeechState = .quiet
+
+    private var analyzer: WearerSpeechAnalyzer
+    private var envelope: [(time: TimeInterval, value: Double)] = []
+    private var rotation: [(time: TimeInterval, value: Double)] = []
+    private var previous: HeadMotionSample?
+    /// When the window most recently became active, or nil while it is inactive.
+    private var activeSince: TimeInterval?
+    /// Timestamp of the last active window, used to time the hangover.
+    private var lastActiveAt: TimeInterval?
+
+    public init(config: WearerSpeechConfig = .init()) {
+        self.config = config
+        self.analyzer = WearerSpeechAnalyzer(config: config)
+    }
+
+    /// Clears all temporal state and returns to `.quiet`, retaining configuration.
+    /// Mirrors `MotionGesturePipeline.reset()`; called automatically on a stream gap.
+    public mutating func reset() {
+        envelope.removeAll()
+        rotation.removeAll()
+        previous = nil
+        activeSince = nil
+        lastActiveAt = nil
+        state = .quiet
+    }
+
+    /// Feeds one sample and reports the resulting state.
+    @discardableResult
+    public mutating func ingest(_ sample: HeadMotionSample) -> WearerSpeechState {
+        ingestDetailed(sample).state
+    }
+
+    /// Feeds one sample and reports the state, the transition and the evidence.
+    @discardableResult
+    public mutating func ingestDetailed(_ sample: HeadMotionSample) -> WearerSpeechUpdate {
+        let previousState = state
+
+        // A discontinuity in the stream (dropped samples, a stopped and restarted capture,
+        // a replay seeking) must not be differenced: the jump would read as one enormous
+        // jerk, and the retained window describes a stretch of time that no longer
+        // adjoins this sample. Start over instead.
+        if let last = previous {
+            let delta = sample.timestamp - last.timestamp
+            if delta <= 0 || delta > config.maxSampleGapSeconds {
+                reset()
+            }
+        }
+
+        guard let last = previous else {
+            // First sample of a stream: nothing to difference against yet.
+            previous = sample
+            return finish(previousState: previousState, envelope: 0,
+                          analysis: emptyAnalysis(holding: previousState == .speaking))
+        }
+
+        let value = WearerSpeechAnalyzer.envelopeValue(from: last, to: sample)
+        previous = sample
+        envelope.append((sample.timestamp, value))
+        rotation.append((sample.timestamp, sample.rotationMagnitude))
+        let cutoff = sample.timestamp - config.windowSeconds
+        envelope.removeAll { $0.time < cutoff }
+        rotation.removeAll { $0.time < cutoff }
+
+        let holding = state == .speaking
+        let activity = analyzer.windowActivity(
+            envelope: envelope.map(\.value),
+            rotation: rotation.map(\.value),
+            holding: holding
+        )
+
+        if activity.detected {
+            if activeSince == nil { activeSince = sample.timestamp }
+            lastActiveAt = sample.timestamp
+        } else {
+            activeSince = nil
+        }
+        let sustained = activeSince.map { sample.timestamp - $0 } ?? 0
+
+        let analysis = analyzer.applyDurationGate(
+            to: activity, sustainedSeconds: sustained, holding: holding
+        )
+
+        var inHangover = false
+        if analysis.detected {
+            state = .speaking
+        } else if holding,
+                  let lastActiveAt,
+                  sample.timestamp - lastActiveAt <= config.hangoverSeconds {
+            // Hangover: an inter-word pause is not the end of an utterance.
+            inHangover = true
+        } else {
+            state = .quiet
+        }
+
+        return finish(previousState: previousState, envelope: value,
+                      analysis: analysis, inHangover: inHangover)
+    }
+
+    private func emptyAnalysis(holding: Bool) -> WearerSpeechAnalysis {
+        analyzer.windowActivity(envelope: [], rotation: [], holding: holding)
+    }
+
+    private func finish(previousState: WearerSpeechState, envelope: Double,
+                        analysis: WearerSpeechAnalysis,
+                        inHangover: Bool = false) -> WearerSpeechUpdate {
+        let transition: WearerSpeechTransition?
+        switch (previousState, state) {
+        case (.quiet, .speaking): transition = .startedSpeaking
+        case (.speaking, .quiet): transition = .stoppedSpeaking
+        default: transition = nil
+        }
+        return WearerSpeechUpdate(
+            state: state,
+            transition: transition,
+            envelope: envelope,
+            analysis: analysis,
+            inHangover: inHangover
+        )
+    }
+}

--- a/Sources/TapQDetectionBaseline/WearerSpeechCalibrator.swift
+++ b/Sources/TapQDetectionBaseline/WearerSpeechCalibrator.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// Jerk-envelope values captured during a wearer-speech calibration: a few seconds of
+/// silence followed by a few seconds of the wearer reading aloud with the head still.
+///
+/// The envelope is always produced by `WearerSpeechAnalyzer.envelopeValue`, the same
+/// function `WearerSpeechDetector` runs live. Anything else would calibrate one quantity
+/// and detect another — and the per-axis and magnitude-only paths do not even share a
+/// scale, so a profile is only valid for streams from the kind of adapter that recorded it.
+public struct WearerSpeechCalibrationSamples: Sendable, Equatable {
+    /// Envelope values from the quiet phase, in g.
+    public var restingEnvelope: [Double]
+    /// Envelope values from the read-aloud phase, in g.
+    public var speakingEnvelope: [Double]
+
+    public init(restingEnvelope: [Double] = [], speakingEnvelope: [Double] = []) {
+        self.restingEnvelope = restingEnvelope
+        self.speakingEnvelope = speakingEnvelope
+    }
+
+    /// Differences two recorded phases into envelope series. Pairs straddling a stream gap
+    /// are dropped rather than differenced, matching the detector's live gap policy, so a
+    /// dropped-sample discontinuity cannot be calibrated against as if it were speech.
+    public init(
+        resting: [HeadMotionSample],
+        speaking: [HeadMotionSample],
+        maximumGapSeconds: TimeInterval = WearerSpeechConfig.defaultMaximumSampleGapSeconds
+    ) {
+        self.init(
+            restingEnvelope: WearerSpeechAnalyzer.envelopeSeries(
+                resting, maximumGapSeconds: maximumGapSeconds),
+            speakingEnvelope: WearerSpeechAnalyzer.envelopeSeries(
+                speaking, maximumGapSeconds: maximumGapSeconds)
+        )
+    }
+}
+
+/// Pure wearer-speech calibration: given a quiet phase and a read-aloud phase, suggest the
+/// hysteresis pair in `WearerSpeechConfig` that sits above this wearer's resting jitter and
+/// below the level their own speech sustains. Stateless and CoreMotion-free, mirroring
+/// `TapCalibrator`.
+///
+/// The statistics differ from `TapCalibrator`'s on purpose, because the physical events do.
+/// A tap is one impulse, so its *peak* is the signal. Speech is a continuous tremor, so its
+/// peak is a syllable onset — a tap-shaped value that would set the threshold far too high
+/// for the detector's breadth gate (`minimumActiveFraction`) to ever pass. The speaking
+/// statistic is therefore the median: the level at least half the speaking samples hold.
+/// Rest keeps the peak, because a threshold has to clear the *worst* of the quiet phase,
+/// not its typical value.
+public enum WearerSpeechCalibrator {
+    /// Fraction of the wearer's sustained speaking level the enter threshold is set to.
+    /// Below 1 so comfortably more than half of speaking samples clear it, which is what
+    /// `WearerSpeechConfig.minimumActiveFraction` (0.5 by default) asks of the window.
+    static let speakingFraction = 0.6
+    /// A saved enter threshold must clear the resting envelope peak by this multiple.
+    static let thresholdRestingHeadroom = 2.0
+    /// Calibration acceptance is stricter than the saved threshold, exactly as in
+    /// `TapCalibrator`: the observed speech must be this far clear of rest before it can
+    /// be trusted to tune anything.
+    static let usabilityRestingHeadroom = 3.0
+    /// The exit half of the hysteresis pair as a fraction of the enter half. The gap is
+    /// what stops a stream hovering at threshold from chattering between states.
+    static let exitFraction = 0.7
+    /// The exit threshold must also stay this far above resting noise. Without the floor a
+    /// quiet-but-not-silent baseline could hold the detector in `.speaking` indefinitely,
+    /// since leaving the state requires the envelope to fall *below* exit.
+    static let exitRestingHeadroom = 1.5
+    /// Hard ceiling on exit relative to enter, so a degenerate capture can never collapse
+    /// the hysteresis gap (or invert it) no matter how the floors interact.
+    static let maxExitFraction = 0.9
+    /// Absolute clamp, in g of per-sample jerk. The floor stops an unusually still
+    /// baseline from producing a profile that reads room vibration as speech; the ceiling
+    /// keeps ordinary speech detectable.
+    static let minThreshold = 0.004
+    static let maxThreshold = 0.20
+    /// Even against a silent baseline, require a measurable sustained tremor. The 25 Hz
+    /// stream's own quantisation noise lives below this.
+    static let minUsableSpeaking = 0.006
+    /// Samples required in each phase before a calibration means anything: half a second
+    /// at 25 Hz. A one-sample phase has no median worth the name.
+    static let minimumSampleCount = 12
+
+    /// Explains both the observed separation and the floor used to accept or reject it, so
+    /// the CLI can print why a calibration failed without re-deriving the policy.
+    public struct Assessment: Sendable, Equatable {
+        /// Largest per-sample jerk observed while quiet (g).
+        public let restingEnvelopePeak: Double
+        /// Median per-sample jerk observed while speaking (g) — the level the wearer's
+        /// speech *sustains*, not the loudest instant of it.
+        public let speakingEnvelopeLevel: Double
+        public let requiredLevel: Double
+        public let restingSampleCount: Int
+        public let speakingSampleCount: Int
+
+        /// Envelope values each phase needs before it can be summarised. Carried on the
+        /// assessment so a caller can say how short a capture fell without reaching for
+        /// the calibrator's own constants.
+        public var requiredSampleCount: Int { minimumSampleCount }
+
+        /// Both phases produced enough envelope values to summarise.
+        public var hasEnoughSamples: Bool {
+            restingSampleCount >= requiredSampleCount
+                && speakingSampleCount >= requiredSampleCount
+        }
+
+        public var isUsable: Bool {
+            hasEnoughSamples && speakingEnvelopeLevel >= requiredLevel
+        }
+    }
+
+    public static func assessment(
+        of samples: WearerSpeechCalibrationSamples
+    ) -> Assessment {
+        let restingPeak = samples.restingEnvelope.max() ?? 0
+        let speakingLevel = median(samples.speakingEnvelope)
+        return Assessment(
+            restingEnvelopePeak: restingPeak,
+            speakingEnvelopeLevel: speakingLevel,
+            requiredLevel: max(minUsableSpeaking, restingPeak * usabilityRestingHeadroom),
+            restingSampleCount: samples.restingEnvelope.count,
+            speakingSampleCount: samples.speakingEnvelope.count
+        )
+    }
+
+    /// Derives a config from captured envelopes, preserving every field of `base` except
+    /// the two thresholds. If no speaking samples were captured, returns `base` unchanged.
+    public static func suggestedConfig(
+        from samples: WearerSpeechCalibrationSamples,
+        base: WearerSpeechConfig = .init()
+    ) -> WearerSpeechConfig {
+        guard !samples.speakingEnvelope.isEmpty else { return base }
+        let restingPeak = samples.restingEnvelope.max() ?? 0
+
+        let fromSpeech = median(samples.speakingEnvelope) * speakingFraction
+        let raised = max(fromSpeech, restingPeak * thresholdRestingHeadroom)
+        let enter = min(max(raised, minThreshold), maxThreshold)
+        let exit = min(
+            max(enter * exitFraction, restingPeak * exitRestingHeadroom),
+            enter * maxExitFraction
+        )
+
+        var config = base
+        config.envelopeEnterThreshold = enter
+        config.envelopeExitThreshold = exit
+        return config
+    }
+
+    /// Whether the captured speech is sustained enough, and separated enough from resting
+    /// noise, that the suggested thresholds can be trusted.
+    public static func isSpeechUsable(_ samples: WearerSpeechCalibrationSamples) -> Bool {
+        assessment(of: samples).isUsable
+    }
+
+    /// Lower median of the values, or 0 when there are none. The lower median rather than
+    /// an interpolated one so the statistic is always a value the wearer actually produced.
+    static func median(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        return sorted[(sorted.count - 1) / 2]
+    }
+}

--- a/Sources/TapQDetectionBaseline/WearerSpeechConfig.swift
+++ b/Sources/TapQDetectionBaseline/WearerSpeechConfig.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Tunable thresholds for wearer-speech detection from the earbud IMU.
+///
+/// The detected quantity is a *jerk envelope*: the sample-to-sample change in user
+/// acceleration, in g. While the wearer talks, jaw motion and skull-borne vibration keep
+/// that envelope modestly but continuously elevated, whereas an impact (tap) elevates it
+/// for one or two samples and a nod/shake elevates it together with high rotation rate.
+/// The three gates below — level, sustain, rotation quiet — are what separate those cases.
+///
+/// Every default here is a provisional uncalibrated starting point: the 25 Hz CoreMotion
+/// stream has never been characterised against ground-truth speech, so the capture study
+/// retunes these values and `WearerSpeechCalibrator` writes them into a saved profile.
+/// Retuning must stay a data change, never a code change.
+public struct WearerSpeechConfig: Sendable, Codable, Equatable {
+    /// Default maximum inter-sample gap; also the gap policy used by
+    /// `WearerSpeechAnalyzer.envelopeSeries` when no explicit value is supplied.
+    public static let defaultMaximumSampleGapSeconds: TimeInterval = 0.5
+
+    /// Envelope level (g, per-sample jerk) a sample must reach to count as "elevated"
+    /// while the detector is *quiet*. The higher half of the hysteresis pair.
+    public var envelopeEnterThreshold: Double
+    /// Envelope level a sample must reach to keep counting as elevated once the detector
+    /// is *speaking*. Deliberately lower than the enter threshold so a stream hovering in
+    /// the mid band settles in whichever state it is already in instead of chattering.
+    public var envelopeExitThreshold: Double
+    /// Fraction of the trailing window that must be elevated before the window counts as
+    /// active. This is the gate that rejects impacts: a tap elevates one or two samples of
+    /// a ~15-sample window, speech elevates most of it.
+    public var minimumActiveFraction: Double
+    /// How long the window must stay continuously active before `.quiet` becomes
+    /// `.speaking`. Onset latency is roughly this plus the time to fill
+    /// `minimumActiveFraction` of the window.
+    public var minimumSpeakingSeconds: TimeInterval
+    /// How long `.speaking` survives an inactive window. Covers the natural gaps between
+    /// words and phrases so one utterance does not fragment into many.
+    public var hangoverSeconds: TimeInterval
+    /// The window's maximum `|rotationRate|` (rad/s) must stay below this. Windowed, not
+    /// instantaneous, exactly like `TapConfig.rotationQuiet`: a nod or shake produces a
+    /// speech-sized acceleration envelope, and only the rotation gate tells them apart.
+    public var rotationQuiet: Double
+    /// Trailing window over which the envelope level and rotation are judged.
+    public var windowSeconds: TimeInterval
+    /// Minimum envelope samples in the window before attempting detection.
+    public var minSamples: Int
+    /// Two consecutive samples further apart than this are not differenced: the stream was
+    /// interrupted, so the detector resets rather than reading the discontinuity as a
+    /// vibration burst.
+    public var maxSampleGapSeconds: TimeInterval
+
+    public init(
+        envelopeEnterThreshold: Double = 0.020,
+        envelopeExitThreshold: Double = 0.012,
+        minimumActiveFraction: Double = 0.5,
+        minimumSpeakingSeconds: TimeInterval = 0.3,
+        hangoverSeconds: TimeInterval = 0.6,
+        rotationQuiet: Double = 0.8,
+        windowSeconds: TimeInterval = 0.6,
+        minSamples: Int = 6,
+        maxSampleGapSeconds: TimeInterval = WearerSpeechConfig.defaultMaximumSampleGapSeconds
+    ) {
+        self.envelopeEnterThreshold = envelopeEnterThreshold
+        self.envelopeExitThreshold = envelopeExitThreshold
+        self.minimumActiveFraction = minimumActiveFraction
+        self.minimumSpeakingSeconds = minimumSpeakingSeconds
+        self.hangoverSeconds = hangoverSeconds
+        self.rotationQuiet = rotationQuiet
+        self.windowSeconds = windowSeconds
+        self.minSamples = minSamples
+        self.maxSampleGapSeconds = maxSampleGapSeconds
+    }
+
+    /// Tolerant decoding, per `HeadGestureConfig`'s policy: the two calibrated envelope
+    /// thresholds are the payload a saved profile exists to carry and stay required, while
+    /// every shape knob falls back to its default. A profile written before a knob existed
+    /// must keep loading — silently discarding a calibration is worse than running one
+    /// knob at its default.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let defaults = WearerSpeechConfig()
+        envelopeEnterThreshold = try c.decode(Double.self, forKey: .envelopeEnterThreshold)
+        envelopeExitThreshold = try c.decode(Double.self, forKey: .envelopeExitThreshold)
+        minimumActiveFraction = try c.decodeIfPresent(Double.self, forKey: .minimumActiveFraction)
+            ?? defaults.minimumActiveFraction
+        minimumSpeakingSeconds = try c.decodeIfPresent(TimeInterval.self, forKey: .minimumSpeakingSeconds)
+            ?? defaults.minimumSpeakingSeconds
+        hangoverSeconds = try c.decodeIfPresent(TimeInterval.self, forKey: .hangoverSeconds)
+            ?? defaults.hangoverSeconds
+        rotationQuiet = try c.decodeIfPresent(Double.self, forKey: .rotationQuiet)
+            ?? defaults.rotationQuiet
+        windowSeconds = try c.decodeIfPresent(TimeInterval.self, forKey: .windowSeconds)
+            ?? defaults.windowSeconds
+        minSamples = try c.decodeIfPresent(Int.self, forKey: .minSamples)
+            ?? defaults.minSamples
+        maxSampleGapSeconds = try c.decodeIfPresent(TimeInterval.self, forKey: .maxSampleGapSeconds)
+            ?? defaults.maxSampleGapSeconds
+    }
+}

--- a/Sources/TapQDetectionBaseline/WearerSpeechMonitor.swift
+++ b/Sources/TapQDetectionBaseline/WearerSpeechMonitor.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Push-driven state holder over `WearerSpeechDetector`. Each ingested motion sample is
+/// forwarded to the detector and the resulting state is surfaced through a transition
+/// callback. A staleness horizon (defaulting to `config.maxSampleGapSeconds`) lets
+/// downstream consumers know whether the most recent answer still describes *now* --
+/// a stream that stops arriving (window closed, AirPods asleep) goes stale, and any
+/// signal adapter built on top reports `isSignalAvailable == false`.
+///
+/// All logic lives here so the platform adapter (`WearerSpeechSignalSource`) stays a
+/// thin shim.
+public final class WearerSpeechMonitor {
+    public let config: WearerSpeechConfig
+
+    /// The staleness horizon: if `monotonicNow() - lastSampleAt` exceeds this, the
+    /// signal is stale and consumers must fail open.
+    public let stalenessHorizon: TimeInterval
+
+    /// The detector's current state.
+    public private(set) var state: WearerSpeechState = .quiet
+
+    /// Whether the most recently ingested sample carried per-axis data. Consumers that
+    /// need direction-aware analysis (attribution) require this; magnitude-only streams
+    /// drive the detector but are not sufficient for attribution.
+    public private(set) var lastSampleHadPerAxisData: Bool = false
+
+    /// Monotonic timestamp of the last ingested sample, or nil if no sample has arrived.
+    public private(set) var lastSampleAt: TimeInterval?
+
+    /// Whether the stream has been explicitly interrupted (teardown / motion loss).
+    public private(set) var interrupted: Bool = false
+
+    /// Fired on every quiet<->speaking transition.
+    public var onTransition: ((WearerSpeechTransition) -> Void)?
+
+    private var detector: WearerSpeechDetector
+    private let monotonicNow: () -> TimeInterval
+
+    public init(config: WearerSpeechConfig = .init(),
+                stalenessHorizon: TimeInterval? = nil,
+                monotonicNow: @escaping () -> TimeInterval = {
+                    ProcessInfo.processInfo.systemUptime
+                }) {
+        self.config = config
+        self.stalenessHorizon = stalenessHorizon ?? config.maxSampleGapSeconds
+        self.detector = WearerSpeechDetector(config: config)
+        self.monotonicNow = monotonicNow
+    }
+
+    /// Feeds one motion sample to the underlying detector and surfaces any transition.
+    @discardableResult
+    public func ingest(_ sample: HeadMotionSample) -> WearerSpeechUpdate {
+        interrupted = false
+        lastSampleAt = monotonicNow()
+        lastSampleHadPerAxisData = sample.hasPerAxisData
+        let update = detector.ingestDetailed(sample)
+        state = update.state
+        if let transition = update.transition {
+            onTransition?(transition)
+        }
+        return update
+    }
+
+    /// Called when the motion stream is interrupted (teardown, motion loss, session
+    /// reset). Resets the detector to `.quiet`, marks the signal as stale, and fires a
+    /// `stoppedSpeaking` transition if the detector was speaking.
+    public func streamInterrupted() {
+        interrupted = true
+        let wasSpeaking = state == .speaking
+        detector.reset()
+        state = .quiet
+        if wasSpeaking {
+            onTransition?(.stoppedSpeaking)
+        }
+    }
+
+    /// True when the last sample is recent enough to describe the present moment.
+    public func isFresh(now: TimeInterval? = nil) -> Bool {
+        guard !interrupted, let last = lastSampleAt else { return false }
+        let current = now ?? monotonicNow()
+        return current - last <= stalenessHorizon
+    }
+}

--- a/Sources/TapQInteractionBaseline/CombinedSpeechActivity.swift
+++ b/Sources/TapQInteractionBaseline/CombinedSpeechActivity.swift
@@ -1,0 +1,66 @@
+import Foundation
+import TapQContracts
+
+/// Merges the TTS engine's activity signal with a backend audio player's activity signal
+/// into a single `SpeechActivitySignaling` that `SpeechGatedVoice` can consume unchanged.
+///
+/// The combined signal reports `isSpeaking == true` whenever *either* source is active:
+/// - The TTS engine is speaking or has utterances queued (`SpeechEngine.isSpeaking`), OR
+/// - The backend audio player is playing response audio (`VoiceResponseAudioPlaying.isPlaying`).
+///
+/// This is the M2 self-hearing guarantee: the microphone stays closed while any audio —
+/// whether from `AVSpeechSynthesizer` or from a cloud voice backend — is sounding.
+///
+/// ## Ownership
+///
+/// Takes sole ownership of both inner observer slots:
+/// - `tts.onSpeakingChange` (the TTS engine's single-observer slot)
+/// - `playback.onPlayingChange` (the audio player's single-observer slot)
+///
+/// Exposes one outer `onSpeakingChange` for `SpeechGatedVoice` to claim. The ownership
+/// chain is: engine → CombinedSpeechActivity → SpeechGatedVoice, with exactly one observer
+/// at each link.
+@MainActor public final class CombinedSpeechActivity: SpeechActivitySignaling {
+    private let tts: SpeechActivitySignaling
+    private let playback: any VoiceResponseAudioPlaying
+
+    /// Combined state: true when either source is active.
+    public private(set) var isSpeaking: Bool
+
+    /// Single observer, fired after each combined-busy↔idle transition.
+    public var onSpeakingChange: (@MainActor (Bool) -> Void)?
+
+    /// - Parameters:
+    ///   - tts: The TTS engine's activity signal (`SpeechEngine`).
+    ///   - playback: The backend audio player's activity signal.
+    ///
+    /// Both inner observer slots must be unclaimed at init time; the asserts mirror the
+    /// `SpeechGatedVoice` pattern.
+    public init(tts: SpeechActivitySignaling, playback: any VoiceResponseAudioPlaying) {
+        assert(tts.onSpeakingChange == nil,
+               "CombinedSpeechActivity takes sole ownership of tts.onSpeakingChange")
+        assert(playback.onPlayingChange == nil,
+               "CombinedSpeechActivity takes sole ownership of playback.onPlayingChange")
+
+        self.tts = tts
+        self.playback = playback
+        self.isSpeaking = tts.isSpeaking || playback.isPlaying
+
+        tts.onSpeakingChange = { [weak self] _ in
+            self?.recompute()
+        }
+        playback.onPlayingChange = { [weak self] _ in
+            self?.recompute()
+        }
+    }
+
+    /// Recomputes the combined state from both sources and fires the outer observer if the
+    /// combined value changed. Idempotent — duplicate edges from either source collapse to
+    /// at most one outer transition.
+    private func recompute() {
+        let combined = tts.isSpeaking || playback.isPlaying
+        guard combined != isSpeaking else { return }
+        isSpeaking = combined
+        onSpeakingChange?(combined)
+    }
+}

--- a/Sources/TapQInteractionBaseline/InteractionController.swift
+++ b/Sources/TapQInteractionBaseline/InteractionController.swift
@@ -169,8 +169,10 @@ public struct DefaultApprovalRequestPresenter: ApprovalRequestPresenting {
                 utterance = promptText(for: request)
             case .details:
                 utterance = detailText(for: request)
-            case .next, .previous, .select, .selectByNumber:
-                // Navigation intents are not meaningful in approval flow — keep listening.
+            case .next, .previous, .select, .selectByNumber, .freeform:
+                // Navigation and free-form intents are not meaningful in approval flow —
+                // keep listening. A free-form answer to an approval is an authorization
+                // surface change and is out of scope for this milestone.
                 break
             }
         }

--- a/Sources/TapQInteractionBaseline/SelectionController.swift
+++ b/Sources/TapQInteractionBaseline/SelectionController.swift
@@ -108,7 +108,7 @@ import TapQContracts
                 // Read-back confirmation: the wearer spoke a free-text answer.
                 // Speak it back, then wait for nod (confirm) or shake (discard).
                 let condensedText = SpokenText.condensed(text, maxWords: 12, maxCharacters: 96)
-                utterance = "You said: '\(SpokenText.sentence(condensedText))' Nod to send, shake to discard."
+                utterance = "You said: '\(SpokenText.sentence(condensedText))' Nod or say yes to send, shake or say no to discard."
                 diagnostics.record("freeform.readback",
                                    fields: ["length": "\(text.count)"])
                 let confirmRemaining = deadline.seconds(after: now())

--- a/Sources/TapQInteractionBaseline/SelectionController.swift
+++ b/Sources/TapQInteractionBaseline/SelectionController.swift
@@ -104,6 +104,49 @@ import TapQContracts
                 // An explicit repeat is the one moment the user has signalled they are
                 // lost, so the controls come back even after the session's first prompt.
                 utterance = promptText(request, cursor: cursor, includeControls: true)
+            case .freeform(let text):
+                // Read-back confirmation: the wearer spoke a free-text answer.
+                // Speak it back, then wait for nod (confirm) or shake (discard).
+                let condensedText = SpokenText.condensed(text, maxWords: 12, maxCharacters: 96)
+                utterance = "You said: '\(SpokenText.sentence(condensedText))' Nod to send, shake to discard."
+                diagnostics.record("freeform.readback",
+                                   fields: ["length": "\(text.count)"])
+                let confirmRemaining = deadline.seconds(after: now())
+                guard confirmRemaining > 0 else {
+                    outcome = "timeout"
+                    return deferToScreen()
+                }
+                let confirmation = await BargeIn.listen(
+                    speech: speech, text: utterance, priority: .approval
+                ) {
+                    await arbiter.listen(timeout: min(timeout, confirmRemaining))
+                }
+                utterance = nil
+                switch confirmation {
+                case .allow, .select:
+                    outcome = "resolved_freeform"
+                    diagnostics.record("freeform.confirmed",
+                                       fields: ["length": "\(text.count)"])
+                    return SelectionResult(choices: [], freeText: text)
+                case .deny:
+                    // Discard and re-listen for a new answer.
+                    diagnostics.record("freeform.discarded")
+                    utterance = promptText(request, cursor: cursor,
+                                           includeControls: false)
+                    continue
+                case .none:
+                    outcome = "timeout"
+                    diagnostics.record("selection.timeout")
+                    return deferToScreen()
+                default:
+                    // Any other intent (navigation, etc.) during read-back confirmation
+                    // is treated as a discard — re-listen.
+                    diagnostics.record("freeform.discarded",
+                                       fields: ["reason": "unexpected_intent"])
+                    utterance = promptText(request, cursor: cursor,
+                                           includeControls: false)
+                    continue
+                }
             case .none:
                 outcome = "timeout"
                 diagnostics.record("selection.timeout")

--- a/Sources/TapQInteractionBaseline/SpeechGatedVoice.swift
+++ b/Sources/TapQInteractionBaseline/SpeechGatedVoice.swift
@@ -49,7 +49,7 @@ import TapQContracts
 
     private func speakingChanged(_ speaking: Bool) {
         if speaking {
-            inner.stop()
+            inner.pauseListening()
         } else if handler != nil {
             diagnostics.record("microphone.reopened")
             startInner()

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -1,0 +1,150 @@
+import Foundation
+import TapQContracts
+
+/// Presents any `VoiceBackend` as the `VoiceCommandProviding` the arbiter already consumes,
+/// so swapping the speech pipe underneath TapQ never reaches the interaction layer.
+///
+/// The window shape is the one `VoiceListener` established and every composition above
+/// depends on: one `start` opens a session and exactly one user turn, the first matched
+/// transcript resolves the window and tears it down, and `stop` closes everything. Turns
+/// are opened only inside `start`, which is what keeps the microphone from being live
+/// between windows no matter which backend is plugged in.
+///
+/// Every degraded path fails open in the same direction as the rest of the voice channel:
+/// a session that cannot be opened, or one that dies mid-window, delivers nothing and
+/// stays quiet. The window still resolves by gesture, tap, or timeout — a voice backend
+/// must never be able to make a window hang.
+@MainActor public final class VoiceBackendCommandProvider: VoiceCommandProviding {
+    /// The keyword grammar, injected rather than defaulted.
+    ///
+    /// `VoiceCommandMatcher` lives in `TapQDetectionBaseline`, and this module deliberately
+    /// depends on nothing but `TapQContracts`; composition passes `VoiceCommandMatcher.match`.
+    public typealias TranscriptMatching = @MainActor (String) -> VoiceCommand?
+
+    private let backend: any VoiceBackend
+    private let match: TranscriptMatching
+    private let diagnostics: TapQDiagnosticEmitter
+
+    private var handler: (@MainActor (VoiceCommand) -> Void)?
+    private var sessionOpen = false
+    private var turnActive = false
+    /// Invalidates events and open-completions belonging to an earlier window. A backend
+    /// event can always arrive one main-actor hop after the window that asked for it was
+    /// torn down; without this, a transcript from a dead window resolves a live one.
+    private var windowGeneration: UInt64 = 0
+
+    public init(backend: any VoiceBackend,
+                match: @escaping TranscriptMatching,
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        self.backend = backend
+        self.match = match
+        self.diagnostics = TapQDiagnosticEmitter(category: "VoiceBackend", sink: diagnosticSink)
+    }
+
+    var isWindowOpenForTesting: Bool { handler != nil }
+
+    public func start(onCommand: @escaping @MainActor (VoiceCommand) -> Void) {
+        guard handler == nil else {
+            diagnostics.record("start.skipped", fields: ["reason": "already_running"])
+            return
+        }
+        windowGeneration &+= 1
+        let generation = windowGeneration
+        handler = onCommand
+        // `open` is async by contract (a socket-backed adapter has to await a handshake),
+        // so the window opens on the next main-actor turn and every step after the await
+        // re-checks that it is still the window that asked.
+        Task { @MainActor [weak self] in
+            await self?.openWindow(generation: generation)
+        }
+    }
+
+    public func stop() {
+        teardown()
+    }
+
+    private func openWindow(generation: UInt64) async {
+        do {
+            try await backend.open { [weak self] event in
+                self?.handle(event, generation: generation)
+            }
+        } catch {
+            guard windowGeneration == generation else { return }
+            diagnostics.record("window.open_failed", level: .warning,
+                               fields: ["error": Self.describe(error)])
+            teardown(expectedGeneration: generation)
+            return
+        }
+        guard windowGeneration == generation else {
+            // `stop()` landed while the handshake was still in flight. The session is ours
+            // and nobody else will ever close it.
+            backend.close()
+            return
+        }
+        sessionOpen = true
+        backend.beginUserTurn()
+        turnActive = true
+        diagnostics.record("window.started")
+    }
+
+    private func handle(_ event: VoiceBackendEvent, generation: UInt64) {
+        guard windowGeneration == generation else { return }
+        switch event {
+        case .transcriptPartial(let transcript):
+            consume(transcript, isFinal: false, generation: generation)
+        case .transcriptFinal(let transcript):
+            consume(transcript, isFinal: true, generation: generation)
+        case .audio:
+            // A command channel has nowhere to put response audio; TapQ speaks through its
+            // own engine. Recorded rather than dropped silently so a misconfigured duplex
+            // backend is visible in the log.
+            diagnostics.record("audio.ignored")
+        case .responseCompleted:
+            break
+        case .sessionFailed(let failure):
+            diagnostics.record("session.failed", level: .warning,
+                               fields: ["detail": failure.localizedDescription])
+            // The session is gone: ending its turn would be a call into a dead backend.
+            turnActive = false
+            teardown(expectedGeneration: generation)
+        }
+    }
+
+    /// Transcripts are cumulative for a turn — the whole utterance so far, not a delta —
+    /// which is exactly what `VoiceListener.handleRecognition` matches against today, so the
+    /// grammar sees the same input it always has.
+    private func consume(_ transcript: String, isFinal: Bool, generation: UInt64) {
+        guard let command = match(transcript) else {
+            if isFinal {
+                // The wearer said something the grammar does not know. Logged so a "voice
+                // does nothing" report stays diagnosable from the log file alone.
+                diagnostics.record("transcript.rejected",
+                                   fields: ["reason": "unmatched",
+                                            "length": "\(transcript.count)"])
+            }
+            return
+        }
+        diagnostics.record("command.matched", fields: ["command": "\(command)"])
+        let callback = handler
+        teardown(expectedGeneration: generation)
+        callback?(command)
+    }
+
+    private func teardown(expectedGeneration: UInt64? = nil) {
+        if let expectedGeneration, expectedGeneration != windowGeneration { return }
+        windowGeneration &+= 1
+        handler = nil
+        if turnActive {
+            turnActive = false
+            backend.endUserTurn()
+        }
+        if sessionOpen {
+            sessionOpen = false
+            backend.close()
+        }
+    }
+
+    private static func describe(_ error: any Error) -> String {
+        (error as? VoiceBackendFailure)?.localizedDescription ?? String(describing: error)
+    }
+}

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -47,6 +47,7 @@ public enum SessionPolicy: Sendable, Equatable {
     private let sessionPolicy: SessionPolicy
     private let supportsBargeIn: Bool
     private let monotonicNow: @MainActor () -> TimeInterval
+    private let responseAudio: (any VoiceResponseAudioPlaying)?
 
     private var handler: (@MainActor (VoiceCommand) -> Void)?
     private var sessionOpen = false
@@ -76,6 +77,7 @@ public enum SessionPolicy: Sendable, Equatable {
                 match: @escaping TranscriptMatching,
                 sessionPolicy: SessionPolicy = .perWindow,
                 supportsBargeIn: Bool = false,
+                responseAudio: (any VoiceResponseAudioPlaying)? = nil,
                 monotonicNow: @escaping @MainActor () -> TimeInterval = {
                     ProcessInfo.processInfo.systemUptime
                 },
@@ -84,6 +86,7 @@ public enum SessionPolicy: Sendable, Equatable {
         self.match = match
         self.sessionPolicy = sessionPolicy
         self.supportsBargeIn = supportsBargeIn
+        self.responseAudio = responseAudio
         self.monotonicNow = monotonicNow
         self.diagnostics = TapQDiagnosticEmitter(category: "VoiceBackend", sink: diagnosticSink)
     }
@@ -182,6 +185,7 @@ public enum SessionPolicy: Sendable, Equatable {
         }
         backend.cancelResponse()
         _responseInFlight = false
+        responseAudio?.stopAndFlush()
         diagnostics.record("response.cancelled_by_coordinator")
     }
 
@@ -228,11 +232,20 @@ public enum SessionPolicy: Sendable, Equatable {
         case .transcriptFinal(let transcript):
             guard handler != nil else { return }
             consume(transcript, isFinal: true)
-        case .audio:
+        case .audio(let chunk):
             guard handler != nil else { return }
-            diagnostics.record("audio.ignored")
+            // An .audio event is proof a response is in flight — gate on the event stream,
+            // not on composed capabilities (FailThrough intersection reports producesAudio:
+            // false even when the active inner pipe is the one producing audio).
+            _responseInFlight = true
+            if let responseAudio {
+                responseAudio.enqueue(chunk)
+            } else {
+                diagnostics.record("audio.ignored")
+            }
         case .responseCompleted:
             _responseInFlight = false
+            responseAudio?.finishStream()
         case .sessionFailed(let failure):
             diagnostics.record("session.failed", level: .warning,
                                fields: ["detail": failure.localizedDescription])
@@ -284,6 +297,7 @@ public enum SessionPolicy: Sendable, Equatable {
         sessionGeneration &+= 1
         handler = nil
         _responseInFlight = false
+        responseAudio?.stopAndFlush()
         if turnActive {
             turnActive = false
             backend.endUserTurn()
@@ -300,6 +314,7 @@ public enum SessionPolicy: Sendable, Equatable {
         windowGeneration &+= 1
         handler = nil
         _responseInFlight = false
+        responseAudio?.stopAndFlush()
         if turnActive {
             turnActive = false
             backend.endUserTurn()

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -238,6 +238,12 @@ public enum SessionPolicy: Sendable, Equatable {
             return
         }
         sessionOpen = true
+        // A fresh session has no in-flight response and no deferred turn. Clear
+        // any stale state carried from a prior conversation that idle-closed while
+        // a response was still tracked (e.g. audio arrived between windows, then
+        // the session timed out before responseCompleted).
+        _responseInFlight = false
+        pendingUserTurn = false
         backend.beginUserTurn()
         turnActive = true
         diagnostics.record("window.started")
@@ -382,6 +388,11 @@ public enum SessionPolicy: Sendable, Equatable {
         guard sessionOpen else { return }
         diagnostics.record("session.idle_closed")
         sessionOpen = false
+        // Clear session-scoped tracking: the session is ending, so any in-flight
+        // response from the prior conversation is gone and a deferred turn waiting
+        // on responseCompleted would never fire.
+        _responseInFlight = false
+        pendingUserTurn = false
         sessionGeneration &+= 1
         backend.close()
     }

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -188,6 +188,7 @@ public enum SessionPolicy: Sendable, Equatable {
                 backend.beginUserTurn()
                 turnActive = true
                 freeformDeliveredThisTurn = false
+                _responseSuppressed = false
                 diagnostics.record("window.started")
             } else {
                 let generation = windowGeneration
@@ -233,10 +234,7 @@ public enum SessionPolicy: Sendable, Equatable {
             // TTS starting (e.g. notification): the turn must not span the TTS interval.
             if turnActive, !(responseAudio?.isPlaying ?? false) {
                 turnActive = false
-                backend.endUserTurn()
-                // The adapter may have entered .responding synchronously (the
-                // session-death race). Track it so the resume start() defers.
-                if supportsBargeIn { _responsePendingFromTurn = true }
+                _responsePendingFromTurn = backend.endUserTurn(expectingResponse: false)
             }
             diagnostics.record("listening.paused")
         }
@@ -259,17 +257,24 @@ public enum SessionPolicy: Sendable, Equatable {
     public var isResponseInFlight: Bool { _responseInFlight }
     private var _responseInFlight = false
 
-    /// True after the provider calls `backend.endUserTurn()` (or `endActiveTurn`) in
-    /// conversation mode. The adapter may have entered `.responding` synchronously (on
-    /// the OpenAI path: commit + response.create), but the provider cannot confirm this
-    /// until the first `.audio` event arrives. In the gap between the commit and the
-    /// first audio delta, `start()` must not call `beginUserTurn()` — the adapter would
-    /// reject it with `responseAlreadyInFlight`, killing the session.
+    /// True after the backend reports that `endUserTurn(expectingResponse: true)` actually
+    /// created a response. Derived exclusively from the backend's ground-truth return value
+    /// — never from proxies like `supportsBargeIn` or turn-active state.
     ///
-    /// Set when `endUserTurn()` is called; cleared when `.audio` promotes it to
-    /// `_responseInFlight`, when `.responseCompleted` settles the response, on session
-    /// teardown, on idle-close, and on a fresh `openWindow`.
+    /// In the gap between the commit+response.create and the first `.audio` delta,
+    /// `start()` must not call `beginUserTurn()` — the adapter would reject it with
+    /// `responseAlreadyInFlight`, killing the session.
+    ///
+    /// Cleared when `.audio` promotes it to `_responseInFlight`, when `.responseCompleted`
+    /// settles the response, on session teardown, on idle-close, and on a fresh `openWindow`.
     private var _responsePendingFromTurn = false
+
+    /// Armed when a match resolves a window while a response is pending or in flight.
+    /// The response was created by a prior `endActiveTurn` (coordinator endpoint) and cannot
+    /// be cancelled immediately because `turnActive` is already false and/or no `.audio` has
+    /// arrived yet. On the first `.audio` (or on `responseCompleted`), the provider cancels
+    /// the response instead of enqueueing. Cleared on the next `beginUserTurn`.
+    private var _responseSuppressed = false
 
     /// Commits the current user turn without tearing down the window.
     ///
@@ -285,14 +290,7 @@ public enum SessionPolicy: Sendable, Equatable {
             return
         }
         turnActive = false
-        backend.endUserTurn()
-        // The adapter may have entered .responding synchronously (OpenAI: commit +
-        // response.create). Track this so the next start() defers rather than calling
-        // beginUserTurn into a responding adapter (the session-death race).
-        // Only set when supportsBargeIn — the proxy for "backend creates responses from
-        // endUserTurn". Transcript-only backends (Apple) stay in .committed/.open, where
-        // beginUserTurn is valid.
-        if supportsBargeIn { _responsePendingFromTurn = true }
+        _responsePendingFromTurn = backend.endUserTurn(expectingResponse: true)
         diagnostics.record("turn.committed_by_coordinator")
     }
 
@@ -353,6 +351,7 @@ public enum SessionPolicy: Sendable, Equatable {
         // the session timed out before responseCompleted).
         _responseInFlight = false
         _responsePendingFromTurn = false
+        _responseSuppressed = false
         pendingUserTurn = false
         freeformDeliveredThisTurn = false
         backend.beginUserTurn()
@@ -373,11 +372,24 @@ public enum SessionPolicy: Sendable, Equatable {
             guard handler != nil else { return }
             consume(transcript, isFinal: true)
         case .audio(let chunk):
+            // A suppressed response: cancel on first audio instead of enqueueing. This
+            // handles the real OpenAI ordering where a match resolves after endActiveTurn
+            // created a response but before any audio arrived.
+            if _responseSuppressed {
+                _responseSuppressed = false
+                _responsePendingFromTurn = false
+                if supportsBargeIn {
+                    backend.cancelResponse()
+                    diagnostics.record("response.suppressed_on_first_audio")
+                }
+                // Do not track as in-flight (we just cancelled it) and do not enqueue.
+                return
+            }
             // Track response-in-flight at session scope, before the window guard. Between
             // windows (handler == nil) the response is still in flight at the adapter level;
             // the next start() must know this to avoid a protocol violation.
             _responseInFlight = true
-            // Audio confirms the response exists; the pending-from-turn guess is promoted.
+            // Audio confirms the response exists; the pending-from-turn report is promoted.
             _responsePendingFromTurn = false
             // Allow audio routing when paused: a pause-for-playback must not interrupt the
             // response that caused the pause. Without the windowPaused check, the first
@@ -396,6 +408,7 @@ public enum SessionPolicy: Sendable, Equatable {
         case .responseCompleted:
             _responseInFlight = false
             _responsePendingFromTurn = false
+            _responseSuppressed = false
             responseAudio?.finishStream()
             // A deferred turn was waiting for this response to complete.
             if pendingUserTurn, handler != nil {
@@ -414,6 +427,7 @@ public enum SessionPolicy: Sendable, Equatable {
             turnActive = false
             _responseInFlight = false
             _responsePendingFromTurn = false
+            _responseSuppressed = false
             pendingUserTurn = false
             teardown()
         }
@@ -474,11 +488,13 @@ public enum SessionPolicy: Sendable, Equatable {
         handler = nil
         _responseInFlight = false
         _responsePendingFromTurn = false
+        _responseSuppressed = false
         pendingUserTurn = false
+        windowPaused = false
         responseAudio?.stopAndFlush()
         if turnActive {
             turnActive = false
-            backend.endUserTurn()
+            backend.endUserTurn(expectingResponse: false)
         }
         if sessionOpen {
             sessionOpen = false
@@ -489,32 +505,42 @@ public enum SessionPolicy: Sendable, Equatable {
     /// End the current window but keep the conversation session alive.
     /// Used in `.conversation` mode when `stop()` is called or a match resolves.
     ///
-    /// When `suppressResponse` is true and `supportsBargeIn`, the response that
-    /// `endUserTurn` may have triggered on the backend (e.g. OpenAI's `response.create`)
-    /// is cancelled immediately. This prevents a spurious cloud response per
-    /// voice-resolved window in conversation mode.
+    /// When `suppressResponse` is true, any response already pending or in flight from a
+    /// prior `endActiveTurn` is suppressed: if audio has arrived (`_responseInFlight`), the
+    /// response is cancelled immediately; if it is still pending (`_responsePendingFromTurn`),
+    /// a suppression mark is armed so the first `.audio` (or `responseCompleted`) cancels it
+    /// instead of enqueueing. The turn-ending `endUserTurn` itself always passes
+    /// `expectingResponse: false`, so no *new* response is created.
     private func endWindowKeepSession(suppressResponse: Bool = false) {
         windowGeneration &+= 1
         handler = nil
         pendingUserTurn = false
+        windowPaused = false
         responseAudio?.stopAndFlush()
         if turnActive {
             turnActive = false
-            backend.endUserTurn()
-            // The adapter may have entered .responding synchronously (the session-death
-            // race). Track it so the next start() defers. Only relevant when the backend
-            // creates responses from endUserTurn (supportsBargeIn proxy).
-            if supportsBargeIn { _responsePendingFromTurn = true }
-            // Suppress only when a response is actually in flight and the inner pipe
-            // supports barge-in. Without the _responseInFlight guard, this path kills
-            // sessions that are in .committed (not .responding) — e.g. OpenAI's
-            // empty-turn guard skips response.create so the adapter stays committed, and
-            // on the Apple fallback cancelResponse always throws bargeInUnsupported.
-            if suppressResponse, supportsBargeIn, _responseInFlight {
+            // TapQ does not want a spoken reply for match-resolved or stop-ended windows.
+            // expectingResponse: false → commit only (for transcription), no response.create.
+            // The return value is the ground truth: false means no response was created.
+            _responsePendingFromTurn = backend.endUserTurn(expectingResponse: false)
+        }
+        // Suppress a response that is already pending or in flight from a prior
+        // endActiveTurn (coordinator endpoint). This is the real OpenAI ordering:
+        // endActiveTurn → commit+response.create → transcript arrives → match resolves.
+        if suppressResponse {
+            if _responseInFlight, supportsBargeIn {
+                // Audio has confirmed the response — cancel immediately.
                 backend.cancelResponse()
                 _responseInFlight = false
                 _responsePendingFromTurn = false
+                responseAudio?.stopAndFlush()
                 diagnostics.record("response.suppressed_match_resolved")
+            } else if _responsePendingFromTurn {
+                // The backend reported it created a response, but no audio has arrived
+                // yet. Arm the suppression mark: the first .audio or responseCompleted
+                // will cancel instead of enqueueing.
+                _responseSuppressed = true
+                diagnostics.record("response.suppression_armed")
             }
         }
         // Session and session generation stay: the backend is still alive.
@@ -549,6 +575,7 @@ public enum SessionPolicy: Sendable, Equatable {
         // on responseCompleted would never fire.
         _responseInFlight = false
         _responsePendingFromTurn = false
+        _responseSuppressed = false
         pendingUserTurn = false
         sessionGeneration &+= 1
         backend.close()

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -48,6 +48,7 @@ public enum SessionPolicy: Sendable, Equatable {
     private let supportsBargeIn: Bool
     private let monotonicNow: @MainActor () -> TimeInterval
     private let responseAudio: (any VoiceResponseAudioPlaying)?
+    private let idleSleep: @MainActor (TimeInterval) async -> Void
 
     private var handler: (@MainActor (VoiceCommand) -> Void)?
     private var sessionOpen = false
@@ -67,6 +68,8 @@ public enum SessionPolicy: Sendable, Equatable {
     private var idleGeneration: UInt64 = 0
     /// True when `shutdown()` has been called. Prevents further opens.
     private var isShutDown = false
+    /// When true, the next `responseCompleted` event should begin a deferred user turn.
+    private var pendingUserTurn = false
 
     /// Observer fired after match evaluation for every final transcript in the current turn.
     /// The callback receives the transcript text and whether it matched a command.
@@ -81,6 +84,9 @@ public enum SessionPolicy: Sendable, Equatable {
                 monotonicNow: @escaping @MainActor () -> TimeInterval = {
                     ProcessInfo.processInfo.systemUptime
                 },
+                idleSleep: @escaping @MainActor (TimeInterval) async -> Void = {
+                    try? await Task.sleep(for: .seconds($0))
+                },
                 diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
         self.backend = backend
         self.match = match
@@ -88,6 +94,7 @@ public enum SessionPolicy: Sendable, Equatable {
         self.supportsBargeIn = supportsBargeIn
         self.responseAudio = responseAudio
         self.monotonicNow = monotonicNow
+        self.idleSleep = idleSleep
         self.diagnostics = TapQDiagnosticEmitter(category: "VoiceBackend", sink: diagnosticSink)
     }
 
@@ -118,7 +125,23 @@ public enum SessionPolicy: Sendable, Equatable {
             }
         case .conversation:
             if sessionOpen {
-                // Session already open: just begin a new turn.
+                // Session already open: begin a new turn, but a response may still be in
+                // flight from the prior window's commit. Calling beginUserTurn while the
+                // adapter is in .responding would cause a protocol violation → session death.
+                if _responseInFlight {
+                    if supportsBargeIn {
+                        // Cancel the in-flight response, then begin the turn.
+                        backend.cancelResponse()
+                        _responseInFlight = false
+                        responseAudio?.stopAndFlush()
+                        diagnostics.record("response.cancelled_for_new_window")
+                    } else {
+                        // Defer the turn until responseCompleted arrives.
+                        pendingUserTurn = true
+                        diagnostics.record("turn.deferred_response_in_flight")
+                        return
+                    }
+                }
                 backend.beginUserTurn()
                 turnActive = true
                 diagnostics.record("window.started")
@@ -233,11 +256,14 @@ public enum SessionPolicy: Sendable, Equatable {
             guard handler != nil else { return }
             consume(transcript, isFinal: true)
         case .audio(let chunk):
+            // Track response-in-flight at session scope, before the window guard. Between
+            // windows (handler == nil) the response is still in flight at the adapter level;
+            // the next start() must know this to avoid a protocol violation.
+            _responseInFlight = true
             guard handler != nil else { return }
             // An .audio event is proof a response is in flight — gate on the event stream,
             // not on composed capabilities (FailThrough intersection reports producesAudio:
             // false even when the active inner pipe is the one producing audio).
-            _responseInFlight = true
             if let responseAudio {
                 responseAudio.enqueue(chunk)
             } else {
@@ -246,12 +272,22 @@ public enum SessionPolicy: Sendable, Equatable {
         case .responseCompleted:
             _responseInFlight = false
             responseAudio?.finishStream()
+            // A deferred turn was waiting for this response to complete.
+            if pendingUserTurn, handler != nil {
+                pendingUserTurn = false
+                backend.beginUserTurn()
+                turnActive = true
+                diagnostics.record("turn.started_after_deferred")
+            } else {
+                pendingUserTurn = false
+            }
         case .sessionFailed(let failure):
             diagnostics.record("session.failed", level: .warning,
                                fields: ["detail": failure.localizedDescription])
             // The session is gone: ending its turn would be a call into a dead backend.
             turnActive = false
             _responseInFlight = false
+            pendingUserTurn = false
             teardown()
         }
     }
@@ -297,6 +333,7 @@ public enum SessionPolicy: Sendable, Equatable {
         sessionGeneration &+= 1
         handler = nil
         _responseInFlight = false
+        pendingUserTurn = false
         responseAudio?.stopAndFlush()
         if turnActive {
             turnActive = false
@@ -313,7 +350,7 @@ public enum SessionPolicy: Sendable, Equatable {
     private func endWindowKeepSession() {
         windowGeneration &+= 1
         handler = nil
-        _responseInFlight = false
+        pendingUserTurn = false
         responseAudio?.stopAndFlush()
         if turnActive {
             turnActive = false
@@ -331,8 +368,9 @@ public enum SessionPolicy: Sendable, Equatable {
         guard case .conversation(let idleClose) = sessionPolicy else { return }
         idleGeneration &+= 1
         let generation = idleGeneration
+        let sleep = idleSleep
         Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(idleClose))
+            await sleep(idleClose)
             self?.fireIdleClose(generation: generation)
         }
     }

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -48,6 +48,7 @@ public enum SessionPolicy: Sendable, Equatable {
     private let supportsBargeIn: Bool
     private let monotonicNow: @MainActor () -> TimeInterval
     private let responseAudio: (any VoiceResponseAudioPlaying)?
+    private let freeformEnabled: Bool
     private let idleSleep: @MainActor (TimeInterval) async -> Void
 
     private var handler: (@MainActor (VoiceCommand) -> Void)?
@@ -72,6 +73,9 @@ public enum SessionPolicy: Sendable, Equatable {
     private var pendingUserTurn = false
     /// True after an idle-close: the next `openWindow` fires `onConversationReopened`.
     private var sessionIdleClosed = false
+    /// Whether a freeform command has been delivered in the current turn.
+    /// Prevents multiple freeform deliveries per turn (one-shot per turn).
+    private var freeformDeliveredThisTurn = false
 
     /// Observer fired after match evaluation for every final transcript in the current turn.
     /// The callback receives the transcript text and whether it matched a command.
@@ -88,6 +92,7 @@ public enum SessionPolicy: Sendable, Equatable {
                 sessionPolicy: SessionPolicy = .perWindow,
                 supportsBargeIn: Bool = false,
                 responseAudio: (any VoiceResponseAudioPlaying)? = nil,
+                freeformEnabled: Bool = false,
                 monotonicNow: @escaping @MainActor () -> TimeInterval = {
                     ProcessInfo.processInfo.systemUptime
                 },
@@ -100,6 +105,7 @@ public enum SessionPolicy: Sendable, Equatable {
         self.sessionPolicy = sessionPolicy
         self.supportsBargeIn = supportsBargeIn
         self.responseAudio = responseAudio
+        self.freeformEnabled = freeformEnabled
         self.monotonicNow = monotonicNow
         self.idleSleep = idleSleep
         self.diagnostics = TapQDiagnosticEmitter(category: "VoiceBackend", sink: diagnosticSink)
@@ -151,6 +157,7 @@ public enum SessionPolicy: Sendable, Equatable {
                 }
                 backend.beginUserTurn()
                 turnActive = true
+                freeformDeliveredThisTurn = false
                 diagnostics.record("window.started")
             } else {
                 let generation = windowGeneration
@@ -251,6 +258,7 @@ public enum SessionPolicy: Sendable, Equatable {
         // the session timed out before responseCompleted).
         _responseInFlight = false
         pendingUserTurn = false
+        freeformDeliveredThisTurn = false
         if sessionIdleClosed {
             sessionIdleClosed = false
             onConversationReopened?()
@@ -295,6 +303,7 @@ public enum SessionPolicy: Sendable, Equatable {
                 pendingUserTurn = false
                 backend.beginUserTurn()
                 turnActive = true
+                freeformDeliveredThisTurn = false
                 diagnostics.record("turn.started_after_deferred")
             } else {
                 pendingUserTurn = false
@@ -338,6 +347,19 @@ public enum SessionPolicy: Sendable, Equatable {
                                    fields: ["reason": "unmatched",
                                             "length": "\(transcript.count)"])
                 onTranscriptFinal?(transcript, false)
+
+                // When free-form is enabled, deliver an unmatched final transcript as a
+                // .freeform command exactly once per turn. Empty/whitespace-only transcripts
+                // are never delivered: nothing useful can be read back or sent.
+                if freeformEnabled, !freeformDeliveredThisTurn {
+                    let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        freeformDeliveredThisTurn = true
+                        diagnostics.record("freeform.delivered",
+                                           fields: ["length": "\(trimmed.count)"])
+                        handler?(.freeform(trimmed))
+                    }
+                }
             }
         }
     }

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -147,7 +147,11 @@ public enum SessionPolicy: Sendable, Equatable {
                 // Session already open: begin a new turn, but a response may still be in
                 // flight from the prior window's commit. Calling beginUserTurn while the
                 // adapter is in .responding would cause a protocol violation → session death.
-                if _responseInFlight {
+                //
+                // _responseInFlight is confirmed by audio; _responsePendingFromTurn is set
+                // when the provider's own endUserTurn/endActiveTurn fires, bridging the gap
+                // between the commit and the first audio delta (the session-death race).
+                if _responseInFlight || _responsePendingFromTurn {
                     if resuming {
                         // Resuming after an activity-driven pause (e.g. playback started).
                         // The response is still completing; do not cancel it — defer the
@@ -156,10 +160,14 @@ public enum SessionPolicy: Sendable, Equatable {
                         diagnostics.record("turn.deferred_resume_response_in_flight")
                         return
                     }
-                    if supportsBargeIn {
-                        // Cancel the in-flight response, then begin the turn.
+                    if supportsBargeIn, _responseInFlight {
+                        // Cancel only when audio has confirmed the response is in flight.
+                        // _responsePendingFromTurn alone means the adapter may be
+                        // responding but we cannot be sure; cancelling from .committed or
+                        // .idle would violate the turn state machine.
                         backend.cancelResponse()
                         _responseInFlight = false
+                        _responsePendingFromTurn = false
                         responseAudio?.stopAndFlush()
                         diagnostics.record("response.cancelled_for_new_window")
                     } else {
@@ -226,6 +234,9 @@ public enum SessionPolicy: Sendable, Equatable {
             if turnActive, !(responseAudio?.isPlaying ?? false) {
                 turnActive = false
                 backend.endUserTurn()
+                // The adapter may have entered .responding synchronously (the
+                // session-death race). Track it so the resume start() defers.
+                if supportsBargeIn { _responsePendingFromTurn = true }
             }
             diagnostics.record("listening.paused")
         }
@@ -248,6 +259,18 @@ public enum SessionPolicy: Sendable, Equatable {
     public var isResponseInFlight: Bool { _responseInFlight }
     private var _responseInFlight = false
 
+    /// True after the provider calls `backend.endUserTurn()` (or `endActiveTurn`) in
+    /// conversation mode. The adapter may have entered `.responding` synchronously (on
+    /// the OpenAI path: commit + response.create), but the provider cannot confirm this
+    /// until the first `.audio` event arrives. In the gap between the commit and the
+    /// first audio delta, `start()` must not call `beginUserTurn()` — the adapter would
+    /// reject it with `responseAlreadyInFlight`, killing the session.
+    ///
+    /// Set when `endUserTurn()` is called; cleared when `.audio` promotes it to
+    /// `_responseInFlight`, when `.responseCompleted` settles the response, on session
+    /// teardown, on idle-close, and on a fresh `openWindow`.
+    private var _responsePendingFromTurn = false
+
     /// Commits the current user turn without tearing down the window.
     ///
     /// Transcripts for the committed audio still route to the armed handler, so a match
@@ -263,6 +286,13 @@ public enum SessionPolicy: Sendable, Equatable {
         }
         turnActive = false
         backend.endUserTurn()
+        // The adapter may have entered .responding synchronously (OpenAI: commit +
+        // response.create). Track this so the next start() defers rather than calling
+        // beginUserTurn into a responding adapter (the session-death race).
+        // Only set when supportsBargeIn — the proxy for "backend creates responses from
+        // endUserTurn". Transcript-only backends (Apple) stay in .committed/.open, where
+        // beginUserTurn is valid.
+        if supportsBargeIn { _responsePendingFromTurn = true }
         diagnostics.record("turn.committed_by_coordinator")
     }
 
@@ -276,6 +306,7 @@ public enum SessionPolicy: Sendable, Equatable {
         }
         backend.cancelResponse()
         _responseInFlight = false
+        _responsePendingFromTurn = false
         responseAudio?.stopAndFlush()
         diagnostics.record("response.cancelled_by_coordinator")
     }
@@ -321,6 +352,7 @@ public enum SessionPolicy: Sendable, Equatable {
         // a response was still tracked (e.g. audio arrived between windows, then
         // the session timed out before responseCompleted).
         _responseInFlight = false
+        _responsePendingFromTurn = false
         pendingUserTurn = false
         freeformDeliveredThisTurn = false
         backend.beginUserTurn()
@@ -345,6 +377,8 @@ public enum SessionPolicy: Sendable, Equatable {
             // windows (handler == nil) the response is still in flight at the adapter level;
             // the next start() must know this to avoid a protocol violation.
             _responseInFlight = true
+            // Audio confirms the response exists; the pending-from-turn guess is promoted.
+            _responsePendingFromTurn = false
             // Allow audio routing when paused: a pause-for-playback must not interrupt the
             // response that caused the pause. Without the windowPaused check, the first
             // enqueue raises isPlaying → CombinedSpeechActivity → SpeechGatedVoice.stop →
@@ -361,6 +395,7 @@ public enum SessionPolicy: Sendable, Equatable {
             }
         case .responseCompleted:
             _responseInFlight = false
+            _responsePendingFromTurn = false
             responseAudio?.finishStream()
             // A deferred turn was waiting for this response to complete.
             if pendingUserTurn, handler != nil {
@@ -378,6 +413,7 @@ public enum SessionPolicy: Sendable, Equatable {
             // The session is gone: ending its turn would be a call into a dead backend.
             turnActive = false
             _responseInFlight = false
+            _responsePendingFromTurn = false
             pendingUserTurn = false
             teardown()
         }
@@ -437,6 +473,7 @@ public enum SessionPolicy: Sendable, Equatable {
         sessionGeneration &+= 1
         handler = nil
         _responseInFlight = false
+        _responsePendingFromTurn = false
         pendingUserTurn = false
         responseAudio?.stopAndFlush()
         if turnActive {
@@ -464,6 +501,10 @@ public enum SessionPolicy: Sendable, Equatable {
         if turnActive {
             turnActive = false
             backend.endUserTurn()
+            // The adapter may have entered .responding synchronously (the session-death
+            // race). Track it so the next start() defers. Only relevant when the backend
+            // creates responses from endUserTurn (supportsBargeIn proxy).
+            if supportsBargeIn { _responsePendingFromTurn = true }
             // Suppress only when a response is actually in flight and the inner pipe
             // supports barge-in. Without the _responseInFlight guard, this path kills
             // sessions that are in .committed (not .responding) — e.g. OpenAI's
@@ -472,6 +513,7 @@ public enum SessionPolicy: Sendable, Equatable {
             if suppressResponse, supportsBargeIn, _responseInFlight {
                 backend.cancelResponse()
                 _responseInFlight = false
+                _responsePendingFromTurn = false
                 diagnostics.record("response.suppressed_match_resolved")
             }
         }
@@ -506,6 +548,7 @@ public enum SessionPolicy: Sendable, Equatable {
         // response from the prior conversation is gone and a deferred turn waiting
         // on responseCompleted would never fire.
         _responseInFlight = false
+        _responsePendingFromTurn = false
         pendingUserTurn = false
         sessionGeneration &+= 1
         backend.close()

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -204,7 +204,11 @@ public enum SessionPolicy: Sendable, Equatable {
         case .perWindow:
             teardown()
         case .conversation:
-            endWindowKeepSession()
+            // Pass suppressResponse: true so an endpoint-created response (from a prior
+            // endActiveTurn) is cancelled or armed for suppression rather than left to be
+            // dropped between windows and cancelled/deferred at the next start(). When no
+            // response is pending, the suppress logic is a no-op.
+            endWindowKeepSession(suppressResponse: true)
         }
     }
 

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -232,6 +232,16 @@ public enum SessionPolicy: Sendable, Equatable {
         // The generation passed here is the window generation at call time. In per-window
         // mode it also serves as the session identity. In conversation mode we derive the
         // session generation separately.
+
+        // Decision 3: resetStickiness on idle-close reopen must fire BEFORE backend.open
+        // so the new conversation re-probes the primary. Firing after open would bind the
+        // reopened conversation to the (possibly stale) fallback.
+        if sessionIdleClosed {
+            sessionIdleClosed = false
+            onConversationReopened?()
+            diagnostics.record("session.reopened_after_idle")
+        }
+
         sessionGeneration &+= 1
         let sessGen = sessionGeneration
         do {
@@ -259,11 +269,6 @@ public enum SessionPolicy: Sendable, Equatable {
         _responseInFlight = false
         pendingUserTurn = false
         freeformDeliveredThisTurn = false
-        if sessionIdleClosed {
-            sessionIdleClosed = false
-            onConversationReopened?()
-            diagnostics.record("session.reopened_after_idle")
-        }
         backend.beginUserTurn()
         turnActive = true
         diagnostics.record("window.started")
@@ -400,8 +405,14 @@ public enum SessionPolicy: Sendable, Equatable {
         if turnActive {
             turnActive = false
             backend.endUserTurn()
-            if suppressResponse, supportsBargeIn {
+            // Suppress only when a response is actually in flight and the inner pipe
+            // supports barge-in. Without the _responseInFlight guard, this path kills
+            // sessions that are in .committed (not .responding) — e.g. OpenAI's
+            // empty-turn guard skips response.create so the adapter stays committed, and
+            // on the Apple fallback cancelResponse always throws bargeInUnsupported.
+            if suppressResponse, supportsBargeIn, _responseInFlight {
                 backend.cancelResponse()
+                _responseInFlight = false
                 diagnostics.record("response.suppressed_match_resolved")
             }
         }

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -1,6 +1,21 @@
 import Foundation
 import TapQContracts
 
+/// Whether a backend session spans a single window or a whole conversation.
+///
+/// `.perWindow` — the M1 default: every `start()`/`stop()` cycle opens and closes the
+/// backend session. Existing behavior, byte-identical.
+///
+/// `.conversation(idleClose:)` — the session is opened on the first `start()` and
+/// outlives individual windows. Turns are per-window; the session is per-conversation.
+/// After a window closes, an idle timer starts; if no new `start()` arrives before the
+/// timer expires and no window is open, the session is closed. A subsequent `start()` after
+/// idle-close reopens from scratch.
+public enum SessionPolicy: Sendable, Equatable {
+    case perWindow
+    case conversation(idleClose: TimeInterval)
+}
+
 /// Presents any `VoiceBackend` as the `VoiceCommandProviding` the arbiter already consumes,
 /// so swapping the speech pipe underneath TapQ never reaches the interaction layer.
 ///
@@ -9,6 +24,11 @@ import TapQContracts
 /// transcript resolves the window and tears it down, and `stop` closes everything. Turns
 /// are opened only inside `start`, which is what keeps the microphone from being live
 /// between windows no matter which backend is plugged in.
+///
+/// In conversation mode (`SessionPolicy.conversation`), `start` opens a new turn on the
+/// existing session rather than opening a new session each time. The session stays open
+/// across windows so WebSocket reconnect churn is eliminated. The backend session is closed
+/// either by `shutdown()` or by the idle timer when no window is open.
 ///
 /// Every degraded path fails open in the same direction as the rest of the voice channel:
 /// a session that cannot be opened, or one that dies mid-window, delivers nothing and
@@ -24,55 +44,164 @@ import TapQContracts
     private let backend: any VoiceBackend
     private let match: TranscriptMatching
     private let diagnostics: TapQDiagnosticEmitter
+    private let sessionPolicy: SessionPolicy
+    private let supportsBargeIn: Bool
+    private let monotonicNow: @MainActor () -> TimeInterval
 
     private var handler: (@MainActor (VoiceCommand) -> Void)?
     private var sessionOpen = false
     private var turnActive = false
-    /// Invalidates events and open-completions belonging to an earlier window. A backend
-    /// event can always arrive one main-actor hop after the window that asked for it was
-    /// torn down; without this, a transcript from a dead window resolves a live one.
+
+    /// In `.perWindow` mode this serves as both session and window identity. In
+    /// `.conversation` mode only `sessionGeneration` guards backend events; this counter
+    /// is bumped on each window cycle but is not used in the event handler.
     private var windowGeneration: UInt64 = 0
+    /// Guards backend events in `.conversation` mode. Bumped only when the session is
+    /// opened or torn down, so events from the live session are never dropped between
+    /// windows.
+    private var sessionGeneration: UInt64 = 0
+
+    // -- Conversation mode state --
+    /// Generation counter for the idle-close task.
+    private var idleGeneration: UInt64 = 0
+    /// True when `shutdown()` has been called. Prevents further opens.
+    private var isShutDown = false
+
+    /// Observer fired after match evaluation for every final transcript in the current turn.
+    /// The callback receives the transcript text and whether it matched a command.
+    /// Needed by WP8 (free-form answers); inert until assigned.
+    public var onTranscriptFinal: ((@MainActor (String, _ matched: Bool) -> Void))?
 
     public init(backend: any VoiceBackend,
                 match: @escaping TranscriptMatching,
+                sessionPolicy: SessionPolicy = .perWindow,
+                supportsBargeIn: Bool = false,
+                monotonicNow: @escaping @MainActor () -> TimeInterval = {
+                    ProcessInfo.processInfo.systemUptime
+                },
                 diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
         self.backend = backend
         self.match = match
+        self.sessionPolicy = sessionPolicy
+        self.supportsBargeIn = supportsBargeIn
+        self.monotonicNow = monotonicNow
         self.diagnostics = TapQDiagnosticEmitter(category: "VoiceBackend", sink: diagnosticSink)
     }
 
     var isWindowOpenForTesting: Bool { handler != nil }
+    var isSessionOpenForTesting: Bool { sessionOpen }
+
+    // MARK: - VoiceCommandProviding
 
     public func start(onCommand: @escaping @MainActor (VoiceCommand) -> Void) {
         guard handler == nil else {
             diagnostics.record("start.skipped", fields: ["reason": "already_running"])
             return
         }
+        guard !isShutDown else {
+            diagnostics.record("start.skipped", fields: ["reason": "shutdown"])
+            return
+        }
         windowGeneration &+= 1
-        let generation = windowGeneration
         handler = onCommand
-        // `open` is async by contract (a socket-backed adapter has to await a handshake),
-        // so the window opens on the next main-actor turn and every step after the await
-        // re-checks that it is still the window that asked.
-        Task { @MainActor [weak self] in
-            await self?.openWindow(generation: generation)
+        // Cancel any pending idle-close: a window is opening.
+        idleGeneration &+= 1
+
+        switch sessionPolicy {
+        case .perWindow:
+            let generation = windowGeneration
+            Task { @MainActor [weak self] in
+                await self?.openWindow(generation: generation)
+            }
+        case .conversation:
+            if sessionOpen {
+                // Session already open: just begin a new turn.
+                backend.beginUserTurn()
+                turnActive = true
+                diagnostics.record("window.started")
+            } else {
+                let generation = windowGeneration
+                Task { @MainActor [weak self] in
+                    await self?.openWindow(generation: generation)
+                }
+            }
         }
     }
 
     public func stop() {
+        switch sessionPolicy {
+        case .perWindow:
+            teardown()
+        case .conversation:
+            endWindowKeepSession()
+        }
+    }
+
+    /// Tears down the entire session. For host teardown at serve exit.
+    /// Idempotent.
+    public func shutdown() {
+        isShutDown = true
+        idleGeneration &+= 1
         teardown()
     }
 
+    // MARK: - Turn coordination hooks (for WP7)
+
+    /// Whether a user turn is currently active — read hook for `WearerTurnCoordinator`.
+    public var isUserTurnActiveForCoordination: Bool { turnActive }
+
+    /// Whether a response is in flight — read hook for `WearerTurnCoordinator`.
+    public var isResponseInFlight: Bool { _responseInFlight }
+    private var _responseInFlight = false
+
+    /// Commits the current user turn without tearing down the window.
+    ///
+    /// Transcripts for the committed audio still route to the armed handler, so a match
+    /// arriving after the commit resolves the window normally (the OpenAI flow: transcript
+    /// only exists post-commit).
+    ///
+    /// Calling with no active turn is a recorded no-op — never a protocol violation surfaced
+    /// to the window.
+    public func endActiveTurn() {
+        guard turnActive else {
+            diagnostics.record("endActiveTurn.skipped", fields: ["reason": "no_active_turn"])
+            return
+        }
+        turnActive = false
+        backend.endUserTurn()
+        diagnostics.record("turn.committed_by_coordinator")
+    }
+
+    /// Cancels the active backend response (barge-in). Only fires when a response is in
+    /// flight and the inner pipe supports barge-in (via the `supportsBargeIn` hint).
+    public func cancelActiveResponse() {
+        guard _responseInFlight, supportsBargeIn else {
+            diagnostics.record("cancelActiveResponse.skipped",
+                               fields: ["reason": _responseInFlight ? "barge_in_unsupported" : "no_response"])
+            return
+        }
+        backend.cancelResponse()
+        _responseInFlight = false
+        diagnostics.record("response.cancelled_by_coordinator")
+    }
+
+    // MARK: - Window lifecycle
+
     private func openWindow(generation: UInt64) async {
+        // The generation passed here is the window generation at call time. In per-window
+        // mode it also serves as the session identity. In conversation mode we derive the
+        // session generation separately.
+        sessionGeneration &+= 1
+        let sessGen = sessionGeneration
         do {
             try await backend.open { [weak self] event in
-                self?.handle(event, generation: generation)
+                self?.handleEvent(event, sessionGeneration: sessGen)
             }
         } catch {
             guard windowGeneration == generation else { return }
             diagnostics.record("window.open_failed", level: .warning,
                                fields: ["error": Self.describe(error)])
-            teardown(expectedGeneration: generation)
+            teardown(expectedWindowGeneration: generation)
             return
         }
         guard windowGeneration == generation else {
@@ -87,53 +216,74 @@ import TapQContracts
         diagnostics.record("window.started")
     }
 
-    private func handle(_ event: VoiceBackendEvent, generation: UInt64) {
-        guard windowGeneration == generation else { return }
+    /// Route backend events. In per-window mode, events are valid only for the session
+    /// generation matching the open. In conversation mode, the same session generation
+    /// spans many windows; events between windows (handler == nil) are simply ignored.
+    private func handleEvent(_ event: VoiceBackendEvent, sessionGeneration sessGen: UInt64) {
+        guard sessionGeneration == sessGen else { return }
         switch event {
         case .transcriptPartial(let transcript):
-            consume(transcript, isFinal: false, generation: generation)
+            guard handler != nil else { return }
+            consume(transcript, isFinal: false)
         case .transcriptFinal(let transcript):
-            consume(transcript, isFinal: true, generation: generation)
+            guard handler != nil else { return }
+            consume(transcript, isFinal: true)
         case .audio:
-            // A command channel has nowhere to put response audio; TapQ speaks through its
-            // own engine. Recorded rather than dropped silently so a misconfigured duplex
-            // backend is visible in the log.
+            guard handler != nil else { return }
             diagnostics.record("audio.ignored")
         case .responseCompleted:
-            break
+            _responseInFlight = false
         case .sessionFailed(let failure):
             diagnostics.record("session.failed", level: .warning,
                                fields: ["detail": failure.localizedDescription])
             // The session is gone: ending its turn would be a call into a dead backend.
             turnActive = false
-            teardown(expectedGeneration: generation)
+            _responseInFlight = false
+            teardown()
         }
     }
 
     /// Transcripts are cumulative for a turn — the whole utterance so far, not a delta —
     /// which is exactly what `VoiceListener.handleRecognition` matches against today, so the
     /// grammar sees the same input it always has.
-    private func consume(_ transcript: String, isFinal: Bool, generation: UInt64) {
-        guard let command = match(transcript) else {
+    private func consume(_ transcript: String, isFinal: Bool) {
+        let command = match(transcript)
+        if let command {
+            diagnostics.record("command.matched", fields: ["command": "\(command)"])
+            let callback = handler
+
+            switch sessionPolicy {
+            case .perWindow:
+                teardown()
+            case .conversation:
+                endWindowKeepSession()
+            }
+
+            if isFinal {
+                onTranscriptFinal?(transcript, true)
+            }
+            callback?(command)
+        } else {
             if isFinal {
                 // The wearer said something the grammar does not know. Logged so a "voice
                 // does nothing" report stays diagnosable from the log file alone.
                 diagnostics.record("transcript.rejected",
                                    fields: ["reason": "unmatched",
                                             "length": "\(transcript.count)"])
+                onTranscriptFinal?(transcript, false)
             }
-            return
         }
-        diagnostics.record("command.matched", fields: ["command": "\(command)"])
-        let callback = handler
-        teardown(expectedGeneration: generation)
-        callback?(command)
     }
 
-    private func teardown(expectedGeneration: UInt64? = nil) {
-        if let expectedGeneration, expectedGeneration != windowGeneration { return }
+    // MARK: - Teardown
+
+    /// Full teardown: ends the turn, closes the session, clears the window.
+    private func teardown(expectedWindowGeneration: UInt64? = nil) {
+        if let expectedWindowGeneration, expectedWindowGeneration != windowGeneration { return }
         windowGeneration &+= 1
+        sessionGeneration &+= 1
         handler = nil
+        _responseInFlight = false
         if turnActive {
             turnActive = false
             backend.endUserTurn()
@@ -142,6 +292,45 @@ import TapQContracts
             sessionOpen = false
             backend.close()
         }
+    }
+
+    /// End the current window but keep the conversation session alive.
+    /// Used in `.conversation` mode when `stop()` is called or a match resolves.
+    private func endWindowKeepSession() {
+        windowGeneration &+= 1
+        handler = nil
+        _responseInFlight = false
+        if turnActive {
+            turnActive = false
+            backend.endUserTurn()
+        }
+        // Session and session generation stay: the backend is still alive.
+        if sessionOpen {
+            startIdleTimer()
+        }
+    }
+
+    // MARK: - Idle timer (conversation mode)
+
+    private func startIdleTimer() {
+        guard case .conversation(let idleClose) = sessionPolicy else { return }
+        idleGeneration &+= 1
+        let generation = idleGeneration
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(idleClose))
+            self?.fireIdleClose(generation: generation)
+        }
+    }
+
+    private func fireIdleClose(generation: UInt64) {
+        guard idleGeneration == generation else { return }
+        // Only close if no window is currently open.
+        guard handler == nil else { return }
+        guard sessionOpen else { return }
+        diagnostics.record("session.idle_closed")
+        sessionOpen = false
+        sessionGeneration &+= 1
+        backend.close()
     }
 
     private static func describe(_ error: any Error) -> String {

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -70,11 +70,18 @@ public enum SessionPolicy: Sendable, Equatable {
     private var isShutDown = false
     /// When true, the next `responseCompleted` event should begin a deferred user turn.
     private var pendingUserTurn = false
+    /// True after an idle-close: the next `openWindow` fires `onConversationReopened`.
+    private var sessionIdleClosed = false
 
     /// Observer fired after match evaluation for every final transcript in the current turn.
     /// The callback receives the transcript text and whether it matched a command.
     /// Needed by WP8 (free-form answers); inert until assigned.
     public var onTranscriptFinal: ((@MainActor (String, _ matched: Bool) -> Void))?
+
+    /// Observer fired when the session reopens after an idle-close. The host uses this to
+    /// call `FailThroughVoiceBackend.resetStickiness()` so the primary is re-probed on a
+    /// new conversation (decision 3).
+    public var onConversationReopened: (@MainActor () -> Void)?
 
     public init(backend: any VoiceBackend,
                 match: @escaping TranscriptMatching,
@@ -244,6 +251,11 @@ public enum SessionPolicy: Sendable, Equatable {
         // the session timed out before responseCompleted).
         _responseInFlight = false
         pendingUserTurn = false
+        if sessionIdleClosed {
+            sessionIdleClosed = false
+            onConversationReopened?()
+            diagnostics.record("session.reopened_after_idle")
+        }
         backend.beginUserTurn()
         turnActive = true
         diagnostics.record("window.started")
@@ -311,7 +323,7 @@ public enum SessionPolicy: Sendable, Equatable {
             case .perWindow:
                 teardown()
             case .conversation:
-                endWindowKeepSession()
+                endWindowKeepSession(suppressResponse: true)
             }
 
             if isFinal {
@@ -353,7 +365,12 @@ public enum SessionPolicy: Sendable, Equatable {
 
     /// End the current window but keep the conversation session alive.
     /// Used in `.conversation` mode when `stop()` is called or a match resolves.
-    private func endWindowKeepSession() {
+    ///
+    /// When `suppressResponse` is true and `supportsBargeIn`, the response that
+    /// `endUserTurn` may have triggered on the backend (e.g. OpenAI's `response.create`)
+    /// is cancelled immediately. This prevents a spurious cloud response per
+    /// voice-resolved window in conversation mode.
+    private func endWindowKeepSession(suppressResponse: Bool = false) {
         windowGeneration &+= 1
         handler = nil
         pendingUserTurn = false
@@ -361,6 +378,10 @@ public enum SessionPolicy: Sendable, Equatable {
         if turnActive {
             turnActive = false
             backend.endUserTurn()
+            if suppressResponse, supportsBargeIn {
+                backend.cancelResponse()
+                diagnostics.record("response.suppressed_match_resolved")
+            }
         }
         // Session and session generation stay: the backend is still alive.
         if sessionOpen {
@@ -388,6 +409,7 @@ public enum SessionPolicy: Sendable, Equatable {
         guard sessionOpen else { return }
         diagnostics.record("session.idle_closed")
         sessionOpen = false
+        sessionIdleClosed = true
         // Clear session-scoped tracking: the session is ending, so any in-flight
         // response from the prior conversation is gone and a deferred turn waiting
         // on responseCompleted would never fire.

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -76,6 +76,10 @@ public enum SessionPolicy: Sendable, Equatable {
     /// Whether a freeform command has been delivered in the current turn.
     /// Prevents multiple freeform deliveries per turn (one-shot per turn).
     private var freeformDeliveredThisTurn = false
+    /// True while the window is paused by `pauseListening()` (activity-driven mic close).
+    /// Audio routing continues so response playback is not interrupted; transcripts and
+    /// command delivery are suspended. Cleared by the next `start()`.
+    private var windowPaused = false
 
     /// Observer fired after match evaluation for every final transcript in the current turn.
     /// The callback receives the transcript text and whether it matched a command.
@@ -137,11 +141,21 @@ public enum SessionPolicy: Sendable, Equatable {
                 await self?.openWindow(generation: generation)
             }
         case .conversation:
+            let resuming = windowPaused
+            windowPaused = false
             if sessionOpen {
                 // Session already open: begin a new turn, but a response may still be in
                 // flight from the prior window's commit. Calling beginUserTurn while the
                 // adapter is in .responding would cause a protocol violation → session death.
                 if _responseInFlight {
+                    if resuming {
+                        // Resuming after an activity-driven pause (e.g. playback started).
+                        // The response is still completing; do not cancel it — defer the
+                        // turn start until responseCompleted arrives.
+                        pendingUserTurn = true
+                        diagnostics.record("turn.deferred_resume_response_in_flight")
+                        return
+                    }
                     if supportsBargeIn {
                         // Cancel the in-flight response, then begin the turn.
                         backend.cancelResponse()
@@ -154,6 +168,14 @@ public enum SessionPolicy: Sendable, Equatable {
                         diagnostics.record("turn.deferred_response_in_flight")
                         return
                     }
+                }
+                if turnActive {
+                    // The turn was preserved across an activity-driven pause (response
+                    // playback started while the turn was still open). No new
+                    // beginUserTurn needed.
+                    freeformDeliveredThisTurn = false
+                    diagnostics.record("window.resumed")
+                    return
                 }
                 backend.beginUserTurn()
                 turnActive = true
@@ -174,6 +196,38 @@ public enum SessionPolicy: Sendable, Equatable {
             teardown()
         case .conversation:
             endWindowKeepSession()
+        }
+    }
+
+    /// Suspends command delivery without tearing down backend state.
+    ///
+    /// In `.perWindow` mode this is identical to `stop()`. In `.conversation` mode, the
+    /// handler is cleared (transcripts are dropped) but the session, the in-flight response,
+    /// and response audio playback are left untouched. This is the correct behavior when the
+    /// activity signal rises because backend audio *started playing*: tearing down playback
+    /// would silence the response that was just enqueued.
+    ///
+    /// When the pause is caused by TTS rather than backend playback (TTS starts while a turn
+    /// is open), the turn is ended to uphold the invariant "a turn never spans a TTS-busy
+    /// interval". The distinction is made by checking `responseAudio?.isPlaying`: if playback
+    /// is active, the activity rise came from playback; otherwise it came from TTS.
+    public func pauseListening() {
+        switch sessionPolicy {
+        case .perWindow:
+            stop()
+        case .conversation:
+            guard handler != nil else { return }
+            windowPaused = true
+            handler = nil
+            // End the turn only when the pause is NOT caused by response playback.
+            // Backend audio starting: the turn was already committed (or is about to be
+            // via the coordinator), and flushing the response would silence the answer.
+            // TTS starting (e.g. notification): the turn must not span the TTS interval.
+            if turnActive, !(responseAudio?.isPlaying ?? false) {
+                turnActive = false
+                backend.endUserTurn()
+            }
+            diagnostics.record("listening.paused")
         }
     }
 
@@ -291,7 +345,12 @@ public enum SessionPolicy: Sendable, Equatable {
             // windows (handler == nil) the response is still in flight at the adapter level;
             // the next start() must know this to avoid a protocol violation.
             _responseInFlight = true
-            guard handler != nil else { return }
+            // Allow audio routing when paused: a pause-for-playback must not interrupt the
+            // response that caused the pause. Without the windowPaused check, the first
+            // enqueue raises isPlaying → CombinedSpeechActivity → SpeechGatedVoice.stop →
+            // provider.pauseListening (handler = nil), and every subsequent chunk would be
+            // silently dropped.
+            guard handler != nil || windowPaused else { return }
             // An .audio event is proof a response is in flight — gate on the event stream,
             // not on composed capabilities (FailThrough intersection reports producesAudio:
             // false even when the active inner pipe is the one producing audio).

--- a/Sources/TapQInteractionBaseline/WearerGatedVoice.swift
+++ b/Sources/TapQInteractionBaseline/WearerGatedVoice.swift
@@ -25,7 +25,7 @@ import TapQContracts
 @MainActor public final class WearerGatedVoice: VoiceCommandProviding {
     /// Generous by design: an under-wide window silently drops real commands, while an
     /// over-wide one only lets through speech the wearer produced moments ago anyway.
-    public static let defaultAttributionWindow: TimeInterval = 2.0
+    public nonisolated static let defaultAttributionWindow: TimeInterval = 2.0
 
     private let inner: VoiceCommandProviding
     private let signal: WearerSpeechSignaling

--- a/Sources/TapQInteractionBaseline/WearerGatedVoice.swift
+++ b/Sources/TapQInteractionBaseline/WearerGatedVoice.swift
@@ -1,0 +1,101 @@
+import Foundation
+import TapQContracts
+
+/// Wraps the raw voice channel so a matched command only resolves a window when the
+/// *wearer* is the one who spoke it. The microphone hears the whole room; the in-ear IMU
+/// only hears the jaw it is attached to, so attribution is decided by motion, never audio.
+///
+/// Delivery policy — a command passes through iff either:
+/// - the wearer was speaking at any point within the trailing attribution window
+///   (recognition latency means a match lands hundreds of milliseconds after the speech
+///   that produced it, so the window looks *backwards* from delivery time), or
+/// - `signal.isSignalAvailable` is false — fail open. A degraded or absent analyzer must
+///   reproduce today's shipped behavior verbatim; attribution may only ever remove
+///   commands it is confident about, never add a new way for a window to hang.
+///
+/// This wrapper never opens or closes the inner microphone — that is `SpeechGatedVoice`'s
+/// job, and duplicating it here would fight it. Documented stacking order at composition
+/// time is `SpeechGatedVoice(wrapping: WearerGatedVoice(wrapping: rawVoice, signal:),
+/// activity:)`: TTS gating owns the mic lifecycle on the outside, attribution filters what
+/// survives on the inside.
+///
+/// Not wired into the live runtime this milestone (same precedent as
+/// `swipeDetectionEnabled: false`): promotion waits on the capture study that validates
+/// the detector's thresholds against ground truth.
+@MainActor public final class WearerGatedVoice: VoiceCommandProviding {
+    /// Generous by design: an under-wide window silently drops real commands, while an
+    /// over-wide one only lets through speech the wearer produced moments ago anyway.
+    public static let defaultAttributionWindow: TimeInterval = 2.0
+
+    private let inner: VoiceCommandProviding
+    private let signal: WearerSpeechSignaling
+    private let attributionWindow: TimeInterval
+    private let monotonicNow: () -> TimeInterval
+    private let diagnostics: TapQDiagnosticEmitter
+    private var handler: (@MainActor (VoiceCommand) -> Void)?
+    /// Monotonic timestamp of the most recent moment the wearer was known to be speaking.
+    /// Survives `stop()`: speech that ended just before a window opened is still the
+    /// wearer's, and the recognizer's latency is exactly why it arrives late.
+    private var lastWearerSpeechAt: TimeInterval?
+
+    /// Takes ownership of `signal.onWearerSpeakingChange` (single-observer signal).
+    public init(wrapping inner: VoiceCommandProviding,
+                signal: WearerSpeechSignaling,
+                attributionWindow: TimeInterval = WearerGatedVoice.defaultAttributionWindow,
+                monotonicNow: @escaping () -> TimeInterval = {
+                    ProcessInfo.processInfo.systemUptime
+                },
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        assert(signal.onWearerSpeakingChange == nil,
+               "WearerGatedVoice takes sole ownership of onWearerSpeakingChange; a second assignment would silently disable voice attribution")
+        self.inner = inner
+        self.signal = signal
+        self.attributionWindow = attributionWindow
+        self.monotonicNow = monotonicNow
+        self.diagnostics = TapQDiagnosticEmitter(category: "WearerGate", sink: diagnosticSink)
+        if signal.isWearerSpeaking {
+            // Composed mid-utterance: the transition already happened, so nothing would
+            // ever record it.
+            lastWearerSpeechAt = monotonicNow()
+        }
+        signal.onWearerSpeakingChange = { [weak self] speaking in
+            self?.wearerSpeakingChanged(speaking)
+        }
+    }
+
+    public func start(onCommand: @escaping @MainActor (VoiceCommand) -> Void) {
+        handler = onCommand
+        inner.start { [weak self] command in
+            guard let self, let handler = self.handler else { return }
+            guard self.isAttributedToWearer() else { return }
+            handler(command)
+        }
+    }
+
+    public func stop() {
+        handler = nil
+        inner.stop()
+    }
+
+    private func wearerSpeakingChanged(_ speaking: Bool) {
+        // Both edges stamp the clock: the rising edge so a command matched during a still
+        // ongoing utterance has an anchor even if the signal wedges, the falling edge so
+        // the trailing window is measured from when the wearer actually stopped.
+        lastWearerSpeechAt = monotonicNow()
+    }
+
+    private func isAttributedToWearer() -> Bool {
+        guard signal.isSignalAvailable else {
+            diagnostics.record("command.passed_signal_unavailable")
+            return true
+        }
+        if signal.isWearerSpeaking { return true }
+        let now = monotonicNow()
+        if let last = lastWearerSpeechAt, now - last <= attributionWindow { return true }
+        let sinceSpeech = lastWearerSpeechAt.map { String(format: "%.3f", now - $0) } ?? "never"
+        diagnostics.record("command.rejected_nonwearer",
+                           fields: ["since_wearer_speech_seconds": sinceSpeech,
+                                    "attribution_window_seconds": String(format: "%.3f", attributionWindow)])
+        return false
+    }
+}

--- a/Sources/TapQInteractionBaseline/WearerGatedVoice.swift
+++ b/Sources/TapQInteractionBaseline/WearerGatedVoice.swift
@@ -77,6 +77,11 @@ import TapQContracts
         inner.stop()
     }
 
+    public func pauseListening() {
+        handler = nil
+        inner.pauseListening()
+    }
+
     private func wearerSpeakingChanged(_ speaking: Bool) {
         // Both edges stamp the clock: the rising edge so a command matched during a still
         // ongoing utterance has an anchor even if the signal wedges, the falling edge so

--- a/Sources/TapQInteractionBaseline/WearerTurnCoordinator.swift
+++ b/Sources/TapQInteractionBaseline/WearerTurnCoordinator.swift
@@ -63,6 +63,11 @@ import TapQContracts
     /// Tracks the last known response-playing state to detect edges for resetting the
     /// barge-in flag.
     private var lastKnownResponsePlaying = false
+    /// Set in `fireEndpoint` when the endpoint call actually ended the turn
+    /// (i.e., `isUserTurnActive()` returns false after calling `endpoint()`). The next
+    /// speech transition that sees an active turn clears this flag and re-arms per-turn
+    /// state, enabling endpointing for the new window.
+    private var needsRearmOnNextActiveTurn = false
 
     /// - Parameters:
     ///   - signal: A `WearerSpeechSignaling` child from a `WearerSpeechSignalSource`.
@@ -105,6 +110,7 @@ import TapQContracts
         hasObservedOnset = false
         endpointFired = false
         bargeInFiredForResponse = false
+        needsRearmOnNextActiveTurn = false
         endpointGeneration &+= 1
         lastKnownResponsePlaying = isResponsePlaying()
     }
@@ -115,6 +121,7 @@ import TapQContracts
         hasObservedOnset = false
         endpointFired = false
         bargeInFiredForResponse = false
+        needsRearmOnNextActiveTurn = false
         endpointGeneration &+= 1
     }
 
@@ -123,6 +130,20 @@ import TapQContracts
     private func handleTransition(speaking: Bool) {
         guard armed else { return }
         guard signal.isSignalAvailable else { return }
+
+        // Per-turn re-arm: when the endpoint fired for a prior turn and actually ended
+        // that turn (needsRearmOnNextActiveTurn was set in fireEndpoint because
+        // isUserTurnActive() returned false after the endpoint() call), the next speech
+        // transition in a new active turn re-arms per-turn state. This is what makes
+        // endpointing work across multiple windows when the coordinator is start()-ed
+        // once for the serve lifetime. Without this, endpointFired stays true after the
+        // first endpoint and blocks all subsequent windows.
+        if needsRearmOnNextActiveTurn, isUserTurnActive() {
+            hasObservedOnset = false
+            endpointFired = false
+            endpointGeneration &+= 1
+            needsRearmOnNextActiveTurn = false
+        }
 
         if speaking {
             handleOnset()
@@ -199,5 +220,12 @@ import TapQContracts
 
         endpointFired = true
         endpoint()
+        // If the endpoint() call ended the turn (the normal path: endpoint() calls
+        // endActiveTurn()), mark that the next active turn should re-arm. Without this
+        // the coordinator works only for the first endpoint when start() is called once
+        // for the serve lifetime.
+        if !isUserTurnActive() {
+            needsRearmOnNextActiveTurn = true
+        }
     }
 }

--- a/Sources/TapQInteractionBaseline/WearerTurnCoordinator.swift
+++ b/Sources/TapQInteractionBaseline/WearerTurnCoordinator.swift
@@ -1,0 +1,203 @@
+import Foundation
+import TapQContracts
+
+/// Coordinates IMU-driven turn control: endpointing (wearer speech-end commits the user
+/// turn) and barge-in (wearer speech-onset during response playback interrupts audio).
+///
+/// Both features are additive — they only *add* calls to the existing resolution paths
+/// (match-on-transcript and window timeout), never gate them. A dead, stale, or unavailable
+/// signal simply means neither feature fires, and the window resolves exactly as it did
+/// before the coordinator existed. This is the fail-open contract.
+///
+/// ## Endpointing
+///
+/// After observing a `startedSpeaking` transition within the current turn (the warm-up
+/// guard — the detector needs approximately one `windowSeconds` of samples before its first
+/// transition is meaningful), a subsequent `stoppedSpeaking` starts an endpoint-delay timer.
+/// If the wearer resumes speaking before the timer fires, the timer is cancelled. On expiry
+/// the coordinator calls `endpoint()` exactly once per turn. The delay sits on top of the
+/// detector's own hangover (default 0.6 s), so total silence-to-commit is approximately
+/// hangover + endpointDelay.
+///
+/// ## Barge-in
+///
+/// A `startedSpeaking` transition while `isResponsePlaying()` returns true calls
+/// `interruptPlayback()` once per response. The coordinator does not reopen the microphone
+/// or manage the gate — `SpeechGatedVoice` handles that through the combined activity
+/// signal once playback stops.
+///
+/// ## Lifecycle
+///
+/// `start()` arms the coordinator at the beginning of a window; `stop()` disarms it at
+/// the end. Between `stop()` and the next `start()`, signal transitions are ignored.
+/// The coordinator does not own the signal child — composition passes it in, and its
+/// lifetime is tied to the runtime, not the coordinator.
+@MainActor public final class WearerTurnCoordinator {
+    /// Seconds of silence (after the detector's own hangover) before the endpoint fires.
+    /// Provisional; the capture study will replace it.
+    public nonisolated static let defaultEndpointDelay: TimeInterval = 0.4
+
+    private let signal: any WearerSpeechSignaling
+    private let endpoint: @MainActor () -> Void
+    private let interruptPlayback: @MainActor () -> Void
+    private let isResponsePlaying: @MainActor () -> Bool
+    private let isUserTurnActive: @MainActor () -> Bool
+    private let endpointDelay: TimeInterval
+    private let delaySleep: @MainActor (TimeInterval) async -> Void
+
+    /// True between `start()` and `stop()`.
+    private var armed = false
+    /// True after observing a `startedSpeaking` in the current armed session. The warm-up
+    /// guard: do not honour a `stoppedSpeaking` unless a `startedSpeaking` preceded it
+    /// within this window, because the detector's first quiet state during warm-up is not
+    /// a meaningful silence.
+    private var hasObservedOnset = false
+    /// Whether the endpoint has already fired for this turn. Reset on `start()`.
+    private var endpointFired = false
+    /// Whether barge-in has already fired for the current response. Reset when the
+    /// response ends (tracked via `lastKnownResponsePlaying`).
+    private var bargeInFiredForResponse = false
+    /// Generation counter for the endpoint-delay timer, so a resume cancels the pending
+    /// timer without requiring cooperative cancellation of a Task.
+    private var endpointGeneration: UInt64 = 0
+    /// Tracks the last known response-playing state to detect edges for resetting the
+    /// barge-in flag.
+    private var lastKnownResponsePlaying = false
+
+    /// - Parameters:
+    ///   - signal: A `WearerSpeechSignaling` child from a `WearerSpeechSignalSource`.
+    ///   - endpoint: Called when the wearer stops speaking and the delay expires. Typically
+    ///     wired to `VoiceBackendCommandProvider.endActiveTurn`.
+    ///   - interruptPlayback: Called on barge-in. Typically wired to flush playback, cancel
+    ///     the backend response, and stop TTS.
+    ///   - isResponsePlaying: Read hook; returns true when backend audio or TTS is playing.
+    ///   - isUserTurnActive: Read hook; returns true when a user turn is open on the provider.
+    ///   - endpointDelay: Seconds of silence after the detector's hangover before committing.
+    ///     Default 0.4 s.
+    ///   - delaySleep: Injectable sleep for testing (virtual clock).
+    public init(
+        signal: any WearerSpeechSignaling,
+        endpoint: @escaping @MainActor () -> Void,
+        interruptPlayback: @escaping @MainActor () -> Void,
+        isResponsePlaying: @escaping @MainActor () -> Bool,
+        isUserTurnActive: @escaping @MainActor () -> Bool,
+        endpointDelay: TimeInterval = WearerTurnCoordinator.defaultEndpointDelay,
+        delaySleep: @escaping @MainActor (TimeInterval) async -> Void = {
+            try? await Task.sleep(for: .seconds($0))
+        }
+    ) {
+        self.signal = signal
+        self.endpoint = endpoint
+        self.interruptPlayback = interruptPlayback
+        self.isResponsePlaying = isResponsePlaying
+        self.isUserTurnActive = isUserTurnActive
+        self.endpointDelay = endpointDelay
+        self.delaySleep = delaySleep
+
+        signal.onWearerSpeakingChange = { [weak self] speaking in
+            self?.handleTransition(speaking: speaking)
+        }
+    }
+
+    /// Arms the coordinator for a new window/turn.
+    public func start() {
+        armed = true
+        hasObservedOnset = false
+        endpointFired = false
+        bargeInFiredForResponse = false
+        endpointGeneration &+= 1
+        lastKnownResponsePlaying = isResponsePlaying()
+    }
+
+    /// Disarms the coordinator at the end of a window.
+    public func stop() {
+        armed = false
+        hasObservedOnset = false
+        endpointFired = false
+        bargeInFiredForResponse = false
+        endpointGeneration &+= 1
+    }
+
+    // MARK: - Private
+
+    private func handleTransition(speaking: Bool) {
+        guard armed else { return }
+        guard signal.isSignalAvailable else { return }
+
+        if speaking {
+            handleOnset()
+        } else {
+            handleOffset()
+        }
+    }
+
+    private func handleOnset() {
+        hasObservedOnset = true
+        // Cancel any pending endpoint-delay timer: the wearer resumed speaking.
+        endpointGeneration &+= 1
+
+        // Barge-in: speech onset while a response is playing.
+        checkBargeIn()
+    }
+
+    private func handleOffset() {
+        // Update barge-in tracking: if the response ended while we were speaking,
+        // we need to clear the flag for the next response.
+        updateBargeInTracking()
+
+        // Endpointing: only after a prior onset in this turn (warm-up guard), and only
+        // while a user turn is active (the turn may have been committed by a transcript
+        // match already).
+        guard hasObservedOnset else { return }
+        guard !endpointFired else { return }
+        guard isUserTurnActive() else { return }
+
+        startEndpointTimer()
+    }
+
+    /// Updates the barge-in response tracking state. Called on every transition to detect
+    /// when a response has ended (even if it ended while the wearer was speaking).
+    private func updateBargeInTracking() {
+        let currentlyPlaying = isResponsePlaying()
+        if !currentlyPlaying {
+            bargeInFiredForResponse = false
+        }
+        lastKnownResponsePlaying = currentlyPlaying
+    }
+
+    private func checkBargeIn() {
+        updateBargeInTracking()
+
+        let currentlyPlaying = isResponsePlaying()
+        guard currentlyPlaying else { return }
+        guard !bargeInFiredForResponse else { return }
+
+        bargeInFiredForResponse = true
+        interruptPlayback()
+    }
+
+    private func startEndpointTimer() {
+        endpointGeneration &+= 1
+        let generation = endpointGeneration
+        let sleep = delaySleep
+        Task { @MainActor [weak self] in
+            await sleep(self?.endpointDelay ?? 0)
+            self?.fireEndpoint(generation: generation)
+        }
+    }
+
+    private func fireEndpoint(generation: UInt64) {
+        guard endpointGeneration == generation else { return }
+        guard armed else { return }
+        guard !endpointFired else { return }
+        // Re-check that the turn is still active: a match or timeout may have resolved
+        // it while the delay was in flight.
+        guard isUserTurnActive() else { return }
+        // Re-check that the signal is still available: if it went stale during the delay,
+        // do not commit (fail open means "do nothing", not "commit on stale data").
+        guard signal.isSignalAvailable else { return }
+
+        endpointFired = true
+        endpoint()
+    }
+}

--- a/Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift
@@ -154,13 +154,14 @@ public enum FailThroughStickiness: Sendable, Equatable {
         active.beginUserTurn()
     }
 
-    public func endUserTurn() {
+    @discardableResult
+    public func endUserTurn(expectingResponse: Bool) -> Bool {
         turnActive = false
         guard let active, !failingOver else {
             diagnostics.record("turn.dropped", fields: ["reason": "failing_over"])
-            return
+            return false
         }
-        active.endUserTurn()
+        return active.endUserTurn(expectingResponse: expectingResponse)
     }
 
     public func sendAudio(_ chunk: VoiceAudioChunk) {

--- a/Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift
@@ -1,0 +1,248 @@
+import Foundation
+import TapQContracts
+
+/// Two backends, one contract: the primary while it works, the fallback the moment it
+/// does not.
+///
+/// This is TapQ's fail-open guarantee written as code. A cloud speech pipe can be down,
+/// throttled, or unreachable on hotel wifi; when that happens the wearer must still be
+/// able to answer an approval, so the session moves to the on-device stack rather than the
+/// window going dead. The caller above never learns any of it happened — it holds one
+/// `VoiceBackend` and keeps talking to it.
+///
+/// What is *not* replayed on failover is audio. Only session state moves: if a user turn
+/// was open, a fresh one is opened on the fallback, and whatever the wearer said into the
+/// dead socket is gone. Buffering audio to re-send would mean holding the wearer's speech
+/// in memory against a failure that may never come, and the recovered turn is a fresh
+/// listen window anyway — the wearer is still mid-sentence into a live microphone.
+///
+/// Failover happens exactly once per `open`. A fallback that fails too is reported as this
+/// wrapper's own `sessionFailed`: there is nothing left to fall through to, and pretending
+/// otherwise would hide a broken voice channel behind an endless reconnect.
+@MainActor public final class FailThroughVoiceBackend: VoiceBackend {
+    /// The conservative intersection of both backends.
+    ///
+    /// Capabilities are static for an instance's lifetime by contract, but which backend is
+    /// active is not, so the only honest answer is what *both* can do. Advertising the
+    /// primary's barge-in would strand a caller mid-failover holding a capability the
+    /// fallback never had.
+    public let capabilities: VoiceBackendCapabilities
+
+    private let primary: any VoiceBackend
+    private let fallback: any VoiceBackend
+    private let diagnostics: TapQDiagnosticEmitter
+
+    private var onEvent: (@MainActor (VoiceBackendEvent) -> Void)?
+    private var active: (any VoiceBackend)?
+    private var primaryOpen = false
+    private var fallbackOpen = false
+    /// True from the primary's failure until the fallback is open (or has failed too).
+    /// Calls arriving in that gap have no backend to reach.
+    private var failingOver = false
+    /// Tracked here rather than read off a backend, because it is what gets replayed.
+    private var turnActive = false
+    private var generation: UInt64 = 0
+
+    public init(primary: any VoiceBackend,
+                fallback: any VoiceBackend,
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        self.primary = primary
+        self.fallback = fallback
+        self.capabilities = VoiceBackendCapabilities(
+            supportsBargeIn: primary.capabilities.supportsBargeIn
+                && fallback.capabilities.supportsBargeIn,
+            producesAudio: primary.capabilities.producesAudio
+                && fallback.capabilities.producesAudio,
+            duplex: primary.capabilities.duplex && fallback.capabilities.duplex)
+        self.diagnostics = TapQDiagnosticEmitter(category: "VoiceFailThrough", sink: diagnosticSink)
+    }
+
+    var isUsingFallbackForTesting: Bool { fallbackOpen }
+
+    // MARK: - Session lifecycle
+
+    public func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+        guard active == nil, !failingOver else {
+            throw VoiceBackendFailure.protocolViolation("the fail-through session is already open")
+        }
+        generation &+= 1
+        let generation = self.generation
+        self.onEvent = onEvent
+        turnActive = false
+
+        do {
+            try await primary.open { [weak self] event in
+                self?.handlePrimary(event, generation: generation)
+            }
+            guard self.generation == generation else {
+                primary.close()
+                throw VoiceBackendFailure.closed("the session was torn down while opening")
+            }
+            primaryOpen = true
+            active = primary
+            diagnostics.record("primary.opened")
+            return
+        } catch {
+            guard self.generation == generation else { throw Self.failure(from: error) }
+            diagnostics.record("primary.open_failed", level: .warning,
+                               fields: ["detail": Self.describe(error)])
+        }
+
+        do {
+            try await openFallback(generation: generation)
+        } catch {
+            teardown(expectedGeneration: generation)
+            throw error
+        }
+    }
+
+    public func close() {
+        let wasOpen = active != nil || failingOver
+        teardown()
+        if wasOpen { diagnostics.record("session.closed") }
+    }
+
+    // MARK: - Turns
+
+    public func beginUserTurn() {
+        turnActive = true
+        guard let active, !failingOver else {
+            // Recorded, not dropped: the turn is replayed onto the fallback the moment it
+            // is open, so the wearer's window survives the switch.
+            diagnostics.record("turn.deferred", fields: ["reason": "failing_over"])
+            return
+        }
+        active.beginUserTurn()
+    }
+
+    public func endUserTurn() {
+        turnActive = false
+        guard let active, !failingOver else {
+            diagnostics.record("turn.dropped", fields: ["reason": "failing_over"])
+            return
+        }
+        active.endUserTurn()
+    }
+
+    public func sendAudio(_ chunk: VoiceAudioChunk) {
+        guard let active, !failingOver else {
+            diagnostics.record("audio.dropped", fields: ["bytes": "\(chunk.data.count)"])
+            return
+        }
+        active.sendAudio(chunk)
+    }
+
+    public func requestResponse(text: String) {
+        guard let active, !failingOver else {
+            diagnostics.record("response.dropped", fields: ["reason": "failing_over"])
+            return
+        }
+        active.requestResponse(text: text)
+    }
+
+    public func cancelResponse() {
+        guard let active, !failingOver else {
+            diagnostics.record("cancel.dropped", fields: ["reason": "failing_over"])
+            return
+        }
+        active.cancelResponse()
+    }
+
+    // MARK: - Event routing
+
+    private func handlePrimary(_ event: VoiceBackendEvent, generation: UInt64) {
+        guard self.generation == generation, !fallbackOpen, !failingOver else { return }
+        guard case .sessionFailed(let failure) = event else {
+            onEvent?(event)
+            return
+        }
+        diagnostics.record("primary.session_failed", level: .warning,
+                           fields: ["detail": failure.localizedDescription])
+        primary.close()
+        primaryOpen = false
+        active = nil
+        failingOver = true
+        Task { @MainActor [weak self] in
+            await self?.failOver(generation: generation)
+        }
+    }
+
+    private func handleFallback(_ event: VoiceBackendEvent, generation: UInt64) {
+        guard self.generation == generation else { return }
+        guard case .sessionFailed = event else {
+            onEvent?(event)
+            return
+        }
+        // Nothing left underneath: the failure is the wrapper's own now.
+        let callback = onEvent
+        teardown(expectedGeneration: generation)
+        callback?(event)
+    }
+
+    private func failOver(generation: UInt64) async {
+        do {
+            try await openFallback(generation: generation)
+        } catch {
+            guard self.generation == generation else { return }
+            let callback = onEvent
+            let failure = Self.failure(from: error)
+            teardown(expectedGeneration: generation)
+            callback?(.sessionFailed(failure))
+            return
+        }
+        guard self.generation == generation else { return }
+        failingOver = false
+        guard turnActive else { return }
+        active?.beginUserTurn()
+        diagnostics.record("fallback.turn_resumed")
+    }
+
+    private func openFallback(generation: UInt64) async throws {
+        do {
+            try await fallback.open { [weak self] event in
+                self?.handleFallback(event, generation: generation)
+            }
+        } catch {
+            guard self.generation == generation else { throw Self.failure(from: error) }
+            let failure = Self.failure(from: error)
+            diagnostics.record("fallback.open_failed", level: .warning,
+                               fields: ["detail": failure.localizedDescription])
+            throw failure
+        }
+        guard self.generation == generation else {
+            fallback.close()
+            throw VoiceBackendFailure.closed("the session was torn down while opening")
+        }
+        fallbackOpen = true
+        failingOver = false
+        active = fallback
+        diagnostics.record("fallback.opened")
+    }
+
+    private func teardown(expectedGeneration: UInt64? = nil) {
+        if let expectedGeneration, expectedGeneration != generation { return }
+        generation &+= 1
+        onEvent = nil
+        active = nil
+        failingOver = false
+        turnActive = false
+        // Only what was actually opened is closed: a fallback that never ran must see no
+        // traffic at all, which is the guarantee that a healthy primary costs nothing.
+        if primaryOpen {
+            primaryOpen = false
+            primary.close()
+        }
+        if fallbackOpen {
+            fallbackOpen = false
+            fallback.close()
+        }
+    }
+
+    private static func failure(from error: any Error) -> VoiceBackendFailure {
+        (error as? VoiceBackendFailure) ?? .network(String(describing: error))
+    }
+
+    private static func describe(_ error: any Error) -> String {
+        (error as? VoiceBackendFailure)?.localizedDescription ?? String(describing: error)
+    }
+}

--- a/Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift
@@ -1,6 +1,18 @@
 import Foundation
 import TapQContracts
 
+/// Controls whether a primary failure sticks across `open` calls.
+///
+/// `.retryEachOpen` — the M1 default: every `open` tries the primary first.
+///
+/// `.stickyAfterFailure` — once the primary has failed (open-time or mid-session),
+/// subsequent `open`s go straight to the fallback with zero primary traffic. The host
+/// calls `resetStickiness()` to re-probe (e.g. on a new conversation after idle-close).
+public enum FailThroughStickiness: Sendable, Equatable {
+    case retryEachOpen
+    case stickyAfterFailure
+}
+
 /// Two backends, one contract: the primary while it works, the fallback the moment it
 /// does not.
 ///
@@ -30,6 +42,7 @@ import TapQContracts
 
     private let primary: any VoiceBackend
     private let fallback: any VoiceBackend
+    private let stickiness: FailThroughStickiness
     private let diagnostics: TapQDiagnosticEmitter
 
     private var onEvent: (@MainActor (VoiceBackendEvent) -> Void)?
@@ -42,12 +55,16 @@ import TapQContracts
     /// Tracked here rather than read off a backend, because it is what gets replayed.
     private var turnActive = false
     private var generation: UInt64 = 0
+    /// When sticky and the primary has failed, subsequent opens skip the primary entirely.
+    private var primaryStuck = false
 
     public init(primary: any VoiceBackend,
                 fallback: any VoiceBackend,
+                stickiness: FailThroughStickiness = .retryEachOpen,
                 diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
         self.primary = primary
         self.fallback = fallback
+        self.stickiness = stickiness
         self.capabilities = VoiceBackendCapabilities(
             supportsBargeIn: primary.capabilities.supportsBargeIn
                 && fallback.capabilities.supportsBargeIn,
@@ -58,6 +75,15 @@ import TapQContracts
     }
 
     var isUsingFallbackForTesting: Bool { fallbackOpen }
+    var isPrimaryStuckForTesting: Bool { primaryStuck }
+
+    /// Re-enables the primary for the next `open`. A host calls this when starting a new
+    /// conversation (e.g. after idle-close reopen) so the cloud path is re-probed rather
+    /// than stuck on the fallback forever.
+    public func resetStickiness() {
+        primaryStuck = false
+        diagnostics.record("stickiness.reset")
+    }
 
     // MARK: - Session lifecycle
 
@@ -69,6 +95,18 @@ import TapQContracts
         let generation = self.generation
         self.onEvent = onEvent
         turnActive = false
+
+        // When sticky and the primary has already failed, skip straight to the fallback.
+        if primaryStuck {
+            diagnostics.record("primary.skipped_sticky")
+            do {
+                try await openFallback(generation: generation)
+            } catch {
+                teardown(expectedGeneration: generation)
+                throw error
+            }
+            return
+        }
 
         do {
             try await primary.open { [weak self] event in
@@ -86,6 +124,7 @@ import TapQContracts
             guard self.generation == generation else { throw Self.failure(from: error) }
             diagnostics.record("primary.open_failed", level: .warning,
                                fields: ["detail": Self.describe(error)])
+            markPrimaryStuck()
         }
 
         do {
@@ -162,6 +201,7 @@ import TapQContracts
         primaryOpen = false
         active = nil
         failingOver = true
+        markPrimaryStuck()
         Task { @MainActor [weak self] in
             await self?.failOver(generation: generation)
         }
@@ -236,6 +276,11 @@ import TapQContracts
             fallbackOpen = false
             fallback.close()
         }
+    }
+
+    private func markPrimaryStuck() {
+        guard stickiness == .stickyAfterFailure else { return }
+        primaryStuck = true
     }
 
     private static func failure(from error: any Error) -> VoiceBackendFailure {

--- a/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
@@ -65,6 +65,13 @@ import TapQContracts
     private var outbound: [String] = []
     private var pumpRunning = false
 
+    /// Set by `cancelResponse()`, cleared by `beginUserTurn`/teardown. When the next
+    /// `response.done` arrives, the adapter treats it as the documented cancel ack rather
+    /// than as an unrequested completion (which would throw `.noResponseInFlight` from
+    /// `.open` and kill the session). A cancel racing a just-completed response produces an
+    /// `error` event instead; that is also absorbed when this flag is set.
+    private var expectCancelAck = false
+
     /// Cumulative transcript for the current turn — the whole utterance so far, which is
     /// the shape `VoiceCommandMatcher` expects. The service sends deltas.
     private var transcript = ""
@@ -177,6 +184,7 @@ import TapQContracts
         }
         transcript = ""
         turnAudioByteCount = 0
+        expectCancelAck = false
         diagnostics.record("turn.began")
     }
 
@@ -257,6 +265,7 @@ import TapQContracts
         } catch {
             return violated(error)
         }
+        expectCancelAck = true
         diagnostics.record("response.cancelled")
         enqueue(.cancelResponse, generation: sessionGeneration)
     }
@@ -307,6 +316,19 @@ import TapQContracts
             emit(.audio(VoiceAudioChunk(data: audio, format: Self.audioFormat,
                                         timestamp: monotonicNow())))
         case .responseCompleted:
+            if expectCancelAck {
+                // The server acked a locally-initiated cancel with response.done (cancelled).
+                // The state machine is already in .open from cancelResponse(); calling
+                // responseCompleted() would throw .noResponseInFlight. Still emit the event
+                // so the caller clears any response-in-flight tracking (straggler audio
+                // deltas after the cancel re-arm the provider's _responseInFlight, and
+                // without a terminal responseCompleted the next start() would hit the same
+                // violation path).
+                expectCancelAck = false
+                diagnostics.record("cancel_ack.received")
+                emit(.responseCompleted)
+                return
+            }
             do {
                 try turns.responseCompleted()
             } catch {
@@ -318,6 +340,15 @@ import TapQContracts
             }
             emit(.responseCompleted)
         case .failure(let failure):
+            if expectCancelAck, !failure.isAuthorization {
+                // A cancel racing a just-completed response: the server returns an error
+                // because there is nothing to cancel. This is expected and benign — the
+                // response finished normally, and the cancel was simply too late.
+                expectCancelAck = false
+                diagnostics.record("cancel_ack.race_error",
+                                   fields: ["message": failure.message])
+                return
+            }
             let mapped: VoiceBackendFailure = failure.isAuthorization
                 ? .authorization(failure.message)
                 : .protocolViolation(failure.message)
@@ -437,6 +468,7 @@ import TapQContracts
         outbound.removeAll()
         pumpRunning = false
         transcript = ""
+        expectCancelAck = false
         turns.close()
         transport.close()
         // A continuation that is never resumed is a task leaked forever, so teardown from

--- a/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
@@ -69,6 +69,11 @@ import TapQContracts
     /// the shape `VoiceCommandMatcher` expects. The service sends deltas.
     private var transcript = ""
 
+    /// Bytes of audio appended in the current turn. An `endUserTurn` with zero appended
+    /// audio sends neither `commit` nor `response.create` — the OpenAI service rejects an
+    /// empty commit, and a silent teardown turn must not create spurious responses.
+    private var turnAudioByteCount = 0
+
     /// - Parameters:
     ///   - transport: the frame pipe. Injected so tests drive a scripted server and never a
     ///     socket, and so Linux never links a `URLSessionWebSocketTask`.
@@ -171,6 +176,7 @@ import TapQContracts
             return violated(error)
         }
         transcript = ""
+        turnAudioByteCount = 0
         diagnostics.record("turn.began")
     }
 
@@ -189,6 +195,7 @@ import TapQContracts
                     + "\(chunk.format.channels)-channel"))
         }
         guard !chunk.data.isEmpty else { return }
+        turnAudioByteCount += chunk.data.count
         let generation = sessionGeneration
         for block in Self.split(chunk, maxSeconds: Self.maxChunkSeconds) {
             enqueue(.appendInputAudio(block), generation: generation)
@@ -200,6 +207,13 @@ import TapQContracts
             try turns.endUserTurn()
         } catch {
             return violated(error)
+        }
+        // Empty-turn guard: if no audio was appended during this turn, skip the commit
+        // and response.create entirely. The OpenAI service rejects an empty commit, and a
+        // silent teardown turn must not create spurious responses.
+        guard turnAudioByteCount > 0 else {
+            diagnostics.record("turn.empty_skipped")
+            return
         }
         let generation = sessionGeneration
         enqueue(.commitInputAudio, generation: generation)

--- a/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
@@ -1,0 +1,480 @@
+import Foundation
+import TapQContracts
+
+/// A `VoiceBackend` over the OpenAI Realtime API in **manual-turn mode**.
+///
+/// The entire adapter exists to make a duplex, VAD-happy cloud service behave like the
+/// dumb speech pipe `VoiceBackend` describes:
+///
+/// - The first frame on every connection is a `session.update` carrying
+///   `turn_detection: none`, and the handshake is not considered complete until the
+///   service acknowledges it with `session.updated`. Until that ack lands, the service
+///   would be running its own voice-activity detection, and a server-side commit would
+///   resolve an approval window TapQ never authorized.
+/// - Audio only ever leaves during an open user turn, the buffer is committed only from
+///   `endUserTurn()`, and a response is only ever created by TapQ — on commit, or on an
+///   explicit `requestResponse(text:)`.
+/// - `capabilities` reports what the *transport* can do (barge-in, audio, duplex). TapQ
+///   still runs half-duplex; that policy is enforced by `VoiceTurnStateMachine`, which
+///   every inbound call and every server event routes through, so a protocol mistake
+///   surfaces as `sessionFailed(.protocolViolation)` rather than as scrambled turns.
+///
+/// Nothing here can hang: the handshake is bounded by `timeout`, outbound frames drain
+/// through one ordered pump whose failures end the session, and a dropped connection
+/// arrives as `sessionFailed`. The API key lives in the transport's headers and appears in
+/// no diagnostic, no failure description, and no frame this file builds.
+@MainActor public final class OpenAIRealtimeVoiceBackend: VoiceBackend {
+    // `nonisolated` because these are default arguments on this class's own initializers,
+    // which are evaluated in the caller's isolation domain.
+    public nonisolated static let defaultModel = RealtimeDefaults.model
+    public nonisolated static let defaultEndpoint = RealtimeDefaults.endpoint
+    public nonisolated static let defaultTimeout: TimeInterval = 5
+    /// Audio is framed into blocks no longer than this before it is base64-encoded and
+    /// sent. A caller handing over a second of audio would otherwise base64 a second of
+    /// audio in one main-actor turn.
+    public nonisolated static let maxChunkSeconds: TimeInterval = 0.1
+
+    /// The wire format both directions of this session use.
+    public nonisolated static let audioFormat = VoiceAudioFormat.pcm16Mono24k
+
+    public let capabilities = VoiceBackendCapabilities(supportsBargeIn: true,
+                                                       producesAudio: true,
+                                                       duplex: true)
+
+    private let transport: any RealtimeTransporting
+    private let configuration: RealtimeSessionConfiguration
+    private let timeout: TimeInterval
+    private let monotonicNow: @Sendable () -> TimeInterval
+    private let diagnostics: TapQDiagnosticEmitter
+
+    private var turns: VoiceTurnStateMachine
+    private var onEvent: (@MainActor (VoiceBackendEvent) -> Void)?
+    /// Invalidates late transport frames, drain loops, and timeout tasks belonging to a
+    /// session that has already been torn down. Bumped on every open and every teardown.
+    private var sessionGeneration: UInt64 = 0
+
+    private var handshakeContinuation: CheckedContinuation<Void, any Error>?
+    private var handshakeGeneration: UInt64?
+    /// Set when the handshake settles before anyone is waiting on it — the ack can land in
+    /// the same main-actor turn the frame was sent in.
+    private var handshakeOutcome: (generation: UInt64, result: Result<Void, VoiceBackendFailure>)?
+
+    /// Ordered outbound queue. `sendAudio` is synchronous by contract and the transport's
+    /// send is not, so frames queue here and one pump drains them; two concurrent tasks
+    /// would interleave appends into scrambled audio.
+    private var outbound: [String] = []
+    private var pumpRunning = false
+
+    /// Cumulative transcript for the current turn — the whole utterance so far, which is
+    /// the shape `VoiceCommandMatcher` expects. The service sends deltas.
+    private var transcript = ""
+
+    /// - Parameters:
+    ///   - transport: the frame pipe. Injected so tests drive a scripted server and never a
+    ///     socket, and so Linux never links a `URLSessionWebSocketTask`.
+    ///   - monotonicNow: clock for stamping inbound audio chunks, injectable for tests.
+    public init(transport: any RealtimeTransporting,
+                configuration: RealtimeSessionConfiguration = RealtimeSessionConfiguration(),
+                timeout: TimeInterval = OpenAIRealtimeVoiceBackend.defaultTimeout,
+                monotonicNow: @escaping @Sendable () -> TimeInterval = {
+                    ProcessInfo.processInfo.systemUptime
+                },
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        self.transport = transport
+        // The one setting the adapter refuses to take on faith: whatever a caller passes,
+        // this session runs without server-side turn detection.
+        var manualTurns = configuration
+        manualTurns.turnDetection = .disabled
+        self.configuration = manualTurns
+        self.timeout = timeout
+        self.monotonicNow = monotonicNow
+        self.diagnostics = TapQDiagnosticEmitter(category: "OpenAIRealtime", sink: diagnosticSink)
+        self.turns = VoiceTurnStateMachine(
+            capabilities: VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                   duplex: true))
+    }
+
+    #if canImport(Darwin)
+    /// Composition-time convenience: the live WebSocket transport, built from an API key.
+    ///
+    /// Apple-only for the same reason `URLSessionWebSocketRealtimeTransport` is.
+    public convenience init(apiKey: String,
+                            model: String = OpenAIRealtimeVoiceBackend.defaultModel,
+                            endpoint: URL = OpenAIRealtimeVoiceBackend.defaultEndpoint,
+                            timeout: TimeInterval = OpenAIRealtimeVoiceBackend.defaultTimeout,
+                            diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)
+        components?.queryItems = [URLQueryItem(name: "model", value: model)]
+        let url = components?.url ?? endpoint
+        self.init(transport: URLSessionWebSocketRealtimeTransport(url: url, apiKey: apiKey),
+                  configuration: RealtimeSessionConfiguration(model: model),
+                  timeout: timeout,
+                  diagnosticSink: diagnosticSink)
+    }
+    #endif
+
+    var turnStateForTesting: VoiceTurnStateMachine.State { turns.state }
+
+    // MARK: - Session lifecycle
+
+    public func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+        do {
+            try turns.open()
+        } catch {
+            throw VoiceBackendFailure.protocolViolation(Self.describe(error))
+        }
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
+        self.onEvent = onEvent
+        transcript = ""
+
+        do {
+            try await transport.connect()
+        } catch {
+            guard sessionGeneration == generation else {
+                throw VoiceBackendFailure.closed("the session was torn down while connecting")
+            }
+            let failure = Self.failure(from: error)
+            diagnostics.record("connect.failed", level: .warning,
+                               fields: ["detail": failure.localizedDescription])
+            turns.sessionFailed()
+            teardown(expectedGeneration: generation)
+            throw failure
+        }
+        guard sessionGeneration == generation else {
+            // `close()` landed while the connection was still being established. Nobody
+            // else owns this transport, so it is ours to shut.
+            transport.close()
+            throw VoiceBackendFailure.closed("the session was torn down while connecting")
+        }
+
+        startReceiveLoop(generation: generation)
+        handshakeGeneration = generation
+        // Manual-turn mode before anything else, including before any audio can exist.
+        enqueue(.sessionUpdate(configuration), generation: generation)
+        try await awaitHandshake(generation: generation)
+        diagnostics.record("session.opened", fields: ["model": configuration.model])
+    }
+
+    public func close() {
+        let wasOpen = turns.isOpen || onEvent != nil
+        teardown()
+        if wasOpen { diagnostics.record("session.closed") }
+    }
+
+    // MARK: - Turns
+
+    public func beginUserTurn() {
+        do {
+            try turns.beginUserTurn()
+        } catch {
+            return violated(error)
+        }
+        transcript = ""
+        diagnostics.record("turn.began")
+    }
+
+    public func sendAudio(_ chunk: VoiceAudioChunk) {
+        do {
+            try turns.sendAudio()
+        } catch {
+            return violated(error)
+        }
+        guard chunk.format == Self.audioFormat else {
+            // A caller feeding the wrong encoding produces audio the service will happily
+            // transcribe as noise. Loud beats a session that silently mishears everything.
+            return violated(VoiceBackendFailure.protocolViolation(
+                "the session speaks \(Int(Self.audioFormat.sampleRate)) Hz PCM16 mono; "
+                    + "a chunk arrived as \(Int(chunk.format.sampleRate)) Hz "
+                    + "\(chunk.format.channels)-channel"))
+        }
+        guard !chunk.data.isEmpty else { return }
+        let generation = sessionGeneration
+        for block in Self.split(chunk, maxSeconds: Self.maxChunkSeconds) {
+            enqueue(.appendInputAudio(block), generation: generation)
+        }
+    }
+
+    public func endUserTurn() {
+        do {
+            try turns.endUserTurn()
+        } catch {
+            return violated(error)
+        }
+        let generation = sessionGeneration
+        enqueue(.commitInputAudio, generation: generation)
+        // Manual-turn mode is commit-then-create: the service produces nothing until asked,
+        // so the commit that ends the wearer's turn is immediately followed by the request
+        // that starts the model's.
+        do {
+            try turns.requestResponse()
+        } catch {
+            return violated(error)
+        }
+        enqueue(.createResponse(instructions: nil), generation: generation)
+        diagnostics.record("turn.committed")
+    }
+
+    public func requestResponse(text: String) {
+        do {
+            try turns.requestResponse()
+        } catch {
+            return violated(error)
+        }
+        diagnostics.record("response.requested", fields: ["length": "\(text.count)"])
+        enqueue(.createResponse(instructions: text), generation: sessionGeneration)
+    }
+
+    public func cancelResponse() {
+        do {
+            try turns.cancelResponse()
+        } catch {
+            return violated(error)
+        }
+        diagnostics.record("response.cancelled")
+        enqueue(.cancelResponse, generation: sessionGeneration)
+    }
+
+    // MARK: - Inbound
+
+    private func startReceiveLoop(generation: UInt64) {
+        let frames = transport.receiveFrames()
+        Task { @MainActor [weak self] in
+            do {
+                for try await frame in frames {
+                    guard let self, self.sessionGeneration == generation else { return }
+                    self.handle(frame: frame, generation: generation)
+                }
+            } catch {
+                guard let self, self.sessionGeneration == generation else { return }
+                return self.failSession(Self.failure(from: error), generation: generation)
+            }
+            guard let self, self.sessionGeneration == generation else { return }
+            self.failSession(.closed("the realtime peer closed the connection"),
+                             generation: generation)
+        }
+    }
+
+    private func handle(frame: String, generation: UInt64) {
+        let event: RealtimeServerEvent
+        do {
+            event = try RealtimeServerEvent.decode(frame)
+        } catch {
+            return failSession(.protocolViolation(Self.describe(error)), generation: generation)
+        }
+
+        switch event {
+        case .sessionCreated:
+            // Not the ack: the service has a session, but it is still the service's own
+            // VAD running it until `session.updated` confirms otherwise.
+            diagnostics.record("session.created")
+        case .sessionUpdated:
+            settleHandshake(.success(()), generation: generation)
+        case .transcriptDelta(let delta):
+            guard !delta.isEmpty else { return }
+            transcript += delta
+            emit(.transcriptPartial(transcript))
+        case .transcriptCompleted(let settled):
+            if !settled.isEmpty { transcript = settled }
+            emit(.transcriptFinal(transcript))
+        case .audioDelta(let audio):
+            emit(.audio(VoiceAudioChunk(data: audio, format: Self.audioFormat,
+                                        timestamp: monotonicNow())))
+        case .responseCompleted:
+            do {
+                try turns.responseCompleted()
+            } catch {
+                // Nothing was in flight: the service produced a response nobody asked for,
+                // which is the manual-turn contract being broken from the far side.
+                return failSession(
+                    .protocolViolation("the realtime peer completed a response TapQ never requested"),
+                    generation: generation)
+            }
+            emit(.responseCompleted)
+        case .failure(let failure):
+            let mapped: VoiceBackendFailure = failure.isAuthorization
+                ? .authorization(failure.message)
+                : .protocolViolation(failure.message)
+            failSession(mapped, generation: generation)
+        case .unsupported(let type):
+            diagnostics.record("event.ignored", fields: ["type": type])
+        }
+    }
+
+    // MARK: - Outbound pump
+
+    private func enqueue(_ event: RealtimeClientEvent, generation: UInt64) {
+        guard sessionGeneration == generation else { return }
+        let frame: String
+        do {
+            frame = try event.encodedFrame()
+        } catch {
+            return failSession(.protocolViolation(Self.describe(error)), generation: generation)
+        }
+        outbound.append(frame)
+        guard !pumpRunning else { return }
+        pumpRunning = true
+        Task { @MainActor [weak self] in
+            await self?.drainOutbound(generation: generation)
+        }
+    }
+
+    private func drainOutbound(generation: UInt64) async {
+        while true {
+            // A stale pump touches nothing: the live session owns `pumpRunning` now.
+            guard sessionGeneration == generation else { return }
+            guard !outbound.isEmpty else {
+                pumpRunning = false
+                return
+            }
+            let frame = outbound.removeFirst()
+            do {
+                try await transport.send(frame)
+            } catch {
+                guard sessionGeneration == generation else { return }
+                pumpRunning = false
+                return failSession(Self.failure(from: error), generation: generation)
+            }
+        }
+    }
+
+    // MARK: - Handshake
+
+    private func awaitHandshake(generation: UInt64) async throws {
+        if let outcome = handshakeOutcome, outcome.generation == generation {
+            handshakeOutcome = nil
+            return try outcome.result.get()
+        }
+        guard handshakeGeneration == generation else {
+            throw VoiceBackendFailure.closed("the session was torn down during the handshake")
+        }
+
+        let bound = timeout
+        let deadline = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(bound))
+            guard !Task.isCancelled else { return }
+            self?.failSession(
+                .network("the realtime session handshake timed out after \(Self.format(bound))s"),
+                generation: generation)
+        }
+        defer { deadline.cancel() }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            handshakeContinuation = continuation
+        }
+    }
+
+    private func settleHandshake(_ result: Result<Void, VoiceBackendFailure>, generation: UInt64) {
+        guard handshakeGeneration == generation else { return }
+        handshakeGeneration = nil
+        guard let continuation = handshakeContinuation else {
+            handshakeOutcome = (generation, result)
+            return
+        }
+        handshakeContinuation = nil
+        continuation.resume(with: result.mapError { $0 as any Error })
+    }
+
+    // MARK: - Failure and teardown
+
+    private func violated(_ error: any Error) {
+        let failure = (error as? VoiceBackendFailure) ?? .protocolViolation(Self.describe(error))
+        failSession(failure, generation: sessionGeneration)
+    }
+
+    /// Ends the session and reports it exactly once.
+    ///
+    /// While the handshake is still outstanding the failure is delivered by throwing out of
+    /// `open`, not as an event — a caller whose `open` threw never installed a window and
+    /// must not also be told the window died.
+    private func failSession(_ failure: VoiceBackendFailure, generation: UInt64) {
+        guard sessionGeneration == generation else { return }
+        diagnostics.record("session.failed", level: .warning,
+                           fields: ["detail": failure.localizedDescription])
+        let callback = onEvent
+        let handshaking = handshakeGeneration == generation
+        turns.sessionFailed()
+        if handshaking {
+            settleHandshake(.failure(failure), generation: generation)
+            teardown(expectedGeneration: generation)
+            return
+        }
+        teardown(expectedGeneration: generation)
+        callback?(.sessionFailed(failure))
+    }
+
+    private func teardown(expectedGeneration: UInt64? = nil) {
+        if let expectedGeneration, expectedGeneration != sessionGeneration { return }
+        let generation = sessionGeneration
+        sessionGeneration &+= 1
+        onEvent = nil
+        outbound.removeAll()
+        pumpRunning = false
+        transcript = ""
+        turns.close()
+        transport.close()
+        // A continuation that is never resumed is a task leaked forever, so teardown from
+        // any path settles an outstanding handshake before it forgets about it.
+        if handshakeGeneration == generation {
+            settleHandshake(
+                .failure(.closed("the session was torn down during the handshake")),
+                generation: generation)
+        }
+    }
+
+    private func emit(_ event: VoiceBackendEvent) {
+        onEvent?(event)
+    }
+
+    // MARK: - Pure helpers
+
+    /// Splits a chunk into blocks of at most `maxSeconds` of PCM16 audio, preserving order
+    /// and never splitting a sample frame in half.
+    static func split(_ chunk: VoiceAudioChunk, maxSeconds: TimeInterval) -> [Data] {
+        let bytesPerFrame = max(1, 2 * chunk.format.channels)
+        let framesPerBlock = max(1, Int(maxSeconds * chunk.format.sampleRate))
+        let blockSize = framesPerBlock * bytesPerFrame
+        guard chunk.data.count > blockSize else { return chunk.data.isEmpty ? [] : [chunk.data] }
+
+        var blocks: [Data] = []
+        var index = chunk.data.startIndex
+        while index < chunk.data.endIndex {
+            let end = chunk.data.index(index, offsetBy: blockSize, limitedBy: chunk.data.endIndex)
+                ?? chunk.data.endIndex
+            blocks.append(Data(chunk.data[index..<end]))
+            index = end
+        }
+        return blocks
+    }
+
+    private static func failure(from error: any Error) -> VoiceBackendFailure {
+        switch error {
+        case let failure as VoiceBackendFailure:
+            return failure
+        case let failure as RealtimeTransportFailure:
+            switch failure {
+            case .connectFailed(let detail):
+                return .network("connect failed: \(detail)")
+            case .sendFailed(let detail):
+                return .network("send failed: \(detail)")
+            case .receiveFailed(let detail):
+                return .network("receive failed: \(detail)")
+            case .closed(let detail):
+                return .closed(detail)
+            }
+        default:
+            return .network(String(describing: error))
+        }
+    }
+
+    private static func describe(_ error: any Error) -> String {
+        if let violation = error as? VoiceTurnViolation { return violation.localizedDescription }
+        if let failure = error as? VoiceBackendFailure { return failure.localizedDescription }
+        if let message = error as? RealtimeMessageError { return message.localizedDescription }
+        return String(describing: error)
+    }
+
+    private static func format(_ seconds: TimeInterval) -> String {
+        String(format: "%g", seconds)
+    }
+}

--- a/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
@@ -202,31 +202,43 @@ import TapQContracts
         }
     }
 
-    public func endUserTurn() {
+    @discardableResult
+    public func endUserTurn(expectingResponse: Bool) -> Bool {
         do {
             try turns.endUserTurn()
         } catch {
-            return violated(error)
+            violated(error)
+            return false
         }
         // Empty-turn guard: if no audio was appended during this turn, skip the commit
         // and response.create entirely. The OpenAI service rejects an empty commit, and a
         // silent teardown turn must not create spurious responses.
         guard turnAudioByteCount > 0 else {
             diagnostics.record("turn.empty_skipped")
-            return
+            return false
         }
         let generation = sessionGeneration
         enqueue(.commitInputAudio, generation: generation)
+        // When TapQ does not want a spoken reply (match-resolved, gesture stop,
+        // activity pause), commit for transcription only — no response.create.
+        // Input transcription rides the commit, not the response, so match-by-transcript
+        // still works on the committed audio.
+        guard expectingResponse else {
+            diagnostics.record("turn.committed_no_response")
+            return false
+        }
         // Manual-turn mode is commit-then-create: the service produces nothing until asked,
         // so the commit that ends the wearer's turn is immediately followed by the request
         // that starts the model's.
         do {
             try turns.requestResponse()
         } catch {
-            return violated(error)
+            violated(error)
+            return false
         }
         enqueue(.createResponse(instructions: nil), generation: generation)
         diagnostics.record("turn.committed")
+        return true
     }
 
     public func requestResponse(text: String) {

--- a/Sources/TapQVoiceBackends/RealtimeMessages.swift
+++ b/Sources/TapQVoiceBackends/RealtimeMessages.swift
@@ -1,0 +1,298 @@
+import Foundation
+
+/// Defaults for the OpenAI Realtime slice TapQ speaks.
+///
+/// Statics rather than literals sprinkled through the adapter, matching
+/// `OpenAILunaQuestionClassifier.defaultModel` / `.defaultEndpoint` / `.defaultTimeout`.
+public enum RealtimeDefaults {
+    public static let model = "gpt-realtime"
+    public static let endpoint = URL(string: "wss://api.openai.com/v1/realtime")!
+    /// Whisper-class transcription of the *wearer's* audio. Without this the session
+    /// returns only the model's own words, and TapQ's grammar has nothing to match.
+    public static let inputTranscriptionModel = "gpt-4o-transcribe"
+    /// The only encoding this adapter frames, matching `VoiceAudioFormat.pcm16Mono24k`.
+    public static let audioFormat = "pcm16"
+}
+
+/// A frame that could not be built or understood.
+public enum RealtimeMessageError: Error, LocalizedError, Equatable, Sendable {
+    case encodingFailed(String)
+    case malformedFrame(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .encodingFailed(let detail):
+            return "The realtime client event could not be encoded: \(detail)."
+        case .malformedFrame(let detail):
+            return "The realtime server frame could not be read: \(detail)."
+        }
+    }
+}
+
+/// Server-side voice activity detection, which TapQ always turns off.
+///
+/// Modelled as a value rather than hardcoded so the disabling is visible on the wire and
+/// assertable in a test. A backend that ends turns from its own VAD resolves approval
+/// windows TapQ's interaction controller never authorized — see the non-negotiables on
+/// `VoiceBackend`.
+public struct RealtimeTurnDetection: Codable, Equatable, Sendable {
+    public let type: String
+
+    public init(type: String) {
+        self.type = type
+    }
+
+    /// Manual-turn mode: the server never commits a buffer or starts a response on its
+    /// own. The only value TapQ ever sends.
+    public static let disabled = RealtimeTurnDetection(type: "none")
+}
+
+/// Transcription settings for the wearer's own audio.
+public struct RealtimeInputTranscription: Codable, Equatable, Sendable {
+    public let model: String
+
+    public init(model: String = RealtimeDefaults.inputTranscriptionModel) {
+        self.model = model
+    }
+}
+
+/// The `session` payload of a `session.update`.
+///
+/// Only the fields this slice needs. Everything absent is left at the service default on
+/// purpose: an adapter that pins settings it does not care about turns every upstream
+/// default change into a TapQ behavior change.
+public struct RealtimeSessionConfiguration: Codable, Equatable, Sendable {
+    public var model: String
+    public var modalities: [String]
+    public var inputAudioFormat: String
+    public var outputAudioFormat: String
+    public var inputAudioTranscription: RealtimeInputTranscription?
+    /// Always `.disabled` for TapQ. Settable only so a test can prove the adapter refuses
+    /// to ship anything else.
+    public var turnDetection: RealtimeTurnDetection
+    public var instructions: String?
+    public var voice: String?
+
+    public init(model: String = RealtimeDefaults.model,
+                modalities: [String] = ["audio", "text"],
+                inputAudioFormat: String = RealtimeDefaults.audioFormat,
+                outputAudioFormat: String = RealtimeDefaults.audioFormat,
+                inputAudioTranscription: RealtimeInputTranscription? = RealtimeInputTranscription(),
+                turnDetection: RealtimeTurnDetection = .disabled,
+                instructions: String? = nil,
+                voice: String? = nil) {
+        self.model = model
+        self.modalities = modalities
+        self.inputAudioFormat = inputAudioFormat
+        self.outputAudioFormat = outputAudioFormat
+        self.inputAudioTranscription = inputAudioTranscription
+        self.turnDetection = turnDetection
+        self.instructions = instructions
+        self.voice = voice
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case modalities
+        case instructions
+        case voice
+        case inputAudioFormat = "input_audio_format"
+        case outputAudioFormat = "output_audio_format"
+        case inputAudioTranscription = "input_audio_transcription"
+        case turnDetection = "turn_detection"
+    }
+}
+
+/// Everything TapQ ever says to the realtime service.
+///
+/// Pinned to the OpenAI Realtime protocol as observed 2026-05 (`gpt-realtime` family).
+/// The set is small by design — this is a speech pipe, and every client event beyond
+/// these five would be policy leaking across the `VoiceBackend` boundary.
+public enum RealtimeClientEvent: Equatable, Sendable {
+    /// Configures the session. Always the first frame on a connection: until it lands, the
+    /// service is running its own VAD.
+    case sessionUpdate(RealtimeSessionConfiguration)
+    /// Appends PCM16 audio to the input buffer. Base64 is the protocol's framing, not a
+    /// choice this adapter makes.
+    case appendInputAudio(Data)
+    /// Commits the input buffer. In manual-turn mode this is the *only* thing that ends a
+    /// user turn, and only TapQ sends it.
+    case commitInputAudio
+    /// Asks the model to respond. `instructions` carries TapQ's own text when the caller
+    /// wants something specific spoken.
+    case createResponse(instructions: String?)
+    /// Barge-in: abandon the in-flight response.
+    case cancelResponse
+
+    /// The JSON text frame for this event.
+    ///
+    /// Keys are sorted so a frame is byte-stable across runs — worth it for readable test
+    /// failures and for log lines that diff cleanly.
+    public func encodedFrame() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data: Data
+        do {
+            switch self {
+            case .sessionUpdate(let configuration):
+                data = try encoder.encode(SessionUpdateFrame(session: configuration))
+            case .appendInputAudio(let audio):
+                data = try encoder.encode(AppendFrame(audio: audio.base64EncodedString()))
+            case .commitInputAudio:
+                data = try encoder.encode(CommitFrame())
+            case .createResponse(let instructions):
+                let response = instructions.map { ResponseCreateFrame.Response(instructions: $0) }
+                data = try encoder.encode(ResponseCreateFrame(response: response))
+            case .cancelResponse:
+                data = try encoder.encode(ResponseCancelFrame())
+            }
+        } catch {
+            throw RealtimeMessageError.encodingFailed(String(describing: error))
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// The `type` this event carries on the wire, for assertions and diagnostics.
+    public var wireType: String {
+        switch self {
+        case .sessionUpdate: return "session.update"
+        case .appendInputAudio: return "input_audio_buffer.append"
+        case .commitInputAudio: return "input_audio_buffer.commit"
+        case .createResponse: return "response.create"
+        case .cancelResponse: return "response.cancel"
+        }
+    }
+
+    private struct SessionUpdateFrame: Encodable {
+        let type = "session.update"
+        let session: RealtimeSessionConfiguration
+    }
+
+    private struct AppendFrame: Encodable {
+        let type = "input_audio_buffer.append"
+        let audio: String
+    }
+
+    private struct CommitFrame: Encodable {
+        let type = "input_audio_buffer.commit"
+    }
+
+    private struct ResponseCreateFrame: Encodable {
+        struct Response: Encodable {
+            let instructions: String
+        }
+
+        let type = "response.create"
+        let response: Response?
+    }
+
+    private struct ResponseCancelFrame: Encodable {
+        let type = "response.cancel"
+    }
+}
+
+/// An `error` event from the service.
+public struct RealtimeServerFailure: Equatable, Sendable {
+    public let type: String?
+    public let code: String?
+    public let message: String
+
+    public init(type: String?, code: String?, message: String) {
+        self.type = type
+        self.code = code
+        self.message = message
+    }
+
+    /// True when retrying will not help because the credentials are the problem.
+    ///
+    /// Matched on substrings rather than an exact code list: the service has renamed these
+    /// codes before, and mistaking an auth failure for a transport blip means a fail-through
+    /// wrapper reconnecting forever against a key that will never work.
+    public var isAuthorization: Bool {
+        let haystack = [type, code, message].compactMap { $0 }.joined(separator: " ").lowercased()
+        return ["api_key", "api key", "unauthorized", "authentication", "invalid_request_error.auth"]
+            .contains { haystack.contains($0) }
+    }
+}
+
+/// Everything TapQ understands the service to say.
+///
+/// Unknown `type`s decode to `.unsupported` rather than throwing: the realtime protocol
+/// gains events regularly, and a session that dies because the service mentioned a new
+/// one would be a voice channel that breaks on somebody else's release schedule.
+public enum RealtimeServerEvent: Equatable, Sendable {
+    case sessionCreated
+    /// The configuration TapQ sent has been applied. This — not `session.created` — is the
+    /// handshake ack, because before it lands the service is still running its own VAD.
+    case sessionUpdated
+    /// Incremental transcript of the *wearer's* audio.
+    case transcriptDelta(String)
+    /// Settled transcript of the wearer's audio for the committed turn.
+    case transcriptCompleted(String)
+    /// Response audio, already base64-decoded to PCM16 bytes.
+    case audioDelta(Data)
+    /// The response finished.
+    case responseCompleted
+    case failure(RealtimeServerFailure)
+    /// A event type this adapter does not model, kept for diagnostics.
+    case unsupported(String)
+
+    public static func decode(_ frame: String) throws -> RealtimeServerEvent {
+        guard let data = frame.data(using: .utf8) else {
+            throw RealtimeMessageError.malformedFrame("the frame is not UTF-8")
+        }
+        let envelope: Envelope
+        do {
+            envelope = try JSONDecoder().decode(Envelope.self, from: data)
+        } catch {
+            throw RealtimeMessageError.malformedFrame("no readable `type` field")
+        }
+
+        switch envelope.type {
+        case "session.created":
+            return .sessionCreated
+        case "session.updated":
+            return .sessionUpdated
+        case "conversation.item.input_audio_transcription.delta":
+            return .transcriptDelta(envelope.delta ?? "")
+        case "conversation.item.input_audio_transcription.completed":
+            return .transcriptCompleted(envelope.transcript ?? envelope.text ?? "")
+        case "response.output_audio.delta", "response.audio.delta":
+            guard let encoded = envelope.delta else {
+                throw RealtimeMessageError.malformedFrame("\(envelope.type) carried no audio")
+            }
+            guard let audio = Data(base64Encoded: encoded) else {
+                throw RealtimeMessageError.malformedFrame(
+                    "\(envelope.type) carried audio that is not base64")
+            }
+            return .audioDelta(audio)
+        case "response.done", "response.completed":
+            return .responseCompleted
+        case "error":
+            guard let error = envelope.error else {
+                throw RealtimeMessageError.malformedFrame("an error event carried no error")
+            }
+            return .failure(RealtimeServerFailure(type: error.type, code: error.code,
+                                                  message: error.message ?? "unspecified"))
+        default:
+            return .unsupported(envelope.type)
+        }
+    }
+
+    /// Tolerant by construction: unknown keys are ignored by `Decodable`, and every field
+    /// past `type` is optional, so a frame that renames a payload field degrades to an
+    /// empty transcript rather than a dead session.
+    private struct Envelope: Decodable {
+        struct ErrorBody: Decodable {
+            let type: String?
+            let code: String?
+            let message: String?
+        }
+
+        let type: String
+        let delta: String?
+        let transcript: String?
+        let text: String?
+        let error: ErrorBody?
+    }
+}

--- a/Sources/TapQVoiceBackends/RealtimeTransport.swift
+++ b/Sources/TapQVoiceBackends/RealtimeTransport.swift
@@ -1,0 +1,154 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Why a realtime transport could not do what it was asked.
+///
+/// Split by stage rather than collapsed into one case because the adapter maps them to
+/// different `VoiceBackendFailure`s: a connect that never happened is worth failing over
+/// for, while a peer that hung up mid-session is a closed session.
+public enum RealtimeTransportFailure: Error, LocalizedError, Equatable, Sendable {
+    case connectFailed(String)
+    case sendFailed(String)
+    case receiveFailed(String)
+    case closed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .connectFailed(let detail):
+            return "The realtime transport could not connect: \(detail)."
+        case .sendFailed(let detail):
+            return "The realtime transport could not send a frame: \(detail)."
+        case .receiveFailed(let detail):
+            return "The realtime transport stopped receiving: \(detail)."
+        case .closed(let detail):
+            return "The realtime transport is closed: \(detail)."
+        }
+    }
+}
+
+/// The one thing `OpenAIRealtimeVoiceBackend` needs from the outside world: an ordered,
+/// bidirectional stream of JSON text frames.
+///
+/// This exists so no test ever opens a socket. It is also insurance:
+/// `URLSessionWebSocketTask` is only reliably available on Apple platforms, and the
+/// corelibs implementation has a long history of misbehaving, so the live class below is
+/// compiled out where it cannot be trusted while the adapter above stays portable and
+/// fully exercised.
+///
+/// `@MainActor` to match the backend that drives it — the adapter's whole state lives on
+/// the main actor, and a transport on a different isolation domain would mean hopping for
+/// every 100 ms audio frame.
+@MainActor public protocol RealtimeTransporting: AnyObject {
+    /// Establishes the connection. Throws `RealtimeTransportFailure` on failure.
+    func connect() async throws
+
+    /// Sends one text frame. Frames must arrive at the peer in call order — the realtime
+    /// protocol is a sequence of appends terminated by a commit, and a reordered append is
+    /// scrambled audio.
+    func send(_ frame: String) async throws
+
+    /// Frames from the peer, in order.
+    ///
+    /// Finishes normally when the peer closes cleanly, and throws
+    /// `RealtimeTransportFailure` when the connection drops. Call once per connection.
+    func receiveFrames() -> AsyncThrowingStream<String, any Error>
+
+    /// Tears the connection down. Idempotent and non-throwing, like every teardown path in
+    /// this codebase.
+    func close()
+}
+
+#if canImport(Darwin)
+/// The live transport: a WebSocket to the OpenAI Realtime endpoint.
+///
+/// Compiled only where `URLSessionWebSocketTask` ships in Foundation proper (Apple
+/// platforms). On Linux the package still builds — the adapter, the message codec, and
+/// every test depend on `RealtimeTransporting`, never on this class.
+///
+/// Deliberately thin: it holds no protocol knowledge, no retry policy, and no timeout of
+/// its own. Timeouts belong to the adapter, which is where the session state that decides
+/// what a timeout means lives.
+@MainActor public final class URLSessionWebSocketRealtimeTransport: RealtimeTransporting {
+    private let url: URL
+    private let headers: [String: String]
+    private let session: URLSession
+    private var task: URLSessionWebSocketTask?
+
+    /// - Parameters:
+    ///   - url: the realtime endpoint, model already in the query string.
+    ///   - apiKey: sent as a bearer header and never stored anywhere else, never logged,
+    ///     and never included in a failure description.
+    public init(url: URL, apiKey: String, session: URLSession = .shared) {
+        self.url = url
+        self.headers = [
+            "Authorization": "Bearer \(apiKey)",
+            "OpenAI-Beta": "realtime=v1",
+        ]
+        self.session = session
+    }
+
+    public func connect() async throws {
+        guard task == nil else {
+            throw RealtimeTransportFailure.connectFailed("the transport is already connected")
+        }
+        var request = URLRequest(url: url)
+        for (field, value) in headers {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+        let task = session.webSocketTask(with: request)
+        self.task = task
+        task.resume()
+    }
+
+    public func send(_ frame: String) async throws {
+        guard let task else {
+            throw RealtimeTransportFailure.closed("no connection is open")
+        }
+        do {
+            try await task.send(.string(frame))
+        } catch {
+            throw RealtimeTransportFailure.sendFailed(String(describing: error))
+        }
+    }
+
+    public func receiveFrames() -> AsyncThrowingStream<String, any Error> {
+        guard let task else {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: RealtimeTransportFailure.closed("no connection is open"))
+            }
+        }
+        return AsyncThrowingStream { continuation in
+            // The receive loop captures the task, not `self`: it outlives any main-actor
+            // hop and must not keep the transport alive on its own.
+            let pump = Task.detached {
+                while true {
+                    do {
+                        switch try await task.receive() {
+                        case .string(let frame):
+                            continuation.yield(frame)
+                        case .data(let data):
+                            // The realtime protocol is text-only; binary here means the
+                            // peer is speaking something this adapter does not know.
+                            continuation.yield(String(decoding: data, as: UTF8.self))
+                        @unknown default:
+                            continue
+                        }
+                    } catch {
+                        continuation.finish(
+                            throwing: RealtimeTransportFailure.receiveFailed(String(describing: error)))
+                        return
+                    }
+                }
+            }
+            continuation.onTermination = { _ in pump.cancel() }
+        }
+    }
+
+    public func close() {
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+    }
+}
+#endif

--- a/Sources/TapQVoiceBackends/VoiceBackendProvider.swift
+++ b/Sources/TapQVoiceBackends/VoiceBackendProvider.swift
@@ -1,0 +1,143 @@
+import Foundation
+import TapQContracts
+
+/// The speech pipe requested for a runtime instance.
+///
+/// Two values, because there are exactly two things a wearer can mean: the on-device stack
+/// TapQ has always shipped, or the cloud one *with* the on-device stack underneath it.
+/// There is no "OpenAI only" — a voice channel that can go dead when the wifi does is not a
+/// channel TapQ is willing to compose, so the realtime path is always the primary of a
+/// `FailThroughVoiceBackend` whose fallback is the Apple backend.
+public enum VoiceBackendProvider: String, CaseIterable, Equatable, Sendable {
+    /// Apple's on-device recognizer. The default, and byte for byte today's composition.
+    case apple
+    /// OpenAI Realtime in manual-turn mode, backed by the Apple stack.
+    case openaiRealtime = "openai-realtime"
+
+    /// How the runtime reports the choice on its ready line, or nil when there is nothing
+    /// worth reporting.
+    ///
+    /// The default is deliberately silent: a status line that always prints "apple" would
+    /// add a line to every operator's console to tell them nothing changed.
+    public var statusDescription: String? {
+        switch self {
+        case .apple:
+            return nil
+        case .openaiRealtime:
+            return "openai-realtime (fail-through: apple)"
+        }
+    }
+}
+
+/// A startup configuration error for an explicitly requested voice backend.
+///
+/// Both cases are command-line mistakes rather than environment conditions, so — unlike the
+/// stage-2 reasoner, which degrades — they abort serving, exactly as a misconfigured
+/// question classifier does. Silently serving on the Apple stack after the operator asked
+/// for a cloud one would hide the misconfiguration behind working voice.
+public enum VoiceBackendConfigurationError: Error, LocalizedError, Equatable {
+    case missingOpenAIAPIKey
+    case realtimeUnsupportedPlatform
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingOpenAIAPIKey:
+            return "OpenAI Realtime voice requires OPENAI_API_KEY "
+                + "in the TapQ process environment."
+        case .realtimeUnsupportedPlatform:
+            return "OpenAI Realtime voice was requested, but this build has no realtime "
+                + "transport. Select apple instead."
+        }
+    }
+}
+
+/// A composed backend together with the provider it was built for.
+///
+/// Mirrors `QuestionClassifierSelection`: the caller gets the thing it asked for plus enough
+/// to describe what it got, and never has to ask the composition what it is.
+public struct VoiceBackendSelection {
+    public let backend: any VoiceBackend
+    public let provider: VoiceBackendProvider
+
+    public init(backend: any VoiceBackend, provider: VoiceBackendProvider) {
+        self.backend = backend
+        self.provider = provider
+    }
+
+    /// Ready-line text for this selection; nil for the default path.
+    public var statusDescription: String? { provider.statusDescription }
+}
+
+/// Resolves runtime provider policy into a composed `VoiceBackend`.
+///
+/// The Apple backend arrives as a closure rather than a value for two reasons: this target
+/// is portable and must never import AVFoundation or Speech, and the fallback should only be
+/// constructed by the path that actually composes one. Nothing here opens a microphone, a
+/// socket, or a recognizer — construction is inert until somebody calls `open`.
+public enum VoiceBackendFactory {
+    /// Resolves an explicit runtime policy into a backend. Configuration mistakes throw at
+    /// startup; runtime failures are the composition's business — the realtime path fails
+    /// through to Apple rather than surfacing anything to the caller.
+    @MainActor
+    public static func select(
+        provider: VoiceBackendProvider,
+        openAIAPIKey: String? = nil,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
+        makeAppleBackend: @MainActor () -> any VoiceBackend
+    ) throws -> VoiceBackendSelection {
+        try select(
+            provider: provider,
+            openAIAPIKey: openAIAPIKey,
+            diagnosticSink: diagnosticSink,
+            makeAppleBackend: makeAppleBackend,
+            makeRealtimeBackend: liveRealtimeBackend
+        )
+    }
+
+    /// Test seam: the realtime primary is injectable so composition can be proven without
+    /// building a live WebSocket transport.
+    @MainActor
+    static func select(
+        provider: VoiceBackendProvider,
+        openAIAPIKey: String?,
+        diagnosticSink: any TapQDiagnosticSink,
+        makeAppleBackend: @MainActor () -> any VoiceBackend,
+        makeRealtimeBackend: @MainActor (String, any TapQDiagnosticSink) throws -> any VoiceBackend
+    ) throws -> VoiceBackendSelection {
+        switch provider {
+        case .apple:
+            // No wrapper at all: the default path is the closure's product, unmediated.
+            return VoiceBackendSelection(backend: makeAppleBackend(), provider: .apple)
+
+        case .openaiRealtime:
+            guard let apiKey = openAIAPIKey?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !apiKey.isEmpty else {
+                throw VoiceBackendConfigurationError.missingOpenAIAPIKey
+            }
+            let primary = try makeRealtimeBackend(apiKey, diagnosticSink)
+            return VoiceBackendSelection(
+                backend: FailThroughVoiceBackend(
+                    primary: primary,
+                    fallback: makeAppleBackend(),
+                    diagnosticSink: diagnosticSink
+                ),
+                provider: .openaiRealtime
+            )
+        }
+    }
+
+    @MainActor
+    private static func liveRealtimeBackend(
+        apiKey: String,
+        diagnosticSink: any TapQDiagnosticSink
+    ) throws -> any VoiceBackend {
+        #if canImport(Darwin)
+        return OpenAIRealtimeVoiceBackend(apiKey: apiKey, diagnosticSink: diagnosticSink)
+        #else
+        // The live transport is compiled out where `URLSessionWebSocketTask` cannot be
+        // trusted, so there is nothing to hand back and refusing is the honest answer.
+        throw VoiceBackendConfigurationError.realtimeUnsupportedPlatform
+        #endif
+    }
+}

--- a/Sources/TapQVoiceBackends/VoiceBackendProvider.swift
+++ b/Sources/TapQVoiceBackends/VoiceBackendProvider.swift
@@ -75,19 +75,31 @@ public struct VoiceBackendSelection {
 /// constructed by the path that actually composes one. Nothing here opens a microphone, a
 /// socket, or a recognizer — construction is inert until somebody calls `open`.
 public enum VoiceBackendFactory {
+    /// Optional decorator applied to the realtime primary before it is wrapped in
+    /// `FailThroughVoiceBackend`. The executable passes a microphone-pump constructor here
+    /// so the portable factory never imports AVFoundation, mirroring the existing
+    /// `makeAppleBackend` closure pattern.
+    public typealias RealtimePrimaryDecorator = @MainActor (any VoiceBackend) -> any VoiceBackend
+
     /// Resolves an explicit runtime policy into a backend. Configuration mistakes throw at
     /// startup; runtime failures are the composition's business — the realtime path fails
     /// through to Apple rather than surfacing anything to the caller.
+    ///
+    /// - Parameter decorateRealtimePrimary: when non-nil, wraps the realtime primary (e.g.
+    ///   with a microphone pump) before it enters the fail-through composition. The Apple
+    ///   provider path never invokes it.
     @MainActor
     public static func select(
         provider: VoiceBackendProvider,
         openAIAPIKey: String? = nil,
+        decorateRealtimePrimary: RealtimePrimaryDecorator? = nil,
         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
         makeAppleBackend: @MainActor () -> any VoiceBackend
     ) throws -> VoiceBackendSelection {
         try select(
             provider: provider,
             openAIAPIKey: openAIAPIKey,
+            decorateRealtimePrimary: decorateRealtimePrimary,
             diagnosticSink: diagnosticSink,
             makeAppleBackend: makeAppleBackend,
             makeRealtimeBackend: liveRealtimeBackend
@@ -100,6 +112,7 @@ public enum VoiceBackendFactory {
     static func select(
         provider: VoiceBackendProvider,
         openAIAPIKey: String?,
+        decorateRealtimePrimary: RealtimePrimaryDecorator? = nil,
         diagnosticSink: any TapQDiagnosticSink,
         makeAppleBackend: @MainActor () -> any VoiceBackend,
         makeRealtimeBackend: @MainActor (String, any TapQDiagnosticSink) throws -> any VoiceBackend
@@ -115,7 +128,8 @@ public enum VoiceBackendFactory {
                   !apiKey.isEmpty else {
                 throw VoiceBackendConfigurationError.missingOpenAIAPIKey
             }
-            let primary = try makeRealtimeBackend(apiKey, diagnosticSink)
+            let rawPrimary = try makeRealtimeBackend(apiKey, diagnosticSink)
+            let primary = decorateRealtimePrimary?(rawPrimary) ?? rawPrimary
             return VoiceBackendSelection(
                 backend: FailThroughVoiceBackend(
                     primary: primary,

--- a/Sources/TapQVoiceBackends/VoiceBackendProvider.swift
+++ b/Sources/TapQVoiceBackends/VoiceBackendProvider.swift
@@ -88,11 +88,15 @@ public enum VoiceBackendFactory {
     /// - Parameter decorateRealtimePrimary: when non-nil, wraps the realtime primary (e.g.
     ///   with a microphone pump) before it enters the fail-through composition. The Apple
     ///   provider path never invokes it.
+    /// - Parameter failThroughStickiness: stickiness policy for the `FailThroughVoiceBackend`.
+    ///   `.retryEachOpen` (default) retries the primary on every `open`; `.stickyAfterFailure`
+    ///   keeps the fallback until `resetStickiness()` is called (conversation mode).
     @MainActor
     public static func select(
         provider: VoiceBackendProvider,
         openAIAPIKey: String? = nil,
         decorateRealtimePrimary: RealtimePrimaryDecorator? = nil,
+        failThroughStickiness: FailThroughStickiness = .retryEachOpen,
         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
         makeAppleBackend: @MainActor () -> any VoiceBackend
     ) throws -> VoiceBackendSelection {
@@ -100,6 +104,7 @@ public enum VoiceBackendFactory {
             provider: provider,
             openAIAPIKey: openAIAPIKey,
             decorateRealtimePrimary: decorateRealtimePrimary,
+            failThroughStickiness: failThroughStickiness,
             diagnosticSink: diagnosticSink,
             makeAppleBackend: makeAppleBackend,
             makeRealtimeBackend: liveRealtimeBackend
@@ -113,6 +118,7 @@ public enum VoiceBackendFactory {
         provider: VoiceBackendProvider,
         openAIAPIKey: String?,
         decorateRealtimePrimary: RealtimePrimaryDecorator? = nil,
+        failThroughStickiness: FailThroughStickiness = .retryEachOpen,
         diagnosticSink: any TapQDiagnosticSink,
         makeAppleBackend: @MainActor () -> any VoiceBackend,
         makeRealtimeBackend: @MainActor (String, any TapQDiagnosticSink) throws -> any VoiceBackend
@@ -134,6 +140,7 @@ public enum VoiceBackendFactory {
                 backend: FailThroughVoiceBackend(
                     primary: primary,
                     fallback: makeAppleBackend(),
+                    stickiness: failThroughStickiness,
                     diagnosticSink: diagnosticSink
                 ),
                 provider: .openaiRealtime

--- a/Sources/TapQWireProtocol/WireMessages.swift
+++ b/Sources/TapQWireProtocol/WireMessages.swift
@@ -17,26 +17,34 @@ public enum WireType {
 /// fails open (shim passes through; broker replies error, which the shim also treats
 /// as pass-through), so a stale binary degrades loudly in logs, never wrongly allows.
 public enum WireProtocol {
-    public static let version = 3
+    public static let version = 4
     /// The immediately preceding protocol remains wire-compatible for messages that do
     /// not depend on `approval_source`. This keeps the legacy macOS runtime fallback useful
     /// for strict-policy and shared events without exposing native PermissionRequest to a
     /// broker that would interpret it as legacy PreToolUse.
     public static let legacyBridgeVersion = 2
+    /// v3 request shapes are identical to v4 (only an additive optional response field
+    /// was introduced), so the broker accepts v3 peers without downgrade. This keeps every
+    /// installed v3 shim working against a v4 broker.
+    public static let previousAcceptedVersion = 3
 
     /// nil = peer predates versioning; it speaks version 1 de facto.
+    /// The broker accepts both the current version and `previousAcceptedVersion`.
     public static func isCompatible(_ other: Int?, current: Int = version) -> Bool {
-        (other ?? 1) == current
+        let peer = other ?? 1
+        return peer == current || (current == version && peer == previousAcceptedVersion)
     }
 
     /// Selects the version a current shim may safely put on an outbound message.
-    /// Brokers themselves continue to require an exact version via `isCompatible`.
+    /// Brokers themselves continue to require a compatible version via `isCompatible`.
     public static func outboundVersion(
         for peerVersion: Int?,
         approvalSource: ApprovalSource?
     ) -> Int? {
         let peer = peerVersion ?? 1
         if peer == version { return version }
+        // v4 shim speaks v3 to a v3 broker — request shapes are identical.
+        if peer == previousAcceptedVersion { return previousAcceptedVersion }
         if peer == legacyBridgeVersion, approvalSource != .permissionRequest {
             return legacyBridgeVersion
         }
@@ -246,13 +254,14 @@ public enum BrokerResponse: Sendable, Equatable {
     case decision(Decision, reason: String?)
     case ok
     case error(String)
-    case selection(indices: [Int], labels: [String])
+    case selection(indices: [Int], labels: [String], freeText: String? = nil)
     case stopQuestion(reply: String?)
 
     private enum Key: String, CodingKey {
         case decision, reason, ok, error
         case selectedIndices = "selected_indices"
         case selectedLabels = "selected_labels"
+        case freeText = "free_text"
         case action, reply
     }
 
@@ -272,9 +281,10 @@ extension BrokerResponse: Codable {
             try c.encode(true, forKey: .ok)
         case .error(let msg):
             try c.encode(msg, forKey: .error)
-        case .selection(let indices, let labels):
+        case .selection(let indices, let labels, let freeText):
             try c.encode(indices, forKey: .selectedIndices)
             try c.encode(labels, forKey: .selectedLabels)
+            if let freeText { try c.encode(freeText, forKey: .freeText) }
         case .stopQuestion(let reply):
             if let reply {
                 try c.encode("answer", forKey: .action)
@@ -296,7 +306,8 @@ extension BrokerResponse: Codable {
             self = .error(msg)
         } else if let indices = try c.decodeIfPresent([Int].self, forKey: .selectedIndices),
                   let labels = try c.decodeIfPresent([String].self, forKey: .selectedLabels) {
-            self = .selection(indices: indices, labels: labels)
+            let freeText = try c.decodeIfPresent(String.self, forKey: .freeText)
+            self = .selection(indices: indices, labels: labels, freeText: freeText)
         } else if let action = try c.decodeIfPresent(String.self, forKey: .action) {
             self = .stopQuestion(reply: action == "answer" ? try c.decodeIfPresent(String.self, forKey: .reply) : nil)
         } else {

--- a/Tests/TapQAppleAdaptersTests/AppleVoiceBackendTests.swift
+++ b/Tests/TapQAppleAdaptersTests/AppleVoiceBackendTests.swift
@@ -1,0 +1,588 @@
+import XCTest
+import AVFoundation
+import Speech
+import TapQContracts
+@testable import TapQAppleAdapters
+
+@MainActor
+final class AppleVoiceBackendTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    private final class FakeRecognitionTask: VoiceRecognitionTasking {
+        private(set) var cancellations = 0
+        func cancel() { cancellations += 1 }
+    }
+
+    private final class FakeRecognizer: VoiceSpeechRecognizing {
+        var isAvailable = true
+        var supportsOnDeviceRecognition = true
+        var localeIdentifier: String? = "en-US"
+        var returnsTask = true
+        private(set) var requests: [SFSpeechAudioBufferRecognitionRequest] = []
+        private(set) var tasks: [FakeRecognitionTask] = []
+
+        func recognitionTask(
+            with request: SFSpeechAudioBufferRecognitionRequest,
+            resultHandler: @escaping (SFSpeechRecognitionResult?, (any Error)?) -> Void
+        ) -> (any VoiceRecognitionTasking)? {
+            requests.append(request)
+            guard returnsTask else { return nil }
+            let task = FakeRecognitionTask()
+            tasks.append(task)
+            return task
+        }
+    }
+
+    private final class FakeAudioSource: VoiceAudioSource {
+        var startFailure: (any Error)?
+        private(set) var starts = 0
+        private(set) var stops = 0
+        private var invalidation: (@MainActor (VoiceAudioSourceFailure) -> Void)?
+
+        func start(
+            onBuffer: @escaping (AVAudioPCMBuffer, AVAudioTime) -> Void,
+            onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
+        ) throws {
+            _ = onBuffer
+            starts += 1
+            invalidation = onInvalidation
+            if let startFailure { throw startFailure }
+        }
+
+        func stop() { stops += 1 }
+
+        func invalidate(
+            _ failure: VoiceAudioSourceFailure = .init(stage: .configurationChanged,
+                                                       detail: "test route change")
+        ) {
+            invalidation?(failure)
+        }
+    }
+
+    /// Stands in for the host's shared `SpeechEngine`; the completion is held so a test can
+    /// finish an utterance on its own schedule.
+    @MainActor
+    private final class FakeSpeech: SpeechPresenting {
+        private(set) var spoken: [(text: String, priority: SpeechPriority)] = []
+        private(set) var stopAllCount = 0
+        private var pendingFinish: (() -> Void)?
+
+        func speak(_ text: String, priority: SpeechPriority, onFinish: (() -> Void)?) {
+            spoken.append((text, priority))
+            pendingFinish = onFinish
+        }
+
+        func stopAll() { stopAllCount += 1 }
+
+        func finishUtterance() {
+            let finish = pendingFinish
+            pendingFinish = nil
+            finish?()
+        }
+    }
+
+    private enum TestFailure: Error { case expected }
+
+    private struct Fixture {
+        let backend: AppleVoiceBackend
+        let recognizer: FakeRecognizer
+        let source: FakeAudioSource
+        let speech: FakeSpeech
+        let sink: RecordingSink
+    }
+
+    private func makeFixture(sources: [FakeAudioSource]? = nil) -> Fixture {
+        let recognizer = FakeRecognizer()
+        let source = sources?.first ?? FakeAudioSource()
+        let all = sources ?? [source]
+        var index = 0
+        let speech = FakeSpeech()
+        let sink = RecordingSink()
+        let backend = AppleVoiceBackend(
+            recognizer: recognizer,
+            makeAudioSource: {
+                defer { index += 1 }
+                return all[min(index, all.count - 1)]
+            },
+            speech: speech,
+            diagnosticSink: sink
+        )
+        return Fixture(backend: backend, recognizer: recognizer, source: source,
+                       speech: speech, sink: sink)
+    }
+
+    private func openWindow(_ fixture: Fixture,
+                            collecting events: EventLog) async throws {
+        try await fixture.backend.open { events.append($0) }
+    }
+
+    /// Reference box so a test can keep collecting events after the backend tears itself
+    /// down mid-callback.
+    @MainActor
+    private final class EventLog {
+        private(set) var events: [VoiceBackendEvent] = []
+        func append(_ event: VoiceBackendEvent) { events.append(event) }
+    }
+
+    // MARK: - Session lifecycle
+
+    func testCapabilitiesAreTranscriptOnly() {
+        let fixture = makeFixture()
+        XCTAssertEqual(fixture.backend.capabilities, .transcriptOnly)
+        XCTAssertFalse(fixture.backend.capabilities.producesAudio)
+        XCTAssertFalse(fixture.backend.capabilities.supportsBargeIn)
+        XCTAssertFalse(fixture.backend.capabilities.duplex)
+    }
+
+    func testOpenDoesNotTouchTheMicrophone() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+
+        try await openWindow(fixture, collecting: log)
+
+        XCTAssertEqual(fixture.source.starts, 0,
+                       "the mic opens per turn, never for the length of a session")
+        XCTAssertEqual(fixture.recognizer.requests.count, 0)
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .open)
+        XCTAssertTrue(fixture.sink.names.contains("session.opened"))
+    }
+
+    func testOpenWithUnavailableRecognizerThrowsAndCreatesNoTask() async {
+        let fixture = makeFixture()
+        fixture.recognizer.isAvailable = false
+
+        do {
+            try await fixture.backend.open { _ in XCTFail("no session, no events") }
+            XCTFail("an unavailable recognizer must fail the open")
+        } catch let failure as VoiceBackendFailure {
+            guard case .authorization(let detail) = failure else {
+                return XCTFail("expected an authorization failure, got \(failure)")
+            }
+            XCTAssertTrue(detail.contains("en-US"))
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+
+        XCTAssertEqual(fixture.recognizer.requests.count, 0)
+        XCTAssertEqual(fixture.source.starts, 0)
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+        XCTAssertEqual(fixture.sink.events.last { $0.name == "open.failed" }?.fields["reason"],
+                       "recognizer_unavailable")
+    }
+
+    func testSecondOpenIsAProtocolViolation() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+
+        do {
+            try await fixture.backend.open { _ in }
+            XCTFail("double open must throw")
+        } catch let failure as VoiceBackendFailure {
+            guard case .protocolViolation = failure else {
+                return XCTFail("expected a protocol violation, got \(failure)")
+            }
+        }
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .open,
+                       "the live session survives a rejected second open")
+    }
+
+    func testCloseIsIdempotentAndStopsTheMicrophone() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.close()
+        fixture.backend.close()
+        fixture.backend.close()
+
+        XCTAssertEqual(fixture.source.stops, 1)
+        XCTAssertEqual(fixture.recognizer.tasks[0].cancellations, 1)
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+        XCTAssertEqual(log.events, [], "teardown is not a failure")
+    }
+
+    func testSessionReopensAfterClose() async throws {
+        let first = FakeAudioSource()
+        let second = FakeAudioSource()
+        let fixture = makeFixture(sources: [first, second])
+        let log = EventLog()
+
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+        fixture.backend.close()
+
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        XCTAssertEqual(first.starts, 1)
+        XCTAssertEqual(second.starts, 1, "each turn gets a fresh audio source")
+        XCTAssertEqual(fixture.recognizer.requests.count, 2)
+    }
+
+    // MARK: - Turn lifecycle
+
+    func testBeginUserTurnOpensTheMicrophoneAndAnOnDeviceRequest() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+
+        fixture.backend.beginUserTurn()
+
+        XCTAssertEqual(fixture.source.starts, 1)
+        XCTAssertEqual(fixture.recognizer.requests.count, 1)
+        XCTAssertTrue(fixture.recognizer.requests[0].shouldReportPartialResults)
+        XCTAssertTrue(fixture.recognizer.requests[0].requiresOnDeviceRecognition)
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .userTurn)
+        XCTAssertTrue(fixture.sink.names.contains("turn.began"))
+    }
+
+    func testOffDeviceRecognitionWhenTheRecognizerCannotStayLocal() async throws {
+        let fixture = makeFixture()
+        fixture.recognizer.supportsOnDeviceRecognition = false
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+
+        fixture.backend.beginUserTurn()
+
+        XCTAssertFalse(fixture.recognizer.requests[0].requiresOnDeviceRecognition)
+    }
+
+    func testEndUserTurnClosesTheMicrophoneButKeepsRecognizing() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.endUserTurn()
+
+        XCTAssertEqual(fixture.source.stops, 1, "the mic closes the instant the turn commits")
+        XCTAssertEqual(fixture.recognizer.tasks[0].cancellations, 0,
+                       "the settled transcript is still owed to the caller")
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .committed)
+    }
+
+    func testBeginUserTurnBeforeOpenIsRejectedWithoutTouchingHardware() {
+        let fixture = makeFixture()
+
+        fixture.backend.beginUserTurn()
+
+        XCTAssertEqual(fixture.source.starts, 0)
+        XCTAssertEqual(fixture.recognizer.requests.count, 0)
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+        XCTAssertTrue(fixture.sink.names.contains("session.failed"))
+    }
+
+    func testDoubleBeginUserTurnFailsTheSession() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.beginUserTurn()
+
+        XCTAssertEqual(log.events.count, 1)
+        guard case .sessionFailed(.protocolViolation) = log.events[0] else {
+            return XCTFail("expected a protocol violation, got \(log.events)")
+        }
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+        XCTAssertEqual(fixture.source.stops, 1, "a failed session never leaves the mic open")
+    }
+
+    func testEndUserTurnWithNoTurnOpenFailsTheSession() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+
+        fixture.backend.endUserTurn()
+
+        guard case .sessionFailed(.protocolViolation) = log.events.first else {
+            return XCTFail("expected a protocol violation, got \(log.events)")
+        }
+    }
+
+    func testSendAudioIsIgnoredByAMicrophoneOwningBackend() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.sendAudio(VoiceAudioChunk(data: Data(repeating: 3, count: 320),
+                                                  format: .pcm16Mono16k, timestamp: 1))
+
+        XCTAssertEqual(log.events, [], "pushed audio is dropped, never a session failure")
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .userTurn)
+        let ignored = fixture.sink.events.last { $0.name == "audio.ignored" }
+        XCTAssertEqual(ignored?.fields["reason"], "backend_owns_microphone")
+        XCTAssertEqual(ignored?.fields["bytes"], "320")
+    }
+
+    // MARK: - Transcripts
+
+    func testPartialAndFinalTranscriptsReachTheCaller() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.deliverRecognitionForTesting(transcript: "yes")
+        fixture.backend.endUserTurn()
+        fixture.backend.deliverRecognitionForTesting(transcript: "yes please", isFinal: true)
+
+        XCTAssertEqual(log.events, [.transcriptPartial("yes"),
+                                    .transcriptFinal("yes please"),
+                                    .responseCompleted])
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .open)
+        XCTAssertEqual(fixture.recognizer.tasks[0].cancellations, 1,
+                       "recognition resources are released once the turn is settled")
+    }
+
+    func testEmptyTranscriptsAreNotForwarded() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.deliverRecognitionForTesting(transcript: "")
+        fixture.backend.deliverRecognitionForTesting(transcript: nil)
+
+        XCTAssertEqual(log.events, [])
+    }
+
+    func testRecognizerFinalDuringAUserTurnNeverEndsTheTurn() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        // SFSpeechRecognizer's own silence heuristic declaring the utterance over.
+        fixture.backend.deliverRecognitionForTesting(transcript: "maybe", isFinal: true)
+
+        XCTAssertEqual(log.events, [.transcriptFinal("maybe")],
+                       "the transcript is data; the turn boundary is TapQ's alone")
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .userTurn)
+        XCTAssertEqual(fixture.source.stops, 0, "the mic stays open until TapQ commits")
+        XCTAssertEqual(
+            fixture.sink.events.last { $0.name == "transcript.final_during_turn" }?
+                .fields["reason"],
+            "recognizer_vad_ignored")
+    }
+
+    func testCallerClosingFromInsideATranscriptEventIsSafe() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        // The real consumer resolves its window on a matched partial and tears the backend
+        // down from inside the event callback.
+        try await fixture.backend.open { [weak backend = fixture.backend] event in
+            log.append(event)
+            if case .transcriptPartial = event { backend?.close() }
+        }
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.deliverRecognitionForTesting(transcript: "yes")
+
+        XCTAssertEqual(log.events, [.transcriptPartial("yes")])
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+        XCTAssertEqual(fixture.source.stops, 1)
+    }
+
+    func testRecognitionErrorFailsTheSession() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.deliverRecognitionForTesting(error: TestFailure.expected)
+
+        guard case .sessionFailed(.network(let detail)) = log.events.first else {
+            return XCTFail("expected a network failure, got \(log.events)")
+        }
+        XCTAssertTrue(detail.contains("recognition failed"))
+        XCTAssertEqual(fixture.source.stops, 1)
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+    }
+
+    func testStaleRecognitionCallbacksAreIgnored() async throws {
+        let first = FakeAudioSource()
+        let second = FakeAudioSource()
+        let fixture = makeFixture(sources: [first, second])
+        let log = EventLog()
+
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+        let staleGeneration = fixture.backend.sessionGenerationForTesting
+        fixture.backend.close()
+
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.deliverRecognitionForTesting(transcript: "yes",
+                                                     generation: staleGeneration)
+        fixture.backend.deliverRecognitionForTesting(error: TestFailure.expected,
+                                                     generation: staleGeneration)
+
+        XCTAssertEqual(log.events, [],
+                       "a callback from the previous session must not reach this one")
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .userTurn)
+        XCTAssertEqual(second.stops, 0)
+    }
+
+    // MARK: - Route and capture failures
+
+    func testRouteChangeSurfacesSessionFailed() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.source.invalidate()
+
+        guard case .sessionFailed(.network(let detail)) = log.events.first else {
+            return XCTFail("expected a network failure, got \(log.events)")
+        }
+        XCTAssertTrue(detail.contains("configuration_changed"))
+        XCTAssertTrue(detail.contains("test route change"))
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+        XCTAssertEqual(fixture.source.stops, 1)
+    }
+
+    func testStaleRouteCallbackDoesNotFailTheLiveSession() async throws {
+        let first = FakeAudioSource()
+        let second = FakeAudioSource()
+        let fixture = makeFixture(sources: [first, second])
+        let log = EventLog()
+
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+        fixture.backend.close()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        first.invalidate()
+
+        XCTAssertEqual(log.events, [])
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .userTurn)
+    }
+
+    func testMicrophoneStartFailureFailsTheSessionBeforeRecognition() async throws {
+        let fixture = makeFixture()
+        fixture.source.startFailure = VoiceAudioSourceFailure(
+            stage: .engineStart, detail: "input device disappeared")
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+
+        fixture.backend.beginUserTurn()
+
+        guard case .sessionFailed(.network(let detail)) = log.events.first else {
+            return XCTFail("expected a network failure, got \(log.events)")
+        }
+        XCTAssertTrue(detail.contains("engine_start"))
+        XCTAssertTrue(detail.contains("input device disappeared"))
+        XCTAssertEqual(fixture.recognizer.requests.count, 0,
+                       "no recognition task for a window with no microphone")
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+    }
+
+    func testMissingRecognitionTaskFailsTheSession() async throws {
+        let fixture = makeFixture()
+        fixture.recognizer.returnsTask = false
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+
+        fixture.backend.beginUserTurn()
+
+        guard case .sessionFailed(.network(let detail)) = log.events.first else {
+            return XCTFail("expected a network failure, got \(log.events)")
+        }
+        XCTAssertTrue(detail.contains("no task"))
+        XCTAssertEqual(fixture.source.stops, 1)
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+    }
+
+    // MARK: - Responses
+
+    func testRequestResponseReachesTheInjectedSpeechPresenter() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+
+        fixture.backend.requestResponse(text: "Deploying to staging.")
+
+        XCTAssertEqual(fixture.speech.spoken.count, 1)
+        XCTAssertEqual(fixture.speech.spoken[0].text, "Deploying to staging.")
+        XCTAssertEqual(fixture.speech.spoken[0].priority, .notification)
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .responding)
+
+        fixture.speech.finishUtterance()
+        await Task.yield()
+        XCTAssertEqual(log.events, [.responseCompleted])
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .open)
+    }
+
+    func testRequestResponseDuringAUserTurnIsRejectedHalfDuplex() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.beginUserTurn()
+
+        fixture.backend.requestResponse(text: "talking over the wearer")
+
+        XCTAssertEqual(fixture.speech.spoken.count, 0, "nothing is spoken into an open mic")
+        guard case .sessionFailed(.protocolViolation(let detail)) = log.events.first else {
+            return XCTFail("expected a protocol violation, got \(log.events)")
+        }
+        XCTAssertTrue(detail.contains("half-duplex"))
+    }
+
+    func testLateSynthesizerCompletionAfterCloseIsIgnored() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.requestResponse(text: "status")
+
+        fixture.backend.close()
+        fixture.speech.finishUtterance()
+        await Task.yield()
+
+        XCTAssertEqual(log.events, [])
+        XCTAssertEqual(fixture.backend.turnStateForTesting, .idle)
+    }
+
+    func testCancelResponseIsRejectedWhenBargeInIsUnsupported() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await openWindow(fixture, collecting: log)
+        fixture.backend.requestResponse(text: "status")
+
+        fixture.backend.cancelResponse()
+
+        guard case .sessionFailed(.protocolViolation(let detail)) = log.events.first else {
+            return XCTFail("expected a protocol violation, got \(log.events)")
+        }
+        XCTAssertTrue(detail.contains("barge-in"))
+        XCTAssertEqual(fixture.speech.stopAllCount, 0,
+                       "an unsupported cancel must not half-succeed")
+    }
+}

--- a/Tests/TapQAppleAdaptersTests/AppleVoiceBackendTests.swift
+++ b/Tests/TapQAppleAdaptersTests/AppleVoiceBackendTests.swift
@@ -276,7 +276,7 @@ final class AppleVoiceBackendTests: XCTestCase {
         try await openWindow(fixture, collecting: log)
         fixture.backend.beginUserTurn()
 
-        fixture.backend.endUserTurn()
+        fixture.backend.endUserTurn(expectingResponse: true)
 
         XCTAssertEqual(fixture.source.stops, 1, "the mic closes the instant the turn commits")
         XCTAssertEqual(fixture.recognizer.tasks[0].cancellations, 0,
@@ -316,7 +316,7 @@ final class AppleVoiceBackendTests: XCTestCase {
         let log = EventLog()
         try await openWindow(fixture, collecting: log)
 
-        fixture.backend.endUserTurn()
+        fixture.backend.endUserTurn(expectingResponse: true)
 
         guard case .sessionFailed(.protocolViolation) = log.events.first else {
             return XCTFail("expected a protocol violation, got \(log.events)")
@@ -348,7 +348,7 @@ final class AppleVoiceBackendTests: XCTestCase {
         fixture.backend.beginUserTurn()
 
         fixture.backend.deliverRecognitionForTesting(transcript: "yes")
-        fixture.backend.endUserTurn()
+        fixture.backend.endUserTurn(expectingResponse: true)
         fixture.backend.deliverRecognitionForTesting(transcript: "yes please", isFinal: true)
 
         XCTAssertEqual(log.events, [.transcriptPartial("yes"),

--- a/Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift
+++ b/Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift
@@ -1,0 +1,657 @@
+import AVFoundation
+import XCTest
+import TapQContracts
+@testable import TapQAppleAdapters
+
+@MainActor
+final class BackendAudioPlaybackTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    /// Records every scheduler call and replays completions synchronously on demand.
+    @MainActor
+    private final class FakeScheduler: AudioPlaybackScheduling {
+        enum Call: Equatable, CustomStringConvertible {
+            case start(sampleRate: Double, channels: Int)
+            case schedule(frameCount: Int)
+            case stop
+
+            var description: String {
+                switch self {
+                case .start(let rate, let ch): return "start(\(rate), \(ch))"
+                case .schedule(let frames): return "schedule(\(frames))"
+                case .stop: return "stop"
+                }
+            }
+        }
+
+        private(set) var calls: [Call] = []
+        /// Pending completions from `schedule` calls, in FIFO order.
+        private var completions: [@MainActor () -> Void] = []
+
+        var startFailure: AudioPlaybackSchedulerFailure?
+        var scheduleFailure: AudioPlaybackSchedulerFailure?
+        var stopFailure: AudioPlaybackSchedulerFailure?
+
+        func start(sampleRate: Double, channels: Int) -> Result<Void, AudioPlaybackSchedulerFailure> {
+            calls.append(.start(sampleRate: sampleRate, channels: channels))
+            if let failure = startFailure { return .failure(failure) }
+            return .success(())
+        }
+
+        func schedule(_ buffer: AVAudioPCMBuffer, completion: @escaping @MainActor () -> Void) -> Result<Void, AudioPlaybackSchedulerFailure> {
+            calls.append(.schedule(frameCount: Int(buffer.frameLength)))
+            if let failure = scheduleFailure { return .failure(failure) }
+            completions.append(completion)
+            return .success(())
+        }
+
+        func stop() -> Result<Void, AudioPlaybackSchedulerFailure> {
+            calls.append(.stop)
+            completions.removeAll()
+            if let failure = stopFailure { return .failure(failure) }
+            return .success(())
+        }
+
+        /// Fires the next pending completion (FIFO). Returns true if a completion was fired.
+        /// Runs synchronously on the main actor — the completion calls `bufferCompleted`
+        /// directly without a Task hop, so the state machine advances in-line.
+        @discardableResult
+        func fireNextCompletion() -> Bool {
+            guard !completions.isEmpty else { return false }
+            let completion = completions.removeFirst()
+            completion()
+            return true
+        }
+
+        /// Fires all pending completions in order.
+        func fireAllCompletions() {
+            while fireNextCompletion() {}
+        }
+
+        var pendingCompletionCount: Int { completions.count }
+    }
+
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    // MARK: - Fixture
+
+    private struct Fixture {
+        let playback: BackendAudioPlayback
+        let scheduler: FakeScheduler
+        let sink: RecordingSink
+    }
+
+    private func makeFixture() -> Fixture {
+        let scheduler = FakeScheduler()
+        let sink = RecordingSink()
+        let playback = BackendAudioPlayback(scheduler: scheduler, diagnosticSink: sink)
+        return Fixture(playback: playback, scheduler: scheduler, sink: sink)
+    }
+
+    // MARK: - Chunk helpers
+
+    /// Creates a `VoiceAudioChunk` with `sampleCount` PCM16 mono samples at the given rate.
+    private func pcm16Chunk(
+        sampleCount: Int = 120,
+        sampleRate: Double = 24_000,
+        channels: Int = 1,
+        timestamp: TimeInterval = 0
+    ) -> VoiceAudioChunk {
+        let bytesPerSample = 2 * channels
+        var data = Data(count: sampleCount * bytesPerSample)
+        // Fill with a simple ramp so values are nonzero.
+        data.withUnsafeMutableBytes { ptr in
+            guard let base = ptr.baseAddress?.assumingMemoryBound(to: Int16.self) else { return }
+            for i in 0..<(sampleCount * channels) {
+                base[i] = Int16(clamping: i)
+            }
+        }
+        return VoiceAudioChunk(
+            data: data,
+            format: VoiceAudioFormat(sampleRate: sampleRate, channels: channels),
+            timestamp: timestamp
+        )
+    }
+
+    // MARK: - isPlaying rises synchronously on first enqueue
+
+    func testIsPlayingRisesSynchronouslyOnFirstEnqueue() {
+        let f = makeFixture()
+        XCTAssertFalse(f.playback.isPlaying)
+
+        f.playback.enqueue(pcm16Chunk())
+
+        XCTAssertTrue(f.playback.isPlaying,
+                      "isPlaying must be true immediately after the first enqueue")
+    }
+
+    func testOnPlayingChangeFiresOnFirstEnqueue() {
+        let f = makeFixture()
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        f.playback.enqueue(pcm16Chunk())
+
+        XCTAssertEqual(edges, [true])
+    }
+
+    func testSubsequentEnqueueDoesNotFireDuplicateEdge() {
+        let f = makeFixture()
+        f.playback.enqueue(pcm16Chunk())
+
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        f.playback.enqueue(pcm16Chunk())
+
+        XCTAssertEqual(edges, [], "no duplicate rising edge for subsequent enqueues")
+    }
+
+    // MARK: - PCM16 to AVAudioPCMBuffer conversion
+
+    func testPCM16ConversionProducesCorrectFrameCount() {
+        let f = makeFixture()
+        let chunk = pcm16Chunk(sampleCount: 240, sampleRate: 24_000, channels: 1)
+
+        f.playback.enqueue(chunk)
+
+        let scheduled = f.scheduler.calls.compactMap { call -> Int? in
+            if case .schedule(let frames) = call { return frames }
+            return nil
+        }
+        XCTAssertEqual(scheduled, [240])
+    }
+
+    func testPCM16ConversionPreservesValues() {
+        // Create a chunk with known values.
+        let values: [Int16] = [1000, -1000, 32767, -32768]
+        var data = Data(count: values.count * MemoryLayout<Int16>.size)
+        data.withUnsafeMutableBytes { ptr in
+            let base = ptr.baseAddress!.assumingMemoryBound(to: Int16.self)
+            for (i, v) in values.enumerated() {
+                base[i] = v
+            }
+        }
+        let chunk = VoiceAudioChunk(
+            data: data,
+            format: VoiceAudioFormat(sampleRate: 24_000, channels: 1),
+            timestamp: 0
+        )
+
+        // Use a spy scheduler that captures the buffer.
+        let scheduler = BufferCapturingScheduler()
+        let playback = BackendAudioPlayback(scheduler: scheduler)
+        playback.enqueue(chunk)
+
+        guard let buffer = scheduler.lastBuffer else {
+            return XCTFail("expected a scheduled buffer")
+        }
+        XCTAssertEqual(buffer.frameLength, 4)
+        guard let int16Data = buffer.int16ChannelData else {
+            return XCTFail("expected int16 channel data")
+        }
+        XCTAssertEqual(int16Data[0][0], 1000)
+        XCTAssertEqual(int16Data[0][1], -1000)
+        XCTAssertEqual(int16Data[0][2], 32767)
+        XCTAssertEqual(int16Data[0][3], -32768)
+    }
+
+    func testMonoConversionFrameCount() {
+        let f = makeFixture()
+        let chunk = pcm16Chunk(sampleCount: 100, sampleRate: 24_000, channels: 1)
+        f.playback.enqueue(chunk)
+
+        let scheduled = f.scheduler.calls.compactMap { call -> Int? in
+            if case .schedule(let frames) = call { return frames }
+            return nil
+        }
+        XCTAssertEqual(scheduled, [100])
+    }
+
+    // MARK: - Engine lifecycle
+
+    func testEngineStartedLazilyOnFirstEnqueue() {
+        let f = makeFixture()
+        XCTAssertFalse(f.scheduler.calls.contains(where: {
+            if case .start = $0 { return true }; return false
+        }))
+
+        f.playback.enqueue(pcm16Chunk(sampleRate: 24_000, channels: 1))
+
+        let starts = f.scheduler.calls.compactMap { call -> (Double, Int)? in
+            if case .start(let rate, let ch) = call { return (rate, ch) }
+            return nil
+        }
+        XCTAssertEqual(starts.count, 1)
+        XCTAssertEqual(starts[0].0, 24_000)
+        XCTAssertEqual(starts[0].1, 1)
+    }
+
+    func testEngineStoppedAfterDrain() {
+        let f = makeFixture()
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+
+        XCTAssertTrue(f.scheduler.calls.contains(.stop),
+                      "engine stops after all buffers drain")
+        XCTAssertFalse(f.playback.isPlaying)
+    }
+
+    func testEngineNotStoppedBeforeDrain() {
+        let f = makeFixture()
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.finishStream()
+
+        // Completion has not fired yet.
+        XCTAssertFalse(f.scheduler.calls.contains(.stop),
+                       "engine stays running while buffers are outstanding")
+        XCTAssertTrue(f.playback.isPlaying)
+    }
+
+    // MARK: - Drain requires finishStream + all completions
+
+    func testDrainOnlyAfterFinishStreamAndLastCompletion() {
+        let f = makeFixture()
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.enqueue(pcm16Chunk())
+
+        // Only completions, no finishStream yet.
+        f.scheduler.fireAllCompletions()
+        XCTAssertTrue(f.playback.isPlaying, "not drained: finishStream not called")
+
+        f.playback.finishStream()
+        XCTAssertFalse(f.playback.isPlaying, "drained: finishStream + all completions")
+    }
+
+    func testFinishStreamThenCompletionsDrains() {
+        let f = makeFixture()
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.enqueue(pcm16Chunk())
+
+        f.playback.finishStream()
+        XCTAssertTrue(f.playback.isPlaying, "still playing: completions pending")
+
+        f.scheduler.fireNextCompletion()
+        XCTAssertTrue(f.playback.isPlaying, "still playing: one completion pending")
+
+        f.scheduler.fireNextCompletion()
+        XCTAssertFalse(f.playback.isPlaying, "drained after last completion")
+    }
+
+    // MARK: - stopAndFlush
+
+    func testStopAndFlushCancelsOutstandingAndFiresFallingEdge() {
+        let f = makeFixture()
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertEqual(edges, [true])
+
+        f.playback.stopAndFlush()
+
+        XCTAssertFalse(f.playback.isPlaying)
+        XCTAssertEqual(edges, [true, false], "exactly one falling edge")
+        XCTAssertTrue(f.scheduler.calls.contains(.stop))
+    }
+
+    func testStopAndFlushWhenIdleDoesNotFireEdge() {
+        let f = makeFixture()
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        f.playback.stopAndFlush()
+
+        XCTAssertEqual(edges, [], "no edge when already idle")
+        XCTAssertFalse(f.playback.isPlaying)
+    }
+
+    func testStopAndFlushIsIdempotent() {
+        let f = makeFixture()
+        f.playback.enqueue(pcm16Chunk())
+
+        f.playback.stopAndFlush()
+        f.playback.stopAndFlush()
+        f.playback.stopAndFlush()
+
+        // Only one stop call (the second and third see engineRunning == false).
+        let stopCount = f.scheduler.calls.filter { $0 == .stop }.count
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    // MARK: - Generation-counted completions: stale completions after flush are ignored
+
+    func testStaleCompletionsAfterFlushAreIgnored() {
+        let f = makeFixture()
+
+        // Capture the completion by using a different scheduler approach:
+        // The FakeScheduler stores completions; we can fire them after stopAndFlush.
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertEqual(f.scheduler.pendingCompletionCount, 1)
+
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        f.playback.stopAndFlush()
+        XCTAssertEqual(edges, [false])
+
+        // Now "fire" the stale completion. stopAndFlush cleared the completions array
+        // in the fake, but in production the completion would still arrive from the
+        // internal AVAudioEngine thread. Simulate by calling bufferCompleted directly.
+        // Since the FakeScheduler clears completions on stop, we simulate the stale
+        // completion indirectly by enqueuing a fresh response and checking no extra edges.
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertEqual(edges, [false, true], "fresh response starts cleanly")
+    }
+
+    func testStaleCompletionFromPriorResponseDoesNotAffectNewResponse() {
+        let f = makeFixture()
+
+        // First response.
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.stopAndFlush()
+
+        // Second response.
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertEqual(edges, [true])
+
+        // Second response drains normally.
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+        XCTAssertEqual(edges, [true, false])
+    }
+
+    // MARK: - Scheduler failure -> fail-open
+
+    func testEngineStartFailureGoesFailOpen() {
+        let f = makeFixture()
+        f.scheduler.startFailure = AudioPlaybackSchedulerFailure(
+            stage: .playbackEngineStart,
+            detail: "no output device"
+        )
+
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        f.playback.enqueue(pcm16Chunk())
+
+        // isPlaying rose synchronously then fell on failure.
+        XCTAssertFalse(f.playback.isPlaying)
+        XCTAssertEqual(edges, [true, false])
+        XCTAssertTrue(f.sink.names.contains("playback.unavailable"),
+                      "fail-open diagnostic recorded")
+    }
+
+    func testSubsequentEnqueuesDroppedAfterEngineStartFailure() {
+        let f = makeFixture()
+        f.scheduler.startFailure = AudioPlaybackSchedulerFailure(
+            stage: .playbackEngineStart,
+            detail: "no output device"
+        )
+
+        f.playback.enqueue(pcm16Chunk())
+        let callsAfterFirstEnqueue = f.scheduler.calls.count
+
+        // Further enqueues for the same response are silently dropped.
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.enqueue(pcm16Chunk())
+
+        XCTAssertEqual(f.scheduler.calls.count, callsAfterFirstEnqueue,
+                       "subsequent enqueues are dropped in the fail-open state")
+    }
+
+    func testFreshResponseAfterFailureAttemptsNewEngine() {
+        let f = makeFixture()
+        f.scheduler.startFailure = AudioPlaybackSchedulerFailure(
+            stage: .playbackEngineStart,
+            detail: "no output device"
+        )
+
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertFalse(f.playback.isPlaying)
+
+        // Clear the failure.
+        f.scheduler.startFailure = nil
+        // A fresh response (after stopAndFlush resets the fail state).
+        f.playback.stopAndFlush()
+
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertTrue(f.playback.isPlaying, "fresh engine attempt succeeds")
+    }
+
+    func testScheduleFailureGoesFailOpen() {
+        let f = makeFixture()
+
+        // First enqueue succeeds (starts engine), then inject schedule failure.
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertTrue(f.playback.isPlaying)
+
+        f.scheduler.scheduleFailure = AudioPlaybackSchedulerFailure(
+            stage: .playbackSchedule,
+            detail: "node not playing"
+        )
+
+        f.playback.enqueue(pcm16Chunk())
+
+        // Should have entered fail-open.
+        XCTAssertFalse(f.playback.isPlaying)
+        XCTAssertTrue(f.sink.names.contains("playback.unavailable"))
+    }
+
+    // MARK: - Multiple sequential responses
+
+    func testMultipleSequentialResponses() {
+        let f = makeFixture()
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        // Response 1.
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+        XCTAssertEqual(edges, [true, false])
+
+        // Response 2.
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+        XCTAssertEqual(edges, [true, false, true, false])
+    }
+
+    func testEachResponseGetsAFreshEngineStart() {
+        let f = makeFixture()
+
+        // Response 1.
+        f.playback.enqueue(pcm16Chunk(sampleRate: 24_000))
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+
+        // Response 2 (different sample rate).
+        f.playback.enqueue(pcm16Chunk(sampleRate: 16_000))
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+
+        let starts = f.scheduler.calls.compactMap { call -> (Double, Int)? in
+            if case .start(let rate, let ch) = call { return (rate, ch) }
+            return nil
+        }
+        XCTAssertEqual(starts.count, 2)
+        XCTAssertEqual(starts[0].0, 24_000)
+        XCTAssertEqual(starts[1].0, 16_000)
+    }
+
+    // MARK: - stopAndFlush mid-response then new response
+
+    func testStopAndFlushMidResponseThenNewResponse() {
+        let f = makeFixture()
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        // Start first response.
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.enqueue(pcm16Chunk())
+
+        // Barge-in: stop everything.
+        f.playback.stopAndFlush()
+        XCTAssertEqual(edges, [true, false])
+
+        // New response.
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+        XCTAssertEqual(edges, [true, false, true, false])
+    }
+
+    // MARK: - Empty/invalid chunks
+
+    func testEmptyChunkDoesNotCrash() {
+        let f = makeFixture()
+        let emptyChunk = VoiceAudioChunk(
+            data: Data(),
+            format: .pcm16Mono24k,
+            timestamp: 0
+        )
+
+        // Should not crash; isPlaying rises but the buffer conversion returns nil (0 frames),
+        // so nothing is scheduled. The engine start may or may not fire depending on ordering.
+        f.playback.enqueue(emptyChunk)
+
+        // No schedule call for an empty chunk.
+        let scheduled = f.scheduler.calls.filter {
+            if case .schedule = $0 { return true }; return false
+        }
+        XCTAssertEqual(scheduled.count, 0)
+    }
+
+    func testOddByteCountChunkTruncatesToWholeFrames() {
+        let f = makeFixture()
+        // 5 bytes of PCM16 mono = 2 whole frames (4 bytes), 1 byte remainder.
+        let chunk = VoiceAudioChunk(
+            data: Data(repeating: 0, count: 5),
+            format: VoiceAudioFormat(sampleRate: 24_000, channels: 1),
+            timestamp: 0
+        )
+
+        f.playback.enqueue(chunk)
+
+        let scheduled = f.scheduler.calls.compactMap { call -> Int? in
+            if case .schedule(let frames) = call { return frames }
+            return nil
+        }
+        XCTAssertEqual(scheduled, [2], "truncated to 2 whole frames")
+    }
+
+    // MARK: - Diagnostic events
+
+    func testEngineStartRecordsDiagnostic() {
+        let f = makeFixture()
+        f.playback.enqueue(pcm16Chunk())
+
+        XCTAssertTrue(f.sink.names.contains("playback.engine_started"))
+    }
+
+    func testFailOpenRecordsUnavailableDiagnostic() {
+        let f = makeFixture()
+        f.scheduler.startFailure = AudioPlaybackSchedulerFailure(
+            stage: .playbackEngineStart, detail: "test")
+
+        f.playback.enqueue(pcm16Chunk())
+
+        XCTAssertTrue(f.sink.names.contains("playback.unavailable"))
+    }
+
+    // MARK: - Interleaved buffers in order
+
+    func testBuffersScheduledInFIFOOrder() {
+        let f = makeFixture()
+
+        f.playback.enqueue(pcm16Chunk(sampleCount: 100))
+        f.playback.enqueue(pcm16Chunk(sampleCount: 200))
+        f.playback.enqueue(pcm16Chunk(sampleCount: 300))
+
+        let scheduled = f.scheduler.calls.compactMap { call -> Int? in
+            if case .schedule(let frames) = call { return frames }
+            return nil
+        }
+        XCTAssertEqual(scheduled, [100, 200, 300])
+    }
+
+    // MARK: - Full lifecycle integration
+
+    func testFullResponseLifecycle() {
+        let f = makeFixture()
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        // Enqueue 3 chunks.
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertEqual(edges, [true])
+        XCTAssertTrue(f.playback.isPlaying)
+
+        // Signal end of stream.
+        f.playback.finishStream()
+        XCTAssertTrue(f.playback.isPlaying, "still draining")
+
+        // Complete buffers one at a time.
+        f.scheduler.fireNextCompletion()
+        XCTAssertTrue(f.playback.isPlaying)
+        f.scheduler.fireNextCompletion()
+        XCTAssertTrue(f.playback.isPlaying)
+        f.scheduler.fireNextCompletion()
+
+        // Now fully drained.
+        XCTAssertFalse(f.playback.isPlaying)
+        XCTAssertEqual(edges, [true, false])
+    }
+
+    // MARK: - Buffer capturing scheduler (for value-level assertions)
+
+    @MainActor
+    private final class BufferCapturingScheduler: AudioPlaybackScheduling {
+        var lastBuffer: AVAudioPCMBuffer?
+        private var completions: [@MainActor () -> Void] = []
+
+        func start(sampleRate: Double, channels: Int) -> Result<Void, AudioPlaybackSchedulerFailure> {
+            .success(())
+        }
+
+        func schedule(_ buffer: AVAudioPCMBuffer, completion: @escaping @MainActor () -> Void) -> Result<Void, AudioPlaybackSchedulerFailure> {
+            lastBuffer = buffer
+            completions.append(completion)
+            return .success(())
+        }
+
+        func stop() -> Result<Void, AudioPlaybackSchedulerFailure> {
+            completions.removeAll()
+            return .success(())
+        }
+    }
+}

--- a/Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift
+++ b/Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift
@@ -32,6 +32,7 @@ final class BackendAudioPlaybackTests: XCTestCase {
         var startFailure: AudioPlaybackSchedulerFailure?
         var scheduleFailure: AudioPlaybackSchedulerFailure?
         var stopFailure: AudioPlaybackSchedulerFailure?
+        var onConfigurationChange: (@MainActor () -> Void)?
 
         func start(sampleRate: Double, channels: Int) -> Result<Void, AudioPlaybackSchedulerFailure> {
             calls.append(.start(sampleRate: sampleRate, channels: channels))
@@ -632,12 +633,111 @@ final class BackendAudioPlaybackTests: XCTestCase {
         XCTAssertEqual(edges, [true, false])
     }
 
+    // MARK: - Configuration change -> fail-open (defect 4)
+
+    func testConfigurationChangeMidResponseEntersFailOpen() {
+        let f = makeFixture()
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertTrue(f.playback.isPlaying)
+        XCTAssertEqual(edges, [true])
+
+        // Simulate an AVAudioEngineConfigurationChange (e.g. AirPods disconnect).
+        f.scheduler.onConfigurationChange?()
+
+        // Should have entered the fail-open state.
+        XCTAssertFalse(f.playback.isPlaying,
+                       "isPlaying must be false after configuration change")
+        XCTAssertEqual(edges, [true, false])
+        XCTAssertTrue(f.sink.names.contains("playback.configuration_changed"),
+                      "configuration change diagnostic recorded")
+        XCTAssertTrue(f.sink.names.contains("playback.unavailable"),
+                      "fail-open diagnostic recorded")
+    }
+
+    func testConfigurationChangeDropsSubsequentEnqueues() {
+        let f = makeFixture()
+
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertTrue(f.playback.isPlaying)
+        let callsBeforeChange = f.scheduler.calls.count
+
+        // Configuration change.
+        f.scheduler.onConfigurationChange?()
+        XCTAssertFalse(f.playback.isPlaying)
+
+        // Further enqueues for the same response are silently dropped.
+        f.playback.enqueue(pcm16Chunk())
+        f.playback.enqueue(pcm16Chunk())
+
+        XCTAssertEqual(f.scheduler.calls.count, callsBeforeChange + 1,
+                       "only the stop from enterFailedState, no new schedules")
+    }
+
+    func testFreshResponseAfterConfigurationChangeAttemptsNewEngine() {
+        let f = makeFixture()
+
+        f.playback.enqueue(pcm16Chunk())
+        f.scheduler.onConfigurationChange?()
+        XCTAssertFalse(f.playback.isPlaying)
+
+        // Reset for a new response.
+        f.playback.stopAndFlush()
+
+        // A fresh response should attempt a new engine.
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertTrue(f.playback.isPlaying, "fresh engine attempt after config change succeeds")
+    }
+
+    func testStaleConfigurationChangeAfterStopAndFlushIsIgnored() {
+        let f = makeFixture()
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertEqual(edges, [true])
+
+        // Capture the callback before stopAndFlush clears it.
+        let staleCallback = f.scheduler.onConfigurationChange
+
+        f.playback.stopAndFlush()
+        XCTAssertEqual(edges, [true, false])
+
+        // Fire the stale callback. It should be nil (cleared by stopAndFlush).
+        XCTAssertNil(f.scheduler.onConfigurationChange,
+                     "onConfigurationChange cleared by stopAndFlush")
+
+        // Even if someone held a reference and fired it, the generation guard would block it.
+        staleCallback?()
+
+        // No extra edges from the stale callback.
+        XCTAssertEqual(edges, [true, false])
+    }
+
+    func testConfigurationChangeCallbackClearedOnDrain() {
+        let f = makeFixture()
+
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertNotNil(f.scheduler.onConfigurationChange,
+                        "callback set while engine is running")
+
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+
+        // After drain, the engine is stopped and the callback is cleared.
+        XCTAssertNil(f.scheduler.onConfigurationChange,
+                     "callback cleared after drain")
+    }
+
     // MARK: - Buffer capturing scheduler (for value-level assertions)
 
     @MainActor
     private final class BufferCapturingScheduler: AudioPlaybackScheduling {
         var lastBuffer: AVAudioPCMBuffer?
         private var completions: [@MainActor () -> Void] = []
+        var onConfigurationChange: (@MainActor () -> Void)?
 
         func start(sampleRate: Double, channels: Int) -> Result<Void, AudioPlaybackSchedulerFailure> {
             .success(())

--- a/Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift
+++ b/Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift
@@ -446,6 +446,54 @@ final class BackendAudioPlaybackTests: XCTestCase {
         XCTAssertTrue(f.playback.isPlaying, "fresh engine attempt succeeds")
     }
 
+    /// Regression for defect 2: finishStream (not stopAndFlush) must clear the
+    /// per-response failure flag so the next response can attempt a fresh engine.
+    ///
+    /// In the composed flow, VoiceBackendCommandProvider calls finishStream() on
+    /// responseCompleted — it never calls stopAndFlush() between responses inside
+    /// one window. Before the fix, failedForCurrentResponse stayed true after
+    /// finishStream, silencing every subsequent response until the window ended.
+    func testFreshResponseAfterFailureViaFinishStreamAttemptsNewEngine() {
+        let f = makeFixture()
+        f.scheduler.startFailure = AudioPlaybackSchedulerFailure(
+            stage: .playbackEngineStart,
+            detail: "no output device"
+        )
+
+        var edges: [Bool] = []
+        f.playback.onPlayingChange = { edges.append($0) }
+
+        // First response: engine start fails.
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertFalse(f.playback.isPlaying)
+        XCTAssertTrue(f.sink.names.contains("playback.unavailable"),
+                      "fail-open diagnostic for the first response")
+
+        // The provider calls finishStream() on responseCompleted — NOT stopAndFlush.
+        f.playback.finishStream()
+
+        // Clear the injected failure so the next engine start succeeds.
+        f.scheduler.startFailure = nil
+
+        // Second response: must attempt a fresh engine (not silently drop).
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertTrue(f.playback.isPlaying,
+                      "the second response must attempt a fresh engine after finishStream")
+
+        // Verify the scheduler received a second start call.
+        let startCount = f.scheduler.calls.compactMap { call -> Bool? in
+            if case .start = call { return true }
+            return nil
+        }.count
+        XCTAssertEqual(startCount, 2,
+                       "two start calls: one failed, one succeeded")
+
+        // Drain the second response normally.
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+        XCTAssertFalse(f.playback.isPlaying)
+    }
+
     func testScheduleFailureGoesFailOpen() {
         let f = makeFixture()
 

--- a/Tests/TapQAppleAdaptersTests/HeadGestureDetectorTests.swift
+++ b/Tests/TapQAppleAdaptersTests/HeadGestureDetectorTests.swift
@@ -679,4 +679,185 @@ final class HeadGestureDetectorTests: XCTestCase {
         XCTAssertEqual(event?.fields["gesture"], "nod")
         XCTAssertNotNil(event?.fields["p2p_pitch"])
     }
+
+    // MARK: - MotionSampleObserving hook
+
+    @MainActor
+    final class RecordingMotionObserver: MotionSampleObserving {
+        var samples: [HeadMotionSample] = []
+        var interruptedCount = 0
+
+        func ingest(_ sample: HeadMotionSample) {
+            samples.append(sample)
+        }
+        func streamInterrupted() {
+            interruptedCount += 1
+        }
+    }
+
+    func testObserverReceivesSamplesFromInjectedSource() {
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source)
+        let observer = RecordingMotionObserver()
+        detector.setMotionSampleObserver(observer)
+
+        detector.start { (_: HeadGesture) in }
+        let sample1 = HeadMotionSample(
+            timestamp: 1.0, pitch: 0.1, yaw: 0.2, roll: 0,
+            userAcceleration: MotionVector(x: 0.01, y: 0, z: 0),
+            rotationRate: .zero,
+            gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+        let sample2 = HeadMotionSample(
+            timestamp: 1.04, pitch: 0.15, yaw: 0.25, roll: 0,
+            userAcceleration: MotionVector(x: 0.02, y: 0, z: 0),
+            rotationRate: .zero,
+            gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+        source.emit(sample1)
+        source.emit(sample2)
+
+        XCTAssertEqual(observer.samples, [sample1, sample2])
+        detector.stop()
+    }
+
+    func testObserverStreamInterruptedOnStop() {
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source)
+        let observer = RecordingMotionObserver()
+        detector.setMotionSampleObserver(observer)
+
+        detector.start { (_: HeadGesture) in }
+        // start -> resetSession -> streamInterrupted (1)
+        let afterStart = observer.interruptedCount
+        source.emit(pitch: 0.1, yaw: 0.1, at: 1)
+        detector.stop()
+        // stop -> teardown -> streamInterrupted (+1)
+
+        XCTAssertEqual(observer.interruptedCount, afterStart + 1,
+                       "teardown must notify the observer")
+    }
+
+    func testObserverStreamInterruptedOnStopCapture() {
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source)
+        let observer = RecordingMotionObserver()
+        detector.setMotionSampleObserver(observer)
+
+        XCTAssertTrue(detector.startCapture { (_: HeadMotionSample) in })
+        // startCapture -> resetSession -> streamInterrupted (1)
+        let afterStart = observer.interruptedCount
+        source.emit(pitch: 0.1, yaw: 0.1, at: 1)
+        detector.stopCapture()
+        // stopCapture -> teardown -> streamInterrupted (+1)
+
+        XCTAssertEqual(observer.interruptedCount, afterStart + 1,
+                       "teardown must notify the observer")
+    }
+
+    func testObserverStreamInterruptedOnMotionLoss() async {
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source, motionLossGrace: 0.01)
+        let observer = RecordingMotionObserver()
+        detector.setMotionSampleObserver(observer)
+
+        detector.start { (_: HeadGesture) in }
+        source.fail()
+
+        let didInterrupt = await waitUntil { observer.interruptedCount >= 1 }
+        XCTAssertTrue(didInterrupt)
+        XCTAssertEqual(observer.interruptedCount, 1)
+        detector.stop()
+    }
+
+    func testNoObserverZeroBehaviorChange() {
+        // Without an observer, all existing behavior is unchanged
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source)
+        // Do NOT attach any observer
+        var emitted: [HeadGesture] = []
+        detector.start { emitted.append($0) }
+        for t0 in [0.0, 0.8] {
+            for (i, v) in Self.zigzag.enumerated() {
+                source.emit(pitch: v, yaw: Self.flat[i], at: t0 + Double(i) * 0.04)
+            }
+        }
+        XCTAssertEqual(emitted, [.nod], "gesture detection unchanged without observer")
+        detector.stop()
+    }
+
+    func testObserverDoesNotReceiveCaptureModeSamples() {
+        // In capture mode, samples go to onSample, not to ingest(), so the observer
+        // should NOT receive them (capture mode bypasses the detection pipeline).
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source)
+        let observer = RecordingMotionObserver()
+        detector.setMotionSampleObserver(observer)
+
+        var capturedSamples: [HeadMotionSample] = []
+        XCTAssertTrue(detector.startCapture { capturedSamples.append($0) })
+        source.emit(pitch: 0.1, yaw: 0.1, at: 1)
+
+        XCTAssertEqual(capturedSamples.count, 1,
+                       "capture callback receives the sample")
+        XCTAssertEqual(observer.samples.count, 0,
+                       "observer does not receive capture-mode samples")
+        detector.stopCapture()
+    }
+
+    func testObserverWeakReferenceDoesNotRetain() {
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source)
+
+        var observer: RecordingMotionObserver? = RecordingMotionObserver()
+        weak var weakObserver = observer
+        detector.setMotionSampleObserver(observer)
+        observer = nil
+
+        // The observer should have been deallocated since it's held weakly
+        XCTAssertNil(weakObserver, "observer should not be retained by the detector")
+
+        // Should not crash with a nil observer
+        detector.start { (_: HeadGesture) in }
+        source.emit(pitch: 0.1, yaw: 0.1, at: 1)
+        detector.stop()
+    }
+
+    func testDetachObserverBySettingNil() {
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source)
+        let observer = RecordingMotionObserver()
+        detector.setMotionSampleObserver(observer)
+        detector.setMotionSampleObserver(nil)
+
+        detector.start { (_: HeadGesture) in }
+        source.emit(pitch: 0.1, yaw: 0.1, at: 1)
+        detector.stop()
+
+        XCTAssertEqual(observer.samples.count, 0)
+        XCTAssertEqual(observer.interruptedCount, 0)
+    }
+
+    func testObserverStreamInterruptedOnNewSession() {
+        let source = FakeMotionSource()
+        let detector = HeadGestureDetector(source: source)
+        let observer = RecordingMotionObserver()
+        detector.setMotionSampleObserver(observer)
+
+        detector.start { (_: HeadGesture) in }
+        // start -> resetSession -> streamInterrupted (1)
+        source.emit(pitch: 0.1, yaw: 0.1, at: 1)
+        detector.stop()
+        // stop -> teardown -> streamInterrupted (2)
+        let afterFirstStop = observer.interruptedCount
+
+        // Starting a new session resets, which calls streamInterrupted again
+        detector.start { (_: HeadGesture) in }
+        // start -> resetSession -> streamInterrupted (afterFirstStop + 1)
+        XCTAssertEqual(observer.interruptedCount, afterFirstStop + 1,
+                       "resetSession on new start notifies observer")
+        source.emit(pitch: 0.2, yaw: 0.2, at: 2)
+        XCTAssertEqual(observer.samples.count, 2)
+        detector.stop()
+    }
 }

--- a/Tests/TapQAppleAdaptersTests/MicrophoneEnvelopeSourceTests.swift
+++ b/Tests/TapQAppleAdaptersTests/MicrophoneEnvelopeSourceTests.swift
@@ -1,0 +1,379 @@
+import AVFoundation
+import XCTest
+import TapQAudioCaptureBridge
+import TapQAudioCaptureBridgeTestSupport
+import TapQContracts
+@testable import TapQAppleAdapters
+
+/// One tick per nanosecond and a round anchor, so every expected timestamp in the source
+/// tests is readable arithmetic. File scope keeps it reachable from the `@Sendable` anchor
+/// provider the source is built with.
+private let testAnchor = AudioClockAnchor(
+    hostTime: 1_000_000_000,
+    uptime: 500,
+    timebaseNumerator: 1,
+    timebaseDenominator: 1
+)
+
+@MainActor
+final class MicrophoneEnvelopeSourceTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    private final class FakeAudioSource: VoiceAudioSource {
+        var startFailure: (any Error)?
+        private(set) var starts = 0
+        private(set) var stops = 0
+        private var buffers: ((AVAudioPCMBuffer, AVAudioTime) -> Void)?
+        private var invalidation: (@MainActor (VoiceAudioSourceFailure) -> Void)?
+
+        func start(
+            onBuffer: @escaping (AVAudioPCMBuffer, AVAudioTime) -> Void,
+            onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
+        ) throws {
+            starts += 1
+            buffers = onBuffer
+            invalidation = onInvalidation
+            if let startFailure { throw startFailure }
+        }
+
+        func stop() {
+            stops += 1
+        }
+
+        func emit(_ buffer: AVAudioPCMBuffer, hostTime: UInt64) {
+            buffers?(buffer, AVAudioTime(hostTime: hostTime))
+        }
+
+        func invalidate(
+            _ failure: VoiceAudioSourceFailure = .init(
+                stage: .configurationChanged,
+                detail: "audio input route changed"
+            )
+        ) {
+            invalidation?(failure)
+        }
+    }
+
+    // MARK: - Envelope math
+
+    func testEnvelopeOfAConstantToneIsItsAmplitude() throws {
+        let buffer = try pcmBuffer(channels: [[0.5, -0.5, 0.5, -0.5]])
+        let envelope = try XCTUnwrap(MicrophoneEnvelopeSource.envelope(of: buffer))
+        XCTAssertEqual(envelope.rms, 0.5, accuracy: 1e-6)
+        XCTAssertEqual(envelope.peak, 0.5, accuracy: 1e-6)
+    }
+
+    func testEnvelopeSeparatesPeakFromRMS() throws {
+        // A single loud frame in an otherwise quiet block: peak sees it, RMS averages it
+        // away. Keeping both is what lets the study distinguish a tap from speech.
+        let buffer = try pcmBuffer(channels: [[0, 0, 0, 1.0]])
+        let envelope = try XCTUnwrap(MicrophoneEnvelopeSource.envelope(of: buffer))
+        XCTAssertEqual(envelope.rms, 0.5, accuracy: 1e-6)
+        XCTAssertEqual(envelope.peak, 1.0, accuracy: 1e-6)
+    }
+
+    func testEnvelopeOfSilenceIsZero() throws {
+        let buffer = try pcmBuffer(channels: [[0, 0, 0, 0]])
+        let envelope = try XCTUnwrap(MicrophoneEnvelopeSource.envelope(of: buffer))
+        XCTAssertEqual(envelope.rms, 0)
+        XCTAssertEqual(envelope.peak, 0)
+    }
+
+    func testEnvelopeAveragesAcrossChannels() throws {
+        let buffer = try pcmBuffer(channels: [[1, 1], [0, 0]])
+        let envelope = try XCTUnwrap(MicrophoneEnvelopeSource.envelope(of: buffer))
+        // Mean square is (1 + 1 + 0 + 0) / 4.
+        XCTAssertEqual(envelope.rms, (0.5 as Double).squareRoot(), accuracy: 1e-6)
+        XCTAssertEqual(envelope.peak, 1.0, accuracy: 1e-6)
+    }
+
+    func testEmptyBlockHasNoEnvelope() throws {
+        let format = try XCTUnwrap(
+            AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1))
+        let buffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 16))
+        buffer.frameLength = 0
+        XCTAssertNil(MicrophoneEnvelopeSource.envelope(of: buffer))
+    }
+
+    func testIntegerBlockHasNoEnvelope() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4))
+        buffer.frameLength = 4
+        XCTAssertNil(
+            MicrophoneEnvelopeSource.envelope(of: buffer),
+            "a format the tap cannot reduce is dropped rather than guessed at"
+        )
+    }
+
+    // MARK: - Clock alignment
+
+    func testAnchorConvertsHostTimeToTheMotionClock() {
+        // Apple silicon's timebase: 125 nanoseconds per 3 ticks.
+        let anchor = AudioClockAnchor(
+            hostTime: 1_000_000,
+            uptime: 1_234.5,
+            timebaseNumerator: 125,
+            timebaseDenominator: 3
+        )
+
+        XCTAssertEqual(anchor.uptime(forHostTime: 1_000_000), 1_234.5, accuracy: 1e-9)
+        // +24_000 ticks = 1_000_000 ns = 1 ms.
+        XCTAssertEqual(anchor.uptime(forHostTime: 1_024_000), 1_234.501, accuracy: 1e-9)
+        XCTAssertEqual(
+            anchor.uptime(forHostTime: 976_000), 1_234.499, accuracy: 1e-9,
+            "a block stamped before the anchor read converts to a time before it"
+        )
+    }
+
+    func testAnchorSurvivesADegenerateTimebase() {
+        let anchor = AudioClockAnchor(
+            hostTime: 0, uptime: 10, timebaseNumerator: 1, timebaseDenominator: 0)
+        XCTAssertEqual(anchor.timebaseDenominator, 1)
+        XCTAssertEqual(anchor.uptime(forHostTime: 1_000_000_000), 11, accuracy: 1e-9)
+    }
+
+    func testCurrentAnchorReadsAUsableTimebase() {
+        let anchor = AudioClockAnchor.current()
+        XCTAssertGreaterThan(anchor.hostTime, 0)
+        XCTAssertGreaterThan(anchor.uptime, 0)
+        XCTAssertGreaterThan(anchor.timebaseNumerator, 0)
+        XCTAssertGreaterThan(anchor.timebaseDenominator, 0)
+    }
+
+    // MARK: - Source lifecycle
+
+    func testTrackIsReportedOnceBeforeBlocksOnTheMotionClock() async throws {
+        let audio = FakeAudioSource()
+        let source = MicrophoneEnvelopeSource(
+            makeAudioSource: { audio },
+            anchorProvider: { testAnchor }
+        )
+        var tracks: [MicrophoneEnvelopeTrack] = []
+        var blocks: [MicrophoneEnvelopeBlock] = []
+        let received = expectation(description: "two blocks")
+        received.expectedFulfillmentCount = 2
+
+        try source.start(
+            onTrack: { tracks.append($0) },
+            onBlock: {
+                XCTAssertEqual(tracks.count, 1, "the track is known before any block")
+                blocks.append($0)
+                received.fulfill()
+            },
+            onInvalidation: { XCTFail("unexpected invalidation: \($0)") }
+        )
+        audio.emit(
+            try pcmBuffer(channels: [[0.5, -0.5, 0.5, -0.5]]),
+            hostTime: 1_000_000_000
+        )
+        audio.emit(
+            try pcmBuffer(channels: [[0, 0, 0, 1.0]]),
+            hostTime: 1_500_000_000
+        )
+        await fulfillment(of: [received], timeout: 2)
+
+        XCTAssertEqual(tracks, [MicrophoneEnvelopeTrack(sampleRate: 48_000, blockFrames: 4)])
+        XCTAssertEqual(blocks.count, 2)
+        XCTAssertEqual(blocks[0].timestamp, 500, accuracy: 1e-9)
+        XCTAssertEqual(blocks[0].rms, 0.5, accuracy: 1e-6)
+        XCTAssertEqual(
+            blocks[1].timestamp, 500.5, accuracy: 1e-9,
+            "half a second of host ticks is half a second on the motion clock"
+        )
+        XCTAssertEqual(blocks[1].peak, 1.0, accuracy: 1e-6)
+    }
+
+    func testStopIsIdempotentAndDropsBlocksQueuedBehindIt() async throws {
+        let audio = FakeAudioSource()
+        let source = MicrophoneEnvelopeSource(
+            makeAudioSource: { audio },
+            anchorProvider: { testAnchor }
+        )
+        var blocks: [MicrophoneEnvelopeBlock] = []
+        let first = expectation(description: "first block")
+
+        try source.start(
+            onTrack: { _ in },
+            onBlock: { blocks.append($0); first.fulfill() },
+            onInvalidation: { XCTFail("unexpected invalidation: \($0)") }
+        )
+        audio.emit(try pcmBuffer(channels: [[0.5, 0.5]]), hostTime: 1_000_000_000)
+        await fulfillment(of: [first], timeout: 2)
+
+        source.stop()
+        source.stop()
+        XCTAssertEqual(audio.stops, 1)
+        XCTAssertFalse(source.isRunning)
+
+        audio.emit(try pcmBuffer(channels: [[0.9, 0.9]]), hostTime: 1_100_000_000)
+        for _ in 0..<8 { await Task.yield() }
+        XCTAssertEqual(blocks.count, 1, "a block delivered after teardown is dropped")
+    }
+
+    func testStartFailureThrowsATypedFailureAndLeavesNothingOpen() {
+        let audio = FakeAudioSource()
+        audio.startFailure = VoiceAudioSourceFailure(
+            stage: .engineStart, detail: "input device disappeared")
+        let source = MicrophoneEnvelopeSource(
+            makeAudioSource: { audio },
+            anchorProvider: { testAnchor }
+        )
+
+        XCTAssertThrowsError(
+            try source.start(
+                onTrack: { _ in XCTFail("a failed start has no track") },
+                onBlock: { _ in XCTFail("a failed start has no blocks") },
+                onInvalidation: { _ in }
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? MicrophoneEnvelopeFailure,
+                MicrophoneEnvelopeFailure(
+                    stage: .engineStart, detail: "input device disappeared")
+            )
+        }
+        XCTAssertFalse(source.isRunning)
+        XCTAssertEqual(audio.stops, 1)
+    }
+
+    func testSecondStartWhileOpenIsRejectedWithoutDisturbingTheFirst() throws {
+        let audio = FakeAudioSource()
+        let source = MicrophoneEnvelopeSource(
+            makeAudioSource: { audio },
+            anchorProvider: { testAnchor }
+        )
+
+        try source.start(onTrack: { _ in }, onBlock: { _ in }, onInvalidation: { _ in })
+        XCTAssertThrowsError(
+            try source.start(onTrack: { _ in }, onBlock: { _ in }, onInvalidation: { _ in })
+        ) { error in
+            XCTAssertEqual(
+                (error as? MicrophoneEnvelopeFailure)?.stage, .alreadyRunning)
+        }
+        XCTAssertTrue(source.isRunning)
+        XCTAssertEqual(audio.starts, 1)
+        XCTAssertEqual(audio.stops, 0)
+    }
+
+    func testRouteChangeSurfacesATypedFailureAndTearsDownOnce() throws {
+        let audio = FakeAudioSource()
+        let sink = RecordingSink()
+        let source = MicrophoneEnvelopeSource(
+            makeAudioSource: { audio },
+            anchorProvider: { testAnchor },
+            diagnosticSink: sink
+        )
+        var failures: [MicrophoneEnvelopeFailure] = []
+
+        try source.start(
+            onTrack: { _ in },
+            onBlock: { _ in },
+            onInvalidation: { failures.append($0) }
+        )
+        audio.invalidate()
+        audio.invalidate()
+
+        XCTAssertEqual(failures, [MicrophoneEnvelopeFailure(
+            stage: .configurationChanged, detail: "audio input route changed")])
+        XCTAssertFalse(source.isRunning)
+        XCTAssertEqual(audio.stops, 1)
+        let event = sink.events.last { $0.name == "capture.invalidated" }
+        XCTAssertEqual(event?.level, .warning)
+        XCTAssertEqual(event?.fields["stage"], "configuration_changed")
+    }
+
+    func testFreshWindowAfterARouteChangeIgnoresTheOldSource() async throws {
+        let first = FakeAudioSource()
+        let second = FakeAudioSource()
+        let sources = [first, second]
+        var factoryCalls = 0
+        let source = MicrophoneEnvelopeSource(
+            makeAudioSource: {
+                defer { factoryCalls += 1 }
+                return sources[factoryCalls]
+            },
+            anchorProvider: { testAnchor }
+        )
+
+        try source.start(onTrack: { _ in }, onBlock: { _ in }, onInvalidation: { _ in })
+        first.invalidate()
+
+        var blocks: [MicrophoneEnvelopeBlock] = []
+        let delivered = expectation(description: "block from the second window")
+        try source.start(
+            onTrack: { _ in },
+            onBlock: { blocks.append($0); delivered.fulfill() },
+            onInvalidation: { XCTFail("unexpected invalidation: \($0)") }
+        )
+        first.emit(try pcmBuffer(channels: [[0.9, 0.9]]), hostTime: 1_000_000_000)
+        second.emit(try pcmBuffer(channels: [[0.25, -0.25]]), hostTime: 1_000_000_000)
+        await fulfillment(of: [delivered], timeout: 2)
+        for _ in 0..<8 { await Task.yield() }
+
+        XCTAssertEqual(factoryCalls, 2)
+        XCTAssertEqual(blocks.count, 1, "the discarded source's blocks never arrive")
+        XCTAssertEqual(blocks[0].rms, 0.25, accuracy: 1e-6)
+    }
+
+    // MARK: - Teardown reporting
+
+    func testEngineTeardownFailureReachesItsOwner() {
+        let engine = TapQThrowingAudioCaptureEngine()
+        let audio = AVAudioEngineVoiceAudioSource(capture: engine)
+        var failures: [VoiceAudioSourceFailure] = []
+        audio.onTeardownFailure = { failures.append($0) }
+
+        audio.stop()
+
+        XCTAssertEqual(failures.count, 1, "a failed engine stop is reported, not discarded")
+        XCTAssertEqual(failures.first?.stage, .audioTeardown)
+        XCTAssertTrue(failures.first?.detail.contains("engine-running") == true)
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a float PCM buffer from per-channel frames. Needs no audio hardware.
+    private func pcmBuffer(
+        channels: [[Float]],
+        sampleRate: Double = 48_000
+    ) throws -> AVAudioPCMBuffer {
+        let frames = try XCTUnwrap(channels.first?.count)
+        let format = try XCTUnwrap(AVAudioFormat(
+            standardFormatWithSampleRate: sampleRate,
+            channels: AVAudioChannelCount(channels.count)
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format, frameCapacity: AVAudioFrameCount(frames)))
+        buffer.frameLength = AVAudioFrameCount(frames)
+        let data = try XCTUnwrap(buffer.floatChannelData)
+        for (index, samples) in channels.enumerated() {
+            XCTAssertEqual(samples.count, frames, "channels must be the same length")
+            for (frame, value) in samples.enumerated() {
+                data[index][frame * buffer.stride] = value
+            }
+        }
+        return buffer
+    }
+}

--- a/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
+++ b/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
@@ -120,8 +120,12 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
             isTurnActive = false
         }
 
+        /// Full audio chunks for value-level assertions (monotonicity test).
+        private(set) var sentAudioChunks: [VoiceAudioChunk] = []
+
         func sendAudio(_ chunk: VoiceAudioChunk) {
             calls.append(.sendAudio(chunk.data.count))
+            sentAudioChunks.append(chunk)
         }
 
         func requestResponse(text: String) {
@@ -253,8 +257,13 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
         try await fixture.pump.open { log.append($0) }
         fixture.pump.beginUserTurn()
 
-        fixture.audioSource.emit(try monoFloatBuffer(values: [0.5, -0.5, 0.5, -0.5]))
-        fixture.audioSource.emit(try monoFloatBuffer(values: [0.25, -0.25, 0.25, -0.25]))
+        // Use realistic buffer sizes (480 frames = 10 ms at 48 kHz). Tiny buffers
+        // (< ~8 frames) may produce zero output after a 2:1 downsample because
+        // the SRC filter's priming delay consumes all the input.
+        fixture.audioSource.emit(try monoFloatBuffer(
+            values: [Float](repeating: 0.5, count: 480)))
+        fixture.audioSource.emit(try monoFloatBuffer(
+            values: [Float](repeating: 0.25, count: 480)))
 
         // Yield enough to let the AsyncStream consumer process both blocks.
         for _ in 0..<30 { await Task.yield() }
@@ -280,9 +289,11 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
         fixture.pump.beginUserTurn()
 
         // Emit a 48 kHz stereo float buffer (the common hardware format).
+        // Use a realistic frame count; tiny buffers may produce zero output
+        // after the SRC filter's priming delay.
         fixture.audioSource.emit(try stereoFloatBuffer(
-            left: [0.5, -0.5, 0.5, -0.5],
-            right: [0.25, -0.25, 0.25, -0.25],
+            left: [Float](repeating: 0.5, count: 480),
+            right: [Float](repeating: 0.25, count: 480),
             sampleRate: 48_000
         ))
 
@@ -293,8 +304,8 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
             if case .sendAudio(let bytes) = call { return bytes }
             return nil
         }
-        // With 4 frames at 48 kHz -> ~2 frames at 24 kHz, so we expect some PCM16 data
-        // (2 bytes per sample * channels * frames)
+        // With 480 frames at 48 kHz -> ~240 frames at 24 kHz, so we expect
+        // PCM16 mono data (2 bytes per sample).
         XCTAssertGreaterThan(audioSends.reduce(0, +), 0,
                              "audio must be converted and delivered")
     }
@@ -509,7 +520,10 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
             received.fulfill()
         }
 
-        fixture.audioSource.emit(try monoFloatBuffer(values: [0.5, -0.5, 0.5, -0.5]))
+        // Use a realistic buffer size; tiny buffers may produce zero converter
+        // output (SRC priming), which means the RMS value is never delivered.
+        fixture.audioSource.emit(try monoFloatBuffer(
+            values: [Float](repeating: 0.5, count: 480)))
         await fulfillment(of: [received], timeout: 2)
 
         XCTAssertEqual(levels.count, 1)
@@ -662,6 +676,63 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
                        "the microphone must not open when the inner session died during beginUserTurn")
         XCTAssertFalse(pump.isTurnActiveForTesting,
                        "turnActive must be false after inner session failure")
+    }
+
+    // MARK: - Monotonicity regression (defect 1 — SRC priming duplicate)
+
+    /// Feeds several consecutive monotonic-ramp float buffers through the pump,
+    /// concatenates the int16 payloads received by the inner fake, and asserts the
+    /// decoded samples are monotonically nondecreasing after the converter's ramp-in.
+    ///
+    /// Before the fix, AVAudioConverter's SRC priming pulled the input block twice
+    /// on the first convert() after converter creation, duplicating the first tap
+    /// buffer into the output stream. The monotonic ramp becomes
+    /// [0,1,2,...,N, 0,1,2,...] — a clear violation that this test catches.
+    func testConvertedSamplesAreMonotonicallyNondecreasingAfterRampIn() async throws {
+        let fixture = makeFixture(format: .pcm16Mono24k)
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        // Build 5 consecutive ramp buffers at 48 kHz mono float, 480 frames each.
+        // Global ramp: buffer 0 = [0.0, 0.0001, 0.0002, ...], buffer 1 continues.
+        let framesPerBuffer = 480
+        let bufferCount = 5
+        for bufferIndex in 0..<bufferCount {
+            let offset = bufferIndex * framesPerBuffer
+            var values = [Float](repeating: 0, count: framesPerBuffer)
+            for i in 0..<framesPerBuffer {
+                values[i] = Float(offset + i) * 0.0001
+            }
+            let buffer = try monoFloatBuffer(values: values, sampleRate: 48_000)
+            fixture.audioSource.emit(buffer)
+        }
+
+        // Yield enough to let the AsyncStream consumer process all blocks.
+        for _ in 0..<60 { await Task.yield() }
+
+        // Concatenate all int16 payloads from the inner backend.
+        let allData = fixture.inner.sentAudioChunks.reduce(Data()) { $0 + $1.data }
+        let sampleCount = allData.count / MemoryLayout<Int16>.size
+        XCTAssertGreaterThan(sampleCount, 0, "some converted audio must arrive")
+
+        let samples: [Int16] = allData.withUnsafeBytes { raw in
+            let ptr = raw.bindMemory(to: Int16.self)
+            return Array(ptr)
+        }
+
+        // Skip the first few samples (converter ramp-in transient from the
+        // resampler's filter delay). 10 samples is generous.
+        let skipCount = min(10, samples.count)
+        var violations = 0
+        for i in (skipCount + 1)..<samples.count {
+            if samples[i] < samples[i - 1] {
+                violations += 1
+            }
+        }
+        XCTAssertEqual(violations, 0,
+                       "samples must be monotonically nondecreasing after ramp-in; " +
+                       "found \(violations) violations in \(samples.count) samples")
     }
 
     // MARK: - Helpers

--- a/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
+++ b/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
@@ -115,9 +115,11 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
             isTurnActive = true
         }
 
-        func endUserTurn() {
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool {
             calls.append(.endUserTurn)
             isTurnActive = false
+            return false
         }
 
         /// Full audio chunks for value-level assertions (monotonicity test).
@@ -318,7 +320,7 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
         try await fixture.pump.open { log.append($0) }
         fixture.pump.beginUserTurn()
 
-        fixture.pump.endUserTurn()
+        fixture.pump.endUserTurn(expectingResponse: true)
 
         XCTAssertEqual(fixture.audioSource.stops, 1,
                        "the mic closes before the inner commit")
@@ -383,7 +385,7 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
         let log = EventLog()
         try await fixture.pump.open { log.append($0) }
         fixture.pump.beginUserTurn()
-        fixture.pump.endUserTurn()
+        fixture.pump.endUserTurn(expectingResponse: true)
 
         // Audio arriving after the turn ended should not reach the inner.
         let sendsBefore = fixture.inner.calls.filter {
@@ -408,7 +410,7 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
         try await fixture.pump.open { log.append($0) }
         fixture.pump.beginUserTurn()
 
-        fixture.pump.endUserTurn()
+        fixture.pump.endUserTurn(expectingResponse: true)
         fixture.pump.close()
         fixture.pump.close()
 
@@ -600,7 +602,7 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
 
         // First turn.
         fixture.pump.beginUserTurn()
-        fixture.pump.endUserTurn()
+        fixture.pump.endUserTurn(expectingResponse: true)
 
         // Second turn.
         fixture.pump.beginUserTurn()
@@ -642,7 +644,8 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
             callback?(.sessionFailed(.protocolViolation("A response is already in flight.")))
         }
 
-        func endUserTurn() { calls.append("endUserTurn") }
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool { calls.append("endUserTurn"); return false }
         func sendAudio(_ chunk: VoiceAudioChunk) { calls.append("sendAudio") }
         func requestResponse(text: String) { calls.append("requestResponse") }
         func cancelResponse() { calls.append("cancelResponse") }

--- a/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
+++ b/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
@@ -596,6 +596,74 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
         XCTAssertEqual(first.stops, 1)
     }
 
+    // MARK: - Inner session failure during beginUserTurn (defect 2)
+
+    /// An inner backend that synchronously emits `sessionFailed` from `beginUserTurn`,
+    /// simulating a state-machine violation in `OpenAIRealtimeVoiceBackend` (e.g.
+    /// `responseAlreadyInFlight` -> `violated()` -> `failSession`).
+    @MainActor
+    private final class FailingOnBeginBackend: VoiceBackend {
+        let capabilities: VoiceBackendCapabilities = VoiceBackendCapabilities(
+            supportsBargeIn: true, producesAudio: true, duplex: true)
+
+        private var handler: (@MainActor (VoiceBackendEvent) -> Void)?
+        private(set) var calls: [String] = []
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            calls.append("open")
+            handler = onEvent
+        }
+
+        func close() {
+            calls.append("close")
+            handler = nil
+        }
+
+        func beginUserTurn() {
+            calls.append("beginUserTurn")
+            // Synchronously fail the session, exactly as the OpenAI adapter does when
+            // VoiceTurnStateMachine.beginUserTurn throws from .responding.
+            let callback = handler
+            handler = nil
+            callback?(.sessionFailed(.protocolViolation("A response is already in flight.")))
+        }
+
+        func endUserTurn() { calls.append("endUserTurn") }
+        func sendAudio(_ chunk: VoiceAudioChunk) { calls.append("sendAudio") }
+        func requestResponse(text: String) { calls.append("requestResponse") }
+        func cancelResponse() { calls.append("cancelResponse") }
+    }
+
+    func testBeginUserTurnInnerFailureDoesNotOpenMicrophone() async throws {
+        let inner = FailingOnBeginBackend()
+        let audioSource = FakeAudioSource()
+        let sink = RecordingSink()
+        let pump = MicrophonePumpVoiceBackend(
+            inner: inner,
+            format: .pcm16Mono24k,
+            makeAudioSource: { audioSource },
+            diagnosticSink: sink
+        )
+
+        let log = EventLog()
+        try await pump.open { log.append($0) }
+
+        // beginUserTurn will cause the inner to synchronously emit sessionFailed.
+        pump.beginUserTurn()
+
+        // The session failed event should have been relayed.
+        XCTAssertEqual(log.events.count, 1)
+        guard case .sessionFailed = log.events.first else {
+            return XCTFail("expected sessionFailed, got \(log.events)")
+        }
+
+        // The critical assertion: the audio source must never have been started.
+        XCTAssertEqual(audioSource.starts, 0,
+                       "the microphone must not open when the inner session died during beginUserTurn")
+        XCTAssertFalse(pump.isTurnActiveForTesting,
+                       "turnActive must be false after inner session failure")
+    }
+
     // MARK: - Helpers
 
     private func monoFloatBuffer(

--- a/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
+++ b/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
@@ -1,0 +1,645 @@
+import AVFoundation
+import XCTest
+import TapQContracts
+@testable import TapQAppleAdapters
+
+@MainActor
+final class MicrophonePumpVoiceBackendTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    /// A `VoiceAudioSource` that captures and replays buffers without hardware.
+    private final class FakeAudioSource: VoiceAudioSource {
+        var startFailure: (any Error)?
+        private(set) var starts = 0
+        private(set) var stops = 0
+        private var bufferHandler: ((AVAudioPCMBuffer, AVAudioTime) -> Void)?
+        private var invalidationHandler: (@MainActor (VoiceAudioSourceFailure) -> Void)?
+
+        func start(
+            onBuffer: @escaping (AVAudioPCMBuffer, AVAudioTime) -> Void,
+            onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
+        ) throws {
+            starts += 1
+            bufferHandler = onBuffer
+            invalidationHandler = onInvalidation
+            if let startFailure { throw startFailure }
+        }
+
+        func stop() {
+            stops += 1
+            bufferHandler = nil
+            invalidationHandler = nil
+        }
+
+        func emit(_ buffer: AVAudioPCMBuffer, hostTime: UInt64 = 1_000_000_000) {
+            bufferHandler?(buffer, AVAudioTime(hostTime: hostTime))
+        }
+
+        func invalidate(
+            _ failure: VoiceAudioSourceFailure = .init(
+                stage: .configurationChanged,
+                detail: "audio input route changed"
+            )
+        ) {
+            invalidationHandler?(failure)
+        }
+    }
+
+    /// A `VoiceBackend` that records its call sequence and replays scripted events, local
+    /// to this test file so it does not depend on `TapQVoiceBackendsTests`.
+    @MainActor
+    private final class FakeInnerBackend: VoiceBackend {
+        enum Call: Equatable {
+            case open
+            case close
+            case beginUserTurn
+            case endUserTurn
+            case sendAudio(Int)
+            case requestResponse(String)
+            case cancelResponse
+        }
+
+        let capabilities: VoiceBackendCapabilities
+        private(set) var calls: [Call] = []
+        private(set) var isOpen = false
+        var isTurnActive = false
+        var openFailure: VoiceBackendFailure?
+        private var handler: (@MainActor (VoiceBackendEvent) -> Void)?
+
+        init(capabilities: VoiceBackendCapabilities = VoiceBackendCapabilities(
+            supportsBargeIn: true, producesAudio: true, duplex: true
+        )) {
+            self.capabilities = capabilities
+        }
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            calls.append(.open)
+            if let openFailure { throw openFailure }
+            isOpen = true
+            handler = onEvent
+        }
+
+        func close() {
+            calls.append(.close)
+            isOpen = false
+            isTurnActive = false
+            handler = nil
+        }
+
+        func beginUserTurn() {
+            calls.append(.beginUserTurn)
+            isTurnActive = true
+        }
+
+        func endUserTurn() {
+            calls.append(.endUserTurn)
+            isTurnActive = false
+        }
+
+        func sendAudio(_ chunk: VoiceAudioChunk) {
+            calls.append(.sendAudio(chunk.data.count))
+        }
+
+        func requestResponse(text: String) {
+            calls.append(.requestResponse(text))
+        }
+
+        func cancelResponse() {
+            calls.append(.cancelResponse)
+        }
+
+        func emit(_ event: VoiceBackendEvent) {
+            handler?(event)
+        }
+    }
+
+    /// Reference box so events collected inside a closure survive teardown.
+    @MainActor
+    private final class EventLog {
+        private(set) var events: [VoiceBackendEvent] = []
+        func append(_ event: VoiceBackendEvent) { events.append(event) }
+    }
+
+    private struct Fixture {
+        let pump: MicrophonePumpVoiceBackend
+        let inner: FakeInnerBackend
+        let audioSource: FakeAudioSource
+        let sink: RecordingSink
+    }
+
+    private func makeFixture(
+        format: VoiceAudioFormat = .pcm16Mono24k,
+        sources: [FakeAudioSource]? = nil,
+        innerCapabilities: VoiceBackendCapabilities = VoiceBackendCapabilities(
+            supportsBargeIn: true, producesAudio: true, duplex: true
+        )
+    ) -> Fixture {
+        let inner = FakeInnerBackend(capabilities: innerCapabilities)
+        let source = sources?.first ?? FakeAudioSource()
+        let all = sources ?? [source]
+        var index = 0
+        let sink = RecordingSink()
+        let pump = MicrophonePumpVoiceBackend(
+            inner: inner,
+            format: format,
+            makeAudioSource: {
+                defer { index += 1 }
+                return all[min(index, all.count - 1)]
+            },
+            diagnosticSink: sink
+        )
+        return Fixture(pump: pump, inner: inner, audioSource: source, sink: sink)
+    }
+
+    // MARK: - Capabilities
+
+    func testCapabilitiesForwardFromInner() {
+        let fixture = makeFixture()
+        XCTAssertTrue(fixture.pump.capabilities.supportsBargeIn)
+        XCTAssertTrue(fixture.pump.capabilities.producesAudio)
+        XCTAssertTrue(fixture.pump.capabilities.duplex)
+    }
+
+    func testCapabilitiesReflectTranscriptOnlyInner() {
+        let fixture = makeFixture(innerCapabilities: .transcriptOnly)
+        XCTAssertEqual(fixture.pump.capabilities, .transcriptOnly)
+    }
+
+    // MARK: - Session lifecycle
+
+    func testOpenForwardsToInner() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+
+        XCTAssertEqual(fixture.inner.calls, [.open])
+        XCTAssertEqual(fixture.audioSource.starts, 0,
+                       "the mic opens per turn, never for the length of a session")
+    }
+
+    func testCloseForwardsToInnerAndStopsMicrophone() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+        fixture.pump.close()
+
+        XCTAssertEqual(fixture.audioSource.stops, 1)
+        XCTAssertTrue(fixture.inner.calls.contains(.close))
+    }
+
+    func testCloseWithoutMicOpenIsIdempotent() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.close()
+
+        XCTAssertEqual(fixture.audioSource.stops, 0,
+                       "no mic was open, nothing to stop")
+        XCTAssertTrue(fixture.inner.calls.contains(.close))
+    }
+
+    // MARK: - Mic opens only inside a user turn
+
+    func testMicOpensOnBeginUserTurn() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+
+        fixture.pump.beginUserTurn()
+
+        XCTAssertEqual(fixture.audioSource.starts, 1)
+        XCTAssertTrue(fixture.inner.calls.contains(.beginUserTurn))
+    }
+
+    func testMicNeverOpensOnOpen() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+
+        XCTAssertEqual(fixture.audioSource.starts, 0,
+                       "the never-always-on invariant: mic opens per turn only")
+    }
+
+    // MARK: - Audio delivery
+
+    func testBuffersReachInnerSendAudioInOrder() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.audioSource.emit(try monoFloatBuffer(values: [0.5, -0.5, 0.5, -0.5]))
+        fixture.audioSource.emit(try monoFloatBuffer(values: [0.25, -0.25, 0.25, -0.25]))
+
+        // Yield enough to let the AsyncStream consumer process both blocks.
+        for _ in 0..<30 { await Task.yield() }
+
+        let audioSends = fixture.inner.calls.compactMap { call -> Int? in
+            if case .sendAudio(let bytes) = call { return bytes }
+            return nil
+        }
+        XCTAssertGreaterThanOrEqual(audioSends.count, 1,
+                                    "converted audio must reach the inner backend")
+        // Verify the sends are in order (first block's byte count <= second).
+        if audioSends.count >= 2 {
+            XCTAssertGreaterThan(audioSends[0], 0)
+            XCTAssertGreaterThan(audioSends[1], 0)
+        }
+    }
+
+    func testConvertedAudioIsInTheDeclaredWireFormat() async throws {
+        // Use a spy inner that records the format of received chunks.
+        let fixture = makeFixture(format: .pcm16Mono24k)
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        // Emit a 48 kHz stereo float buffer (the common hardware format).
+        fixture.audioSource.emit(try stereoFloatBuffer(
+            left: [0.5, -0.5, 0.5, -0.5],
+            right: [0.25, -0.25, 0.25, -0.25],
+            sampleRate: 48_000
+        ))
+
+        for _ in 0..<20 { await Task.yield() }
+
+        // The inner.sendAudio call should have received PCM16 mono 24k data.
+        let audioSends = fixture.inner.calls.compactMap { call -> Int? in
+            if case .sendAudio(let bytes) = call { return bytes }
+            return nil
+        }
+        // With 4 frames at 48 kHz -> ~2 frames at 24 kHz, so we expect some PCM16 data
+        // (2 bytes per sample * channels * frames)
+        XCTAssertGreaterThan(audioSends.reduce(0, +), 0,
+                             "audio must be converted and delivered")
+    }
+
+    // MARK: - endUserTurn stops mic before forwarding
+
+    func testEndUserTurnStopsMicBeforeForwardingToInner() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.pump.endUserTurn()
+
+        XCTAssertEqual(fixture.audioSource.stops, 1,
+                       "the mic closes before the inner commit")
+        // The inner should see beginUserTurn then endUserTurn.
+        let turnCalls = fixture.inner.calls.filter {
+            $0 == .beginUserTurn || $0 == .endUserTurn
+        }
+        XCTAssertEqual(turnCalls, [.beginUserTurn, .endUserTurn])
+    }
+
+    func testMicStopsOnClose() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+        fixture.pump.close()
+
+        XCTAssertEqual(fixture.audioSource.stops, 1)
+    }
+
+    // MARK: - Route change mid-turn
+
+    func testRouteChangeMidTurnSurfacesSessionFailed() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.audioSource.invalidate()
+
+        // The pump should close the inner and emit sessionFailed.
+        XCTAssertEqual(log.events.count, 1)
+        guard case .sessionFailed(.network(let detail)) = log.events.first else {
+            return XCTFail("expected a network session failure, got \(log.events)")
+        }
+        XCTAssertTrue(detail.contains("microphone"))
+        XCTAssertTrue(fixture.inner.calls.contains(.close),
+                      "the inner backend is closed on route change")
+        XCTAssertEqual(fixture.audioSource.stops, 1)
+    }
+
+    func testRouteChangeSurfacedOnlyOnce() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.audioSource.invalidate()
+        // Second invalidation should be dropped (generation mismatch).
+        fixture.audioSource.invalidate()
+
+        let failures = log.events.filter {
+            if case .sessionFailed = $0 { return true }; return false
+        }
+        XCTAssertEqual(failures.count, 1, "route change surfaced exactly once")
+    }
+
+    // MARK: - Stale audio after teardown
+
+    func testStaleAudioAfterTeardownIsDropped() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+        fixture.pump.endUserTurn()
+
+        // Audio arriving after the turn ended should not reach the inner.
+        let sendsBefore = fixture.inner.calls.filter {
+            if case .sendAudio = $0 { return true }; return false
+        }.count
+
+        fixture.audioSource.emit(try monoFloatBuffer(values: [0.9, 0.9, 0.9, 0.9]))
+        for _ in 0..<20 { await Task.yield() }
+
+        let sendsAfter = fixture.inner.calls.filter {
+            if case .sendAudio = $0 { return true }; return false
+        }.count
+        XCTAssertEqual(sendsBefore, sendsAfter,
+                       "audio delivered after teardown must be dropped")
+    }
+
+    // MARK: - Stop is idempotent
+
+    func testStopIsIdempotent() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.pump.endUserTurn()
+        fixture.pump.close()
+        fixture.pump.close()
+
+        // Only 1 stop from endUserTurn; close after should not crash.
+        XCTAssertEqual(fixture.audioSource.stops, 1)
+    }
+
+    // MARK: - Inner events relay to caller
+
+    func testTranscriptEventsRelayedToCaller() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.inner.emit(.transcriptPartial("ye"))
+        fixture.inner.emit(.transcriptFinal("yes"))
+
+        XCTAssertEqual(log.events, [
+            .transcriptPartial("ye"),
+            .transcriptFinal("yes"),
+        ])
+    }
+
+    func testAudioEventsRelayedToCaller() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        let chunk = VoiceAudioChunk(data: Data([1, 2, 3, 4]),
+                                     format: .pcm16Mono24k, timestamp: 1)
+        fixture.inner.emit(.audio(chunk))
+
+        XCTAssertEqual(log.events, [.audio(chunk)])
+    }
+
+    func testResponseCompletedRelayedToCaller() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+
+        fixture.inner.emit(.responseCompleted)
+
+        XCTAssertEqual(log.events, [.responseCompleted])
+    }
+
+    func testInnerSessionFailedClosesTheMicAndRelays() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        let failure = VoiceBackendFailure.network("socket dropped")
+        fixture.inner.emit(.sessionFailed(failure))
+
+        XCTAssertEqual(log.events, [.sessionFailed(failure)])
+        XCTAssertEqual(fixture.audioSource.stops, 1,
+                       "mic stops when the inner session dies")
+        XCTAssertFalse(fixture.pump.isTurnActiveForTesting)
+    }
+
+    // MARK: - Forwarding
+
+    func testRequestResponseForwards() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.requestResponse(text: "hello")
+
+        XCTAssertTrue(fixture.inner.calls.contains(.requestResponse("hello")))
+    }
+
+    func testCancelResponseForwards() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.cancelResponse()
+
+        XCTAssertTrue(fixture.inner.calls.contains(.cancelResponse))
+    }
+
+    func testExternalSendAudioForwards() async throws {
+        let fixture = makeFixture()
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        let chunk = VoiceAudioChunk(data: Data(repeating: 7, count: 320),
+                                     format: .pcm16Mono24k, timestamp: 1)
+        fixture.pump.sendAudio(chunk)
+
+        XCTAssertTrue(fixture.inner.calls.contains(.sendAudio(320)))
+    }
+
+    // MARK: - onInputLevel hook
+
+    func testInputLevelHookReceivesRMSValues() async throws {
+        let fixture = makeFixture()
+        var levels: [Double] = []
+        fixture.pump.onInputLevel = { levels.append($0) }
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        let received = expectation(description: "input level received")
+        fixture.pump.onInputLevel = {
+            levels.append($0)
+            received.fulfill()
+        }
+
+        fixture.audioSource.emit(try monoFloatBuffer(values: [0.5, -0.5, 0.5, -0.5]))
+        await fulfillment(of: [received], timeout: 2)
+
+        XCTAssertEqual(levels.count, 1)
+        XCTAssertEqual(levels[0], 0.5, accuracy: 0.1)
+    }
+
+    // MARK: - Mic start failure
+
+    func testMicStartFailureRelaysSessionFailed() async throws {
+        let fixture = makeFixture()
+        fixture.audioSource.startFailure = VoiceAudioSourceFailure(
+            stage: .engineStart, detail: "input device disappeared")
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+
+        fixture.pump.beginUserTurn()
+
+        XCTAssertEqual(log.events.count, 1)
+        guard case .sessionFailed(.network) = log.events.first else {
+            return XCTFail("expected a network session failure, got \(log.events)")
+        }
+    }
+
+    // MARK: - PCM16 extraction
+
+    func testExtractPCM16DataFromInterleavedBuffer() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 24_000,
+            channels: 1,
+            interleaved: true
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4))
+        buffer.frameLength = 4
+
+        let int16Data = try XCTUnwrap(buffer.int16ChannelData)
+        int16Data[0][0] = 1000
+        int16Data[0][1] = -1000
+        int16Data[0][2] = 32767
+        int16Data[0][3] = -32768
+
+        let data = MicrophonePumpVoiceBackend.extractPCM16Data(from: buffer)
+        XCTAssertEqual(data.count, 8, "4 int16 samples = 8 bytes")
+
+        // Verify first sample is 1000 in little-endian.
+        let firstSample = data.withUnsafeBytes { ptr in
+            ptr.load(fromByteOffset: 0, as: Int16.self)
+        }
+        XCTAssertEqual(firstSample, 1000)
+    }
+
+    // MARK: - RMS computation
+
+    func testComputeRMSOfConstantTone() throws {
+        let buffer = try monoFloatBuffer(values: [0.5, -0.5, 0.5, -0.5])
+        let rms = MicrophonePumpVoiceBackend.computeRMS(buffer)
+        XCTAssertEqual(rms, 0.5, accuracy: 1e-6)
+    }
+
+    func testComputeRMSOfSilence() throws {
+        let buffer = try monoFloatBuffer(values: [0, 0, 0, 0])
+        let rms = MicrophonePumpVoiceBackend.computeRMS(buffer)
+        XCTAssertEqual(rms, 0)
+    }
+
+    // MARK: - Multiple turns on the same session
+
+    func testSecondTurnGetsAFreshMicWindow() async throws {
+        let first = FakeAudioSource()
+        let second = FakeAudioSource()
+        let fixture = makeFixture(sources: [first, second])
+        let log = EventLog()
+        try await fixture.pump.open { log.append($0) }
+
+        // First turn.
+        fixture.pump.beginUserTurn()
+        fixture.pump.endUserTurn()
+
+        // Second turn.
+        fixture.pump.beginUserTurn()
+
+        XCTAssertEqual(first.starts, 1)
+        XCTAssertEqual(second.starts, 1, "each turn gets a fresh audio source")
+        XCTAssertEqual(first.stops, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func monoFloatBuffer(
+        values: [Float],
+        sampleRate: Double = 48_000
+    ) throws -> AVAudioPCMBuffer {
+        let format = try XCTUnwrap(AVAudioFormat(
+            standardFormatWithSampleRate: sampleRate,
+            channels: 1
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(values.count)
+        ))
+        buffer.frameLength = AVAudioFrameCount(values.count)
+        let data = try XCTUnwrap(buffer.floatChannelData)
+        for (i, v) in values.enumerated() {
+            data[0][i * buffer.stride] = v
+        }
+        return buffer
+    }
+
+    private func stereoFloatBuffer(
+        left: [Float],
+        right: [Float],
+        sampleRate: Double = 48_000
+    ) throws -> AVAudioPCMBuffer {
+        let frames = left.count
+        let format = try XCTUnwrap(AVAudioFormat(
+            standardFormatWithSampleRate: sampleRate,
+            channels: 2
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(frames)
+        ))
+        buffer.frameLength = AVAudioFrameCount(frames)
+        let data = try XCTUnwrap(buffer.floatChannelData)
+        for (i, v) in left.enumerated() {
+            data[0][i * buffer.stride] = v
+        }
+        for (i, v) in right.enumerated() {
+            data[1][i * buffer.stride] = v
+        }
+        return buffer
+    }
+}

--- a/Tests/TapQAppleAdaptersTests/VoiceListenerTests.swift
+++ b/Tests/TapQAppleAdaptersTests/VoiceListenerTests.swift
@@ -69,7 +69,7 @@ final class VoiceListenerTests: XCTestCase {
         private var invalidation: (@MainActor (VoiceAudioSourceFailure) -> Void)?
 
         func start(
-            onBuffer: @escaping (AVAudioPCMBuffer) -> Void,
+            onBuffer: @escaping (AVAudioPCMBuffer, AVAudioTime) -> Void,
             onInvalidation: @escaping @MainActor (VoiceAudioSourceFailure) -> Void
         ) throws {
             _ = onBuffer
@@ -174,10 +174,10 @@ final class VoiceListenerTests: XCTestCase {
             return sources[factoryCalls]
         }
 
-        guard case .started = controller.start(onBuffer: { _ in }, onInvalidation: { _ in })
+        guard case .started = controller.start(onBuffer: { _, _ in }, onInvalidation: { _ in })
         else { return XCTFail("first source should start") }
         guard case .alreadyRunning = controller.start(
-            onBuffer: { _ in },
+            onBuffer: { _, _ in },
             onInvalidation: { _ in }
         ) else { return XCTFail("duplicate start should be idempotent") }
         XCTAssertEqual(factoryCalls, 1)
@@ -187,7 +187,7 @@ final class VoiceListenerTests: XCTestCase {
         controller.stop()
         XCTAssertEqual(first.stops, 1)
 
-        guard case .started = controller.start(onBuffer: { _ in }, onInvalidation: { _ in })
+        guard case .started = controller.start(onBuffer: { _, _ in }, onInvalidation: { _ in })
         else { return XCTFail("restart should use a fresh source") }
         XCTAssertEqual(factoryCalls, 2)
         XCTAssertEqual(second.starts, 1)
@@ -209,14 +209,14 @@ final class VoiceListenerTests: XCTestCase {
         }
 
         guard case .failed(let error) = controller.start(
-            onBuffer: { _ in },
+            onBuffer: { _, _ in },
             onInvalidation: { _ in }
         ) else { return XCTFail("invalid input must fail") }
         XCTAssertEqual(error as? VoiceAudioSourceFailure, failure)
         XCTAssertFalse(controller.isRunning)
         XCTAssertEqual(rejected.stops, 1)
 
-        guard case .started = controller.start(onBuffer: { _ in }, onInvalidation: { _ in })
+        guard case .started = controller.start(onBuffer: { _, _ in }, onInvalidation: { _ in })
         else { return XCTFail("later route should get a fresh source") }
         XCTAssertTrue(controller.isRunning)
         XCTAssertEqual(factoryCalls, 2)
@@ -237,7 +237,7 @@ final class VoiceListenerTests: XCTestCase {
         }
 
         guard case .started = controller.start(
-            onBuffer: { _ in },
+            onBuffer: { _, _ in },
             onInvalidation: invalidationHandler
         ) else { return XCTFail("first source should start") }
         first.invalidate()
@@ -246,7 +246,7 @@ final class VoiceListenerTests: XCTestCase {
         XCTAssertEqual(invalidations.count, 1)
 
         guard case .started = controller.start(
-            onBuffer: { _ in },
+            onBuffer: { _, _ in },
             onInvalidation: invalidationHandler
         ) else { return XCTFail("second source should start") }
         first.invalidate()
@@ -271,7 +271,7 @@ final class VoiceListenerTests: XCTestCase {
         let controller = VoiceAudioSourceController { source }
 
         guard case .failed(let error) = controller.start(
-            onBuffer: { _ in },
+            onBuffer: { _, _ in },
             onInvalidation: { invalidations.append($0) }
         ) else { return XCTFail("route change during start must fail the source") }
 

--- a/Tests/TapQAppleAdaptersTests/WearerSpeechSignalSourceTests.swift
+++ b/Tests/TapQAppleAdaptersTests/WearerSpeechSignalSourceTests.swift
@@ -1,0 +1,320 @@
+import XCTest
+@testable import TapQAppleAdapters
+import TapQContracts
+import TapQDetectionBaseline
+
+/// Synthetic 25 Hz motion stream builder matching the pattern from
+/// `WearerSpeechAnalyzerTests` and `WearerSpeechMonitorTests`.
+private struct StreamBuilder {
+    static let rate: TimeInterval = 1.0 / 25.0
+
+    private(set) var samples: [HeadMotionSample] = []
+    private var time: TimeInterval = 100
+    private var sign: Double = 1
+    private var baseline: Double = 0.05
+
+    mutating func append(seconds: TimeInterval, jerk: Double, rotation: Double = 0.02) {
+        let count = Int((seconds / StreamBuilder.rate).rounded())
+        for _ in 0..<count {
+            sign = -sign
+            samples.append(HeadMotionSample(
+                timestamp: time,
+                pitch: 0,
+                yaw: 0,
+                accelerationMagnitude: baseline + sign * jerk / 2,
+                rotationMagnitude: rotation
+            ))
+            time += StreamBuilder.rate
+        }
+    }
+
+    mutating func appendPerAxis(seconds: TimeInterval, jerk: Double, rotation: Double = 0.02) {
+        let count = Int((seconds / StreamBuilder.rate).rounded())
+        for _ in 0..<count {
+            sign = -sign
+            samples.append(HeadMotionSample(
+                timestamp: time,
+                pitch: 0,
+                yaw: 0,
+                roll: 0,
+                userAcceleration: MotionVector(x: sign * jerk / 2, y: 0, z: 0),
+                rotationRate: MotionVector(x: 0, y: rotation, z: 0),
+                gravity: MotionVector(x: 0, y: 0, z: -1)
+            ))
+            time += StreamBuilder.rate
+        }
+    }
+
+    mutating func drain() -> [HeadMotionSample] {
+        defer { samples = [] }
+        return samples
+    }
+}
+
+@MainActor
+final class WearerSpeechSignalSourceTests: XCTestCase {
+    private final class Clock {
+        var now: TimeInterval = 100
+        func advance(_ seconds: TimeInterval) { now += seconds }
+    }
+
+    private func makeSource(
+        config: WearerSpeechConfig = .init(),
+        clock: Clock = Clock()
+    ) -> (WearerSpeechSignalSource, Clock) {
+        let source = WearerSpeechSignalSource(
+            config: config,
+            monotonicNow: { clock.now }
+        )
+        source.isAttached = true
+        return (source, clock)
+    }
+
+    // MARK: - Multicast: two children get independent callbacks
+
+    func testTwoChildrenGetIndependentCallbacksForOneTransition() {
+        let (source, clock) = makeSource()
+        let child1 = source.makeSignal()
+        let child2 = source.makeSignal()
+
+        var child1Callbacks: [Bool] = []
+        var child2Callbacks: [Bool] = []
+        child1.onWearerSpeakingChange = { child1Callbacks.append($0) }
+        child2.onWearerSpeakingChange = { child2Callbacks.append($0) }
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+
+        XCTAssertEqual(child1Callbacks, [true], "child1 got startedSpeaking")
+        XCTAssertEqual(child2Callbacks, [true], "child2 got startedSpeaking")
+        XCTAssertTrue(child1.isWearerSpeaking)
+        XCTAssertTrue(child2.isWearerSpeaking)
+    }
+
+    func testChildrenGetBothTransitions() {
+        let (source, clock) = makeSource()
+        let child = source.makeSignal()
+
+        var callbacks: [Bool] = []
+        child.onWearerSpeakingChange = { callbacks.append($0) }
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 1.5, jerk: 0.04)
+        builder.appendPerAxis(seconds: 2.5, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+
+        XCTAssertEqual(callbacks, [true, false])
+        XCTAssertFalse(child.isWearerSpeaking)
+    }
+
+    // MARK: - Ownership assert: each child has its own slot
+
+    func testEachChildHasIndependentObserverSlot() {
+        let (source, _) = makeSource()
+        let child1 = source.makeSignal()
+        let child2 = source.makeSignal()
+
+        var c1Count = 0
+        var c2Count = 0
+        child1.onWearerSpeakingChange = { _ in c1Count += 1 }
+        child2.onWearerSpeakingChange = { _ in c2Count += 1 }
+
+        // Reassign child1's observer -- should not affect child2
+        child1.onWearerSpeakingChange = nil
+
+        let (source2, clock2) = makeSource()
+        let childA = source2.makeSignal()
+        let childB = source2.makeSignal()
+
+        var aCallbacks: [Bool] = []
+        var bCallbacks: [Bool] = []
+        childA.onWearerSpeakingChange = { aCallbacks.append($0) }
+        childB.onWearerSpeakingChange = { bCallbacks.append($0) }
+
+        // Clear childA's observer
+        childA.onWearerSpeakingChange = nil
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            clock2.advance(StreamBuilder.rate)
+            source2.ingest(sample)
+        }
+
+        XCTAssertTrue(aCallbacks.isEmpty, "cleared observer should not fire")
+        XCTAssertEqual(bCallbacks, [true], "other child should still fire")
+
+        withExtendedLifetime((child1, child2, childA, childB)) {}
+    }
+
+    // MARK: - Availability matrix
+
+    func testAvailableWhenAttachedFreshAndPerAxis() {
+        let (source, clock) = makeSource()
+        let child = source.makeSignal()
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+
+        XCTAssertTrue(child.isSignalAvailable)
+    }
+
+    func testUnavailableWhenNotAttached() {
+        let clock = Clock()
+        let source = WearerSpeechSignalSource(monotonicNow: { clock.now })
+        // isAttached defaults to false
+        let child = source.makeSignal()
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+
+        XCTAssertFalse(child.isSignalAvailable)
+    }
+
+    func testUnavailableWhenStale() {
+        let config = WearerSpeechConfig()
+        let (source, clock) = makeSource(config: config)
+        let child = source.makeSignal()
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+        XCTAssertTrue(child.isSignalAvailable)
+
+        clock.advance(config.maxSampleGapSeconds + 0.1)
+        XCTAssertFalse(child.isSignalAvailable)
+    }
+
+    func testUnavailableWhenMagnitudeOnly() {
+        let (source, clock) = makeSource()
+        let child = source.makeSignal()
+
+        // Magnitude-only samples
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            XCTAssertFalse(sample.hasPerAxisData)
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+
+        XCTAssertFalse(child.isSignalAvailable,
+                       "magnitude-only stream is insufficient for attribution")
+    }
+
+    func testUnavailableWhenNoSamplesYet() {
+        let (source, _) = makeSource()
+        let child = source.makeSignal()
+        XCTAssertFalse(child.isSignalAvailable)
+    }
+
+    func testUnavailableAfterStreamInterrupted() {
+        let (source, clock) = makeSource()
+        let child = source.makeSignal()
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+        XCTAssertTrue(child.isSignalAvailable)
+
+        source.streamInterrupted()
+        XCTAssertFalse(child.isSignalAvailable)
+    }
+
+    // MARK: - Stream interrupted propagation
+
+    func testStreamInterruptedResetsStateAndNotifiesChildren() {
+        let (source, clock) = makeSource()
+        let child = source.makeSignal()
+        var callbacks: [Bool] = []
+        child.onWearerSpeakingChange = { callbacks.append($0) }
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+        XCTAssertTrue(child.isWearerSpeaking)
+
+        source.streamInterrupted()
+        XCTAssertFalse(child.isWearerSpeaking)
+        XCTAssertEqual(callbacks, [true, false])
+    }
+
+    func testStreamInterruptedWhileQuietDoesNotNotify() {
+        let (source, clock) = makeSource()
+        let child = source.makeSignal()
+        var callbacks: [Bool] = []
+        child.onWearerSpeakingChange = { callbacks.append($0) }
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+
+        source.streamInterrupted()
+        XCTAssertTrue(callbacks.isEmpty)
+    }
+
+    // MARK: - MotionSampleObserving conformance
+
+    func testConformsToMotionSampleObserving() {
+        let (source, _) = makeSource()
+        // Verify the protocol conformance compiles and works
+        let observer: any MotionSampleObserving = source
+        let sample = HeadMotionSample(
+            timestamp: 100, pitch: 0, yaw: 0, roll: 0,
+            userAcceleration: MotionVector(x: 0.01, y: 0, z: 0),
+            rotationRate: .zero,
+            gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+        observer.ingest(sample)
+        observer.streamInterrupted()
+        withExtendedLifetime(source) {}
+    }
+
+    // MARK: - Detached child reads defaults
+
+    func testDetachedChildReadsDefaults() {
+        let (source, clock) = makeSource()
+        let child = source.makeSignal()
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            source.ingest(sample)
+        }
+        XCTAssertTrue(child.isWearerSpeaking)
+
+        // Let source deallocate -- child should report safe defaults
+        // Can't easily force dealloc in this test, but verify the weak reference pattern
+        // by testing that the child reads from the source while it exists
+        XCTAssertTrue(child.isWearerSpeaking)
+        XCTAssertTrue(child.isSignalAvailable)
+    }
+}

--- a/Tests/TapQBrokerRuntimeTests/BrokerRoundTripTests.swift
+++ b/Tests/TapQBrokerRuntimeTests/BrokerRoundTripTests.swift
@@ -338,6 +338,61 @@ final class BrokerRoundTripTests: XCTestCase {
         XCTAssertEqual(response, .selection(indices: [1], labels: ["B"]))
     }
 
+    func testSelectionFreeTextResponseCarriesFreeText() async throws {
+        defer { transport.stop() }
+        let server = BrokerServer(
+            transport: transport,
+            token: "tok",
+            onApproval: { _ in .ask },
+            onNotification: { _ in },
+            onSelection: { _ in
+                SelectionResult(choices: [], freeText: "deploy to staging")
+            }
+        )
+        try server.start()
+
+        let response = try await send(
+            #"{"type":"selection.request","token":"tok","protocol_version":4,"session_id":"s","request_id":"r1","question":"Pick","options":[{"label":"A","description":"a"},{"label":"B","description":"b"}],"multi_select":false}"#
+        )
+        XCTAssertEqual(response, .selection(indices: [], labels: [], freeText: "deploy to staging"))
+    }
+
+    func testSelectionLabelResponseByteIdenticalToBeforeWP9() async throws {
+        defer { transport.stop() }
+        let server = BrokerServer(
+            transport: transport,
+            token: "tok",
+            onApproval: { _ in .ask },
+            onNotification: { _ in },
+            onSelection: { request in
+                SelectionResult(choices: [.init(index: 1, label: request.options[1].label)])
+            }
+        )
+        try server.start()
+
+        let response = try await send(
+            #"{"type":"selection.request","token":"tok","protocol_version":4,"session_id":"s","request_id":"r1","question":"Pick","options":[{"label":"A","description":"a"},{"label":"B","description":"b"}],"multi_select":false}"#
+        )
+        XCTAssertEqual(response, .selection(indices: [1], labels: ["B"]))
+    }
+
+    func testV3RequestAcceptedByV4Broker() async throws {
+        defer { transport.stop() }
+        let server = BrokerServer(
+            transport: transport,
+            token: "tok",
+            onApproval: { _ in .allow },
+            onNotification: { _ in }
+        )
+        try server.start()
+
+        let response = try await send(
+            #"{"type":"approval.request","token":"tok","protocol_version":3,"session_id":"s","tool_name":"Bash","tool_input":{},"approval_source":"pre_tool_use","request_id":"r1"}"#
+        )
+        XCTAssertEqual(response, .decision(.allow, reason: nil),
+                       "a v3 request must be accepted by the v4 broker")
+    }
+
     func testStopQuestionRoundTrip() async throws {
         defer { transport.stop() }
         let server = BrokerServer(

--- a/Tests/TapQCLITests/CLICommandParserTests.swift
+++ b/Tests/TapQCLITests/CLICommandParserTests.swift
@@ -155,6 +155,27 @@ final class CLICommandParserTests: XCTestCase {
         XCTAssertFalse(options.wearerGateEnabled)
     }
 
+    func testServeImuTurnControlFlag() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--imu-turn-control",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertTrue(options.imuTurnControlEnabled)
+    }
+
+    func testServeDefaultsToImuTurnControlOff() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(["serve"])
+        else { return XCTFail("Expected a serve command.") }
+        XCTAssertFalse(options.imuTurnControlEnabled)
+    }
+
+    func testServeBothWearerGateAndImuTurnControl() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--wearer-gate", "--imu-turn-control",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertTrue(options.wearerGateEnabled)
+        XCTAssertTrue(options.imuTurnControlEnabled)
+    }
+
     func testServeHelpHasDedicatedTopic() throws {
         XCTAssertEqual(try CLICommandParser.parse(["serve", "--help"]), .help(.serve))
         XCTAssertEqual(try CLICommandParser.parse(["help", "serve"]), .help(.serve))

--- a/Tests/TapQCLITests/CLICommandParserTests.swift
+++ b/Tests/TapQCLITests/CLICommandParserTests.swift
@@ -142,6 +142,19 @@ final class CLICommandParserTests: XCTestCase {
         XCTAssertEqual(options.voiceBackend, .openaiRealtime)
     }
 
+    func testServeWearerGateFlag() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--wearer-gate",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertTrue(options.wearerGateEnabled)
+    }
+
+    func testServeDefaultsToWearerGateOff() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(["serve"])
+        else { return XCTFail("Expected a serve command.") }
+        XCTAssertFalse(options.wearerGateEnabled)
+    }
+
     func testServeHelpHasDedicatedTopic() throws {
         XCTAssertEqual(try CLICommandParser.parse(["serve", "--help"]), .help(.serve))
         XCTAssertEqual(try CLICommandParser.parse(["help", "serve"]), .help(.serve))

--- a/Tests/TapQCLITests/CLICommandParserTests.swift
+++ b/Tests/TapQCLITests/CLICommandParserTests.swift
@@ -176,6 +176,27 @@ final class CLICommandParserTests: XCTestCase {
         XCTAssertTrue(options.imuTurnControlEnabled)
     }
 
+    func testServeVoiceFreeformFlag() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--voice-freeform",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertTrue(options.voiceFreeformEnabled)
+    }
+
+    func testServeDefaultsToVoiceFreeformOff() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(["serve"])
+        else { return XCTFail("Expected a serve command.") }
+        XCTAssertFalse(options.voiceFreeformEnabled)
+    }
+
+    func testServeVoiceFreeformWithBackend() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--voice-backend", "openai-realtime", "--voice-freeform",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertTrue(options.voiceFreeformEnabled)
+        XCTAssertEqual(options.voiceBackend, .openaiRealtime)
+    }
+
     func testServeHelpHasDedicatedTopic() throws {
         XCTAssertEqual(try CLICommandParser.parse(["serve", "--help"]), .help(.serve))
         XCTAssertEqual(try CLICommandParser.parse(["help", "serve"]), .help(.serve))

--- a/Tests/TapQCLITests/CLICommandParserTests.swift
+++ b/Tests/TapQCLITests/CLICommandParserTests.swift
@@ -109,6 +109,28 @@ final class CLICommandParserTests: XCTestCase {
         XCTAssertEqual(command, .capture(CaptureOptions()))
     }
 
+    func testCaptureMicEnvelopeSidecarPath() throws {
+        let command = try CLICommandParser.parse([
+            "capture", "--output", "imu.jsonl", "--mic-envelope", "env.jsonl", "--force",
+        ])
+        XCTAssertEqual(command, .capture(CaptureOptions(
+            outputPath: "imu.jsonl",
+            force: true,
+            micEnvelopePath: "env.jsonl"
+        )))
+    }
+
+    func testCaptureMicEnvelopeIsOptionalAndNeedsAPath() throws {
+        XCTAssertEqual(
+            try CLICommandParser.parse(["capture"]),
+            .capture(CaptureOptions()),
+            "a capture without the flag stays microphone-free"
+        )
+        XCTAssertThrowsError(try CLICommandParser.parse(["capture", "--mic-envelope"]))
+        XCTAssertThrowsError(
+            try CLICommandParser.parse(["capture", "--mic-envelope", "--force"]))
+    }
+
     func testCalibrateAliasParsesRunOptions() throws {
         let command = try CLICommandParser.parse([
             "calibrate", "tap", "--rest-seconds", "1", "--nod-seconds", "2",

--- a/Tests/TapQCLITests/CLICommandParserTests.swift
+++ b/Tests/TapQCLITests/CLICommandParserTests.swift
@@ -141,7 +141,89 @@ final class CLICommandParserTests: XCTestCase {
     func testCombinedProfilePathIsRejected() {
         XCTAssertThrowsError(try CLICommandParser.parse([
             "calibration", "run", "--profile", "combined.json",
-        ]))
+        ])) { error in
+            // The message has to name all three documents, or it sends the user looking
+            // for a flag pair that no longer covers the `all` target.
+            let message = (error as? CLIUsageError)?.message ?? ""
+            XCTAssertTrue(message.contains("--gesture-profile"), message)
+            XCTAssertTrue(message.contains("--tap-profile"), message)
+            XCTAssertTrue(message.contains("--wearer-speech-profile"), message)
+        }
+    }
+
+    func testWearerSpeechTargetParsesRunOptions() throws {
+        let command = try CLICommandParser.parse([
+            "calibration", "run", "wearer-speech",
+            "--rest-seconds", "2", "--speak-seconds", "8",
+            "--profile", "speech.json", "--non-interactive",
+        ])
+        var options = CalibrationRunOptions(target: .wearerSpeech)
+        options.restDuration = 2
+        options.speakDuration = 8
+        options.wearerSpeechProfilePath = "speech.json"
+        options.nonInteractive = true
+        XCTAssertEqual(command, .calibration(.run(options)))
+    }
+
+    func testAllTargetAcceptsTheWearerSpeechProfilePathAlongsideTheOthers() throws {
+        let command = try CLICommandParser.parse([
+            "calibration", "run", "all",
+            "--gesture-profile", "gesture.json",
+            "--tap-profile", "tap.json",
+            "--wearer-speech-profile", "speech.json",
+            "--speak-seconds", "5",
+        ])
+        var options = CalibrationRunOptions()
+        options.speakDuration = 5
+        options.gestureProfilePath = "gesture.json"
+        options.tapProfilePath = "tap.json"
+        options.wearerSpeechProfilePath = "speech.json"
+        XCTAssertEqual(command, .calibration(.run(options)))
+    }
+
+    func testWearerSpeechShowAndResetRouteTheSelectedProfilePath() throws {
+        var show = CalibrationShowOptions(target: .wearerSpeech)
+        show.wearerSpeechProfilePath = "speech.json"
+        show.json = true
+        XCTAssertEqual(
+            try CLICommandParser.parse([
+                "calibration", "show", "wearer-speech", "--profile", "speech.json", "--json",
+            ]),
+            .calibration(.show(show))
+        )
+
+        var reset = CalibrationResetOptions(target: .wearerSpeech)
+        reset.wearerSpeechProfilePath = "speech.json"
+        reset.confirmed = true
+        XCTAssertEqual(
+            try CLICommandParser.parse([
+                "calibration", "reset", "wearer-speech", "--wearer-speech-profile",
+                "speech.json", "--yes",
+            ]),
+            .calibration(.reset(reset))
+        )
+    }
+
+    func testUnknownCalibrationTargetNamesEveryValidTarget() {
+        XCTAssertThrowsError(try CLICommandParser.parse([
+            "calibration", "show", "speech",
+        ])) { error in
+            XCTAssertEqual(
+                (error as? CLIUsageError)?.message,
+                "Calibration target must be 'all', 'gesture', 'tap', or 'wearer-speech'."
+            )
+        }
+    }
+
+    /// `all` now means three documents, not two.
+    func testAllTargetCoversEveryProfileKind() {
+        XCTAssertEqual(
+            CalibrationTarget.all.profileKinds,
+            [.gesture, .tap, .wearerSpeech]
+        )
+        XCTAssertTrue(CalibrationTarget.all.includes(.wearerSpeech))
+        XCTAssertFalse(CalibrationTarget.tap.includes(.wearerSpeech))
+        XCTAssertFalse(CalibrationTarget.wearerSpeech.includes(.tap))
     }
 
     func testCalibrationManagementCommands() throws {

--- a/Tests/TapQCLITests/CLICommandParserTests.swift
+++ b/Tests/TapQCLITests/CLICommandParserTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import TapQCLI
+import TapQVoiceBackends
 
 final class CLICommandParserTests: XCTestCase {
     func testNoArgumentsShowsRootHelp() throws {
@@ -97,6 +98,48 @@ final class CLICommandParserTests: XCTestCase {
                 "--question-classifier must be 'auto', 'apple', 'anthropic', 'openai', or 'local'."
             )
         }
+    }
+
+    func testServeDefaultsToTheAppleVoiceBackend() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(["serve"])
+        else { return XCTFail("Expected a serve command.") }
+        XCTAssertEqual(options.voiceBackend, .apple)
+    }
+
+    /// Every spelling the enum offers has to be a spelling the flag takes: a case the parser
+    /// rejects would be a provider nobody can select.
+    func testServeAcceptsEveryVoiceBackendSpelling() throws {
+        for provider in VoiceBackendProvider.allCases {
+            XCTAssertEqual(
+                try CLICommandParser.parse(["serve", "--voice-backend", provider.rawValue]),
+                .serve(ServeOptions(voiceBackend: provider))
+            )
+        }
+    }
+
+    func testServeRejectsUnknownVoiceBackend() {
+        XCTAssertThrowsError(try CLICommandParser.parse([
+            "serve", "--voice-backend", "whisper",
+        ])) { error in
+            XCTAssertEqual(
+                (error as? CLIUsageError)?.message,
+                "--voice-backend must be 'apple' or 'openai-realtime'."
+            )
+        }
+    }
+
+    func testServeVoiceBackendRequiresValue() {
+        XCTAssertThrowsError(try CLICommandParser.parse(["serve", "--voice-backend"]))
+    }
+
+    /// The two provider flags are unrelated knobs on the same command, and the parser must
+    /// not let one shadow the other.
+    func testVoiceBackendAndQuestionClassifierAreIndependent() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--question-classifier", "local", "--voice-backend", "openai-realtime",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertEqual(options.questionClassifier, .local)
+        XCTAssertEqual(options.voiceBackend, .openaiRealtime)
     }
 
     func testServeHelpHasDedicatedTopic() throws {

--- a/Tests/TapQCLITests/CalibrationProfileTests.swift
+++ b/Tests/TapQCLITests/CalibrationProfileTests.swift
@@ -184,6 +184,26 @@ final class CalibrationProfileTests: XCTestCase {
         }
     }
 
+    /// A corrupt (non-JSON) wearer-speech profile must fail the same way a corrupt gesture
+    /// or tap profile does: `store.loadWearerSpeech()` throws (the runtime propagates this
+    /// to abort serve). When the file simply does not exist, `store.exists(.wearerSpeech)`
+    /// is false and the runtime skips loading (uses defaults) — matching `loadGestureIfPresent`.
+    func testMalformedWearerSpeechProfileThrowsLikeGestureAndTap() throws {
+        let store = testStore()
+        // Pre-condition: file absent → exists reports false.
+        XCTAssertFalse(store.exists(.wearerSpeech))
+
+        // Write invalid JSON.
+        try FileManager.default.createDirectory(
+            at: store.wearerSpeechProfileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("not-json".utf8).write(to: store.wearerSpeechProfileURL)
+        XCTAssertTrue(store.exists(.wearerSpeech))
+        XCTAssertThrowsError(try store.loadWearerSpeech(),
+                             "malformed wearer-speech profile must throw, matching gesture/tap")
+    }
+
     /// The raw value is the on-disk and JSON spelling and must stay snake_case; the display
     /// name is what CLI output uses so nothing prints "Wearer_speech".
     func testWearerSpeechKindSpelling() {

--- a/Tests/TapQCLITests/CalibrationProfileTests.swift
+++ b/Tests/TapQCLITests/CalibrationProfileTests.swift
@@ -28,6 +28,10 @@ final class CalibrationProfileTests: XCTestCase {
             store.tapProfileURL,
             directory.appendingPathComponent("tap-calibration.json")
         )
+        XCTAssertEqual(
+            store.wearerSpeechProfileURL,
+            directory.appendingPathComponent("wearer-speech-calibration.json")
+        )
     }
 
     func testIndependentRoundTripAndReset() throws {
@@ -63,6 +67,68 @@ final class CalibrationProfileTests: XCTestCase {
         XCTAssertFalse(try store.reset(.tap))
     }
 
+    func testWearerSpeechRoundTripsAndResetsWithoutTouchingTheOtherProfiles() throws {
+        let store = testStore()
+        try store.save(TapQGestureCalibrationProfile(
+            config: HeadGestureConfig(amplitudeThreshold: 0.12),
+            quality: GestureCalibrationQuality(
+                restingSampleCount: 20, nodSampleCount: 30, shakeSampleCount: 30)
+        ))
+        try store.save(TapQTapCalibrationProfile(
+            config: TapConfig(amplitudeThreshold: 0.42),
+            quality: TapCalibrationQuality(
+                restingSampleCount: 20, tapSampleCount: 25,
+                restingAccelerationPeak: 0.02, tapAccelerationPeak: 0.84)
+        ))
+
+        let speech = TapQWearerSpeechCalibrationProfile(
+            calibratedAt: Date(timeIntervalSince1970: 1_700_000_002),
+            config: WearerSpeechConfig(
+                envelopeEnterThreshold: 0.018, envelopeExitThreshold: 0.011),
+            quality: WearerSpeechCalibrationQuality(
+                restingSampleCount: 74,
+                speakingSampleCount: 149,
+                restingEnvelopePeak: 0.004,
+                speakingEnvelopeLevel: 0.030
+            )
+        )
+        try store.save(speech)
+        XCTAssertEqual(try store.loadWearerSpeech(), speech)
+
+        XCTAssertTrue(try store.reset(.wearerSpeech))
+        XCTAssertFalse(store.exists(.wearerSpeech))
+        XCTAssertTrue(store.exists(.gesture), "resetting wearer speech must preserve gestures")
+        XCTAssertTrue(store.exists(.tap), "resetting wearer speech must preserve taps")
+        XCTAssertFalse(try store.reset(.wearerSpeech))
+    }
+
+    /// Resetting either older profile must leave a wearer-speech calibration in place —
+    /// the same independence guarantee, checked in the other direction.
+    func testResettingGestureAndTapPreservesWearerSpeech() throws {
+        let store = testStore()
+        try store.save(TapQWearerSpeechCalibrationProfile(
+            config: WearerSpeechConfig(),
+            quality: WearerSpeechCalibrationQuality(
+                restingSampleCount: 74, speakingSampleCount: 149,
+                restingEnvelopePeak: 0.004, speakingEnvelopeLevel: 0.030)
+        ))
+        try store.save(TapQGestureCalibrationProfile(
+            config: HeadGestureConfig(),
+            quality: GestureCalibrationQuality(
+                restingSampleCount: 20, nodSampleCount: 30, shakeSampleCount: 30)
+        ))
+
+        XCTAssertTrue(try store.reset(.gesture))
+        XCTAssertFalse(try store.reset(.tap))
+        XCTAssertTrue(store.exists(.wearerSpeech))
+    }
+
+    func testEachProfileKindHasItsOwnFile() {
+        let store = testStore()
+        let urls = CalibrationProfileKind.allCases.map { store.url(for: $0) }
+        XCTAssertEqual(Set(urls).count, CalibrationProfileKind.allCases.count)
+    }
+
     func testRejectsUnsupportedSchemasIndependently() throws {
         let store = testStore()
         let profile = TapQTapCalibrationProfile(
@@ -83,10 +149,58 @@ final class CalibrationProfileTests: XCTestCase {
         }
     }
 
+    func testRejectsUnsupportedWearerSpeechSchemaOnSaveAndLoad() throws {
+        let store = testStore()
+        let profile = TapQWearerSpeechCalibrationProfile(
+            schemaVersion: 999,
+            config: .init(),
+            quality: .init(
+                restingSampleCount: 1,
+                speakingSampleCount: 1,
+                restingEnvelopePeak: 0.001,
+                speakingEnvelopeLevel: 0.03
+            )
+        )
+        XCTAssertThrowsError(try store.save(profile)) { error in
+            XCTAssertEqual(
+                error as? CalibrationStoreError,
+                .unsupportedSchema(.wearerSpeech, 999)
+            )
+        }
+
+        // A future schema already on disk must be refused rather than silently reused.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try FileManager.default.createDirectory(
+            at: store.wearerSpeechProfileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try encoder.encode(profile).write(to: store.wearerSpeechProfileURL)
+        XCTAssertThrowsError(try store.loadWearerSpeech()) { error in
+            XCTAssertEqual(
+                error as? CalibrationStoreError,
+                .unsupportedSchema(.wearerSpeech, 999)
+            )
+        }
+    }
+
+    /// The raw value is the on-disk and JSON spelling and must stay snake_case; the display
+    /// name is what CLI output uses so nothing prints "Wearer_speech".
+    func testWearerSpeechKindSpelling() {
+        XCTAssertEqual(CalibrationProfileKind.wearerSpeech.rawValue, "wearer_speech")
+        XCTAssertEqual(CalibrationProfileKind.wearerSpeech.displayName, "Wearer speech")
+        XCTAssertEqual(
+            CalibrationStoreError.unsupportedSchema(.wearerSpeech, 2).localizedDescription,
+            "The wearer speech calibration profile schema 2 is not supported by this TapQ version."
+        )
+    }
+
     private func testStore() -> CalibrationStore {
         CalibrationStore(
             gestureProfileURL: directory.appendingPathComponent("nested/gesture.json"),
-            tapProfileURL: directory.appendingPathComponent("nested/tap.json")
+            tapProfileURL: directory.appendingPathComponent("nested/tap.json"),
+            wearerSpeechProfileURL: directory
+                .appendingPathComponent("nested/wearer-speech.json")
         )
     }
 }

--- a/Tests/TapQCLITests/CalibrationTimelineTests.swift
+++ b/Tests/TapQCLITests/CalibrationTimelineTests.swift
@@ -7,7 +7,8 @@ final class CalibrationTimelineTests: XCTestCase {
             restDuration: 3,
             nodDuration: 4,
             shakeDuration: 4,
-            tapDuration: 4
+            tapDuration: 4,
+            speakDuration: 6
         ))
 
         XCTAssertNil(timeline.phase(at: 0.5))
@@ -18,8 +19,41 @@ final class CalibrationTimelineTests: XCTestCase {
         XCTAssertEqual(timeline.phase(at: 10.0), .shake)
         XCTAssertNil(timeline.phase(at: 14.5))
         XCTAssertEqual(timeline.phase(at: 15.0), .tap)
-        XCTAssertNil(timeline.phase(at: 19.0))
-        XCTAssertEqual(timeline.totalDuration, 19)
+        XCTAssertNil(timeline.phase(at: 19.5))
+        XCTAssertEqual(timeline.phase(at: 20.0), .speak)
+        XCTAssertNil(timeline.phase(at: 26.0))
+        XCTAssertEqual(timeline.totalDuration, 26)
+    }
+
+    /// The speak phase follows the tap phase across a discarded transition: the two share
+    /// the acceleration channel, and a fingertip still on the earbud would read as speech.
+    func testSpeakPhaseComesLastAndAfterADiscardedTransition() {
+        let timeline = CalibrationTimeline(options: CalibrationRunOptions(
+            restDuration: 3, nodDuration: 4, shakeDuration: 4,
+            tapDuration: 4, speakDuration: 6
+        ))
+        XCTAssertEqual(timeline.stages.last?.phase, .speak)
+        let phases = timeline.stages.map(\.phase)
+        guard let speakIndex = phases.firstIndex(of: .speak) else {
+            return XCTFail("expected a speak stage")
+        }
+        XCTAssertNil(phases[speakIndex - 1], "the stage before speak must be discarded")
+        XCTAssertEqual(phases[speakIndex - 2], .tap)
+    }
+
+    func testWearerSpeechOnlyTimelineCapturesFreshRestingBaselineAndNothingElse() {
+        var options = CalibrationRunOptions(target: .wearerSpeech)
+        options.restDuration = 3
+        options.speakDuration = 6
+        let timeline = CalibrationTimeline(options: options)
+
+        XCTAssertEqual(timeline.totalDuration, 11)
+        XCTAssertEqual(timeline.phase(at: 1), .resting)
+        XCTAssertNil(timeline.phase(at: 4.5))
+        XCTAssertEqual(timeline.phase(at: 5), .speak)
+        XCTAssertFalse(timeline.stages.contains {
+            $0.phase == .nod || $0.phase == .shake || $0.phase == .tap
+        })
     }
 
     func testGestureOnlyTimelineDoesNotRepeatTap() {
@@ -30,7 +64,9 @@ final class CalibrationTimelineTests: XCTestCase {
         let timeline = CalibrationTimeline(options: options)
 
         XCTAssertEqual(timeline.totalDuration, 14)
-        XCTAssertFalse(timeline.stages.contains { $0.phase == .tap })
+        XCTAssertFalse(timeline.stages.contains {
+            $0.phase == .tap || $0.phase == .speak
+        })
     }
 
     func testTapOnlyTimelineCapturesFreshRestingBaseline() {
@@ -43,6 +79,8 @@ final class CalibrationTimelineTests: XCTestCase {
         XCTAssertEqual(timeline.phase(at: 1), .resting)
         XCTAssertNil(timeline.phase(at: 4.5))
         XCTAssertEqual(timeline.phase(at: 5), .tap)
-        XCTAssertFalse(timeline.stages.contains { $0.phase == .nod || $0.phase == .shake })
+        XCTAssertFalse(timeline.stages.contains {
+            $0.phase == .nod || $0.phase == .shake || $0.phase == .speak
+        })
     }
 }

--- a/Tests/TapQCLITests/EnvelopeCaptureTests.swift
+++ b/Tests/TapQCLITests/EnvelopeCaptureTests.swift
@@ -126,7 +126,7 @@ final class EnvelopeCaptureTests: XCTestCase {
     // MARK: - Recorder
 
     @MainActor
-    func testRecorderRefusesToOverwriteWithoutForce() throws {
+    func testRecorderRefusesToOverwriteWithoutForce() async throws {
         let url = directory.appendingPathComponent("env.jsonl")
         try Data("stale".utf8).write(to: url)
 
@@ -140,7 +140,7 @@ final class EnvelopeCaptureTests: XCTestCase {
     }
 
     @MainActor
-    func testRecorderDropsBlocksThatLandAfterClose() throws {
+    func testRecorderDropsBlocksThatLandAfterClose() async throws {
         let url = directory.appendingPathComponent("env.jsonl")
         let recorder = try EnvelopeSidecarRecorder(url: url, force: false)
         recorder.writeTrack(MicEnvelopeTrackMeta(sampleRate: 48_000, blockFrames: 1_024))

--- a/Tests/TapQCLITests/EnvelopeCaptureTests.swift
+++ b/Tests/TapQCLITests/EnvelopeCaptureTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import XCTest
+@testable import TapQCLI
+
+final class EnvelopeCaptureTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("tapq-envelope-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    // MARK: - Formatting
+
+    func testMetaLineCarriesSchemaAndClock() {
+        let line = EnvelopeSampleFormatter.metaLine(
+            for: MicEnvelopeTrackMeta(sampleRate: 48_000, blockFrames: 1_024))
+        XCTAssertEqual(
+            line,
+            #"{"block_frames":1024,"clock":"boottime","sample_rate":48000,"schema":"tapq-mic-envelope-v1"}"#
+        )
+    }
+
+    func testSampleLineIsSortedJSONOnTheMotionClock() {
+        let line = EnvelopeSampleFormatter.line(
+            for: MicEnvelopeSample(timestamp: 12.5, rms: 0.25, peak: 0.5))
+        XCTAssertEqual(line, #"{"peak":0.5,"rms":0.25,"timestamp":12.5}"#)
+    }
+
+    // MARK: - Reading
+
+    func testWriterReaderRoundTrip() throws {
+        let meta = MicEnvelopeTrackMeta(sampleRate: 44_100, blockFrames: 512)
+        let samples = [
+            MicEnvelopeSample(timestamp: 100.0, rms: 0.01, peak: 0.02),
+            MicEnvelopeSample(timestamp: 100.0116, rms: 0.2, peak: 0.44),
+            MicEnvelopeSample(timestamp: 100.0232, rms: 0.18, peak: 0.4),
+        ]
+        var lines = [EnvelopeSampleFormatter.metaLine(for: meta)]
+        lines += samples.map(EnvelopeSampleFormatter.line(for:))
+
+        let track = try EnvelopeTrackReader.track(fromText: lines.joined(separator: "\n"))
+
+        XCTAssertEqual(track.meta, meta)
+        XCTAssertEqual(track.samples, samples)
+    }
+
+    func testReaderRoundTripsThroughTheSidecarRecorder() async throws {
+        let url = directory.appendingPathComponent("env.jsonl")
+        let meta = MicEnvelopeTrackMeta(sampleRate: 48_000, blockFrames: 1_024)
+        let recorder = try await MainActor.run { try EnvelopeSidecarRecorder(url: url, force: false) }
+        await MainActor.run {
+            recorder.writeTrack(meta)
+            recorder.append(MicEnvelopeSample(timestamp: 1, rms: 0.5, peak: 0.75))
+            recorder.append(MicEnvelopeSample(timestamp: 2, rms: 0.05, peak: 0.09))
+            recorder.close()
+        }
+
+        let track = try EnvelopeTrackReader.track(fromFileAt: url)
+        XCTAssertEqual(track.meta, meta)
+        XCTAssertEqual(track.samples.count, 2)
+        XCTAssertEqual(track.samples[1].peak, 0.09)
+        await MainActor.run { XCTAssertEqual(recorder.sampleCount, 2) }
+    }
+
+    func testReaderSkipsBlankLinesAndAcceptsATrackWithNoSamples() throws {
+        let meta = EnvelopeSampleFormatter.metaLine(
+            for: MicEnvelopeTrackMeta(sampleRate: 16_000, blockFrames: 256))
+        let track = try EnvelopeTrackReader.track(fromText: "\n" + meta + "\n\n")
+        XCTAssertEqual(track.meta.sampleRate, 16_000)
+        XCTAssertTrue(track.samples.isEmpty)
+    }
+
+    func testReaderRejectsAnUnknownSchema() throws {
+        let text = #"{"block_frames":1024,"clock":"boottime","sample_rate":48000,"schema":"tapq-mic-envelope-v2"}"#
+        XCTAssertThrowsError(try EnvelopeTrackReader.track(fromText: text)) { error in
+            XCTAssertEqual(
+                error as? EnvelopeTrackReadError,
+                .unsupportedSchema("tapq-mic-envelope-v2")
+            )
+        }
+    }
+
+    func testReaderRejectsATrackWithoutItsHeaderLine() throws {
+        let sample = EnvelopeSampleFormatter.line(
+            for: MicEnvelopeSample(timestamp: 1, rms: 0.1, peak: 0.2))
+        XCTAssertThrowsError(
+            try EnvelopeTrackReader.track(fromText: sample, path: "/tmp/env.jsonl")
+        ) { error in
+            XCTAssertEqual(error as? EnvelopeTrackReadError, .missingMeta("/tmp/env.jsonl"))
+        }
+        XCTAssertThrowsError(try EnvelopeTrackReader.track(fromText: "")) { error in
+            XCTAssertEqual(error as? EnvelopeTrackReadError, .missingMeta("<text>"))
+        }
+    }
+
+    func testReaderReportsTheOffendingSampleLineNumber() throws {
+        let text = [
+            EnvelopeSampleFormatter.metaLine(
+                for: MicEnvelopeTrackMeta(sampleRate: 48_000, blockFrames: 1_024)),
+            EnvelopeSampleFormatter.line(
+                for: MicEnvelopeSample(timestamp: 1, rms: 0.1, peak: 0.2)),
+            #"{"timestamp":2,"rms":"loud"}"#,
+        ].joined(separator: "\n")
+
+        XCTAssertThrowsError(try EnvelopeTrackReader.track(fromText: text)) { error in
+            guard case .badLine(let line, _)? = error as? EnvelopeTrackReadError else {
+                return XCTFail("expected a bad-line error, got \(error)")
+            }
+            XCTAssertEqual(line, 3)
+        }
+    }
+
+    func testReaderReportsAnUnreadablePath() throws {
+        let missing = directory.appendingPathComponent("absent.jsonl")
+        XCTAssertThrowsError(try EnvelopeTrackReader.track(fromFileAt: missing)) { error in
+            XCTAssertEqual(error as? EnvelopeTrackReadError, .unreadable(missing.path))
+        }
+    }
+
+    // MARK: - Recorder
+
+    @MainActor
+    func testRecorderRefusesToOverwriteWithoutForce() throws {
+        let url = directory.appendingPathComponent("env.jsonl")
+        try Data("stale".utf8).write(to: url)
+
+        XCTAssertThrowsError(try EnvelopeSidecarRecorder(url: url, force: false))
+
+        let recorder = try EnvelopeSidecarRecorder(url: url, force: true)
+        recorder.writeTrack(MicEnvelopeTrackMeta(sampleRate: 48_000, blockFrames: 1_024))
+        recorder.close()
+        let text = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertFalse(text.contains("stale"))
+    }
+
+    @MainActor
+    func testRecorderDropsBlocksThatLandAfterClose() throws {
+        let url = directory.appendingPathComponent("env.jsonl")
+        let recorder = try EnvelopeSidecarRecorder(url: url, force: false)
+        recorder.writeTrack(MicEnvelopeTrackMeta(sampleRate: 48_000, blockFrames: 1_024))
+        recorder.append(MicEnvelopeSample(timestamp: 1, rms: 0.1, peak: 0.2))
+        recorder.close()
+
+        // A block queued behind teardown must not reach a closed descriptor.
+        recorder.append(MicEnvelopeSample(timestamp: 2, rms: 0.1, peak: 0.2))
+        recorder.writeTrack(MicEnvelopeTrackMeta(sampleRate: 1, blockFrames: 1))
+        recorder.close()
+
+        XCTAssertEqual(recorder.sampleCount, 1)
+        let track = try EnvelopeTrackReader.track(fromFileAt: url)
+        XCTAssertEqual(track.samples.count, 1)
+    }
+
+    // MARK: - Errors
+
+    func testCaptureErrorsExplainWhatSurvived() {
+        XCTAssertTrue(
+            TapQEnvelopeCaptureError.startFailed("engine_start: no input")
+                .localizedDescription.contains("Nothing was recorded")
+        )
+        let truncated = TapQEnvelopeCaptureError
+            .invalidated("configuration_changed: audio input route changed")
+            .localizedDescription
+        XCTAssertTrue(truncated.contains("truncated"))
+        XCTAssertTrue(truncated.contains("motion capture finished"))
+    }
+}

--- a/Tests/TapQCLITests/ReplayCommandParsingTests.swift
+++ b/Tests/TapQCLITests/ReplayCommandParsingTests.swift
@@ -9,6 +9,7 @@ final class ReplayCommandParsingTests: XCTestCase {
             "--format", "csv", "--tolerance", "2.5", "--json",
             "--encoder-model", "model.mlpackage",
             "--gesture-profile", "g.json", "--tap-profile", "t.json",
+            "--wearer-speech-profile", "w.json", "--mic-envelope", "env.jsonl",
         ])
         var expected = ReplayOptions()
         expected.inputPath = "capture.jsonl"
@@ -19,7 +20,27 @@ final class ReplayCommandParsingTests: XCTestCase {
         expected.encoderModelPath = "model.mlpackage"
         expected.gestureProfilePath = "g.json"
         expected.tapProfilePath = "t.json"
+        expected.wearerSpeechProfilePath = "w.json"
+        expected.micEnvelopePath = "env.jsonl"
         XCTAssertEqual(command, .replay(expected))
+    }
+
+    /// The wearer-speech arm is opt-in on both sides: no profile, no ground truth.
+    func testReplayWearerSpeechOptionsDefaultToNil() throws {
+        guard case .replay(let options) = try CLICommandParser.parse([
+            "replay", "--input", "capture.jsonl",
+        ]) else { return XCTFail("Expected a replay command.") }
+        XCTAssertNil(options.wearerSpeechProfilePath)
+        XCTAssertNil(options.micEnvelopePath)
+    }
+
+    func testReplayWearerSpeechOptionsRequireValues() {
+        XCTAssertThrowsError(try CLICommandParser.parse([
+            "replay", "--input", "capture.jsonl", "--mic-envelope",
+        ]))
+        XCTAssertThrowsError(try CLICommandParser.parse([
+            "replay", "--input", "capture.jsonl", "--wearer-speech-profile",
+        ]))
     }
 
     func testReplayRequiresInput() {

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -50,7 +50,8 @@ final class TapQCLIApplicationTests: XCTestCase {
                 reasonerStatus: configuration.reasonerMode == .off
                     ? nil
                     : "\(configuration.reasonerMode.rawValue)"
-                        + " (\(configuration.reasonerProvider.rawValue))"
+                        + " (\(configuration.reasonerProvider.rawValue))",
+                wearerSpeechStatus: configuration.wearerGateEnabled ? "gate" : nil
             ))
         }
     }
@@ -445,6 +446,45 @@ final class TapQCLIApplicationTests: XCTestCase {
                           "serve help must name every provider the parser accepts")
         }
         XCTAssertTrue(buffer.output.contains("OPENAI_API_KEY"))
+    }
+
+    @MainActor
+    func testServeWearerGateFlagPassesThroughAndReportsStatus() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: ["serve", "--wearer-gate"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(runtime.configurations.first?.wearerGateEnabled == true)
+        XCTAssertTrue(buffer.output.contains("Wearer speech: gate"),
+                      "the gate status must be visible to the operator")
+    }
+
+    /// Without --wearer-gate, no status line and the configuration is off.
+    @MainActor
+    func testServeWithoutWearerGateChangesNothing() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: ["serve"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertFalse(runtime.configurations.first?.wearerGateEnabled == true)
+        XCTAssertFalse(buffer.output.contains("Wearer speech:"),
+                       "no wearer-speech status line without the flag")
+    }
+
+    @MainActor
+    func testServeHelpDocumentsTheWearerGateFlag() async {
+        let buffer = Buffer()
+        let status = await application(io: buffer.io).run(arguments: ["help", "serve"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("--wearer-gate"))
+        XCTAssertTrue(buffer.output.contains("fail-open"))
     }
 
     @MainActor

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -533,6 +533,25 @@ final class TapQCLIApplicationTests: XCTestCase {
         XCTAssertFalse(runtime.configurations.first?.imuTurnControlEnabled == true)
     }
 
+    /// Regression for defect 2: --imu-turn-control alone must NOT activate the wearer
+    /// attribution gate. The flag split is: --wearer-gate for attribution, --imu-turn-control
+    /// for endpointing/barge-in. Turn-control-only must pass wearerGateEnabled: false so the
+    /// runtime composes no WearerGatedVoice — commands from any speaker pass through.
+    @MainActor
+    func testServeImuTurnControlAloneDoesNotActivateWearerGate() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: ["serve", "--imu-turn-control"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(runtime.configurations.first?.imuTurnControlEnabled == true,
+                      "turn control must be enabled")
+        XCTAssertFalse(runtime.configurations.first?.wearerGateEnabled == true,
+                       "wearer gate must NOT be enabled when only --imu-turn-control is set")
+    }
+
     @MainActor
     func testServeHelpDocumentsTheWearerGateFlag() async {
         let buffer = Buffer()

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -79,6 +79,9 @@ final class TapQCLIApplicationTests: XCTestCase {
     private final class FakeCapture: TapQMotionCapturing {
         var sessions: [[TimedSample]]
         let clock: TestClock?
+        /// Runs while the motion stream is open, so a test can script whatever the
+        /// microphone arm does during the recording rather than only around it.
+        var duringCapture: (@MainActor () -> Void)?
         private(set) var durations: [TimeInterval] = []
 
         init(sessions: [[TimedSample]], clock: TestClock? = nil) {
@@ -96,6 +99,50 @@ final class TapQCLIApplicationTests: XCTestCase {
                 clock?.now = item.time
                 onSample(item.sample)
             }
+            duringCapture?()
+        }
+    }
+
+    /// Scripted microphone arm. It follows the `TapQAudioEnvelopeCapturing` contract —
+    /// header block first, then samples — so the CLI-level tests exercise the same
+    /// ordering the live source promises.
+    @MainActor
+    private final class FakeEnvelopeCapture: TapQAudioEnvelopeCapturing {
+        var startFailure: TapQEnvelopeCaptureError?
+        var track = MicEnvelopeTrackMeta(sampleRate: 48_000, blockFrames: 1_024)
+        var blocks: [MicEnvelopeSample] = []
+        private(set) var starts = 0
+        private(set) var stops = 0
+        private var onTrack: (@MainActor (MicEnvelopeTrackMeta) -> Void)?
+        private var onSample: (@MainActor (MicEnvelopeSample) -> Void)?
+        private var onInvalidation: (@MainActor (TapQEnvelopeCaptureError) -> Void)?
+
+        func start(
+            onTrack: @escaping @MainActor (MicEnvelopeTrackMeta) -> Void,
+            onSample: @escaping @MainActor (MicEnvelopeSample) -> Void,
+            onInvalidation: @escaping @MainActor (TapQEnvelopeCaptureError) -> Void
+        ) throws {
+            if let startFailure { throw startFailure }
+            starts += 1
+            self.onTrack = onTrack
+            self.onSample = onSample
+            self.onInvalidation = onInvalidation
+        }
+
+        func stop() {
+            stops += 1
+        }
+
+        func emitBlocks() {
+            onTrack?(track)
+            for block in blocks { onSample?(block) }
+        }
+
+        func invalidate(
+            _ error: TapQEnvelopeCaptureError = .invalidated(
+                "configuration_changed: audio input route changed")
+        ) {
+            onInvalidation?(error)
         }
     }
 
@@ -145,6 +192,164 @@ final class TapQCLIApplicationTests: XCTestCase {
         XCTAssertTrue(text.hasPrefix(MotionSampleFormatter.csvHeader + "\n"))
         XCTAssertEqual(text.split(separator: "\n").count, 3)
         XCTAssertTrue(buffer.error.contains("Captured 2 samples"))
+    }
+
+    @MainActor
+    func testCaptureCoRecordsAMicrophoneEnvelopeSidecar() async throws {
+        let buffer = Buffer()
+        let capture = FakeCapture(sessions: [[
+            TimedSample(time: 0, sample: sample(100.0)),
+            TimedSample(time: 0, sample: sample(100.04)),
+        ]])
+        let envelope = FakeEnvelopeCapture()
+        envelope.blocks = [
+            MicEnvelopeSample(timestamp: 100.01, rms: 0.02, peak: 0.05),
+            MicEnvelopeSample(timestamp: 100.03, rms: 0.31, peak: 0.62),
+        ]
+        capture.duringCapture = { envelope.emitBlocks() }
+        let app = application(io: buffer.io, capture: capture, envelopeCapture: envelope)
+        let motionURL = directory.appendingPathComponent("imu.jsonl")
+        let envelopeURL = directory.appendingPathComponent("env.jsonl")
+
+        let status = await app.run(arguments: [
+            "capture", "--duration", "1", "--output", motionURL.path,
+            "--mic-envelope", envelopeURL.path,
+        ])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertEqual(envelope.starts, 1)
+        XCTAssertGreaterThanOrEqual(envelope.stops, 1)
+        let track = try EnvelopeTrackReader.track(fromFileAt: envelopeURL)
+        XCTAssertEqual(track.meta, envelope.track)
+        XCTAssertEqual(track.samples, envelope.blocks)
+        let motion = try String(contentsOf: motionURL, encoding: .utf8)
+        XCTAssertEqual(motion.split(separator: "\n").count, 2)
+        XCTAssertTrue(buffer.error.contains("Captured 2 microphone envelope blocks"))
+    }
+
+    @MainActor
+    func testCaptureWithoutTheFlagNeverOpensTheMicrophone() async throws {
+        let buffer = Buffer()
+        let envelope = FakeEnvelopeCapture()
+        let plain = FakeCapture(sessions: [[TimedSample(time: 0, sample: sample(1))]])
+        let withAdapter = FakeCapture(sessions: [[TimedSample(time: 0, sample: sample(1))]])
+        let plainURL = directory.appendingPathComponent("plain.jsonl")
+        let adapterURL = directory.appendingPathComponent("adapter.jsonl")
+
+        let plainStatus = await application(io: buffer.io, capture: plain)
+            .run(arguments: ["capture", "--duration", "1", "--output", plainURL.path])
+        let adapterStatus = await application(
+            io: buffer.io, capture: withAdapter, envelopeCapture: envelope
+        ).run(arguments: ["capture", "--duration", "1", "--output", adapterURL.path])
+
+        XCTAssertEqual(plainStatus, 0)
+        XCTAssertEqual(adapterStatus, 0)
+        XCTAssertEqual(envelope.starts, 0, "a capture without the flag stays microphone-free")
+        XCTAssertEqual(
+            try Data(contentsOf: plainURL),
+            try Data(contentsOf: adapterURL),
+            "having an envelope adapter available must not change capture output"
+        )
+    }
+
+    @MainActor
+    func testCaptureRefusesToOverwriteAnExistingSidecarWithoutForce() async throws {
+        let buffer = Buffer()
+        let capture = FakeCapture(sessions: [[TimedSample(time: 0, sample: sample(1))]])
+        let envelope = FakeEnvelopeCapture()
+        let envelopeURL = directory.appendingPathComponent("env.jsonl")
+        try Data("previous session\n".utf8).write(to: envelopeURL)
+        let app = application(io: buffer.io, capture: capture, envelopeCapture: envelope)
+
+        let refused = await app.run(arguments: [
+            "capture", "--duration", "1", "--output", directory.appendingPathComponent("a.jsonl").path,
+            "--mic-envelope", envelopeURL.path,
+        ])
+        XCTAssertEqual(refused, 1)
+        XCTAssertTrue(buffer.error.contains("Use --force to replace it"))
+        XCTAssertTrue(capture.durations.isEmpty, "nothing is captured when the sidecar is refused")
+        XCTAssertEqual(envelope.starts, 0)
+
+        capture.duringCapture = { envelope.emitBlocks() }
+        let forced = await app.run(arguments: [
+            "capture", "--duration", "1", "--output", directory.appendingPathComponent("b.jsonl").path,
+            "--mic-envelope", envelopeURL.path, "--force",
+        ])
+        XCTAssertEqual(forced, 0)
+        let text = try String(contentsOf: envelopeURL, encoding: .utf8)
+        XCTAssertFalse(text.contains("previous session"))
+        XCTAssertTrue(text.hasPrefix(EnvelopeSampleFormatter.metaLine(for: envelope.track)))
+    }
+
+    @MainActor
+    func testMicrophoneStartFailureAbortsBeforeAnyMotionIsCaptured() async {
+        let buffer = Buffer()
+        let capture = FakeCapture(sessions: [[TimedSample(time: 0, sample: sample(1))]])
+        let envelope = FakeEnvelopeCapture()
+        envelope.startFailure = .startFailed("engine_start: input device disappeared")
+        let app = application(io: buffer.io, capture: capture, envelopeCapture: envelope)
+
+        let status = await app.run(arguments: [
+            "capture", "--duration", "1",
+            "--output", directory.appendingPathComponent("imu.jsonl").path,
+            "--mic-envelope", directory.appendingPathComponent("env.jsonl").path,
+        ])
+
+        XCTAssertEqual(status, 69)
+        XCTAssertTrue(buffer.error.contains("input device disappeared"))
+        XCTAssertTrue(buffer.error.contains("Nothing was recorded"))
+        XCTAssertTrue(capture.durations.isEmpty)
+    }
+
+    @MainActor
+    func testMicEnvelopeWithoutAnAudioAdapterFailsClosed() async {
+        let buffer = Buffer()
+        let capture = FakeCapture(sessions: [[TimedSample(time: 0, sample: sample(1))]])
+        let app = application(io: buffer.io, capture: capture)
+
+        let status = await app.run(arguments: [
+            "capture", "--duration", "1",
+            "--output", directory.appendingPathComponent("imu.jsonl").path,
+            "--mic-envelope", directory.appendingPathComponent("env.jsonl").path,
+        ])
+
+        XCTAssertEqual(status, 69)
+        XCTAssertTrue(buffer.error.contains("Microphone envelope co-recording is unavailable"))
+        XCTAssertTrue(capture.durations.isEmpty)
+    }
+
+    @MainActor
+    func testMidCaptureRouteChangeKeepsTheMotionTrackAndExitsNonzero() async throws {
+        let buffer = Buffer()
+        let capture = FakeCapture(sessions: [[
+            TimedSample(time: 0, sample: sample(1)),
+            TimedSample(time: 0, sample: sample(2)),
+        ]])
+        let envelope = FakeEnvelopeCapture()
+        envelope.blocks = [MicEnvelopeSample(timestamp: 1.0, rms: 0.1, peak: 0.2)]
+        capture.duringCapture = {
+            envelope.emitBlocks()
+            envelope.invalidate()
+        }
+        let motionURL = directory.appendingPathComponent("imu.jsonl")
+        let envelopeURL = directory.appendingPathComponent("env.jsonl")
+        let app = application(io: buffer.io, capture: capture, envelopeCapture: envelope)
+
+        let status = await app.run(arguments: [
+            "capture", "--duration", "1", "--output", motionURL.path,
+            "--mic-envelope", envelopeURL.path,
+        ])
+
+        XCTAssertEqual(status, 1)
+        XCTAssertTrue(buffer.error.contains("truncated"))
+        XCTAssertTrue(buffer.error.contains("Captured 2 samples."))
+        let motion = try String(contentsOf: motionURL, encoding: .utf8)
+        XCTAssertEqual(
+            motion.split(separator: "\n").count, 2,
+            "the IMU capture still finishes and is written"
+        )
+        let track = try EnvelopeTrackReader.track(fromFileAt: envelopeURL)
+        XCTAssertEqual(track.samples.count, 1)
     }
 
     @MainActor
@@ -1078,6 +1283,7 @@ final class TapQCLIApplicationTests: XCTestCase {
     private func application(
         io: TapQCLIIO,
         capture: (any TapQMotionCapturing)? = nil,
+        envelopeCapture: (any TapQAudioEnvelopeCapturing)? = nil,
         runtime: (any TapQRuntimeServing)? = nil,
         reasonerLoader: TapQReasonerLoading? = nil,
         benchReasonerLoader: TapQReasonerLoading? = nil,
@@ -1091,6 +1297,7 @@ final class TapQCLIApplicationTests: XCTestCase {
         TapQCLIApplication(
             io: io,
             motionCapture: capture,
+            envelopeCapture: envelopeCapture,
             runtimeService: runtime,
             reasonerLoader: reasonerLoader,
             benchReasonerLoader: benchReasonerLoader,

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -241,43 +241,193 @@ final class TapQCLIApplicationTests: XCTestCase {
         let app = application(io: buffer.io, capture: capture, monotonicNow: { clock.now })
         let gestureURL = directory.appendingPathComponent("gesture.json")
         let tapURL = directory.appendingPathComponent("tap.json")
+        let speechURL = directory.appendingPathComponent("wearer-speech.json")
         let common = [
             "--gesture-profile", gestureURL.path,
             "--tap-profile", tapURL.path,
+            "--wearer-speech-profile", speechURL.path,
         ]
 
         let runStatus = await app.run(arguments: [
             "calibrate", "--non-interactive",
             "--rest-seconds", "0.1", "--nod-seconds", "0.1",
             "--shake-seconds", "0.1", "--tap-seconds", "0.1",
+            "--speak-seconds", "0.1",
         ] + common)
         XCTAssertEqual(runStatus, 0)
 
         let store = CalibrationStore(
             gestureProfileURL: gestureURL,
-            tapProfileURL: tapURL
+            tapProfileURL: tapURL,
+            wearerSpeechProfileURL: speechURL
         )
         let gesture = try store.loadGesture()
         let tap = try store.loadTap()
+        let speech = try store.loadWearerSpeech()
         XCTAssertGreaterThan(gesture.quality.nodSampleCount, 0)
         XCTAssertGreaterThan(tap.quality.tapAccelerationPeak, 0.3)
+        XCTAssertEqual(speech.quality.speakingEnvelopeLevel, 0.03, accuracy: 1e-9)
+        XCTAssertEqual(speech.quality.restingEnvelopePeak, 0.002, accuracy: 1e-9)
+        XCTAssertGreaterThan(speech.quality.speakingSampleCount, 0)
+        XCTAssertLessThan(
+            speech.config.envelopeExitThreshold, speech.config.envelopeEnterThreshold)
         XCTAssertEqual(capture.durations.count, 1)
-        XCTAssertEqual(capture.durations.first ?? 0, 4.4, accuracy: 0.000_001)
+        XCTAssertEqual(capture.durations.first ?? 0, 5.5, accuracy: 0.000_001)
         let persistedGesture = try String(contentsOf: gestureURL, encoding: .utf8)
         let persistedTap = try String(contentsOf: tapURL, encoding: .utf8)
+        let persistedSpeech = try String(contentsOf: speechURL, encoding: .utf8)
         XCTAssertFalse(persistedGesture.contains("\"restingPitch\""))
         XCTAssertFalse(persistedTap.contains("\"tapAccel\""))
+        XCTAssertFalse(persistedSpeech.contains("\"speakingEnvelope\""))
 
         buffer.output = ""
         let showStatus = await app.run(arguments: ["calibration", "show"] + common)
         XCTAssertEqual(showStatus, 0)
         XCTAssertTrue(buffer.output.contains("Gesture threshold"))
         XCTAssertTrue(buffer.output.contains("Observed peak"))
+        XCTAssertTrue(buffer.output.contains("Wearer speech thresholds"))
+        XCTAssertTrue(buffer.output.contains("Observed envelope"))
 
+        buffer.output = ""
+        let jsonStatus = await app.run(arguments: ["calibration", "show", "--json"] + common)
+        XCTAssertEqual(jsonStatus, 0)
+        XCTAssertTrue(buffer.output.contains("\"gesture\""))
+        XCTAssertTrue(buffer.output.contains("\"tap\""))
+        XCTAssertTrue(buffer.output.contains("\"wearer_speech\""))
+
+        buffer.output = ""
         let resetStatus = await app.run(arguments: ["calibration", "reset", "--yes"] + common)
         XCTAssertEqual(resetStatus, 0)
+        XCTAssertTrue(buffer.output.contains("Wearer speech calibration profile removed"))
+        XCTAssertFalse(buffer.output.contains("Wearer_speech"))
         XCTAssertFalse(FileManager.default.fileExists(atPath: gestureURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: tapURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: speechURL.path))
+    }
+
+    /// The third profile has to be independently runnable, showable and resettable, or a
+    /// weak speak phase would cost the user their gesture and tap calibration.
+    @MainActor
+    func testWearerSpeechTargetRunsShowsAndResetsWithoutTouchingTheOtherProfiles() async throws {
+        let gestureURL = directory.appendingPathComponent("gesture.json")
+        let tapURL = directory.appendingPathComponent("tap.json")
+        let speechURL = directory.appendingPathComponent("wearer-speech.json")
+        let common = [
+            "--gesture-profile", gestureURL.path,
+            "--tap-profile", tapURL.path,
+            "--wearer-speech-profile", speechURL.path,
+        ]
+
+        let fullBuffer = Buffer()
+        let fullClock = TestClock()
+        let fullApp = application(
+            io: fullBuffer.io,
+            capture: FakeCapture(sessions: [calibrationSamples()], clock: fullClock),
+            monotonicNow: { fullClock.now }
+        )
+        let fullStatus = await fullApp.run(arguments: [
+            "calibration", "run", "all", "--non-interactive",
+            "--rest-seconds", "0.1", "--nod-seconds", "0.1",
+            "--shake-seconds", "0.1", "--tap-seconds", "0.1",
+            "--speak-seconds", "0.1",
+        ] + common)
+        XCTAssertEqual(fullStatus, 0)
+
+        let buffer = Buffer()
+        let clock = TestClock()
+        let capture = FakeCapture(sessions: [wearerSpeechOnlySamples()], clock: clock)
+        let app = application(io: buffer.io, capture: capture, monotonicNow: { clock.now })
+
+        let runStatus = await app.run(arguments: [
+            "calibration", "run", "wearer-speech", "--non-interactive",
+            "--rest-seconds", "0.1", "--speak-seconds", "0.1",
+            "--profile", speechURL.path,
+        ])
+        XCTAssertEqual(runStatus, 0)
+        // warmup 1 + rest 0.1 + transition 1 + speak 0.1
+        XCTAssertEqual(capture.durations, [2.2])
+        XCTAssertTrue(buffer.output.contains("Wearer speech calibration saved"))
+
+        buffer.output = ""
+        let showStatus = await app.run(arguments: [
+            "calibration", "show", "wearer-speech", "--profile", speechURL.path,
+        ])
+        XCTAssertEqual(showStatus, 0)
+        XCTAssertTrue(buffer.output.contains("Wearer speech thresholds"))
+        XCTAssertFalse(buffer.output.contains("Gesture threshold"))
+        XCTAssertFalse(buffer.output.contains("Tap threshold"))
+
+        buffer.output = ""
+        let resetStatus = await app.run(arguments: [
+            "calibration", "reset", "wearer-speech", "--yes", "--profile", speechURL.path,
+        ])
+        XCTAssertEqual(resetStatus, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: speechURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: gestureURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tapURL.path))
+    }
+
+    @MainActor
+    func testUnusableSpeakPhaseFailsButKeepsGestureAndTapProfiles() async throws {
+        let buffer = Buffer()
+        let clock = TestClock()
+        let capture = FakeCapture(
+            // A tremor buried in resting jitter: measured, but not separable from rest.
+            sessions: [calibrationSamples(speakJerk: 0.001)],
+            clock: clock
+        )
+        let app = application(io: buffer.io, capture: capture, monotonicNow: { clock.now })
+        let gestureURL = directory.appendingPathComponent("gesture.json")
+        let tapURL = directory.appendingPathComponent("tap.json")
+        let speechURL = directory.appendingPathComponent("wearer-speech.json")
+
+        let status = await app.run(arguments: [
+            "calibration", "run", "all", "--non-interactive",
+            "--rest-seconds", "0.1", "--nod-seconds", "0.1",
+            "--shake-seconds", "0.1", "--tap-seconds", "0.1",
+            "--speak-seconds", "0.1",
+            "--gesture-profile", gestureURL.path,
+            "--tap-profile", tapURL.path,
+            "--wearer-speech-profile", speechURL.path,
+        ])
+
+        XCTAssertEqual(status, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: gestureURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tapURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: speechURL.path))
+        XCTAssertTrue(buffer.output.contains("Wearer speech envelope:"))
+        XCTAssertTrue(buffer.error.contains("sufficiently separated from resting motion"))
+        XCTAssertTrue(buffer.error.contains("run wearer-speech"))
+    }
+
+    /// A short capture and a weak one fail for unrelated reasons, so they must not share
+    /// a remedy: this one tells the user to lengthen the phase, not to speak up.
+    @MainActor
+    func testTooFewSpeakSamplesReportsTheSampleShortfall() async throws {
+        let buffer = Buffer()
+        let clock = TestClock()
+        let capture = FakeCapture(
+            sessions: [calibrationSamples(speakCount: 3)],
+            clock: clock
+        )
+        let app = application(io: buffer.io, capture: capture, monotonicNow: { clock.now })
+        let speechURL = directory.appendingPathComponent("wearer-speech.json")
+
+        let status = await app.run(arguments: [
+            "calibration", "run", "all", "--non-interactive",
+            "--rest-seconds", "0.1", "--nod-seconds", "0.1",
+            "--shake-seconds", "0.1", "--tap-seconds", "0.1",
+            "--speak-seconds", "0.1",
+            "--gesture-profile", directory.appendingPathComponent("gesture.json").path,
+            "--tap-profile", directory.appendingPathComponent("tap.json").path,
+            "--wearer-speech-profile", speechURL.path,
+        ])
+
+        XCTAssertEqual(status, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: speechURL.path))
+        XCTAssertTrue(buffer.error.contains("too few motion samples"))
+        XCTAssertTrue(buffer.error.contains("--speak-seconds"))
+        XCTAssertFalse(buffer.error.contains("sufficiently separated from resting motion"))
     }
 
     @MainActor
@@ -335,7 +485,8 @@ final class TapQCLIApplicationTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: tapURL.path))
         let savedTap = try CalibrationStore(
             gestureProfileURL: gestureURL,
-            tapProfileURL: tapURL
+            tapProfileURL: tapURL,
+            wearerSpeechProfileURL: directory.appendingPathComponent("wearer-speech.json")
         ).loadTap()
         XCTAssertEqual(savedTap.config.amplitudeThreshold, 0.05, accuracy: 1e-9)
     }
@@ -963,15 +1114,23 @@ final class TapQCLIApplicationTests: XCTestCase {
         )
     }
 
+    /// A full four-phase session. Resting and speak run at 25 Hz because wearer-speech
+    /// calibration differences consecutive samples: widely spaced fixtures would be read as
+    /// stream gaps and dropped, leaving the envelope empty.
     private func calibrationSamples(
-        tapValues: [Double] = [0.05, 0.8, 0.06]
+        tapValues: [Double] = [0.05, 0.8, 0.06],
+        speakJerk: Double = 0.03,
+        speakCount: Int = 20
     ) -> [TimedSample] {
-        let resting = [
-            HeadMotionSample(timestamp: 0, pitch: 0, yaw: 0,
-                             accelerationMagnitude: 0.01, rotationMagnitude: 0),
-            HeadMotionSample(timestamp: 1, pitch: 0.01, yaw: -0.01,
-                             accelerationMagnitude: 0.02, rotationMagnitude: 0),
-        ]
+        let resting = (0..<20).map { index in
+            HeadMotionSample(
+                timestamp: Double(index) * 0.04,
+                pitch: index.isMultiple(of: 2) ? 0 : 0.01,
+                yaw: index.isMultiple(of: 2) ? 0 : -0.01,
+                accelerationMagnitude: index.isMultiple(of: 2) ? 0.010 : 0.012,
+                rotationMagnitude: 0
+            )
+        }
         let nod = [-0.3, 0.3, -0.3, 0.3].enumerated().map {
             HeadMotionSample(timestamp: Double($0.offset), pitch: $0.element, yaw: 0,
                              accelerationMagnitude: 0.1, rotationMagnitude: 1)
@@ -984,10 +1143,44 @@ final class TapQCLIApplicationTests: XCTestCase {
             HeadMotionSample(timestamp: Double($0.offset), pitch: 0, yaw: 0,
                              accelerationMagnitude: $0.element, rotationMagnitude: 0.05)
         }
+        let speak = (0..<speakCount).map { index in
+            HeadMotionSample(
+                timestamp: Double(index) * 0.04,
+                pitch: 0,
+                yaw: 0,
+                accelerationMagnitude: 0.05 + (index.isMultiple(of: 2) ? 0 : speakJerk),
+                rotationMagnitude: 0.02
+            )
+        }
         return resting.map { TimedSample(time: 1.01, sample: $0) }
             + nod.map { TimedSample(time: 2.11, sample: $0) }
             + shake.map { TimedSample(time: 3.21, sample: $0) }
             + tap.map { TimedSample(time: 4.31, sample: $0) }
+            + speak.map { TimedSample(time: 5.41, sample: $0) }
+    }
+
+    /// Phase markers for the wearer-speech-only timeline: warmup 1, rest 0.1, transition 1,
+    /// speak 0.1.
+    private func wearerSpeechOnlySamples() -> [TimedSample] {
+        let resting = (0..<20).map { index in
+            TimedSample(time: 1.01, sample: HeadMotionSample(
+                timestamp: Double(index) * 0.04,
+                pitch: 0,
+                yaw: 0,
+                accelerationMagnitude: index.isMultiple(of: 2) ? 0.010 : 0.012,
+                rotationMagnitude: 0
+            ))
+        }
+        let speak = (0..<20).map { index in
+            TimedSample(time: 2.11, sample: HeadMotionSample(
+                timestamp: Double(index) * 0.04,
+                pitch: 0,
+                yaw: 0,
+                accelerationMagnitude: 0.05 + (index.isMultiple(of: 2) ? 0 : 0.03),
+                rotationMagnitude: 0.02
+            ))
+        }
+        return resting + speak
     }
 
     private func tapOnlySamples() -> [TimedSample] {

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import TapQCLI
 import TapQContextBaseline
 import TapQDetectionBaseline
+import TapQVoiceBackends
 import TapQWireProtocol
 
 final class TapQCLIApplicationTests: XCTestCase {
@@ -43,6 +44,9 @@ final class TapQCLIApplicationTests: XCTestCase {
                 tapProfileLoaded: true,
                 motionAvailable: true,
                 voiceAvailable: false,
+                // The live host derives the line the same way: from the provider it was
+                // handed, with the default reporting nothing.
+                voiceBackendStatus: configuration.voiceBackend.statusDescription,
                 reasonerStatus: configuration.reasonerMode == .off
                     ? nil
                     : "\(configuration.reasonerMode.rawValue)"
@@ -387,6 +391,60 @@ final class TapQCLIApplicationTests: XCTestCase {
         XCTAssertEqual(configuration.questionClassifier, .anthropic)
         XCTAssertTrue(buffer.output.contains("TapQ runtime is ready"))
         XCTAssertTrue(buffer.output.contains("AirPods motion: available"))
+    }
+
+    @MainActor
+    func testServePassesTheVoiceBackendThroughAndReportsIt() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: [
+            "serve", "--voice-backend", "openai-realtime",
+        ])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertEqual(runtime.configurations.first?.voiceBackend, .openaiRealtime)
+        XCTAssertTrue(
+            buffer.output.contains("Voice backend: openai-realtime (fail-through: apple)"),
+            "the operator has to be able to see which pipe is primary and what backs it"
+        )
+    }
+
+    /// The default must be invisible: no flag, no configuration change, no extra line.
+    @MainActor
+    func testTheDefaultVoiceBackendChangesNothingAboutServe() async {
+        let omitted = Buffer()
+        let explicit = Buffer()
+        let omittedRuntime = FakeRuntime()
+        let explicitRuntime = FakeRuntime()
+
+        let omittedStatus = await application(io: omitted.io, runtime: omittedRuntime)
+            .run(arguments: ["serve"])
+        let explicitStatus = await application(io: explicit.io, runtime: explicitRuntime)
+            .run(arguments: ["serve", "--voice-backend", "apple"])
+
+        XCTAssertEqual(omittedStatus, 0)
+        XCTAssertEqual(explicitStatus, 0)
+        XCTAssertEqual(omittedRuntime.configurations.first?.voiceBackend, .apple)
+        XCTAssertEqual(explicitRuntime.configurations.first?.voiceBackend, .apple)
+        XCTAssertEqual(omitted.output, explicit.output)
+        XCTAssertFalse(omitted.output.contains("Voice backend:"),
+                       "the shipped path earns no status line")
+    }
+
+    @MainActor
+    func testServeHelpDocumentsTheVoiceBackendFlag() async {
+        let buffer = Buffer()
+        let status = await application(io: buffer.io).run(arguments: ["help", "serve"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("--voice-backend"))
+        for provider in VoiceBackendProvider.allCases {
+            XCTAssertTrue(buffer.output.contains(provider.rawValue),
+                          "serve help must name every provider the parser accepts")
+        }
+        XCTAssertTrue(buffer.output.contains("OPENAI_API_KEY"))
     }
 
     @MainActor

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -1862,4 +1862,62 @@ final class TapQCLIApplicationTests: XCTestCase {
         }
         return resting + tap
     }
+
+    // MARK: - --voice-freeform (WP8)
+
+    @MainActor
+    func testServeVoiceFreeformFlagPassedToConfiguration() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: [
+            "serve", "--voice-backend", "openai-realtime", "--voice-freeform",
+        ])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(runtime.configurations.first?.voiceFreeformEnabled == true)
+    }
+
+    @MainActor
+    func testServeWithoutVoiceFreeformDefaultsToOff() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: ["serve"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertFalse(runtime.configurations.first?.voiceFreeformEnabled == true)
+    }
+
+    @MainActor
+    func testServeVoiceFreeformRejectedOnAppleProvider() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: [
+            "serve", "--voice-freeform",
+        ])
+
+        XCTAssertEqual(status, 64,
+                       "voice-freeform on .apple must fail with usage error")
+        XCTAssertTrue(buffer.error.contains("--voice-freeform requires --voice-backend"))
+    }
+
+    @MainActor
+    func testServeVoiceFreeformExplicitAppleRejected() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: [
+            "serve", "--voice-backend", "apple", "--voice-freeform",
+        ])
+
+        XCTAssertEqual(status, 64,
+                       "voice-freeform with explicit apple must also fail")
+        XCTAssertTrue(buffer.error.contains("--voice-freeform requires --voice-backend"))
+    }
 }

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -30,6 +30,20 @@ final class TapQCLIApplicationTests: XCTestCase {
         private(set) var configurations: [TapQRuntimeConfiguration] = []
         private(set) var receivedReasonerLoader = false
 
+        static func wearerSpeechStatus(
+            configuration: TapQRuntimeConfiguration
+        ) -> String? {
+            let gate = configuration.wearerGateEnabled
+            let turnControl = configuration.imuTurnControlEnabled
+            guard gate || turnControl else { return nil }
+            switch (gate, turnControl) {
+            case (true, true): return "gate+turn-control"
+            case (true, false): return "gate"
+            case (false, true): return "turn-control"
+            case (false, false): return nil
+            }
+        }
+
         func serve(
             configuration: TapQRuntimeConfiguration,
             reasonerLoader: TapQReasonerLoading?,
@@ -51,7 +65,7 @@ final class TapQCLIApplicationTests: XCTestCase {
                     ? nil
                     : "\(configuration.reasonerMode.rawValue)"
                         + " (\(configuration.reasonerProvider.rawValue))",
-                wearerSpeechStatus: configuration.wearerGateEnabled ? "gate" : nil
+                wearerSpeechStatus: Self.wearerSpeechStatus(configuration: configuration)
             ))
         }
     }
@@ -478,6 +492,48 @@ final class TapQCLIApplicationTests: XCTestCase {
     }
 
     @MainActor
+    func testServeImuTurnControlFlagPassesThroughAndReportsStatus() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: ["serve", "--imu-turn-control"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(runtime.configurations.first?.imuTurnControlEnabled == true)
+        XCTAssertTrue(buffer.output.contains("Wearer speech: turn-control"),
+                      "the turn-control status must be visible to the operator")
+    }
+
+    @MainActor
+    func testServeBothGateAndTurnControlReportsCombinedStatus() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: [
+            "serve", "--wearer-gate", "--imu-turn-control",
+        ])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(runtime.configurations.first?.wearerGateEnabled == true)
+        XCTAssertTrue(runtime.configurations.first?.imuTurnControlEnabled == true)
+        XCTAssertTrue(buffer.output.contains("Wearer speech: gate+turn-control"))
+    }
+
+    @MainActor
+    func testServeWithoutImuTurnControlChangesNothing() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: ["serve"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertFalse(runtime.configurations.first?.imuTurnControlEnabled == true)
+    }
+
+    @MainActor
     func testServeHelpDocumentsTheWearerGateFlag() async {
         let buffer = Buffer()
         let status = await application(io: buffer.io).run(arguments: ["help", "serve"])
@@ -485,6 +541,17 @@ final class TapQCLIApplicationTests: XCTestCase {
         XCTAssertEqual(status, 0)
         XCTAssertTrue(buffer.output.contains("--wearer-gate"))
         XCTAssertTrue(buffer.output.contains("fail-open"))
+    }
+
+    @MainActor
+    func testServeHelpDocumentsTheImuTurnControlFlag() async {
+        let buffer = Buffer()
+        let status = await application(io: buffer.io).run(arguments: ["help", "serve"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("--imu-turn-control"))
+        XCTAssertTrue(buffer.output.contains("Endpointing"))
+        XCTAssertTrue(buffer.output.contains("Barge-in"))
     }
 
     @MainActor

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -1270,6 +1270,292 @@ final class TapQCLIApplicationTests: XCTestCase {
         return url
     }
 
+    // MARK: - Replay: wearer speech
+
+    /// One synthetic capture: two quiet seconds, three spoken ones, two quiet again, at the
+    /// 25 Hz the motion adapters deliver. "Spoken" is a sustained sample-to-sample
+    /// acceleration change with the head held still, which is what the detector looks for.
+    /// Per-axis, because that is what a real capture file carries and what survives the
+    /// formatter/reader round trip these tests run through.
+    private struct SpokenCapture {
+        static let rate: TimeInterval = 1.0 / 25.0
+        let samples: [HeadMotionSample]
+        let speechStart: TimeInterval
+        let speechEnd: TimeInterval
+
+        init() {
+            var samples: [HeadMotionSample] = []
+            var time: TimeInterval = 100
+            var sign = 1.0
+            func append(seconds: TimeInterval, jerk: Double) {
+                for _ in 0..<Int((seconds / Self.rate).rounded()) {
+                    sign = -sign
+                    samples.append(HeadMotionSample(
+                        timestamp: time, pitch: 0, yaw: 0, roll: 0,
+                        userAcceleration: MotionVector(x: sign * jerk / 2, y: 0, z: 0),
+                        rotationRate: MotionVector(x: 0, y: 0.02, z: 0),
+                        gravity: MotionVector(x: 0, y: 0, z: -1)))
+                    time += Self.rate
+                }
+            }
+            append(seconds: 2, jerk: 0.002)
+            speechStart = time
+            append(seconds: 3, jerk: 0.05)
+            speechEnd = time
+            append(seconds: 2, jerk: 0.002)
+            self.samples = samples
+        }
+    }
+
+    @MainActor
+    private func writeCapture(_ capture: SpokenCapture) throws -> URL {
+        let url = directory.appendingPathComponent("speech-capture.jsonl")
+        let text = capture.samples
+            .map { MotionSampleFormatter.line(for: $0, format: .jsonl) }
+            .joined(separator: "\n")
+        try Data((text + "\n").utf8).write(to: url)
+        return url
+    }
+
+    @MainActor
+    private func writeSpeechLabels(_ capture: SpokenCapture, extra: [String] = []) throws -> URL {
+        let url = directory.appendingPathComponent("labels.jsonl")
+        let speech = """
+        {"start": \(capture.speechStart), "end": \(capture.speechEnd), \
+        "label": "wearer_speech"}
+        """
+        try Data((([speech] + extra).joined(separator: "\n") + "\n").utf8).write(to: url)
+        return url
+    }
+
+    /// An envelope sidecar that is loud exactly while the capture is spoken, written
+    /// through the same formatter the capture command uses.
+    @MainActor
+    private func writeEnvelope(_ capture: SpokenCapture, offset: TimeInterval = 0) throws -> URL {
+        let url = directory.appendingPathComponent("env-\(offset).jsonl")
+        let meta = MicEnvelopeTrackMeta(sampleRate: 48_000, blockFrames: 960)
+        var lines = [EnvelopeSampleFormatter.metaLine(for: meta)]
+        var time = capture.samples[0].timestamp
+        let last = capture.samples.last!.timestamp
+        while time <= last {
+            let loud = time >= capture.speechStart && time < capture.speechEnd
+            lines.append(EnvelopeSampleFormatter.line(for: MicEnvelopeSample(
+                timestamp: time + offset,
+                rms: loud ? 0.08 : 0.002,
+                peak: loud ? 0.16 : 0.004)))
+            time += 0.02
+        }
+        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: url)
+        return url
+    }
+
+    @MainActor
+    func testReplayScoresWearerSpeechAgainstLabels() async throws {
+        let buffer = Buffer()
+        let capture = SpokenCapture()
+        let captureURL = try writeCapture(capture)
+        let labelsURL = try writeSpeechLabels(capture)
+
+        let status = await application(io: buffer.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--labels", labelsURL.path,
+            "--tolerance", "0.7",
+        ])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("Wearer speech (truth: labels): 1 detected, 1 labeled"),
+                      buffer.output)
+        XCTAssertTrue(buffer.output.contains("onset latency:"), buffer.output)
+        XCTAssertTrue(buffer.output.contains("false activations: 0"), buffer.output)
+    }
+
+    @MainActor
+    func testReplayWearerSpeechJSONCarriesEveryMetric() async throws {
+        let buffer = Buffer()
+        let capture = SpokenCapture()
+        let captureURL = try writeCapture(capture)
+        let labelsURL = try writeSpeechLabels(capture)
+
+        let status = await application(io: buffer.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--labels", labelsURL.path,
+            "--tolerance", "0.7", "--json",
+        ])
+        XCTAssertEqual(status, 0)
+
+        let report = try JSONSerialization.jsonObject(
+            with: Data(buffer.output.utf8)) as? [String: Any]
+        let speech = try XCTUnwrap(report?["wearer_speech"] as? [String: Any])
+        XCTAssertEqual(speech["truth_source"] as? String, "labels")
+        XCTAssertGreaterThan(try XCTUnwrap(speech["frame_precision"] as? Double), 0.9)
+        XCTAssertGreaterThan(try XCTUnwrap(speech["frame_recall"] as? Double), 0.9)
+        XCTAssertGreaterThan(try XCTUnwrap(speech["f1"] as? Double), 0.9)
+        XCTAssertGreaterThan(
+            try XCTUnwrap(speech["onset_latency_mean_seconds"] as? Double), 0,
+            "the detector cannot know about speech before it has heard any")
+        XCTAssertEqual(speech["false_activations_per_minute"] as? Double, 0)
+        XCTAssertEqual(speech["detected_intervals"] as? Int, 1)
+        XCTAssertEqual(speech["truth_intervals"] as? Int, 1)
+    }
+
+    @MainActor
+    func testReplayDerivesWearerSpeechTruthFromAnEnvelopeSidecar() async throws {
+        let buffer = Buffer()
+        let capture = SpokenCapture()
+        let captureURL = try writeCapture(capture)
+        let envelopeURL = try writeEnvelope(capture)
+
+        let status = await application(io: buffer.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--mic-envelope", envelopeURL.path,
+            "--tolerance", "0.7", "--json",
+        ])
+        XCTAssertEqual(status, 0)
+
+        let report = try JSONSerialization.jsonObject(
+            with: Data(buffer.output.utf8)) as? [String: Any]
+        let speech = try XCTUnwrap(report?["wearer_speech"] as? [String: Any])
+        XCTAssertEqual(speech["truth_source"] as? String, "mic_envelope")
+        XCTAssertEqual(speech["truth_intervals"] as? Int, 1)
+        XCTAssertGreaterThan(try XCTUnwrap(speech["f1"] as? Double), 0.8)
+    }
+
+    /// An envelope offset from the IMU clock is the study's silent failure mode; the
+    /// metrics have to make it loud.
+    @MainActor
+    func testReplayMetricsCollapseWhenTheEnvelopeClockIsOffset() async throws {
+        let capture = SpokenCapture()
+        let captureURL = try writeCapture(capture)
+
+        func f1(offset: TimeInterval) async throws -> Double {
+            let buffer = Buffer()
+            let envelopeURL = try writeEnvelope(capture, offset: offset)
+            let status = await application(io: buffer.io).run(arguments: [
+                "replay", "--input", captureURL.path, "--mic-envelope", envelopeURL.path,
+                "--tolerance", "0.5", "--json",
+            ])
+            XCTAssertEqual(status, 0)
+            let report = try JSONSerialization.jsonObject(
+                with: Data(buffer.output.utf8)) as? [String: Any]
+            let speech = try XCTUnwrap(report?["wearer_speech"] as? [String: Any])
+            return try XCTUnwrap(speech["f1"] as? Double)
+        }
+
+        let aligned = try await f1(offset: 0)
+        let skewed = try await f1(offset: 3.0)
+        XCTAssertGreaterThan(aligned, 0.8)
+        XCTAssertLessThan(skewed, aligned / 2)
+    }
+
+    @MainActor
+    func testReplayPrefersLabelsWhenBothTruthSourcesAreSupplied() async throws {
+        let buffer = Buffer()
+        let capture = SpokenCapture()
+        let captureURL = try writeCapture(capture)
+        let labelsURL = try writeSpeechLabels(capture)
+        let envelopeURL = try writeEnvelope(capture, offset: 3.0)
+
+        let status = await application(io: buffer.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--labels", labelsURL.path,
+            "--mic-envelope", envelopeURL.path, "--tolerance", "0.7", "--json",
+        ])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(
+            buffer.error.contains("scoring against the labels"),
+            "the ignored sidecar has to be reported, not silently dropped")
+        let report = try JSONSerialization.jsonObject(
+            with: Data(buffer.output.utf8)) as? [String: Any]
+        let speech = try XCTUnwrap(report?["wearer_speech"] as? [String: Any])
+        XCTAssertEqual(speech["truth_source"] as? String, "labels")
+        XCTAssertGreaterThan(try XCTUnwrap(speech["f1"] as? Double), 0.9)
+    }
+
+    /// The one guarantee every existing benchmark depends on: a replay that does not ask
+    /// for wearer speech reports exactly what it always did.
+    @MainActor
+    func testReplayWithoutSpeechTruthIsUnchanged() async throws {
+        let capture = SpokenCapture()
+        let captureURL = try writeCapture(capture)
+        let eventLabel = """
+        {"start": \(capture.speechStart), "end": \(capture.speechEnd), "label": "nod"}
+        """
+        let eventsURL = directory.appendingPathComponent("events.jsonl")
+        try Data((eventLabel + "\n").utf8).write(to: eventsURL)
+
+        let plain = Buffer()
+        let plainStatus = await application(io: plain.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--labels", eventsURL.path, "--json",
+        ])
+        XCTAssertEqual(plainStatus, 0)
+        XCTAssertFalse(plain.output.contains("wearer_speech"))
+        XCTAssertTrue(plain.output.contains("\"nod\""), plain.output)
+
+        // A wearer-speech profile alone tunes the detector but supplies no truth, so the
+        // section still does not appear.
+        let profiled = Buffer()
+        let profileStatus = await application(io: profiled.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--labels", eventsURL.path, "--json",
+            "--wearer-speech-profile",
+            directory.appendingPathComponent("missing.json").path,
+        ])
+        XCTAssertEqual(profileStatus, 0)
+        XCTAssertEqual(profiled.output, plain.output)
+
+        let text = Buffer()
+        _ = await application(io: text.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--labels", eventsURL.path,
+        ])
+        XCTAssertFalse(text.output.contains("Wearer speech"))
+    }
+
+    @MainActor
+    func testReplayUsesTheCalibratedWearerSpeechProfile() async throws {
+        let buffer = Buffer()
+        let capture = SpokenCapture()
+        let captureURL = try writeCapture(capture)
+        let labelsURL = try writeSpeechLabels(capture)
+        // A profile calibrated on a far louder wearer: the same capture now reads as quiet.
+        let profileURL = directory.appendingPathComponent("deaf-profile.json")
+        try CalibrationStore(
+            gestureProfileURL: directory.appendingPathComponent("g.json"),
+            tapProfileURL: directory.appendingPathComponent("t.json"),
+            wearerSpeechProfileURL: profileURL
+        ).save(TapQWearerSpeechCalibrationProfile(
+            config: WearerSpeechConfig(
+                envelopeEnterThreshold: 0.5, envelopeExitThreshold: 0.4),
+            quality: WearerSpeechCalibrationQuality(
+                restingSampleCount: 50, speakingSampleCount: 50,
+                restingEnvelopePeak: 0.01, speakingEnvelopeLevel: 0.6)
+        ))
+
+        let status = await application(io: buffer.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--labels", labelsURL.path,
+            "--wearer-speech-profile", profileURL.path, "--json",
+        ])
+
+        XCTAssertEqual(status, 0)
+        let report = try JSONSerialization.jsonObject(
+            with: Data(buffer.output.utf8)) as? [String: Any]
+        let speech = try XCTUnwrap(report?["wearer_speech"] as? [String: Any])
+        XCTAssertEqual(speech["detected_intervals"] as? Int, 0)
+        XCTAssertEqual(speech["frame_recall"] as? Double, 0)
+    }
+
+    @MainActor
+    func testReplayFailsOnAnUnreadableEnvelopeSidecar() async throws {
+        let buffer = Buffer()
+        let capture = SpokenCapture()
+        let captureURL = try writeCapture(capture)
+        let envelopeURL = directory.appendingPathComponent("garbage.jsonl")
+        try Data("not an envelope track\n".utf8).write(to: envelopeURL)
+
+        let status = await application(io: buffer.io).run(arguments: [
+            "replay", "--input", captureURL.path, "--mic-envelope", envelopeURL.path,
+        ])
+
+        XCTAssertEqual(status, 1)
+        XCTAssertTrue(buffer.error.contains("missing its tapq-mic-envelope-v1 header line"),
+                      buffer.error)
+    }
+
     @MainActor
     func testUnknownCommandReturnsUsageExitCode() async {
         let buffer = Buffer()

--- a/Tests/TapQCLITests/WearerSpeechReplayTests.swift
+++ b/Tests/TapQCLITests/WearerSpeechReplayTests.swift
@@ -1,0 +1,392 @@
+import XCTest
+@testable import TapQCLI
+import TapQDetectionBaseline
+
+/// Builds a synthetic 25 Hz capture whose sample-to-sample acceleration change is exactly
+/// the jerk asked for, so a "speaking" stretch is reproducible without hardware, a wearer,
+/// or a room.
+private struct CaptureStream {
+    static let rate: TimeInterval = 1.0 / 25.0
+
+    private(set) var samples: [HeadMotionSample] = []
+    private(set) var time: TimeInterval
+    private var sign: Double = 1
+
+    init(start: TimeInterval = 100) { time = start }
+
+    mutating func append(seconds: TimeInterval, jerk: Double, rotation: Double = 0.02) {
+        let count = Int((seconds / Self.rate).rounded())
+        for _ in 0..<count {
+            sign = -sign
+            samples.append(HeadMotionSample(
+                timestamp: time, pitch: 0, yaw: 0,
+                accelerationMagnitude: 0.05 + sign * jerk / 2,
+                rotationMagnitude: rotation
+            ))
+            time += Self.rate
+        }
+    }
+}
+
+/// Builds a synthetic microphone envelope track at a fixed block rate.
+private struct EnvelopeStream {
+    static let rate: TimeInterval = 1.0 / 50.0
+
+    private(set) var samples: [MicEnvelopeSample] = []
+    private(set) var time: TimeInterval
+
+    init(start: TimeInterval = 100) { time = start }
+
+    mutating func append(seconds: TimeInterval, rms: Double) {
+        let count = Int((seconds / Self.rate).rounded())
+        for _ in 0..<count {
+            samples.append(MicEnvelopeSample(
+                timestamp: time, rms: rms, peak: rms * 2))
+            time += Self.rate
+        }
+    }
+
+    /// The same track heard on a clock that runs `offset` seconds ahead of the IMU's.
+    func shifted(by offset: TimeInterval) -> [MicEnvelopeSample] {
+        samples.map {
+            MicEnvelopeSample(timestamp: $0.timestamp + offset, rms: $0.rms, peak: $0.peak)
+        }
+    }
+}
+
+final class WearerSpeechReplayTests: XCTestCase {
+    private func frames(from: TimeInterval, to: TimeInterval,
+                        step: TimeInterval = CaptureStream.rate) -> [TimeInterval] {
+        var times: [TimeInterval] = []
+        var time = from
+        while time <= to + 1e-9 {
+            times.append(time)
+            time += step
+        }
+        return times
+    }
+
+    // MARK: - Label partition
+
+    func testWearerSpeechLinesAreRoutedAwayFromTheEventReader() throws {
+        let text = """
+        {"start": 1.0, "end": 2.0, "label": "nod"}
+        {"start": 3.0, "end": 8.5, "label": "wearer_speech"}
+        {"start": 9.0, "end": 9.5, "label": "tap"}
+        """
+        let partition = try ReplaySpeechLabelReader.partition(fromText: text)
+        XCTAssertEqual(partition.events, [
+            ReplayLabelSegment(start: 1.0, end: 2.0, label: .nod),
+            ReplayLabelSegment(start: 9.0, end: 9.5, label: .tap),
+        ])
+        XCTAssertEqual(partition.speech, [ReplaySpeechSegment(start: 3.0, end: 8.5)])
+    }
+
+    /// A label file written before wearer speech existed must partition to exactly what
+    /// `ReplayLabelReader` alone produces.
+    func testEventOnlyFileIsIdenticalThroughBothReaders() throws {
+        let text = """
+        {"start": 1.0, "end": 2.0, "label": "shake"}
+        {"start": 4.0, "end": 4.4, "label": "swipe_up"}
+        {"start": 2.5, "end": 3.0, "label": "tilt_left"}
+        """
+        XCTAssertEqual(
+            try ReplaySpeechLabelReader.partition(fromText: text).events,
+            try ReplayLabelReader.segments(fromText: text)
+        )
+        XCTAssertTrue(try ReplaySpeechLabelReader.partition(fromText: text).speech.isEmpty)
+    }
+
+    func testUnknownLabelStillThrowsWithItsOriginalLineNumber() {
+        let text = """
+        {"start": 1.0, "end": 2.0, "label": "nod"}
+        {"start": 3.0, "end": 8.5, "label": "wearer_speech"}
+        {"start": 9.0, "end": 9.5, "label": "wink"}
+        """
+        XCTAssertThrowsError(try ReplaySpeechLabelReader.partition(fromText: text)) { error in
+            guard case CaptureReadError.badLabelLine(let line, _) = error else {
+                return XCTFail("unexpected error \(error)")
+            }
+            XCTAssertEqual(line, 3, "removing the speech line must not renumber the rest")
+        }
+    }
+
+    func testReversedSpeechSegmentIsRejected() {
+        let text = #"{"start": 8.0, "end": 3.0, "label": "wearer_speech"}"#
+        XCTAssertThrowsError(try ReplaySpeechLabelReader.partition(fromText: text)) { error in
+            XCTAssertEqual(error as? CaptureReadError, .badLabelLine(1, "start is after end"))
+        }
+    }
+
+    func testSpeechSegmentsAreSortedByStart() throws {
+        let text = """
+        {"start": 8.0, "end": 9.0, "label": "wearer_speech"}
+        {"start": 1.0, "end": 2.0, "label": "wearer_speech"}
+        """
+        XCTAssertEqual(
+            try ReplaySpeechLabelReader.partition(fromText: text).speech,
+            [ReplaySpeechSegment(start: 1, end: 2), ReplaySpeechSegment(start: 8, end: 9)]
+        )
+    }
+
+    // MARK: - Envelope derivation
+
+    func testDeriverFindsTheLoudStretchOfATrack() {
+        var stream = EnvelopeStream()
+        stream.append(seconds: 2, rms: 0.002)
+        stream.append(seconds: 3, rms: 0.08)
+        stream.append(seconds: 2, rms: 0.002)
+
+        let segments = EnvelopeLabelDeriver.segments(from: stream.samples)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].start, 102, accuracy: 0.05)
+        XCTAssertEqual(segments[0].end, 105, accuracy: 0.05)
+    }
+
+    /// The mid-band level sits above the exit threshold but below the enter threshold, so a
+    /// track that dips into it mid-utterance stays one segment instead of two.
+    func testDeriverHysteresisKeepsAnUtteranceWhole() {
+        var stream = EnvelopeStream()
+        stream.append(seconds: 2, rms: 0.002)
+        stream.append(seconds: 1, rms: 0.08)
+        stream.append(seconds: 0.2, rms: 0.03)
+        stream.append(seconds: 1, rms: 0.08)
+        stream.append(seconds: 2, rms: 0.002)
+
+        let thresholds = EnvelopeLabelDeriver.thresholds(for: stream.samples)
+        XCTAssertNotNil(thresholds)
+        XCTAssertLessThan(0.03, thresholds!.enter)
+        XCTAssertGreaterThan(0.03, thresholds!.exit)
+        XCTAssertEqual(EnvelopeLabelDeriver.segments(from: stream.samples).count, 1)
+    }
+
+    /// A gap shorter than `minimumGapSeconds` is an inter-word pause, not two utterances.
+    func testDeriverMergesShortGapsAndDropsShortSegments() {
+        var stream = EnvelopeStream()
+        stream.append(seconds: 2, rms: 0.002)
+        stream.append(seconds: 0.8, rms: 0.08)
+        stream.append(seconds: 0.2, rms: 0.002)
+        stream.append(seconds: 0.8, rms: 0.08)
+        stream.append(seconds: 1, rms: 0.002)
+        // Too short to survive on its own once merging is done.
+        stream.append(seconds: 0.1, rms: 0.08)
+        stream.append(seconds: 2, rms: 0.002)
+
+        let segments = EnvelopeLabelDeriver.segments(from: stream.samples)
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].start, 102, accuracy: 0.05)
+        XCTAssertEqual(segments[0].end, 103.8, accuracy: 0.05)
+    }
+
+    /// A recording of an empty room has no contrast, and inventing a threshold inside its
+    /// dither would label the entire session as speech.
+    func testSilentTrackDerivesNoSpeech() {
+        var stream = EnvelopeStream()
+        stream.append(seconds: 5, rms: 0.0015)
+        stream.append(seconds: 5, rms: 0.0022)
+        XCTAssertNil(EnvelopeLabelDeriver.thresholds(for: stream.samples))
+        XCTAssertTrue(EnvelopeLabelDeriver.segments(from: stream.samples).isEmpty)
+        XCTAssertTrue(EnvelopeLabelDeriver.segments(from: []).isEmpty)
+    }
+
+    func testMergeJoinsOnlyGapsBelowTheMinimum() {
+        let segments = [
+            ReplaySpeechSegment(start: 0, end: 1),
+            ReplaySpeechSegment(start: 1.2, end: 2),
+            ReplaySpeechSegment(start: 3, end: 4),
+        ]
+        XCTAssertEqual(
+            EnvelopeLabelDeriver.merged(segments, minimumGapSeconds: 0.5),
+            [ReplaySpeechSegment(start: 0, end: 2), ReplaySpeechSegment(start: 3, end: 4)]
+        )
+        XCTAssertEqual(
+            EnvelopeLabelDeriver.merged(segments, minimumGapSeconds: 0.1), segments)
+    }
+
+    // MARK: - Interval evaluator
+
+    func testPerfectOverlapScoresOne() {
+        let truth = [ReplaySpeechSegment(start: 2, end: 5)]
+        let metrics = SpeechIntervalEvaluator.evaluate(
+            detected: truth, truth: truth,
+            frameTimes: frames(from: 0, to: 10), tolerance: 0.2, duration: 10)
+        XCTAssertEqual(metrics.precision, 1)
+        XCTAssertEqual(metrics.recall, 1)
+        XCTAssertEqual(metrics.f1, 1)
+        XCTAssertEqual(metrics.falseActivations, 0)
+        XCTAssertEqual(metrics.matchedSegments, 1)
+        XCTAssertEqual(metrics.onsetLatencyMeanSeconds, 0)
+    }
+
+    func testMissedSegmentCostsRecallNotPrecision() {
+        let metrics = SpeechIntervalEvaluator.evaluate(
+            detected: [ReplaySpeechSegment(start: 2, end: 3)],
+            truth: [
+                ReplaySpeechSegment(start: 2, end: 3),
+                ReplaySpeechSegment(start: 6, end: 7),
+            ],
+            frameTimes: frames(from: 0, to: 10), tolerance: 0.2, duration: 10)
+        XCTAssertEqual(metrics.precision, 1)
+        XCTAssertEqual(metrics.recall ?? 0, 0.5, accuracy: 0.02)
+        XCTAssertEqual(metrics.matchedSegments, 1)
+        XCTAssertEqual(metrics.falseActivations, 0)
+    }
+
+    func testSpuriousActivationCostsPrecisionAndIsCounted() {
+        let metrics = SpeechIntervalEvaluator.evaluate(
+            detected: [
+                ReplaySpeechSegment(start: 2, end: 3),
+                ReplaySpeechSegment(start: 8, end: 9),
+            ],
+            truth: [ReplaySpeechSegment(start: 2, end: 3)],
+            frameTimes: frames(from: 0, to: 10), tolerance: 0.2, duration: 60)
+        XCTAssertEqual(metrics.precision ?? 0, 0.5, accuracy: 0.02)
+        XCTAssertEqual(metrics.recall, 1)
+        XCTAssertEqual(metrics.falseActivations, 1)
+        XCTAssertEqual(metrics.falseActivationsPerMinute ?? 0, 1, accuracy: 1e-9)
+    }
+
+    /// Frames just outside a true segment are excused up to `tolerance` and penalised
+    /// beyond it — the edges of an utterance are approximate on both sides.
+    func testEdgeSlackIsForgivenOnlyUpToTolerance() {
+        let truth = [ReplaySpeechSegment(start: 2, end: 5)]
+        let sloppy = [ReplaySpeechSegment(start: 2, end: 5.5)]
+        let forgiven = SpeechIntervalEvaluator.evaluate(
+            detected: sloppy, truth: truth,
+            frameTimes: frames(from: 0, to: 10), tolerance: 1.0, duration: 10)
+        XCTAssertEqual(forgiven.framesFalsePositive, 0)
+        XCTAssertEqual(forgiven.precision, 1)
+
+        let penalised = SpeechIntervalEvaluator.evaluate(
+            detected: sloppy, truth: truth,
+            frameTimes: frames(from: 0, to: 10), tolerance: 0.1, duration: 10)
+        XCTAssertGreaterThan(penalised.framesFalsePositive, 0)
+        XCTAssertLessThan(penalised.precision ?? 1, 1)
+    }
+
+    func testOnsetLatencyIsMeanedOverMatchedSegmentsOnly() {
+        let metrics = SpeechIntervalEvaluator.evaluate(
+            detected: [
+                ReplaySpeechSegment(start: 2.4, end: 3),
+                ReplaySpeechSegment(start: 6.8, end: 7),
+            ],
+            truth: [
+                ReplaySpeechSegment(start: 2, end: 3),
+                ReplaySpeechSegment(start: 6, end: 7),
+                ReplaySpeechSegment(start: 20, end: 21),
+            ],
+            frameTimes: frames(from: 0, to: 25), tolerance: 0.5, duration: 25)
+        XCTAssertEqual(metrics.matchedSegments, 2)
+        XCTAssertEqual(metrics.onsetLatencyMeanSeconds ?? 0, 0.6, accuracy: 1e-9)
+    }
+
+    func testOneDetectionCannotAnswerTwoTrueSegments() {
+        let metrics = SpeechIntervalEvaluator.evaluate(
+            detected: [ReplaySpeechSegment(start: 2, end: 9)],
+            truth: [
+                ReplaySpeechSegment(start: 2, end: 4),
+                ReplaySpeechSegment(start: 7, end: 9),
+            ],
+            frameTimes: frames(from: 0, to: 10), tolerance: 0.2, duration: 10)
+        XCTAssertEqual(metrics.matchedSegments, 1)
+        XCTAssertEqual(metrics.detectedSegments, 1)
+        XCTAssertEqual(metrics.truthSegments, 2)
+    }
+
+    func testEmptyTruthAndEmptyDetectionLeaveMetricsUndefined() {
+        let metrics = SpeechIntervalEvaluator.evaluate(
+            detected: [], truth: [],
+            frameTimes: frames(from: 0, to: 10), tolerance: 0.2, duration: 10)
+        XCTAssertNil(metrics.precision)
+        XCTAssertNil(metrics.recall)
+        XCTAssertNil(metrics.f1)
+        XCTAssertNil(metrics.onsetLatencyMeanSeconds)
+        XCTAssertEqual(metrics.falseActivationsPerMinute, 0)
+    }
+
+    // MARK: - Detector runner
+
+    func testRunnerFindsTheSpokenStretchAndNothingElse() {
+        var stream = CaptureStream()
+        stream.append(seconds: 2, jerk: 0.002)
+        let speechStart = stream.time
+        stream.append(seconds: 3, jerk: 0.05)
+        let speechEnd = stream.time
+        stream.append(seconds: 2, jerk: 0.002)
+
+        let intervals = WearerSpeechReplayRunner.intervals(samples: stream.samples)
+        XCTAssertEqual(intervals.count, 1)
+        // Onset lags by the window fill plus the sustain gate; release lags by the hangover.
+        XCTAssertGreaterThan(intervals[0].start, speechStart)
+        XCTAssertLessThan(intervals[0].start, speechStart + 1.2)
+        XCTAssertGreaterThan(intervals[0].end, speechEnd)
+        XCTAssertLessThan(intervals[0].end, speechEnd + 1.2)
+    }
+
+    func testRunnerReportsNothingForAQuietCapture() {
+        var stream = CaptureStream()
+        stream.append(seconds: 8, jerk: 0.002)
+        XCTAssertTrue(WearerSpeechReplayRunner.intervals(samples: stream.samples).isEmpty)
+    }
+
+    /// A capture that stops mid-utterance still detected it; the interval closes at the
+    /// last sample rather than being discarded.
+    func testRunnerClosesAnOpenIntervalAtTheLastSample() {
+        var stream = CaptureStream()
+        stream.append(seconds: 2, jerk: 0.002)
+        stream.append(seconds: 3, jerk: 0.05)
+
+        let intervals = WearerSpeechReplayRunner.intervals(samples: stream.samples)
+        XCTAssertEqual(intervals.count, 1)
+        XCTAssertEqual(intervals[0].end, stream.samples.last!.timestamp)
+    }
+
+    func testRunnerHonoursACalibratedConfig() {
+        var stream = CaptureStream()
+        stream.append(seconds: 2, jerk: 0.002)
+        stream.append(seconds: 3, jerk: 0.05)
+        stream.append(seconds: 2, jerk: 0.002)
+
+        // A profile calibrated on a much louder wearer never sees this stream as speech.
+        let deaf = WearerSpeechConfig(
+            envelopeEnterThreshold: 0.5, envelopeExitThreshold: 0.4)
+        XCTAssertTrue(
+            WearerSpeechReplayRunner.intervals(samples: stream.samples, config: deaf).isEmpty)
+    }
+
+    // MARK: - Clock alignment
+
+    /// Ground truth on a clock that disagrees with the IMU's is the failure mode a study
+    /// cannot see by eye. Scoring the very same detection against a shifted envelope must
+    /// visibly collapse the metrics, so a misalignment shows up as a bad number rather than
+    /// as a plausible one.
+    func testOffsettingTheEnvelopeClockDegradesTheMetrics() {
+        var capture = CaptureStream()
+        capture.append(seconds: 2, jerk: 0.002)
+        let speechStart = capture.time
+        capture.append(seconds: 3, jerk: 0.05)
+        let speechEnd = capture.time
+        capture.append(seconds: 2, jerk: 0.002)
+
+        var envelope = EnvelopeStream()
+        envelope.append(seconds: speechStart - 100, rms: 0.002)
+        envelope.append(seconds: speechEnd - speechStart, rms: 0.08)
+        envelope.append(seconds: 2, rms: 0.002)
+
+        let detected = WearerSpeechReplayRunner.intervals(samples: capture.samples)
+        let frameTimes = capture.samples.map(\.timestamp)
+        func score(offset: TimeInterval) -> SpeechIntervalMetrics {
+            SpeechIntervalEvaluator.evaluate(
+                detected: detected,
+                truth: EnvelopeLabelDeriver.segments(from: envelope.shifted(by: offset)),
+                frameTimes: frameTimes, tolerance: 0.5, duration: 7)
+        }
+
+        let aligned = score(offset: 0)
+        let skewed = score(offset: 3.0)
+        XCTAssertGreaterThan(aligned.f1 ?? 0, 0.7)
+        XCTAssertLessThan(skewed.f1 ?? 1, (aligned.f1 ?? 0) / 2)
+        XCTAssertGreaterThan(skewed.framesFalsePositive, 0)
+        XCTAssertGreaterThan(skewed.framesFalseNegative, 0)
+    }
+}

--- a/Tests/TapQClaudeAdapterTests/HookShimTests.swift
+++ b/Tests/TapQClaudeAdapterTests/HookShimTests.swift
@@ -256,7 +256,7 @@ final class HookShimTests: XCTestCase {
     }
 
     func testPermissionRequestPassesThroughWhenBrokerRejectsProtocol() {
-        XCTAssertEqual(WireProtocol.version, 3)
+        XCTAssertEqual(WireProtocol.version, 4)
         let input = stdin(#"{"hook_event_name":"PermissionRequest","tool_name":"Bash","tool_input":{}}"#)
         let result = HookShim.handle(stdinData: input) { _, _ in
             Data(#"{"error":"protocol_version"}"#.utf8)
@@ -362,6 +362,51 @@ final class HookShimTests: XCTestCase {
     func testAskUserQuestionPassesThroughOnTimeout() throws {
         let input = stdin(#"{"hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Q","options":[{"label":"A","description":"a"}],"multiSelect":false,"header":"H"}]}}"#)
         let result = HookShim.handle(stdinData: input) { _, _ in Data(#"{"error":"timeout"}"#.utf8) }
+        XCTAssertNil(result.stdout)
+        XCTAssertEqual(result.exitCode, 0)
+    }
+
+    // MARK: - AskUserQuestion free-text reply
+
+    func testAskUserQuestionFreeTextFormatsDenyWithSpokenAnswer() throws {
+        let input = stdin(#"{"hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Where to deploy?","options":[{"label":"Staging","description":"s"},{"label":"Production","description":"p"}],"multiSelect":false,"header":"Deploy"}]},"session_id":"s1","request_id":"r1"}"#)
+        let result = HookShim.handle(stdinData: input) { _, _ in
+            Data(#"{"selected_indices":[],"selected_labels":[],"free_text":"deploy to staging please"}"#.utf8)
+        }
+        let out = try parseOutput(result.stdout)
+        XCTAssertEqual(out.decision, "deny")
+        XCTAssertTrue(out.reason.contains("deploy to staging please"))
+        XCTAssertTrue(out.reason.contains("Where to deploy?"))
+        XCTAssertTrue(out.reason.contains("in their own words"))
+        XCTAssertTrue(out.reason.contains("without re-asking"))
+    }
+
+    func testAskUserQuestionLabelsPreferredOverFreeText() throws {
+        // When both labels and free_text are present, labels take priority.
+        let input = stdin(#"{"hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Pick","options":[{"label":"A","description":"a"},{"label":"B","description":"b"}],"multiSelect":false,"header":"H"}]},"session_id":"s1","request_id":"r1"}"#)
+        let result = HookShim.handle(stdinData: input) { _, _ in
+            Data(#"{"selected_indices":[0],"selected_labels":["A"],"free_text":"something else"}"#.utf8)
+        }
+        let out = try parseOutput(result.stdout)
+        XCTAssertEqual(out.decision, "deny")
+        XCTAssertTrue(out.reason.contains("Selection: 'A'"), "labels must be used, not free text")
+        XCTAssertFalse(out.reason.contains("something else"))
+    }
+
+    func testAskUserQuestionEmptyFreeTextPassesThrough() {
+        let input = stdin(#"{"hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Q","options":[{"label":"A","description":"a"}],"multiSelect":false,"header":"H"}]}}"#)
+        let result = HookShim.handle(stdinData: input) { _, _ in
+            Data(#"{"selected_indices":[],"selected_labels":[],"free_text":""}"#.utf8)
+        }
+        XCTAssertNil(result.stdout)
+        XCTAssertEqual(result.exitCode, 0)
+    }
+
+    func testAskUserQuestionMissingFreeTextPassesThrough() {
+        let input = stdin(#"{"hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Q","options":[{"label":"A","description":"a"}],"multiSelect":false,"header":"H"}]}}"#)
+        let result = HookShim.handle(stdinData: input) { _, _ in
+            Data(#"{"selected_indices":[],"selected_labels":[]}"#.utf8)
+        }
         XCTAssertNil(result.stdout)
         XCTAssertEqual(result.exitCode, 0)
     }

--- a/Tests/TapQCodexAdapterTests/CodexHookShimTests.swift
+++ b/Tests/TapQCodexAdapterTests/CodexHookShimTests.swift
@@ -383,6 +383,97 @@ final class CodexHookShimTests: XCTestCase {
         )
     }
 
+    func testRequestUserInputFreeTextReturnsModelVisibleDeny() throws {
+        let result = CodexHookShim.handle(stdinData: requestUserInput()) { _, _ in
+            Data(#"{"selected_indices":[],"selected_labels":[],"free_text":"deploy to staging please"}"#.utf8)
+        }
+
+        XCTAssertEqual(result.exitCode, 0)
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: Data(try XCTUnwrap(result.stdout).utf8)
+        )
+        let inner = try XCTUnwrap(output["hookSpecificOutput"]?.objectValue)
+        XCTAssertEqual(inner["permissionDecision"]?.stringValue, "deny")
+        let reason = try XCTUnwrap(inner["permissionDecisionReason"]?.stringValue)
+        XCTAssertTrue(
+            reason.contains(
+                #"{"answers":{"deployment_target":{"answers":["deploy to staging please"]}}}"#
+            )
+        )
+        XCTAssertTrue(reason.contains("Treat this request_user_input call as successful"))
+        XCTAssertTrue(reason.contains("Do not re-ask this question"))
+    }
+
+    func testRequestUserInputLabelsPreferredOverFreeText() throws {
+        // When both labels and free_text are present, labels win.
+        let result = CodexHookShim.handle(stdinData: requestUserInput()) { _, _ in
+            Data(#"{"selected_indices":[1],"selected_labels":["Production"],"free_text":"staging"}"#.utf8)
+        }
+
+        XCTAssertEqual(result.exitCode, 0)
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: Data(try XCTUnwrap(result.stdout).utf8)
+        )
+        let reason = try XCTUnwrap(
+            output["hookSpecificOutput"]?["permissionDecisionReason"]?.stringValue
+        )
+        XCTAssertTrue(reason.contains("Production"), "labels must be preferred")
+        XCTAssertFalse(reason.contains(#""staging""#))
+    }
+
+    func testRequestUserInputEmptyFreeTextPassesThrough() {
+        let result = CodexHookShim.handle(stdinData: requestUserInput()) { _, _ in
+            Data(#"{"selected_indices":[],"selected_labels":[],"free_text":"   "}"#.utf8)
+        }
+        XCTAssertEqual(result, CodexHookShim.passThrough)
+    }
+
+    func testRequestUserInputMissingFreeTextPassesThrough() {
+        let result = CodexHookShim.handle(stdinData: requestUserInput()) { _, _ in
+            Data(#"{"selected_indices":[],"selected_labels":[]}"#.utf8)
+        }
+        XCTAssertEqual(result, CodexHookShim.passThrough)
+    }
+
+    func testRequestUserInputFreeTextEscapesSpecialCharacters() throws {
+        let freeText = #"deploy to "blue" env\nplease"#
+        let brokerReply = try JSONEncoder().encode([
+            "selected_indices": JSONValue.array([]),
+            "selected_labels": JSONValue.array([]),
+            "free_text": JSONValue.string(freeText),
+        ])
+        let result = CodexHookShim.handle(stdinData: requestUserInput()) { _, _ in
+            brokerReply
+        }
+
+        let output = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: Data(try XCTUnwrap(result.stdout).utf8)
+        )
+        let reason = try XCTUnwrap(
+            output["hookSpecificOutput"]?["permissionDecisionReason"]?.stringValue
+        )
+        let prefix = try XCTUnwrap(reason.range(of: "response JSON: "))
+        let suffix = try XCTUnwrap(
+            reason.range(
+                of: ". Do not re-ask",
+                range: prefix.upperBound..<reason.endIndex
+            )
+        )
+        let responseJSON = String(reason[prefix.upperBound..<suffix.lowerBound])
+        let response = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: Data(responseJSON.utf8)
+        )
+        XCTAssertEqual(
+            response["answers"]?["deployment_target"]?["answers"]?
+                .arrayValue?.first?.stringValue,
+            freeText
+        )
+    }
+
     func testRequestUserInputRequiresNonblankToolUseID() {
         for toolUseID in [nil, "   "] as [String?] {
             var called = false

--- a/Tests/TapQContextBaselineTests/StopQuestionCoordinatorTests.swift
+++ b/Tests/TapQContextBaselineTests/StopQuestionCoordinatorTests.swift
@@ -176,4 +176,59 @@ final class StopQuestionCoordinatorTests: XCTestCase {
         XCTAssertGreaterThan(remaining, InteractionBudget.total - 5)
         XCTAssertLessThanOrEqual(remaining, InteractionBudget.total)
     }
+
+    // MARK: - Free-text reply (WP8)
+
+    func testFreeTextSelectionProducesReply() async {
+        let classification = ResponseQuestionClassification.multiOption(
+            question: "Which approach?",
+            options: [
+                SelectionOption(label: "Patch", description: "small fix"),
+                SelectionOption(label: "Rewrite", description: "big change"),
+            ]
+        )
+        let (coordinator, _, _) = makeCoordinator(
+            classify: classification,
+            selectionResult: SelectionResult(choices: [], freeText: "use a hybrid approach")
+        )
+        let reply = await coordinator.handle(sessionID: "s1", text: "reply")
+        XCTAssertNotNil(reply)
+        XCTAssertTrue(reply?.contains("they answered: 'use a hybrid approach'") == true)
+    }
+
+    func testFreeTextSelectionRecordsForRepeatSuppression() async {
+        let classification = ResponseQuestionClassification.multiOption(
+            question: "Which approach?",
+            options: [
+                SelectionOption(label: "Patch", description: "small fix"),
+            ]
+        )
+        let (coordinator, _, _) = makeCoordinator(
+            classify: classification,
+            selectionResult: SelectionResult(choices: [], freeText: "use a hybrid approach")
+        )
+        let first = await coordinator.handle(sessionID: "s1", text: "reply")
+        let second = await coordinator.handle(sessionID: "s1", text: "reply")
+        XCTAssertNotNil(first)
+        XCTAssertNil(second, "the same reply text must be deduplicated")
+    }
+
+    func testLabelSelectionStillPreferred() async {
+        // When the result has both labels and freeText, labels win (defensive).
+        let classification = ResponseQuestionClassification.multiOption(
+            question: "Which approach?",
+            options: [
+                SelectionOption(label: "Patch", description: "small fix"),
+            ]
+        )
+        let (coordinator, _, _) = makeCoordinator(
+            classify: classification,
+            selectionResult: SelectionResult(
+                choices: [.init(index: 0, label: "Patch")],
+                freeText: "actually something else")
+        )
+        let reply = await coordinator.handle(sessionID: "s1", text: "reply")
+        XCTAssertTrue(reply?.contains("'Patch'") == true,
+                      "label selection must be preferred over freeText when both present")
+    }
 }

--- a/Tests/TapQContractsTests/VoiceBackendContractTests.swift
+++ b/Tests/TapQContractsTests/VoiceBackendContractTests.swift
@@ -456,7 +456,11 @@ final class VoiceBackendConformanceTests: XCTestCase {
         }
 
         func beginUserTurn() { guarded { try machine.beginUserTurn() } }
-        func endUserTurn() { guarded { try machine.endUserTurn() } }
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool {
+            guarded { try machine.endUserTurn() }
+            return false
+        }
 
         func sendAudio(_ chunk: VoiceAudioChunk) {
             guarded {
@@ -507,7 +511,7 @@ final class VoiceBackendConformanceTests: XCTestCase {
         backend.beginUserTurn()
         backend.sendAudio(VoiceAudioChunk(data: Data(count: 480), format: .pcm16Mono24k, timestamp: 0))
         backend.deliver(.transcriptPartial("ye"))
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         backend.deliver(.transcriptFinal("yes"))
         backend.deliver(.responseCompleted)
 
@@ -534,7 +538,7 @@ final class VoiceBackendConformanceTests: XCTestCase {
         XCTAssertEqual(backend.violations, [.responseDuringUserTurn])
         XCTAssertTrue(backend.spoken.isEmpty)
 
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         backend.requestResponse(text: "Approving.")
         XCTAssertEqual(backend.spoken, ["Approving."])
         XCTAssertEqual(backend.state, .responding)

--- a/Tests/TapQContractsTests/VoiceBackendContractTests.swift
+++ b/Tests/TapQContractsTests/VoiceBackendContractTests.swift
@@ -1,0 +1,595 @@
+import XCTest
+@testable import TapQContracts
+
+final class VoiceBackendContractTests: XCTestCase {
+
+    // MARK: - Legality matrix
+
+    /// Every operation the turn protocol exposes, so the matrix below can be exhaustive
+    /// by construction rather than by whoever wrote the test remembering all seven.
+    private enum Operation: String, CaseIterable {
+        case open
+        case beginUserTurn
+        case sendAudio
+        case endUserTurn
+        case requestResponse
+        case cancelResponse
+        case responseCompleted
+
+        func apply(to machine: inout VoiceTurnStateMachine) throws {
+            switch self {
+            case .open: try machine.open()
+            case .beginUserTurn: try machine.beginUserTurn()
+            case .sendAudio: try machine.sendAudio()
+            case .endUserTurn: try machine.endUserTurn()
+            case .requestResponse: try machine.requestResponse()
+            case .cancelResponse: try machine.cancelResponse()
+            case .responseCompleted: try machine.responseCompleted()
+            }
+        }
+    }
+
+    private enum Outcome: Equatable {
+        case allowed(VoiceTurnStateMachine.State)
+        case rejected(VoiceTurnViolation)
+    }
+
+    /// The whole contract in one table. A transcript-only backend — the default shape,
+    /// and the one the Apple adapter uses — so `cancelResponse` is illegal everywhere.
+    private let transcriptOnlyMatrix: [VoiceTurnStateMachine.State: [Operation: Outcome]] = [
+        .idle: [
+            .open: .allowed(.open),
+            .beginUserTurn: .rejected(.notOpen),
+            .sendAudio: .rejected(.notOpen),
+            .endUserTurn: .rejected(.notOpen),
+            .requestResponse: .rejected(.notOpen),
+            .cancelResponse: .rejected(.notOpen),
+            .responseCompleted: .rejected(.notOpen),
+        ],
+        .open: [
+            .open: .rejected(.alreadyOpen),
+            .beginUserTurn: .allowed(.userTurn),
+            .sendAudio: .rejected(.noUserTurn),
+            .endUserTurn: .rejected(.noUserTurn),
+            .requestResponse: .allowed(.responding),
+            .cancelResponse: .rejected(.bargeInUnsupported),
+            .responseCompleted: .rejected(.noResponseInFlight),
+        ],
+        .userTurn: [
+            .open: .rejected(.alreadyOpen),
+            .beginUserTurn: .rejected(.turnAlreadyInProgress),
+            .sendAudio: .allowed(.userTurn),
+            .endUserTurn: .allowed(.committed),
+            .requestResponse: .rejected(.responseDuringUserTurn),
+            .cancelResponse: .rejected(.bargeInUnsupported),
+            .responseCompleted: .rejected(.noResponseInFlight),
+        ],
+        .committed: [
+            .open: .rejected(.alreadyOpen),
+            // Legal: a transcript-only backend runs turn after turn without ever
+            // producing a response to complete.
+            .beginUserTurn: .allowed(.userTurn),
+            .sendAudio: .rejected(.noUserTurn),
+            .endUserTurn: .rejected(.noUserTurn),
+            .requestResponse: .allowed(.responding),
+            .cancelResponse: .rejected(.bargeInUnsupported),
+            .responseCompleted: .allowed(.open),
+        ],
+        .responding: [
+            .open: .rejected(.alreadyOpen),
+            .beginUserTurn: .rejected(.responseAlreadyInFlight),
+            .sendAudio: .rejected(.noUserTurn),
+            .endUserTurn: .rejected(.noUserTurn),
+            .requestResponse: .rejected(.responseAlreadyInFlight),
+            .cancelResponse: .rejected(.bargeInUnsupported),
+            .responseCompleted: .allowed(.open),
+        ],
+    ]
+
+    func testLegalityMatrixCoversEveryStateAndOperation() throws {
+        // Guards the table itself: a new state or operation must be given a verdict here
+        // rather than slipping through untested.
+        XCTAssertEqual(transcriptOnlyMatrix.count, 5)
+        for (state, row) in transcriptOnlyMatrix {
+            XCTAssertEqual(row.count, Operation.allCases.count,
+                           "state \(state.rawValue) is missing an operation verdict")
+        }
+    }
+
+    func testTranscriptOnlyLegalityMatrix() throws {
+        for (state, row) in transcriptOnlyMatrix {
+            for (operation, expected) in row {
+                var machine = try makeMachine(in: state)
+                let label = "\(operation.rawValue) from \(state.rawValue)"
+                switch expected {
+                case .allowed(let next):
+                    XCTAssertNoThrow(try operation.apply(to: &machine), label)
+                    XCTAssertEqual(machine.state, next, label)
+                case .rejected(let violation):
+                    XCTAssertThrowsError(try operation.apply(to: &machine), label) { error in
+                        XCTAssertEqual(error as? VoiceTurnViolation, violation, label)
+                    }
+                    // A rejected move must be inert: an adapter that reports the
+                    // violation and carries on must still be in a state it can use.
+                    XCTAssertEqual(machine.state, state, "\(label) mutated state")
+                }
+            }
+        }
+    }
+
+    // MARK: - Named invariants (the ones worth failing loudly by name)
+
+    func testSendAudioBeforeOpenIsRejected() {
+        var machine = VoiceTurnStateMachine()
+        XCTAssertThrowsError(try machine.sendAudio()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .notOpen)
+        }
+        XCTAssertFalse(machine.isOpen)
+    }
+
+    func testEndUserTurnBeforeBeginUserTurnIsRejected() throws {
+        var machine = try makeMachine(in: .open)
+        XCTAssertThrowsError(try machine.endUserTurn()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .noUserTurn)
+        }
+        XCTAssertEqual(machine.state, .open)
+    }
+
+    func testDoubleBeginUserTurnIsRejected() throws {
+        var machine = try makeMachine(in: .userTurn)
+        XCTAssertThrowsError(try machine.beginUserTurn()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .turnAlreadyInProgress)
+        }
+        XCTAssertTrue(machine.isUserTurnActive)
+    }
+
+    func testRequestResponseDuringUserTurnIsRejectedByHalfDuplexPolicy() throws {
+        // Even a fully duplex-capable backend: half-duplex is TapQ policy, not a
+        // transport limitation.
+        var machine = try makeMachine(
+            in: .userTurn,
+            capabilities: VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true, duplex: true))
+        XCTAssertThrowsError(try machine.requestResponse()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .responseDuringUserTurn)
+        }
+        XCTAssertEqual(machine.state, .userTurn)
+    }
+
+    func testCancelResponseWithoutBargeInCapabilityIsRejectedEvenWhileResponding() throws {
+        var machine = try makeMachine(in: .responding)
+        XCTAssertFalse(machine.capabilities.supportsBargeIn)
+        XCTAssertThrowsError(try machine.cancelResponse()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .bargeInUnsupported)
+        }
+        XCTAssertEqual(machine.state, .responding)
+    }
+
+    func testCancelResponseWithBargeInCapability() throws {
+        let duplex = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true, duplex: true)
+        var responding = try makeMachine(in: .responding, capabilities: duplex)
+        XCTAssertNoThrow(try responding.cancelResponse())
+        XCTAssertEqual(responding.state, .open)
+
+        for state in [VoiceTurnStateMachine.State.open, .userTurn, .committed] {
+            var machine = try makeMachine(in: state, capabilities: duplex)
+            XCTAssertThrowsError(try machine.cancelResponse(), state.rawValue) { error in
+                XCTAssertEqual(error as? VoiceTurnViolation, .noResponseInFlight, state.rawValue)
+            }
+            XCTAssertEqual(machine.state, state)
+        }
+
+        var idle = VoiceTurnStateMachine(capabilities: duplex)
+        XCTAssertThrowsError(try idle.cancelResponse()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .notOpen)
+        }
+    }
+
+    func testBackendCannotEndATurnNobodyOpened() throws {
+        // The hole the design rule forbids: a backend VAD deciding the wearer stopped
+        // talking. Routed through the machine it is a violation, not a resolved window.
+        var machine = try makeMachine(in: .open)
+        XCTAssertThrowsError(try machine.endUserTurn()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .noUserTurn)
+        }
+        // And it cannot complete a response nobody requested either.
+        XCTAssertThrowsError(try machine.responseCompleted()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .noResponseInFlight)
+        }
+        XCTAssertEqual(machine.state, .open)
+    }
+
+    // MARK: - Happy paths
+
+    func testTranscriptOnlyTurnCycleRepeats() throws {
+        var machine = VoiceTurnStateMachine()
+        try machine.open()
+        for _ in 0..<3 {
+            try machine.beginUserTurn()
+            XCTAssertTrue(machine.isUserTurnActive)
+            try machine.sendAudio()
+            try machine.sendAudio()
+            try machine.endUserTurn()
+            XCTAssertEqual(machine.state, .committed)
+            XCTAssertFalse(machine.isUserTurnActive)
+            try machine.responseCompleted()
+            XCTAssertEqual(machine.state, .open)
+        }
+    }
+
+    func testSpeakingBackendTurnCycle() throws {
+        let duplex = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true, duplex: true)
+        var machine = VoiceTurnStateMachine(capabilities: duplex)
+        try machine.open()
+        try machine.beginUserTurn()
+        try machine.sendAudio()
+        try machine.endUserTurn()
+        try machine.requestResponse()
+        XCTAssertTrue(machine.isResponding)
+        try machine.responseCompleted()
+        XCTAssertEqual(machine.state, .open)
+        XCTAssertFalse(machine.isResponding)
+    }
+
+    func testConsecutiveTurnsWithoutARequestedResponse() throws {
+        // The transcript-only path never asks for a response, so `.committed` must lead
+        // straight into the next turn.
+        var machine = VoiceTurnStateMachine()
+        try machine.open()
+        try machine.beginUserTurn()
+        try machine.endUserTurn()
+        try machine.beginUserTurn()
+        XCTAssertEqual(machine.state, .userTurn)
+    }
+
+    // MARK: - Teardown is always legal
+
+    func testCloseIsLegalAndIdempotentFromEveryState() throws {
+        for state in allStates {
+            var machine = try makeMachine(in: state)
+            machine.close()
+            XCTAssertEqual(machine.state, .idle, state.rawValue)
+            machine.close()
+            XCTAssertEqual(machine.state, .idle, state.rawValue)
+            XCTAssertFalse(machine.isOpen)
+        }
+    }
+
+    func testSessionFailedIsLegalFromEveryStateAndSessionCanReopen() throws {
+        for state in allStates {
+            var machine = try makeMachine(in: state)
+            machine.sessionFailed()
+            XCTAssertEqual(machine.state, .idle, state.rawValue)
+            XCTAssertNoThrow(try machine.open(), state.rawValue)
+            XCTAssertEqual(machine.state, .open, state.rawValue)
+        }
+    }
+
+    func testCapabilitiesSurviveTeardown() throws {
+        let duplex = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true, duplex: true)
+        var machine = try makeMachine(in: .responding, capabilities: duplex)
+        machine.close()
+        XCTAssertTrue(machine.capabilities.supportsBargeIn)
+    }
+
+    // MARK: - Capabilities
+
+    func testCapabilityDefaultsAreTheLeastABackendCanBe() {
+        let defaults = VoiceBackendCapabilities()
+        XCTAssertFalse(defaults.supportsBargeIn)
+        XCTAssertFalse(defaults.producesAudio)
+        XCTAssertFalse(defaults.duplex)
+        XCTAssertEqual(defaults, .transcriptOnly)
+        XCTAssertEqual(VoiceTurnStateMachine().capabilities, .transcriptOnly)
+    }
+
+    func testCapabilitiesEquatable() {
+        XCTAssertNotEqual(VoiceBackendCapabilities(supportsBargeIn: true), .transcriptOnly)
+        XCTAssertNotEqual(VoiceBackendCapabilities(producesAudio: true), .transcriptOnly)
+        XCTAssertNotEqual(VoiceBackendCapabilities(duplex: true), .transcriptOnly)
+        XCTAssertEqual(VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true, duplex: true),
+                       VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true, duplex: true))
+    }
+
+    // MARK: - Audio value types
+
+    func testAudioFormatDefaultsToMonoPCM16() {
+        let format = VoiceAudioFormat(sampleRate: 16_000)
+        XCTAssertEqual(format.channels, 1)
+        XCTAssertTrue(format.pcm16)
+        XCTAssertEqual(format, .pcm16Mono16k)
+        XCTAssertEqual(VoiceAudioFormat.pcm16Mono24k.sampleRate, 24_000)
+        XCTAssertNotEqual(VoiceAudioFormat.pcm16Mono24k, .pcm16Mono16k)
+    }
+
+    func testChunkDurationMatchesPCM16FrameCount() {
+        // 100 ms of mono 24 kHz PCM16 = 2400 frames = 4800 bytes.
+        let chunk = VoiceAudioChunk(data: Data(count: 4_800), format: .pcm16Mono24k, timestamp: 1)
+        XCTAssertEqual(try XCTUnwrap(chunk.durationSeconds), 0.1, accuracy: 1e-9)
+
+        let stereo = VoiceAudioChunk(
+            data: Data(count: 4_800),
+            format: VoiceAudioFormat(sampleRate: 24_000, channels: 2),
+            timestamp: 1)
+        XCTAssertEqual(try XCTUnwrap(stereo.durationSeconds), 0.05, accuracy: 1e-9)
+
+        XCTAssertEqual(VoiceAudioChunk(data: Data(), format: .pcm16Mono24k, timestamp: 0).durationSeconds, 0)
+    }
+
+    func testChunkDurationIsUnknownForNonPCM16Bytes() {
+        let opaque = VoiceAudioChunk(
+            data: Data(count: 1_000),
+            format: VoiceAudioFormat(sampleRate: 24_000, channels: 1, pcm16: false),
+            timestamp: 0)
+        XCTAssertNil(opaque.durationSeconds)
+    }
+
+    func testChunkEquatableComparesBytesFormatAndTimestamp() {
+        let base = VoiceAudioChunk(data: Data([1, 2, 3, 4]), format: .pcm16Mono24k, timestamp: 5)
+        XCTAssertEqual(base, VoiceAudioChunk(data: Data([1, 2, 3, 4]), format: .pcm16Mono24k, timestamp: 5))
+        XCTAssertNotEqual(base, VoiceAudioChunk(data: Data([1, 2, 3, 9]), format: .pcm16Mono24k, timestamp: 5))
+        XCTAssertNotEqual(base, VoiceAudioChunk(data: Data([1, 2, 3, 4]), format: .pcm16Mono16k, timestamp: 5))
+        XCTAssertNotEqual(base, VoiceAudioChunk(data: Data([1, 2, 3, 4]), format: .pcm16Mono24k, timestamp: 6))
+    }
+
+    // MARK: - Events and failures
+
+    func testEventEquatableDistinguishesPartialFromFinal() {
+        XCTAssertEqual(VoiceBackendEvent.transcriptPartial("yes"), .transcriptPartial("yes"))
+        XCTAssertNotEqual(VoiceBackendEvent.transcriptPartial("yes"), .transcriptFinal("yes"))
+        XCTAssertNotEqual(VoiceBackendEvent.transcriptPartial("yes"), .transcriptPartial("no"))
+        XCTAssertEqual(VoiceBackendEvent.responseCompleted, .responseCompleted)
+        XCTAssertNotEqual(VoiceBackendEvent.responseCompleted, .transcriptFinal(""))
+    }
+
+    func testEventEquatableReachesIntoAudioAndFailurePayloads() {
+        let chunk = VoiceAudioChunk(data: Data([7]), format: .pcm16Mono24k, timestamp: 2)
+        let other = VoiceAudioChunk(data: Data([8]), format: .pcm16Mono24k, timestamp: 2)
+        XCTAssertEqual(VoiceBackendEvent.audio(chunk), .audio(chunk))
+        XCTAssertNotEqual(VoiceBackendEvent.audio(chunk), .audio(other))
+        XCTAssertEqual(VoiceBackendEvent.sessionFailed(.network("dropped")), .sessionFailed(.network("dropped")))
+        XCTAssertNotEqual(VoiceBackendEvent.sessionFailed(.network("dropped")),
+                          .sessionFailed(.closed("dropped")))
+    }
+
+    func testFailureEquatableSeparatesReasonAndDetail() {
+        XCTAssertEqual(VoiceBackendFailure.authorization("401"), .authorization("401"))
+        XCTAssertNotEqual(VoiceBackendFailure.authorization("401"), .authorization("403"))
+        XCTAssertNotEqual(VoiceBackendFailure.network("timeout"), .protocolViolation("timeout"))
+    }
+
+    func testFailureDescriptionsAreHumanReadable() throws {
+        let cases: [VoiceBackendFailure] = [
+            .network("socket closed"),
+            .protocolViolation("unexpected response.created"),
+            .authorization("missing key"),
+            .closed("peer hung up"),
+        ]
+        for failure in cases {
+            let text = try XCTUnwrap(failure.errorDescription)
+            XCTAssertFalse(text.isEmpty)
+            XCTAssertTrue(text.hasPrefix("Voice backend"), text)
+        }
+    }
+
+    func testViolationDescriptionsAreHumanReadable() throws {
+        let cases: [VoiceTurnViolation] = [
+            .notOpen, .alreadyOpen, .turnAlreadyInProgress, .noUserTurn,
+            .responseDuringUserTurn, .responseAlreadyInFlight, .noResponseInFlight,
+            .bargeInUnsupported,
+        ]
+        for violation in cases {
+            XCTAssertFalse(try XCTUnwrap(violation.errorDescription).isEmpty)
+        }
+        XCTAssertEqual(VoiceTurnViolation.notOpen, .notOpen)
+        XCTAssertNotEqual(VoiceTurnViolation.notOpen, .alreadyOpen)
+    }
+
+    // MARK: - Helpers
+
+    private var allStates: [VoiceTurnStateMachine.State] {
+        [.idle, .open, .userTurn, .committed, .responding]
+    }
+
+    private func makeMachine(
+        in state: VoiceTurnStateMachine.State,
+        capabilities: VoiceBackendCapabilities = .transcriptOnly
+    ) throws -> VoiceTurnStateMachine {
+        var machine = VoiceTurnStateMachine(capabilities: capabilities)
+        switch state {
+        case .idle:
+            break
+        case .open:
+            try machine.open()
+        case .userTurn:
+            try machine.open()
+            try machine.beginUserTurn()
+        case .committed:
+            try machine.open()
+            try machine.beginUserTurn()
+            try machine.endUserTurn()
+        case .responding:
+            try machine.open()
+            try machine.beginUserTurn()
+            try machine.endUserTurn()
+            try machine.requestResponse()
+        }
+        XCTAssertEqual(machine.state, state)
+        return machine
+    }
+}
+
+/// Proves the protocol is implementable as written — a contract nobody can conform to is
+/// a contract that fails in WP7, not here — and that an adapter routing every call
+/// through `VoiceTurnStateMachine` gets the turn discipline for free.
+@MainActor
+final class VoiceBackendConformanceTests: XCTestCase {
+
+    /// The minimum honest adapter: a transcript-only pipe that checks every call against
+    /// the state machine and reports violations the way a real adapter does.
+    private final class ScriptedBackend: VoiceBackend {
+        let capabilities: VoiceBackendCapabilities
+        private var machine: VoiceTurnStateMachine
+        private var onEvent: (@MainActor (VoiceBackendEvent) -> Void)?
+        private(set) var violations: [VoiceTurnViolation] = []
+        private(set) var sentBytes = 0
+        private(set) var spoken: [String] = []
+
+        init(capabilities: VoiceBackendCapabilities = .transcriptOnly) {
+            self.capabilities = capabilities
+            self.machine = VoiceTurnStateMachine(capabilities: capabilities)
+        }
+
+        var state: VoiceTurnStateMachine.State { machine.state }
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            do {
+                try machine.open()
+            } catch let violation as VoiceTurnViolation {
+                throw VoiceBackendFailure.protocolViolation(violation.rawDetail)
+            }
+            self.onEvent = onEvent
+        }
+
+        func close() {
+            machine.close()
+            onEvent = nil
+        }
+
+        func beginUserTurn() { guarded { try machine.beginUserTurn() } }
+        func endUserTurn() { guarded { try machine.endUserTurn() } }
+
+        func sendAudio(_ chunk: VoiceAudioChunk) {
+            guarded {
+                try machine.sendAudio()
+                sentBytes += chunk.data.count
+            }
+        }
+
+        func requestResponse(text: String) {
+            guarded {
+                try machine.requestResponse()
+                spoken.append(text)
+            }
+        }
+
+        func cancelResponse() { guarded { try machine.cancelResponse() } }
+
+        /// Test hook: the transport handing an event up, checked for legality the same
+        /// way an inbound call is.
+        func deliver(_ event: VoiceBackendEvent) {
+            switch event {
+            case .responseCompleted:
+                guarded { try machine.responseCompleted() }
+            case .sessionFailed:
+                machine.sessionFailed()
+            case .transcriptPartial, .transcriptFinal, .audio:
+                break
+            }
+            onEvent?(event)
+        }
+
+        private func guarded(_ body: () throws -> Void) {
+            do {
+                try body()
+            } catch let violation as VoiceTurnViolation {
+                violations.append(violation)
+            } catch {
+                XCTFail("unexpected error \(error)")
+            }
+        }
+    }
+
+    func testAdapterDrivesAFullTurnAndReportsTranscripts() async throws {
+        let backend = ScriptedBackend()
+        var received: [VoiceBackendEvent] = []
+        try await backend.open { received.append($0) }
+
+        backend.beginUserTurn()
+        backend.sendAudio(VoiceAudioChunk(data: Data(count: 480), format: .pcm16Mono24k, timestamp: 0))
+        backend.deliver(.transcriptPartial("ye"))
+        backend.endUserTurn()
+        backend.deliver(.transcriptFinal("yes"))
+        backend.deliver(.responseCompleted)
+
+        XCTAssertEqual(received, [.transcriptPartial("ye"), .transcriptFinal("yes"), .responseCompleted])
+        XCTAssertEqual(backend.sentBytes, 480)
+        XCTAssertEqual(backend.state, .open)
+        XCTAssertTrue(backend.violations.isEmpty)
+    }
+
+    func testAdapterRejectsAudioOutsideAUserTurn() async throws {
+        let backend = ScriptedBackend()
+        try await backend.open { _ in }
+        backend.sendAudio(VoiceAudioChunk(data: Data(count: 96), format: .pcm16Mono24k, timestamp: 0))
+        XCTAssertEqual(backend.violations, [.noUserTurn])
+        XCTAssertEqual(backend.sentBytes, 0)
+    }
+
+    func testAdapterRefusesToSpeakOverAnOpenUserTurn() async throws {
+        let backend = ScriptedBackend(
+            capabilities: VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true, duplex: true))
+        try await backend.open { _ in }
+        backend.beginUserTurn()
+        backend.requestResponse(text: "Approving.")
+        XCTAssertEqual(backend.violations, [.responseDuringUserTurn])
+        XCTAssertTrue(backend.spoken.isEmpty)
+
+        backend.endUserTurn()
+        backend.requestResponse(text: "Approving.")
+        XCTAssertEqual(backend.spoken, ["Approving."])
+        XCTAssertEqual(backend.state, .responding)
+    }
+
+    func testSecondOpenThrowsTypedFailure() async throws {
+        let backend = ScriptedBackend()
+        try await backend.open { _ in }
+        do {
+            try await backend.open { _ in }
+            XCTFail("expected the second open to throw")
+        } catch let failure as VoiceBackendFailure {
+            XCTAssertEqual(failure, .protocolViolation("alreadyOpen"))
+        }
+    }
+
+    func testSessionFailureClosesTheSessionAndAllowsAFreshOne() async throws {
+        let backend = ScriptedBackend()
+        var received: [VoiceBackendEvent] = []
+        try await backend.open { received.append($0) }
+        backend.beginUserTurn()
+        backend.deliver(.sessionFailed(.network("socket closed")))
+        XCTAssertEqual(backend.state, .idle)
+        XCTAssertEqual(received, [.sessionFailed(.network("socket closed"))])
+
+        try await backend.open { _ in }
+        backend.beginUserTurn()
+        XCTAssertEqual(backend.state, .userTurn)
+        XCTAssertTrue(backend.violations.isEmpty)
+    }
+
+    func testCloseIsSafeFromAnyStateAndRepeatable() async throws {
+        let backend = ScriptedBackend()
+        backend.close()
+        try await backend.open { _ in }
+        backend.beginUserTurn()
+        backend.close()
+        backend.close()
+        XCTAssertEqual(backend.state, .idle)
+    }
+}
+
+private extension VoiceTurnViolation {
+    /// Stable short token for the detail string an adapter attaches to a
+    /// `protocolViolation`, so tests can assert on it without matching prose.
+    var rawDetail: String {
+        switch self {
+        case .notOpen: return "notOpen"
+        case .alreadyOpen: return "alreadyOpen"
+        case .turnAlreadyInProgress: return "turnAlreadyInProgress"
+        case .noUserTurn: return "noUserTurn"
+        case .responseDuringUserTurn: return "responseDuringUserTurn"
+        case .responseAlreadyInFlight: return "responseAlreadyInFlight"
+        case .noResponseInFlight: return "noResponseInFlight"
+        case .bargeInUnsupported: return "bargeInUnsupported"
+        }
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/WearerSpeechAnalyzerTests.swift
+++ b/Tests/TapQDetectionBaselineTests/WearerSpeechAnalyzerTests.swift
@@ -1,0 +1,554 @@
+import XCTest
+@testable import TapQDetectionBaseline
+
+/// Builds synthetic 25 Hz motion streams with a controlled jerk envelope, so every test
+/// below is hardware-independent and reproducible. `jerk` is the sample-to-sample change
+/// in acceleration magnitude the stream is engineered to produce.
+private struct StreamBuilder {
+    static let rate: TimeInterval = 1.0 / 25.0
+
+    private(set) var samples: [HeadMotionSample] = []
+    private var time: TimeInterval = 100
+    private var sign: Double = 1
+    private var baseline: Double = 0.05
+
+    /// Appends `seconds` of a stream whose consecutive acceleration magnitudes differ by
+    /// exactly `jerk`, with a constant rotation magnitude.
+    mutating func append(seconds: TimeInterval, jerk: Double, rotation: Double = 0.02) {
+        let count = Int((seconds / Self.rate).rounded())
+        for _ in 0..<count {
+            sign = -sign
+            samples.append(HeadMotionSample(
+                timestamp: time,
+                pitch: 0,
+                yaw: 0,
+                accelerationMagnitude: baseline + sign * jerk / 2,
+                rotationMagnitude: rotation
+            ))
+            time += Self.rate
+        }
+    }
+
+    /// Appends one lone high-acceleration sample: the `TapAnalyzer`-shaped impact.
+    mutating func appendImpact(_ acceleration: Double, rotation: Double = 0.02) {
+        samples.append(HeadMotionSample(
+            timestamp: time,
+            pitch: 0,
+            yaw: 0,
+            accelerationMagnitude: acceleration,
+            rotationMagnitude: rotation
+        ))
+        time += Self.rate
+    }
+
+    /// Appends per-axis samples whose signed user acceleration flips by `jerk` each step.
+    mutating func appendPerAxis(seconds: TimeInterval, jerk: Double, rotation: Double = 0.02) {
+        let count = Int((seconds / Self.rate).rounded())
+        for _ in 0..<count {
+            sign = -sign
+            samples.append(HeadMotionSample(
+                timestamp: time,
+                pitch: 0,
+                yaw: 0,
+                roll: 0,
+                userAcceleration: MotionVector(x: sign * jerk / 2, y: 0, z: 0),
+                rotationRate: MotionVector(x: 0, y: rotation, z: 0),
+                gravity: MotionVector(x: 0, y: 0, z: -1)
+            ))
+            time += Self.rate
+        }
+    }
+
+    /// Advances the clock without emitting samples — a dropped stretch of stream.
+    mutating func skip(seconds: TimeInterval) {
+        time += seconds
+    }
+
+    /// Returns the samples appended since the last drain and keeps the clock running, so a
+    /// test can feed one continuous stream in phases.
+    mutating func drain() -> [HeadMotionSample] {
+        defer { samples = [] }
+        return samples
+    }
+}
+
+private extension WearerSpeechDetector {
+    /// Feeds every sample and returns the final state.
+    @discardableResult
+    mutating func ingest(all samples: [HeadMotionSample]) -> WearerSpeechState {
+        var state = self.state
+        for sample in samples { state = ingest(sample) }
+        return state
+    }
+
+    /// Feeds every sample and returns the transitions observed, in order.
+    mutating func transitions(over samples: [HeadMotionSample]) -> [WearerSpeechTransition] {
+        samples.compactMap { ingestDetailed($0).transition }
+    }
+}
+
+final class WearerSpeechAnalyzerTests: XCTestCase {
+    // Defaults: enter 0.020, exit 0.012, activeFraction 0.5, minSpeaking 0.3 s,
+    // hangover 0.6 s, rotationQuiet 0.8, window 0.6 s, minSamples 6, maxGap 0.5 s.
+    private let analyzer = WearerSpeechAnalyzer()
+
+    // MARK: - Pure window analysis
+
+    func testSustainedElevationWithQuietHeadIsDetected() {
+        let envelope = [Double](repeating: 0.04, count: 15)
+        let rotation = [Double](repeating: 0.02, count: 15)
+        XCTAssertTrue(analyzer.detect(envelope: envelope, rotation: rotation,
+                                      sustainedSeconds: 0.4, holding: false))
+    }
+
+    func testAnalysisExplainsEveryDecisionGate() {
+        let quietRotation = [Double](repeating: 0.02, count: 15)
+
+        XCTAssertEqual(
+            analyzer.analyze(envelope: [0.04, 0.04], rotation: [0.02, 0.02],
+                             sustainedSeconds: 1, holding: false).rejection,
+            .insufficientSamples
+        )
+        XCTAssertEqual(
+            analyzer.analyze(envelope: [Double](repeating: 0.004, count: 15),
+                             rotation: quietRotation,
+                             sustainedSeconds: 1, holding: false).rejection,
+            .belowEnvelope
+        )
+        XCTAssertEqual(
+            analyzer.analyze(envelope: [Double](repeating: 0.04, count: 15),
+                             rotation: [Double](repeating: 2.5, count: 15),
+                             sustainedSeconds: 1, holding: false).rejection,
+            .rotationNotQuiet
+        )
+        // Breadth gate: one big transient in an otherwise quiet window.
+        var transient = [Double](repeating: 0.004, count: 14)
+        transient.insert(1.19, at: 7)
+        XCTAssertEqual(
+            analyzer.analyze(envelope: transient, rotation: quietRotation,
+                             sustainedSeconds: 1, holding: false).rejection,
+            .tooBrief
+        )
+        // Duration gate: broad elevation that has not lasted long enough yet.
+        XCTAssertEqual(
+            analyzer.analyze(envelope: [Double](repeating: 0.04, count: 15),
+                             rotation: quietRotation,
+                             sustainedSeconds: 0.2, holding: false).rejection,
+            .tooBrief
+        )
+
+        let detected = analyzer.analyze(envelope: [Double](repeating: 0.04, count: 15),
+                                        rotation: quietRotation,
+                                        sustainedSeconds: 0.4, holding: false)
+        XCTAssertNil(detected.rejection)
+        XCTAssertTrue(detected.detected)
+        XCTAssertEqual(detected.envelopeSamples, 15)
+        XCTAssertEqual(detected.rotationSamples, 15)
+        XCTAssertEqual(detected.elevatedSamples, 15)
+        XCTAssertEqual(detected.activeFraction, 1.0)
+        XCTAssertEqual(detected.peakEnvelope, 0.04)
+        XCTAssertEqual(detected.threshold, 0.020)
+        XCTAssertEqual(detected.sustainedSeconds, 0.4)
+    }
+
+    /// The onset duration is served once. Re-serving it on every sample while already
+    /// speaking would make the detector unable to stay in state.
+    func testDurationGateIsSkippedWhileHolding() {
+        let envelope = [Double](repeating: 0.04, count: 15)
+        let rotation = [Double](repeating: 0.02, count: 15)
+        XCTAssertFalse(analyzer.detect(envelope: envelope, rotation: rotation,
+                                       sustainedSeconds: 0, holding: false))
+        XCTAssertTrue(analyzer.detect(envelope: envelope, rotation: rotation,
+                                      sustainedSeconds: 0, holding: true))
+    }
+
+    /// Mid-band level: above the exit threshold, below the enter threshold. It must not be
+    /// enough to start speech, and must be enough to sustain it.
+    func testHysteresisThresholdSelection() {
+        let midBand = [Double](repeating: 0.016, count: 15)
+        let rotation = [Double](repeating: 0.02, count: 15)
+
+        let entering = analyzer.analyze(envelope: midBand, rotation: rotation,
+                                        sustainedSeconds: 1, holding: false)
+        XCTAssertEqual(entering.rejection, .belowEnvelope)
+        XCTAssertEqual(entering.threshold, 0.020)
+
+        let holding = analyzer.analyze(envelope: midBand, rotation: rotation,
+                                       sustainedSeconds: 1, holding: true)
+        XCTAssertTrue(holding.detected)
+        XCTAssertEqual(holding.threshold, 0.012)
+    }
+
+    func testMinimumSamplesRespectsConfiguredValue() {
+        let strict = WearerSpeechAnalyzer(config: WearerSpeechConfig(minSamples: 20))
+        XCTAssertEqual(
+            strict.analyze(envelope: [Double](repeating: 0.04, count: 15),
+                           rotation: [Double](repeating: 0.02, count: 15),
+                           sustainedSeconds: 1, holding: false).rejection,
+            .insufficientSamples
+        )
+    }
+
+    // MARK: - Envelope computation
+
+    func testEnvelopeValueUsesMagnitudesWithoutPerAxisData() {
+        let previous = HeadMotionSample(timestamp: 1, pitch: 0, yaw: 0,
+                                        accelerationMagnitude: 0.05, rotationMagnitude: 0)
+        let current = HeadMotionSample(timestamp: 1.04, pitch: 0, yaw: 0,
+                                       accelerationMagnitude: 0.09, rotationMagnitude: 0)
+        XCTAssertEqual(
+            WearerSpeechAnalyzer.envelopeValue(from: previous, to: current),
+            0.04, accuracy: 1e-12
+        )
+        // Direction of the change is irrelevant; the envelope is a magnitude.
+        XCTAssertEqual(
+            WearerSpeechAnalyzer.envelopeValue(from: current, to: previous),
+            0.04, accuracy: 1e-12
+        )
+    }
+
+    /// With signed data the vector difference sees a reversal that leaves the magnitude
+    /// unchanged — the scalar path would report zero jerk for the same motion.
+    func testEnvelopeValueUsesVectorDifferenceWithPerAxisData() {
+        let previous = HeadMotionSample(
+            timestamp: 1, pitch: 0, yaw: 0, roll: 0,
+            userAcceleration: MotionVector(x: 0.03, y: 0, z: 0),
+            rotationRate: .zero, gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+        let current = HeadMotionSample(
+            timestamp: 1.04, pitch: 0, yaw: 0, roll: 0,
+            userAcceleration: MotionVector(x: -0.03, y: 0, z: 0),
+            rotationRate: .zero, gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+        XCTAssertEqual(previous.accelerationMagnitude, current.accelerationMagnitude)
+        XCTAssertEqual(
+            WearerSpeechAnalyzer.envelopeValue(from: previous, to: current),
+            0.06, accuracy: 1e-12
+        )
+    }
+
+    func testEnvelopeValueFallsBackToMagnitudesWhenEitherSampleLacksPerAxisData() {
+        let magnitudeOnly = HeadMotionSample(timestamp: 1, pitch: 0, yaw: 0,
+                                             accelerationMagnitude: 0.03, rotationMagnitude: 0)
+        let perAxis = HeadMotionSample(
+            timestamp: 1.04, pitch: 0, yaw: 0, roll: 0,
+            userAcceleration: MotionVector(x: -0.03, y: 0, z: 0),
+            rotationRate: .zero, gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+        XCTAssertEqual(
+            WearerSpeechAnalyzer.envelopeValue(from: magnitudeOnly, to: perAxis),
+            0, accuracy: 1e-12
+        )
+    }
+
+    func testEnvelopeSeriesProducesOneValuePerContiguousPair() {
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.4, jerk: 0.04)
+        let series = WearerSpeechAnalyzer.envelopeSeries(builder.samples)
+        XCTAssertEqual(series.count, builder.samples.count - 1)
+        for value in series {
+            XCTAssertEqual(value, 0.04, accuracy: 1e-12)
+        }
+    }
+
+    /// The calibrator shares this helper, so its gap policy must match the detector's:
+    /// a discontinuity is skipped, never differenced into a fake vibration burst.
+    func testEnvelopeSeriesSkipsGapsAndOutOfOrderSamples() {
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.2, jerk: 0.04)
+        let before = builder.samples.count
+        builder.skip(seconds: 2.0)
+        builder.append(seconds: 0.2, jerk: 0.04)
+
+        let series = WearerSpeechAnalyzer.envelopeSeries(builder.samples)
+        XCTAssertEqual(series.count, builder.samples.count - 2)
+        XCTAssertEqual(series.max() ?? 0, 0.04, accuracy: 1e-12)
+
+        let repeated = [builder.samples[before - 1], builder.samples[before - 1]]
+        XCTAssertTrue(WearerSpeechAnalyzer.envelopeSeries(repeated).isEmpty)
+        XCTAssertTrue(WearerSpeechAnalyzer.envelopeSeries([builder.samples[0]]).isEmpty)
+        XCTAssertTrue(WearerSpeechAnalyzer.envelopeSeries([]).isEmpty)
+    }
+
+    // MARK: - Detector
+
+    func testSustainedVibrationIsDetectedAsSpeaking() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+
+        XCTAssertEqual(detector.ingest(all: builder.samples), .speaking)
+        XCTAssertEqual(detector.state, .speaking)
+    }
+
+    func testSpeechIsNotDeclaredBeforeTheOnsetDurationElapses() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.28, jerk: 0.04)
+
+        XCTAssertEqual(detector.ingest(all: builder.samples), .quiet)
+    }
+
+    func testStartAndStopProduceExactlyOneTransitionEach() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        builder.append(seconds: 2.5, jerk: 0.004)
+
+        XCTAssertEqual(detector.transitions(over: builder.samples),
+                       [.startedSpeaking, .stoppedSpeaking])
+        XCTAssertEqual(detector.state, .quiet)
+    }
+
+    func testRestingJitterIsNeverDetected() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 20, jerk: 0.004)
+
+        for sample in builder.samples {
+            XCTAssertEqual(detector.ingestDetailed(sample).state, .quiet)
+        }
+    }
+
+    /// A `TapAnalyzer`-shaped impact — one lone 1.24 g sample in a quiet stream — is a
+    /// transient, not speech. It clears the level gate and dies on the breadth gate.
+    func testSingleImpactSpikeIsRejectedAsTooBrief() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.6, jerk: 0.004)
+        builder.appendImpact(1.24)
+        builder.append(seconds: 0.6, jerk: 0.004)
+
+        var sawImpactWindow = false
+        for sample in builder.samples {
+            let update = detector.ingestDetailed(sample)
+            XCTAssertEqual(update.state, .quiet)
+            if update.envelope > 1 {
+                XCTAssertEqual(update.analysis.rejection, .tooBrief)
+                XCTAssertGreaterThan(update.analysis.peakEnvelope,
+                                     update.analysis.threshold)
+                sawImpactWindow = true
+            }
+        }
+        XCTAssertTrue(sawImpactWindow, "the synthetic impact never reached the detector")
+    }
+
+    /// A nod/shake carries a speech-sized envelope; only the rotation gate separates them.
+    func testHeadGestureStreamIsRejectedByTheRotationGate() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.10, rotation: 2.5)
+
+        var sawRotationRejection = false
+        for sample in builder.samples {
+            let update = detector.ingestDetailed(sample)
+            XCTAssertEqual(update.state, .quiet)
+            if update.analysis.rejection == .rotationNotQuiet { sawRotationRejection = true }
+        }
+        XCTAssertTrue(sawRotationRejection)
+
+        // Same envelope, still head: now it is speech. The rotation was the only difference.
+        var still = WearerSpeechDetector()
+        var quietBuilder = StreamBuilder()
+        quietBuilder.append(seconds: 1.5, jerk: 0.10, rotation: 0.02)
+        XCTAssertEqual(still.ingest(all: quietBuilder.samples), .speaking)
+    }
+
+    /// Mid-band chatter guard: a stream parked between the exit and enter thresholds must
+    /// settle in whichever state it is already in, in both directions.
+    func testMidBandStreamDoesNotChatter() {
+        var fromQuiet = WearerSpeechDetector()
+        var quietBuilder = StreamBuilder()
+        quietBuilder.append(seconds: 4, jerk: 0.016)
+        XCTAssertTrue(fromQuiet.transitions(over: quietBuilder.samples).isEmpty)
+        XCTAssertEqual(fromQuiet.state, .quiet)
+
+        var fromSpeech = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        XCTAssertEqual(fromSpeech.ingest(all: builder.drain()), .speaking)
+
+        builder.append(seconds: 4, jerk: 0.016)
+        XCTAssertTrue(fromSpeech.transitions(over: builder.drain()).isEmpty)
+        XCTAssertEqual(fromSpeech.state, .speaking)
+    }
+
+    /// One utterance must not fragment into many at every inter-word pause.
+    func testHangoverHoldsSpeakingThroughAShortPause() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        builder.append(seconds: 0.4, jerk: 0.004)   // inter-word pause
+        builder.append(seconds: 1.0, jerk: 0.04)
+        builder.append(seconds: 0.4, jerk: 0.004)
+
+        XCTAssertEqual(detector.transitions(over: builder.samples), [.startedSpeaking])
+        XCTAssertEqual(detector.state, .speaking)
+    }
+
+    func testHangoverExpiresAfterALongPause() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        XCTAssertEqual(detector.ingest(all: builder.drain()), .speaking)
+
+        builder.append(seconds: 2.0, jerk: 0.004)
+        XCTAssertEqual(detector.transitions(over: builder.drain()), [.stoppedSpeaking])
+        XCTAssertEqual(detector.state, .quiet)
+    }
+
+    func testHangoverIsReportedWhileItHoldsTheState() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        detector.ingest(all: builder.drain())
+
+        builder.append(seconds: 0.5, jerk: 0.004)
+        let updates = builder.drain().map { detector.ingestDetailed($0) }
+        XCTAssertTrue(updates.contains { $0.inHangover })
+        XCTAssertTrue(updates.allSatisfy { $0.state == .speaking })
+    }
+
+    /// A dropped stretch of stream must not be differenced across: the jump would read as
+    /// one enormous jerk, and the retained window no longer adjoins the new sample.
+    func testTimestampGapResetsTheDetector() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        XCTAssertEqual(detector.ingest(all: builder.drain()), .speaking)
+
+        builder.skip(seconds: 3.0)
+        builder.append(seconds: 0.2, jerk: 0.04)
+
+        let resumed = builder.drain()
+        let updates = resumed.map { detector.ingestDetailed($0) }
+        XCTAssertEqual(updates.first?.transition, .stoppedSpeaking)
+        XCTAssertEqual(updates.first?.envelope, 0)
+        XCTAssertEqual(updates.first?.analysis.rejection, .insufficientSamples)
+        XCTAssertTrue(updates.allSatisfy { $0.state == .quiet })
+        // The window was cleared, so speech has to be re-established from scratch.
+        XCTAssertEqual(updates.last?.analysis.envelopeSamples, resumed.count - 1)
+    }
+
+    func testNonMonotonicTimestampResetsTheDetector() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        detector.ingest(all: builder.drain())
+
+        let rewound = HeadMotionSample(timestamp: 0, pitch: 0, yaw: 0,
+                                       accelerationMagnitude: 0.05, rotationMagnitude: 0.02)
+        let update = detector.ingestDetailed(rewound)
+        XCTAssertEqual(update.state, .quiet)
+        XCTAssertEqual(update.transition, .stoppedSpeaking)
+    }
+
+    func testGapShorterThanTheConfiguredMaximumDoesNotReset() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        detector.ingest(all: builder.drain())
+
+        builder.skip(seconds: 0.2)   // under the 0.5 s gap limit
+        builder.append(seconds: 0.2, jerk: 0.04)
+        XCTAssertEqual(detector.ingest(all: builder.drain()), .speaking)
+    }
+
+    /// Magnitude-only adapters (and every capture recorded before per-axis data existed)
+    /// must still drive the detector.
+    func testMagnitudeOnlyAndPerAxisStreamsBothDetect() {
+        var magnitudeOnly = WearerSpeechDetector()
+        var magnitudeBuilder = StreamBuilder()
+        magnitudeBuilder.append(seconds: 1.5, jerk: 0.04)
+        XCTAssertFalse(magnitudeBuilder.samples[0].hasPerAxisData)
+        XCTAssertEqual(magnitudeOnly.ingest(all: magnitudeBuilder.samples), .speaking)
+
+        var perAxis = WearerSpeechDetector()
+        var perAxisBuilder = StreamBuilder()
+        perAxisBuilder.appendPerAxis(seconds: 1.5, jerk: 0.04)
+        XCTAssertTrue(perAxisBuilder.samples[0].hasPerAxisData)
+        XCTAssertEqual(perAxis.ingest(all: perAxisBuilder.samples), .speaking)
+    }
+
+    func testResetClearsStateAndWindows() {
+        var detector = WearerSpeechDetector()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        detector.ingest(all: builder.drain())
+        XCTAssertEqual(detector.state, .speaking)
+
+        detector.reset()
+        XCTAssertEqual(detector.state, .quiet)
+
+        builder.append(seconds: 0.2, jerk: 0.04)
+        let short = builder.drain()
+        let updates = short.map { detector.ingestDetailed($0) }
+        XCTAssertEqual(updates.first?.envelope, 0)
+        XCTAssertEqual(updates.last?.analysis.envelopeSamples, short.count - 1)
+        XCTAssertTrue(updates.allSatisfy { $0.state == .quiet })
+    }
+
+    func testReconfiguringTheDetectorRebuildsTheAnalyzer() {
+        var detector = WearerSpeechDetector()
+        detector.config = WearerSpeechConfig(envelopeEnterThreshold: 5,
+                                             envelopeExitThreshold: 4)
+        var speech = StreamBuilder()
+        speech.append(seconds: 2.0, jerk: 0.04)
+        XCTAssertEqual(detector.ingest(all: speech.samples), .quiet)
+    }
+
+    // MARK: - Config
+
+    func testConfigRoundTripsThroughJSON() throws {
+        let config = WearerSpeechConfig(
+            envelopeEnterThreshold: 0.031,
+            envelopeExitThreshold: 0.019,
+            minimumActiveFraction: 0.6,
+            minimumSpeakingSeconds: 0.4,
+            hangoverSeconds: 0.8,
+            rotationQuiet: 0.7,
+            windowSeconds: 0.8,
+            minSamples: 9,
+            maxSampleGapSeconds: 0.32
+        )
+        let data = try JSONEncoder().encode(config)
+        XCTAssertEqual(try JSONDecoder().decode(WearerSpeechConfig.self, from: data), config)
+    }
+
+    /// Tolerant decoding, per `HeadGestureConfig`: a profile written before a shape knob
+    /// existed still loads, with that knob at its default.
+    func testConfigDecodesWithOnlyTheCalibratedThresholds() throws {
+        let json = Data("""
+        {"envelopeEnterThreshold": 0.031, "envelopeExitThreshold": 0.019}
+        """.utf8)
+        let decoded = try JSONDecoder().decode(WearerSpeechConfig.self, from: json)
+        let defaults = WearerSpeechConfig()
+
+        XCTAssertEqual(decoded.envelopeEnterThreshold, 0.031)
+        XCTAssertEqual(decoded.envelopeExitThreshold, 0.019)
+        XCTAssertEqual(decoded.minimumActiveFraction, defaults.minimumActiveFraction)
+        XCTAssertEqual(decoded.minimumSpeakingSeconds, defaults.minimumSpeakingSeconds)
+        XCTAssertEqual(decoded.hangoverSeconds, defaults.hangoverSeconds)
+        XCTAssertEqual(decoded.rotationQuiet, defaults.rotationQuiet)
+        XCTAssertEqual(decoded.windowSeconds, defaults.windowSeconds)
+        XCTAssertEqual(decoded.minSamples, defaults.minSamples)
+        XCTAssertEqual(decoded.maxSampleGapSeconds, defaults.maxSampleGapSeconds)
+    }
+
+    func testConfigIgnoresUnknownKeysButRequiresTheThresholds() {
+        let extra = Data("""
+        {"envelopeEnterThreshold": 0.03, "envelopeExitThreshold": 0.02, "futureKnob": 7}
+        """.utf8)
+        XCTAssertNoThrow(try JSONDecoder().decode(WearerSpeechConfig.self, from: extra))
+
+        let missing = Data(#"{"envelopeEnterThreshold": 0.03}"#.utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(WearerSpeechConfig.self, from: missing))
+    }
+
+    func testDefaultConfigKeepsHysteresisOrdered() {
+        let defaults = WearerSpeechConfig()
+        XCTAssertLessThan(defaults.envelopeExitThreshold, defaults.envelopeEnterThreshold)
+        XCTAssertEqual(defaults.maxSampleGapSeconds,
+                       WearerSpeechConfig.defaultMaximumSampleGapSeconds)
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/WearerSpeechCalibratorTests.swift
+++ b/Tests/TapQDetectionBaselineTests/WearerSpeechCalibratorTests.swift
@@ -1,0 +1,275 @@
+import XCTest
+@testable import TapQDetectionBaseline
+
+final class WearerSpeechCalibratorTests: XCTestCase {
+    /// A phase of `count` envelope values alternating narrowly around `level`, which is
+    /// what a sustained tremor looks like once differenced. `spread` keeps the median at
+    /// `level` while giving the peak somewhere to be.
+    private func phase(level: Double, count: Int = 40, spread: Double = 0) -> [Double] {
+        (0..<count).map { level + (($0 % 2 == 0) ? -spread : spread) }
+    }
+
+    private func samples(
+        speaking: [Double],
+        resting: [Double] = []
+    ) -> WearerSpeechCalibrationSamples {
+        WearerSpeechCalibrationSamples(
+            restingEnvelope: resting.isEmpty ? phase(level: 0.003) : resting,
+            speakingEnvelope: speaking
+        )
+    }
+
+    // MARK: - Thresholds
+
+    func testEnterThresholdSitsBetweenRestAndSpeech() {
+        let config = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: phase(level: 0.030), resting: phase(level: 0.004))
+        )
+        XCTAssertLessThan(config.envelopeEnterThreshold, 0.030)
+        XCTAssertGreaterThan(config.envelopeEnterThreshold, 0.004)
+    }
+
+    func testExitThresholdStaysBelowEnterAndAboveRest() {
+        let config = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: phase(level: 0.030), resting: phase(level: 0.004))
+        )
+        XCTAssertLessThan(config.envelopeExitThreshold, config.envelopeEnterThreshold)
+        XCTAssertGreaterThan(config.envelopeExitThreshold, 0.004)
+    }
+
+    /// The exit floor exists so a noisy-but-quiet baseline cannot hold the detector in
+    /// `.speaking` forever: leaving the state requires falling *below* exit.
+    func testNoisyRestPushesTheExitThresholdUpWithoutCrossingEnter() {
+        let quiet = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: phase(level: 0.060), resting: phase(level: 0.001))
+        )
+        let noisy = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: phase(level: 0.060), resting: phase(level: 0.020))
+        )
+        XCTAssertGreaterThan(noisy.envelopeExitThreshold, quiet.envelopeExitThreshold)
+        XCTAssertLessThan(noisy.envelopeExitThreshold, noisy.envelopeEnterThreshold)
+    }
+
+    /// The speaking statistic is a median, so one syllable-onset spike must not drag the
+    /// threshold up — that is the failure mode a peak-based statistic would have.
+    func testOneLoudTransientDoesNotDominateTheThreshold() {
+        var speaking = phase(level: 0.030)
+        let baseline = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: speaking))
+        speaking[7] = 0.9
+        let spiked = WearerSpeechCalibrator.suggestedConfig(from: samples(speaking: speaking))
+        XCTAssertEqual(
+            spiked.envelopeEnterThreshold,
+            baseline.envelopeEnterThreshold,
+            accuracy: 1e-9
+        )
+    }
+
+    func testQuietSpeechClampsToTheFloor() {
+        // 0.001 * 0.6 and the resting headroom both land under the 0.004 floor.
+        let config = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: phase(level: 0.001), resting: phase(level: 0.0005))
+        )
+        XCTAssertEqual(
+            config.envelopeEnterThreshold,
+            WearerSpeechCalibrator.minThreshold,
+            accuracy: 1e-12
+        )
+    }
+
+    func testEnormousEnvelopeClampsToTheCeiling() {
+        let config = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: phase(level: 2.0))
+        )
+        XCTAssertEqual(
+            config.envelopeEnterThreshold,
+            WearerSpeechCalibrator.maxThreshold,
+            accuracy: 1e-12
+        )
+        XCTAssertLessThan(config.envelopeExitThreshold, config.envelopeEnterThreshold)
+    }
+
+    func testNonThresholdFieldsPreserved() {
+        let base = WearerSpeechConfig(
+            envelopeEnterThreshold: 0.99,
+            envelopeExitThreshold: 0.98,
+            minimumActiveFraction: 0.75,
+            minimumSpeakingSeconds: 0.42,
+            hangoverSeconds: 1.25,
+            rotationQuiet: 0.33,
+            windowSeconds: 0.9,
+            minSamples: 11,
+            maxSampleGapSeconds: 0.25
+        )
+        let config = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: phase(level: 0.030)), base: base)
+
+        XCTAssertNotEqual(config.envelopeEnterThreshold, base.envelopeEnterThreshold)
+        XCTAssertNotEqual(config.envelopeExitThreshold, base.envelopeExitThreshold)
+        XCTAssertEqual(config.minimumActiveFraction, base.minimumActiveFraction)
+        XCTAssertEqual(config.minimumSpeakingSeconds, base.minimumSpeakingSeconds)
+        XCTAssertEqual(config.hangoverSeconds, base.hangoverSeconds)
+        XCTAssertEqual(config.rotationQuiet, base.rotationQuiet)
+        XCTAssertEqual(config.windowSeconds, base.windowSeconds)
+        XCTAssertEqual(config.minSamples, base.minSamples)
+        XCTAssertEqual(config.maxSampleGapSeconds, base.maxSampleGapSeconds)
+    }
+
+    func testEmptySpeakingPhaseReturnsBaseUnchanged() {
+        let base = WearerSpeechConfig(
+            envelopeEnterThreshold: 0.042, envelopeExitThreshold: 0.021)
+        let config = WearerSpeechCalibrator.suggestedConfig(
+            from: samples(speaking: []), base: base)
+        XCTAssertEqual(config, base)
+    }
+
+    // MARK: - Usability
+
+    func testSustainedSpeechClearOfRestIsUsable() {
+        XCTAssertTrue(WearerSpeechCalibrator.isSpeechUsable(
+            samples(speaking: phase(level: 0.030), resting: phase(level: 0.004))
+        ))
+    }
+
+    func testSpeechBuriedInRestingNoiseIsNotUsable() {
+        // 0.010 is not >= 3x the 0.008 resting peak.
+        XCTAssertFalse(WearerSpeechCalibrator.isSpeechUsable(
+            samples(speaking: phase(level: 0.010), resting: phase(level: 0.008))
+        ))
+    }
+
+    func testSpeechBelowTheAbsoluteFloorIsNotUsableEvenAgainstSilence() {
+        let assessment = WearerSpeechCalibrator.assessment(
+            of: samplesWithSilentRest(speaking: phase(level: 0.004)))
+        XCTAssertEqual(assessment.restingEnvelopePeak, 0, accuracy: 1e-12)
+        XCTAssertEqual(
+            assessment.requiredLevel,
+            WearerSpeechCalibrator.minUsableSpeaking,
+            accuracy: 1e-12
+        )
+        XCTAssertFalse(assessment.isUsable)
+    }
+
+    func testShortPhasesAreRejectedSeparatelyFromWeakSeparation() {
+        let assessment = WearerSpeechCalibrator.assessment(of: samples(
+            speaking: phase(level: 0.030, count: 4), resting: phase(level: 0.004)
+        ))
+        XCTAssertFalse(assessment.hasEnoughSamples)
+        XCTAssertFalse(assessment.isUsable)
+        XCTAssertGreaterThanOrEqual(
+            assessment.speakingEnvelopeLevel, assessment.requiredLevel,
+            "separation is fine here; only the sample count fails"
+        )
+        XCTAssertEqual(assessment.speakingSampleCount, 4)
+        XCTAssertEqual(assessment.requiredSampleCount, 12)
+    }
+
+    func testAssessmentReportsMedianSpeechAgainstPeakRest() {
+        let assessment = WearerSpeechCalibrator.assessment(of: samples(
+            speaking: phase(level: 0.030, spread: 0.010),
+            resting: phase(level: 0.004, spread: 0.002)
+        ))
+        XCTAssertEqual(assessment.speakingEnvelopeLevel, 0.020, accuracy: 1e-9)
+        XCTAssertEqual(assessment.restingEnvelopePeak, 0.006, accuracy: 1e-9)
+        XCTAssertEqual(assessment.restingSampleCount, 40)
+        XCTAssertEqual(assessment.speakingSampleCount, 40)
+    }
+
+    // MARK: - Envelope derivation
+
+    /// The calibrator must measure with the detector's own envelope function, or a profile
+    /// would tune a quantity the detector never computes.
+    func testSamplesAreDifferencedWithTheDetectorsEnvelope() {
+        var time: TimeInterval = 100
+        func stream(jerk: Double, count: Int) -> [HeadMotionSample] {
+            var result: [HeadMotionSample] = []
+            var sign = 1.0
+            for _ in 0..<count {
+                sign = -sign
+                result.append(HeadMotionSample(
+                    timestamp: time, pitch: 0, yaw: 0,
+                    accelerationMagnitude: 0.05 + sign * jerk / 2,
+                    rotationMagnitude: 0.02
+                ))
+                time += 1.0 / 25.0
+            }
+            return result
+        }
+
+        let derived = WearerSpeechCalibrationSamples(
+            resting: stream(jerk: 0.004, count: 30),
+            speaking: stream(jerk: 0.030, count: 30)
+        )
+        XCTAssertEqual(derived.restingEnvelope.count, 29)
+        XCTAssertEqual(derived.speakingEnvelope.count, 29)
+        XCTAssertEqual(WearerSpeechCalibrator.median(derived.speakingEnvelope),
+                       0.030, accuracy: 1e-9)
+        XCTAssertEqual(derived.restingEnvelope.max() ?? 0, 0.004, accuracy: 1e-9)
+    }
+
+    /// A stream gap is a discontinuity, not a vibration burst; the calibrator drops the
+    /// straddling pair exactly as the live detector resets across one.
+    func testStreamGapsAreNotDifferencedIntoTheEnvelope() {
+        let samples = [
+            HeadMotionSample(timestamp: 100, pitch: 0, yaw: 0,
+                             accelerationMagnitude: 0.05, rotationMagnitude: 0),
+            HeadMotionSample(timestamp: 100.04, pitch: 0, yaw: 0,
+                             accelerationMagnitude: 0.06, rotationMagnitude: 0),
+            // 9 s later, and 1 g away: a differenced jump here would swamp everything.
+            HeadMotionSample(timestamp: 109, pitch: 0, yaw: 0,
+                             accelerationMagnitude: 1.06, rotationMagnitude: 0),
+        ]
+        let derived = WearerSpeechCalibrationSamples(resting: [], speaking: samples)
+        XCTAssertEqual(derived.speakingEnvelope.count, 1)
+        XCTAssertEqual(derived.speakingEnvelope[0], 0.01, accuracy: 1e-9)
+    }
+
+    // MARK: - Round trip through the detector
+
+    /// End to end: a calibrated profile must make the stream it was calibrated on detect.
+    func testCalibratedProfileDetectsTheStreamItWasCalibratedOn() {
+        var time: TimeInterval = 100
+        var sign = 1.0
+        func append(_ result: inout [HeadMotionSample], seconds: Double, jerk: Double) {
+            for _ in 0..<Int((seconds * 25).rounded()) {
+                sign = -sign
+                result.append(HeadMotionSample(
+                    timestamp: time, pitch: 0, yaw: 0,
+                    accelerationMagnitude: 0.05 + sign * jerk / 2,
+                    rotationMagnitude: 0.02
+                ))
+                time += 1.0 / 25.0
+            }
+        }
+        var resting: [HeadMotionSample] = []
+        append(&resting, seconds: 3, jerk: 0.002)
+        var speaking: [HeadMotionSample] = []
+        append(&speaking, seconds: 4, jerk: 0.014)
+
+        let derived = WearerSpeechCalibrationSamples(resting: resting, speaking: speaking)
+        XCTAssertTrue(WearerSpeechCalibrator.isSpeechUsable(derived))
+        let config = WearerSpeechCalibrator.suggestedConfig(from: derived)
+
+        // The uncalibrated default sits above this quiet wearer's envelope entirely.
+        var uncalibrated = WearerSpeechDetector()
+        for sample in speaking { uncalibrated.ingest(sample) }
+        XCTAssertEqual(uncalibrated.state, .quiet)
+
+        var detector = WearerSpeechDetector(config: config)
+        for sample in speaking { detector.ingest(sample) }
+        XCTAssertEqual(detector.state, .speaking)
+
+        var atRest = WearerSpeechDetector(config: config)
+        for sample in resting { atRest.ingest(sample) }
+        XCTAssertEqual(atRest.state, .quiet)
+    }
+
+    private func samplesWithSilentRest(
+        speaking: [Double]
+    ) -> WearerSpeechCalibrationSamples {
+        WearerSpeechCalibrationSamples(
+            restingEnvelope: Array(repeating: 0, count: 40),
+            speakingEnvelope: speaking
+        )
+    }
+}

--- a/Tests/TapQDetectionBaselineTests/WearerSpeechMonitorTests.swift
+++ b/Tests/TapQDetectionBaselineTests/WearerSpeechMonitorTests.swift
@@ -1,0 +1,448 @@
+import XCTest
+@testable import TapQDetectionBaseline
+
+/// Builds synthetic 25 Hz motion streams with a controlled jerk envelope, matching the
+/// existing `WearerSpeechAnalyzerTests` builder. Speech detection fires after sustained
+/// elevation, so the stream must exceed the onset + window duration.
+private struct StreamBuilder {
+    static let rate: TimeInterval = 1.0 / 25.0
+
+    private(set) var samples: [HeadMotionSample] = []
+    private var time: TimeInterval = 100
+    private var sign: Double = 1
+    private var baseline: Double = 0.05
+
+    mutating func append(seconds: TimeInterval, jerk: Double, rotation: Double = 0.02) {
+        let count = Int((seconds / StreamBuilder.rate).rounded())
+        for _ in 0..<count {
+            sign = -sign
+            samples.append(HeadMotionSample(
+                timestamp: time,
+                pitch: 0,
+                yaw: 0,
+                accelerationMagnitude: baseline + sign * jerk / 2,
+                rotationMagnitude: rotation
+            ))
+            time += StreamBuilder.rate
+        }
+    }
+
+    mutating func appendPerAxis(seconds: TimeInterval, jerk: Double, rotation: Double = 0.02) {
+        let count = Int((seconds / StreamBuilder.rate).rounded())
+        for _ in 0..<count {
+            sign = -sign
+            samples.append(HeadMotionSample(
+                timestamp: time,
+                pitch: 0,
+                yaw: 0,
+                roll: 0,
+                userAcceleration: MotionVector(x: sign * jerk / 2, y: 0, z: 0),
+                rotationRate: MotionVector(x: 0, y: rotation, z: 0),
+                gravity: MotionVector(x: 0, y: 0, z: -1)
+            ))
+            time += StreamBuilder.rate
+        }
+    }
+
+    mutating func skip(seconds: TimeInterval) {
+        time += seconds
+    }
+
+    mutating func drain() -> [HeadMotionSample] {
+        defer { samples = [] }
+        return samples
+    }
+}
+
+final class WearerSpeechMonitorTests: XCTestCase {
+    // Defaults: enter 0.020, exit 0.012, activeFraction 0.5, minSpeaking 0.3 s,
+    // hangover 0.6 s, rotationQuiet 0.8, window 0.6 s, minSamples 6, maxGap 0.5 s.
+
+    private final class Clock {
+        var now: TimeInterval = 100
+        func advance(_ seconds: TimeInterval) { now += seconds }
+    }
+
+    private func makeMonitor(
+        config: WearerSpeechConfig = .init(),
+        stalenessHorizon: TimeInterval? = nil,
+        clock: Clock = Clock()
+    ) -> (WearerSpeechMonitor, Clock) {
+        let monitor = WearerSpeechMonitor(
+            config: config,
+            stalenessHorizon: stalenessHorizon,
+            monotonicNow: { clock.now }
+        )
+        return (monitor, clock)
+    }
+
+    // MARK: - Basic speech detection mirrors WearerSpeechDetector
+
+    func testSustainedVibrationTransitionsToSpeaking() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+
+        XCTAssertEqual(monitor.state, .speaking)
+        XCTAssertEqual(transitions, [.startedSpeaking])
+    }
+
+    func testSpeechOnsetAndOffsetProduceExactlyOneTransitionEach() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        builder.append(seconds: 2.5, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+
+        XCTAssertEqual(transitions, [.startedSpeaking, .stoppedSpeaking])
+        XCTAssertEqual(monitor.state, .quiet)
+    }
+
+    func testRestingJitterNeverTransitions() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 5.0, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+
+        XCTAssertTrue(transitions.isEmpty)
+        XCTAssertEqual(monitor.state, .quiet)
+    }
+
+    func testHangoverHoldsSpeakingThroughShortPause() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        builder.append(seconds: 0.4, jerk: 0.004)
+        builder.append(seconds: 1.0, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+
+        XCTAssertEqual(transitions, [.startedSpeaking])
+        XCTAssertEqual(monitor.state, .speaking)
+    }
+
+    // MARK: - Staleness
+
+    func testIsFreshAfterRecentSample() {
+        let (monitor, clock) = makeMonitor()
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+
+        XCTAssertTrue(monitor.isFresh())
+        XCTAssertNotNil(monitor.lastSampleAt)
+    }
+
+    func testIsNotFreshBeforeAnySample() {
+        let (monitor, _) = makeMonitor()
+        XCTAssertFalse(monitor.isFresh())
+        XCTAssertNil(monitor.lastSampleAt)
+    }
+
+    func testGoesStaleAfterHorizon() {
+        let clock = Clock()
+        let config = WearerSpeechConfig()
+        let (monitor, _) = makeMonitor(config: config, clock: clock)
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertTrue(monitor.isFresh())
+
+        // Advance beyond the staleness horizon (defaults to maxSampleGapSeconds = 0.5)
+        clock.advance(config.maxSampleGapSeconds + 0.1)
+        XCTAssertFalse(monitor.isFresh())
+    }
+
+    func testCustomStalenessHorizon() {
+        let clock = Clock()
+        let (monitor, _) = makeMonitor(stalenessHorizon: 1.0, clock: clock)
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertTrue(monitor.isFresh())
+
+        clock.advance(0.8)
+        XCTAssertTrue(monitor.isFresh(), "within custom horizon")
+
+        clock.advance(0.3)
+        XCTAssertFalse(monitor.isFresh(), "beyond custom horizon")
+    }
+
+    func testIsFreshWithExplicitNow() {
+        let (monitor, clock) = makeMonitor()
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+
+        // Explicit now within horizon
+        XCTAssertTrue(monitor.isFresh(now: clock.now + 0.1))
+        // Explicit now beyond horizon
+        XCTAssertFalse(monitor.isFresh(now: clock.now + 1.0))
+    }
+
+    // MARK: - streamInterrupted
+
+    func testStreamInterruptedResetsToQuietAndStale() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertEqual(monitor.state, .speaking)
+        XCTAssertTrue(monitor.isFresh())
+
+        monitor.streamInterrupted()
+
+        XCTAssertEqual(monitor.state, .quiet)
+        XCTAssertFalse(monitor.isFresh())
+        XCTAssertTrue(monitor.interrupted)
+        XCTAssertEqual(transitions, [.startedSpeaking, .stoppedSpeaking])
+    }
+
+    func testStreamInterruptedWhileQuietDoesNotFireTransition() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertEqual(monitor.state, .quiet)
+
+        monitor.streamInterrupted()
+        XCTAssertEqual(monitor.state, .quiet)
+        XCTAssertTrue(transitions.isEmpty, "no transition because state was already quiet")
+    }
+
+    func testStreamInterruptedIdempotent() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        monitor.streamInterrupted()
+        monitor.streamInterrupted()
+
+        XCTAssertEqual(transitions, [.startedSpeaking, .stoppedSpeaking],
+                       "second streamInterrupted must not fire a duplicate transition")
+    }
+
+    func testInterruptedClearsOnNextIngest() {
+        let (monitor, clock) = makeMonitor()
+        monitor.streamInterrupted()
+        XCTAssertTrue(monitor.interrupted)
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 0.2, jerk: 0.004)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertFalse(monitor.interrupted)
+        XCTAssertTrue(monitor.isFresh())
+    }
+
+    // MARK: - Per-axis data tracking
+
+    func testLastSampleHadPerAxisDataTracksCorrectly() {
+        let (monitor, clock) = makeMonitor()
+
+        // Magnitude-only sample
+        let magnitudeOnly = HeadMotionSample(
+            timestamp: 100, pitch: 0, yaw: 0,
+            accelerationMagnitude: 0.05, rotationMagnitude: 0.02
+        )
+        clock.advance(StreamBuilder.rate)
+        monitor.ingest(magnitudeOnly)
+        XCTAssertFalse(monitor.lastSampleHadPerAxisData)
+
+        // Per-axis sample
+        let perAxis = HeadMotionSample(
+            timestamp: 100.04, pitch: 0, yaw: 0, roll: 0,
+            userAcceleration: MotionVector(x: 0.03, y: 0, z: 0),
+            rotationRate: MotionVector(x: 0, y: 0.02, z: 0),
+            gravity: MotionVector(x: 0, y: 0, z: -1)
+        )
+        clock.advance(StreamBuilder.rate)
+        monitor.ingest(perAxis)
+        XCTAssertTrue(monitor.lastSampleHadPerAxisData)
+    }
+
+    func testMagnitudeOnlyStreamReportsCorrectly() {
+        let (monitor, clock) = makeMonitor()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            XCTAssertFalse(sample.hasPerAxisData)
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertFalse(monitor.lastSampleHadPerAxisData)
+    }
+
+    // MARK: - Return value
+
+    func testIngestReturnsTheDetectorUpdate() {
+        let (monitor, clock) = makeMonitor()
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        var lastUpdate: WearerSpeechUpdate?
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            lastUpdate = monitor.ingest(sample)
+        }
+        XCTAssertEqual(lastUpdate?.state, .speaking)
+    }
+
+    // MARK: - Gap handling (inherited from detector)
+
+    func testTimestampGapResetsDetectorState() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        for sample in builder.drain() {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertEqual(monitor.state, .speaking)
+
+        // Skip beyond maxSampleGapSeconds (0.5 s default)
+        builder.skip(seconds: 3.0)
+        builder.append(seconds: 0.2, jerk: 0.04)
+        for sample in builder.drain() {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        // The gap causes the detector to reset, so speaking -> quiet transition fires
+        XCTAssertTrue(transitions.contains(.stoppedSpeaking))
+    }
+
+    // MARK: - Detector reset on stream interrupted + re-establish
+
+    func testSpeechCanBeReEstablishedAfterInterruption() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 1.5, jerk: 0.04)
+        for sample in builder.drain() {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertEqual(monitor.state, .speaking)
+
+        monitor.streamInterrupted()
+        XCTAssertEqual(monitor.state, .quiet)
+
+        // New stream from scratch
+        var newBuilder = StreamBuilder()
+        newBuilder.append(seconds: 1.5, jerk: 0.04)
+        for sample in newBuilder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+        XCTAssertEqual(monitor.state, .speaking)
+        XCTAssertEqual(transitions,
+                       [.startedSpeaking, .stoppedSpeaking, .startedSpeaking])
+    }
+
+    // MARK: - Per-axis streams also detect
+
+    func testPerAxisStreamDetects() {
+        let (monitor, clock) = makeMonitor()
+        var transitions: [WearerSpeechTransition] = []
+        monitor.onTransition = { transitions.append($0) }
+
+        var builder = StreamBuilder()
+        builder.appendPerAxis(seconds: 1.5, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+
+        XCTAssertEqual(monitor.state, .speaking)
+        XCTAssertEqual(transitions, [.startedSpeaking])
+        XCTAssertTrue(monitor.lastSampleHadPerAxisData)
+    }
+
+    // MARK: - Config pass-through
+
+    func testMonitorUsesInjectedConfig() {
+        let strictConfig = WearerSpeechConfig(
+            envelopeEnterThreshold: 5.0,
+            envelopeExitThreshold: 4.0
+        )
+        let (monitor, clock) = makeMonitor(config: strictConfig)
+
+        var builder = StreamBuilder()
+        builder.append(seconds: 2.0, jerk: 0.04)
+        for sample in builder.samples {
+            clock.advance(StreamBuilder.rate)
+            monitor.ingest(sample)
+        }
+
+        XCTAssertEqual(monitor.state, .quiet,
+                       "with impossibly high thresholds, nothing should be detected")
+    }
+
+    func testStalenessHorizonDefaultsToMaxSampleGapSeconds() {
+        let config = WearerSpeechConfig(maxSampleGapSeconds: 0.7)
+        let (monitor, _) = makeMonitor(config: config)
+        XCTAssertEqual(monitor.stalenessHorizon, 0.7)
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/CombinedSpeechActivityTests.swift
+++ b/Tests/TapQInteractionBaselineTests/CombinedSpeechActivityTests.swift
@@ -1,0 +1,294 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+@MainActor
+final class CombinedSpeechActivityTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    @MainActor
+    private final class FakeTTSActivity: SpeechActivitySignaling {
+        var isSpeaking: Bool
+        var onSpeakingChange: (@MainActor (Bool) -> Void)?
+
+        init(speaking: Bool = false) {
+            self.isSpeaking = speaking
+        }
+
+        func setSpeaking(_ speaking: Bool) {
+            guard speaking != isSpeaking else { return }
+            isSpeaking = speaking
+            onSpeakingChange?(speaking)
+        }
+    }
+
+    @MainActor
+    private final class FakePlayback: VoiceResponseAudioPlaying {
+        var isPlaying: Bool
+        var onPlayingChange: (@MainActor (Bool) -> Void)?
+
+        private(set) var enqueued: [VoiceAudioChunk] = []
+        private(set) var finishStreamCount = 0
+        private(set) var stopAndFlushCount = 0
+
+        init(playing: Bool = false) {
+            self.isPlaying = playing
+        }
+
+        func enqueue(_ chunk: VoiceAudioChunk) {
+            enqueued.append(chunk)
+            if !isPlaying {
+                isPlaying = true
+                onPlayingChange?(true)
+            }
+        }
+
+        func finishStream() {
+            finishStreamCount += 1
+            // Simulate drain: immediately transition to idle.
+            guard isPlaying else { return }
+            isPlaying = false
+            onPlayingChange?(false)
+        }
+
+        func stopAndFlush() {
+            stopAndFlushCount += 1
+            guard isPlaying else { return }
+            isPlaying = false
+            onPlayingChange?(false)
+        }
+
+        /// Simulate starting/stopping playback externally.
+        func setPlaying(_ playing: Bool) {
+            guard playing != isPlaying else { return }
+            isPlaying = playing
+            onPlayingChange?(playing)
+        }
+    }
+
+    // MARK: - Truth table
+
+    func testBothIdleYieldsCombinedIdle() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+
+        XCTAssertFalse(combined.isSpeaking)
+    }
+
+    func testTTSBusyAloneYieldsCombinedBusy() {
+        let tts = FakeTTSActivity(speaking: true)
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+
+        XCTAssertTrue(combined.isSpeaking)
+    }
+
+    func testPlaybackBusyAloneYieldsCombinedBusy() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback(playing: true)
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+
+        XCTAssertTrue(combined.isSpeaking)
+    }
+
+    func testBothBusyYieldsCombinedBusy() {
+        let tts = FakeTTSActivity(speaking: true)
+        let playback = FakePlayback(playing: true)
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+
+        XCTAssertTrue(combined.isSpeaking)
+    }
+
+    // MARK: - Transition edges
+
+    func testTTSBecomesBusyRaisesCombined() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        var edges: [Bool] = []
+        combined.onSpeakingChange = { edges.append($0) }
+
+        tts.setSpeaking(true)
+
+        XCTAssertTrue(combined.isSpeaking)
+        XCTAssertEqual(edges, [true])
+    }
+
+    func testPlaybackBecomesBusyRaisesCombined() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        var edges: [Bool] = []
+        combined.onSpeakingChange = { edges.append($0) }
+
+        playback.setPlaying(true)
+
+        XCTAssertTrue(combined.isSpeaking)
+        XCTAssertEqual(edges, [true])
+    }
+
+    func testTTSDrainsWhilePlaybackBusyStaysCombinedBusy() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        var edges: [Bool] = []
+
+        tts.setSpeaking(true)
+        playback.setPlaying(true)
+        combined.onSpeakingChange = { edges.append($0) }
+
+        // TTS finishes but playback is still going
+        tts.setSpeaking(false)
+
+        XCTAssertTrue(combined.isSpeaking, "playback alone keeps combined busy")
+        XCTAssertEqual(edges, [], "no edge: combined was busy and stays busy")
+    }
+
+    func testPlaybackDrainsWhileTTSBusyStaysCombinedBusy() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        var edges: [Bool] = []
+
+        tts.setSpeaking(true)
+        playback.setPlaying(true)
+        combined.onSpeakingChange = { edges.append($0) }
+
+        // Playback finishes but TTS is still going
+        playback.setPlaying(false)
+
+        XCTAssertTrue(combined.isSpeaking, "TTS alone keeps combined busy")
+        XCTAssertEqual(edges, [], "no edge: combined was busy and stays busy")
+    }
+
+    func testBothDrainYieldsCombinedIdle() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        var edges: [Bool] = []
+
+        tts.setSpeaking(true)
+        playback.setPlaying(true)
+        combined.onSpeakingChange = { edges.append($0) }
+
+        tts.setSpeaking(false)
+        playback.setPlaying(false)
+
+        XCTAssertFalse(combined.isSpeaking)
+        XCTAssertEqual(edges, [false], "exactly one falling edge when the last source drains")
+    }
+
+    func testExactlyOneTransitionPerOuterChange() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        var edges: [Bool] = []
+        combined.onSpeakingChange = { edges.append($0) }
+
+        // Full cycle: idle -> tts busy -> both busy -> tts idle -> playback idle
+        tts.setSpeaking(true)       // idle -> busy
+        playback.setPlaying(true)   // busy -> busy (no edge)
+        tts.setSpeaking(false)      // busy -> busy (no edge)
+        playback.setPlaying(false)  // busy -> idle
+
+        XCTAssertEqual(edges, [true, false],
+                       "exactly two transitions for the full busy/idle cycle")
+    }
+
+    func testNoDuplicateEdgesOnRedundantInnerTransitions() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        var edges: [Bool] = []
+        combined.onSpeakingChange = { edges.append($0) }
+
+        // TTS goes busy, idle, busy, idle — playback stays idle throughout.
+        tts.setSpeaking(true)
+        tts.setSpeaking(false)
+        tts.setSpeaking(true)
+        tts.setSpeaking(false)
+
+        XCTAssertEqual(edges, [true, false, true, false],
+                       "each inner edge that changes combined fires exactly one outer edge")
+    }
+
+    // MARK: - Composition with SpeechGatedVoice
+
+    @MainActor
+    private final class FakeVoice: VoiceCommandProviding {
+        var onCommand: (@MainActor (VoiceCommand) -> Void)?
+        private(set) var starts = 0
+        private(set) var stops = 0
+        func start(onCommand: @escaping @MainActor (VoiceCommand) -> Void) {
+            starts += 1
+            self.onCommand = onCommand
+        }
+        func stop() { stops += 1 }
+        func fire(_ command: VoiceCommand) { onCommand?(command) }
+    }
+
+    func testSpeechGatedVoiceHoldsMicClosedWhilePlaybackBusy() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        let inner = FakeVoice()
+        let gated = SpeechGatedVoice(wrapping: inner, activity: combined)
+        var received: [VoiceCommand] = []
+
+        gated.start { received.append($0) }
+        XCTAssertEqual(inner.starts, 1, "mic opens when idle")
+
+        // Backend audio starts playing
+        playback.setPlaying(true)
+        XCTAssertEqual(inner.stops, 1, "mic closes when playback starts")
+
+        // Backend audio drains
+        playback.setPlaying(false)
+        XCTAssertEqual(inner.starts, 2, "mic reopens when playback drains")
+    }
+
+    func testSpeechGatedVoiceHoldsMicClosedWhileTTSAndPlaybackOverlap() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        let inner = FakeVoice()
+        let gated = SpeechGatedVoice(wrapping: inner, activity: combined)
+
+        // Both busy before the window opens
+        tts.setSpeaking(true)
+        playback.setPlaying(true)
+        gated.start { _ in }
+        XCTAssertEqual(inner.starts, 0, "mic stays closed while both are busy")
+
+        // TTS drains first, playback still going
+        tts.setSpeaking(false)
+        XCTAssertEqual(inner.starts, 0, "mic stays closed: playback still busy")
+
+        // Playback drains
+        playback.setPlaying(false)
+        XCTAssertEqual(inner.starts, 1, "mic opens only when everything is idle")
+    }
+
+    func testSpeechGatedVoiceReopensAfterPlaybackDrain() {
+        let tts = FakeTTSActivity()
+        let playback = FakePlayback()
+        let combined = CombinedSpeechActivity(tts: tts, playback: playback)
+        let inner = FakeVoice()
+        let gated = SpeechGatedVoice(wrapping: inner, activity: combined)
+        var received: [VoiceCommand] = []
+
+        gated.start { received.append($0) }
+        XCTAssertEqual(inner.starts, 1)
+
+        // Playback busy then drain
+        playback.setPlaying(true)
+        playback.setPlaying(false)
+        XCTAssertEqual(inner.starts, 2)
+
+        // Voice command arrives after reopen
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes])
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/CombinedSpeechActivityTests.swift
+++ b/Tests/TapQInteractionBaselineTests/CombinedSpeechActivityTests.swift
@@ -69,7 +69,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
 
     // MARK: - Truth table
 
-    func testBothIdleYieldsCombinedIdle() {
+    func testBothIdleYieldsCombinedIdle() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -77,7 +77,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertFalse(combined.isSpeaking)
     }
 
-    func testTTSBusyAloneYieldsCombinedBusy() {
+    func testTTSBusyAloneYieldsCombinedBusy() async {
         let tts = FakeTTSActivity(speaking: true)
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -85,7 +85,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertTrue(combined.isSpeaking)
     }
 
-    func testPlaybackBusyAloneYieldsCombinedBusy() {
+    func testPlaybackBusyAloneYieldsCombinedBusy() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback(playing: true)
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -93,7 +93,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertTrue(combined.isSpeaking)
     }
 
-    func testBothBusyYieldsCombinedBusy() {
+    func testBothBusyYieldsCombinedBusy() async {
         let tts = FakeTTSActivity(speaking: true)
         let playback = FakePlayback(playing: true)
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -103,7 +103,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
 
     // MARK: - Transition edges
 
-    func testTTSBecomesBusyRaisesCombined() {
+    func testTTSBecomesBusyRaisesCombined() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -116,7 +116,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertEqual(edges, [true])
     }
 
-    func testPlaybackBecomesBusyRaisesCombined() {
+    func testPlaybackBecomesBusyRaisesCombined() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -129,7 +129,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertEqual(edges, [true])
     }
 
-    func testTTSDrainsWhilePlaybackBusyStaysCombinedBusy() {
+    func testTTSDrainsWhilePlaybackBusyStaysCombinedBusy() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -146,7 +146,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertEqual(edges, [], "no edge: combined was busy and stays busy")
     }
 
-    func testPlaybackDrainsWhileTTSBusyStaysCombinedBusy() {
+    func testPlaybackDrainsWhileTTSBusyStaysCombinedBusy() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -163,7 +163,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertEqual(edges, [], "no edge: combined was busy and stays busy")
     }
 
-    func testBothDrainYieldsCombinedIdle() {
+    func testBothDrainYieldsCombinedIdle() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -180,7 +180,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertEqual(edges, [false], "exactly one falling edge when the last source drains")
     }
 
-    func testExactlyOneTransitionPerOuterChange() {
+    func testExactlyOneTransitionPerOuterChange() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -197,7 +197,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
                        "exactly two transitions for the full busy/idle cycle")
     }
 
-    func testNoDuplicateEdgesOnRedundantInnerTransitions() {
+    func testNoDuplicateEdgesOnRedundantInnerTransitions() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -229,7 +229,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         func fire(_ command: VoiceCommand) { onCommand?(command) }
     }
 
-    func testSpeechGatedVoiceHoldsMicClosedWhilePlaybackBusy() {
+    func testSpeechGatedVoiceHoldsMicClosedWhilePlaybackBusy() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -249,7 +249,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertEqual(inner.starts, 2, "mic reopens when playback drains")
     }
 
-    func testSpeechGatedVoiceHoldsMicClosedWhileTTSAndPlaybackOverlap() {
+    func testSpeechGatedVoiceHoldsMicClosedWhileTTSAndPlaybackOverlap() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -271,7 +271,7 @@ final class CombinedSpeechActivityTests: XCTestCase {
         XCTAssertEqual(inner.starts, 1, "mic opens only when everything is idle")
     }
 
-    func testSpeechGatedVoiceReopensAfterPlaybackDrain() {
+    func testSpeechGatedVoiceReopensAfterPlaybackDrain() async {
         let tts = FakeTTSActivity()
         let playback = FakePlayback()
         let combined = CombinedSpeechActivity(tts: tts, playback: playback)

--- a/Tests/TapQInteractionBaselineTests/SelectionControllerTests.swift
+++ b/Tests/TapQInteractionBaselineTests/SelectionControllerTests.swift
@@ -260,7 +260,7 @@ final class SelectionControllerTests: XCTestCase {
         let readBack = speech.spoken.first { $0.contains("You said:") }
         XCTAssertNotNil(readBack, "a read-back utterance must be spoken")
         XCTAssertTrue(readBack?.contains("use option B") == true)
-        XCTAssertTrue(readBack?.contains("Nod to send") == true)
+        XCTAssertTrue(readBack?.contains("Nod or say yes to send") == true)
     }
 
     func testFreeformTimeoutAfterReadBack() async {

--- a/Tests/TapQInteractionBaselineTests/SelectionControllerTests.swift
+++ b/Tests/TapQInteractionBaselineTests/SelectionControllerTests.swift
@@ -213,6 +213,90 @@ final class SelectionControllerTests: XCTestCase {
                        "prompt before window 1, option announcement before window 2")
     }
 
+    // MARK: - Free-form read-back confirmation (WP8)
+
+    func testFreeformConfirmReturnsResultWithText() async {
+        let speech = FakeSpeech()
+        // .freeform arrives, then .allow (nod) to confirm
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.freeform("deploy blue canary"), .allow]))
+        let result = await controller.resolve(request())
+        XCTAssertEqual(result.freeText, "deploy blue canary")
+        XCTAssertTrue(result.choices.isEmpty)
+        XCTAssertFalse(result.timedOut)
+    }
+
+    func testFreeformConfirmWithSelectIntent() async {
+        let speech = FakeSpeech()
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.freeform("answer"), .select]))
+        let result = await controller.resolve(request())
+        XCTAssertEqual(result.freeText, "answer")
+        XCTAssertTrue(result.choices.isEmpty)
+    }
+
+    func testFreeformDiscardRelistens() async {
+        let speech = FakeSpeech()
+        // .freeform arrives, deny (shake) discards, then select the first option
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.freeform("wrong"), .deny, .select]))
+        let result = await controller.resolve(request())
+        // After discard, normal selection should work
+        XCTAssertEqual(result.choices.count, 1)
+        XCTAssertEqual(result.choices[0].index, 0)
+        XCTAssertNil(result.freeText, "discarded freeform must not appear in result")
+    }
+
+    func testFreeformReadBackIsSpeoken() async {
+        let speech = FakeSpeech()
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.freeform("use option B"), .allow]))
+        _ = await controller.resolve(request())
+        // The read-back should be spoken after the initial prompt
+        let readBack = speech.spoken.first { $0.contains("You said:") }
+        XCTAssertNotNil(readBack, "a read-back utterance must be spoken")
+        XCTAssertTrue(readBack?.contains("use option B") == true)
+        XCTAssertTrue(readBack?.contains("Nod to send") == true)
+    }
+
+    func testFreeformTimeoutAfterReadBack() async {
+        let speech = FakeSpeech()
+        // .freeform arrives, then timeout (nil) during confirmation
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.freeform("answer"), nil]))
+        let result = await controller.resolve(request())
+        XCTAssertTrue(result.timedOut)
+        XCTAssertNil(result.freeText)
+    }
+
+    func testFreeformNavigationAfterDiscard() async {
+        let speech = FakeSpeech()
+        // freeform -> deny (discard) -> next -> select
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.freeform("wrong"), .deny, .next, .select]))
+        let result = await controller.resolve(request())
+        XCTAssertEqual(result.choices[0].index, 1,
+                       "navigation works after a freeform discard")
+        XCTAssertNil(result.freeText)
+    }
+
+    func testExistingSelectionTestsPassUnmodified() async {
+        // Verify basic selection still works identically (regression sentinel).
+        let controller = SelectionController(
+            speech: FakeSpeech(), arbiter: ScriptedArbiter([.select]))
+        let result = await controller.resolve(request())
+        XCTAssertEqual(result.choices.count, 1)
+        XCTAssertEqual(result.choices[0].index, 0)
+        XCTAssertNil(result.freeText)
+        XCTAssertFalse(result.timedOut)
+    }
+
     // MARK: - Diagnostics
 
     @MainActor

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -910,6 +910,15 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             isPlaying = false
             onPlayingChange?(false)
         }
+
+        /// Simulates all outstanding buffers completing after `finishStream()`. In the real
+        /// `BackendAudioPlayback`, this happens when the last `AVAudioPlayerNode` completion
+        /// fires after `finishStream()` has been called.
+        func completeDrain() {
+            guard isPlaying else { return }
+            isPlaying = false
+            onPlayingChange?(false)
+        }
     }
 
     private func makeProviderWithPlayback(
@@ -1852,5 +1861,169 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertEqual(finals.count, 1)
         XCTAssertEqual(finals[0].0, "freeform text")
         XCTAssertFalse(finals[0].1, "freeform text is unmatched")
+    }
+
+    // MARK: - Playback activity must not self-cancel (defect 1 fix)
+
+    /// Full-composition test proving that backend audio can play to completion on the
+    /// composed --voice-backend openai-realtime path:
+    ///   SpeechGatedVoice(
+    ///     CombinedSpeechActivity(tts, fakePlayback),
+    ///     provider(responseAudio: fakePlayback, .conversation, supportsBargeIn: true)
+    ///   )
+    ///
+    /// Before the fix, the first enqueue raised isPlaying synchronously, which
+    /// CombinedSpeechActivity relayed to SpeechGatedVoice, which called provider.stop(),
+    /// which called endWindowKeepSession() -> responseAudio.stopAndFlush(), flushing the
+    /// chunk just enqueued. The falling edge then reopened the mic, which called
+    /// provider.start() -> cancelResponse(), killing the cloud response. Every chunk
+    /// repeated this cascade: enqueue, stopAndFlush, cancelResponse, beginUserTurn,
+    /// endUserTurn — per chunk. Net effect: no audio ever played.
+    func testPlaybackActivityDoesNotFlushOrCancelResponse() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let sink = RecordingSink()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            responseAudio: playback,
+            idleSleep: { _ in },
+            diagnosticSink: sink)
+        let tts = FakeSpeechActivity()
+        let combinedActivity = CombinedSpeechActivity(tts: tts, playback: playback)
+        let gated = SpeechGatedVoice(
+            wrapping: provider, activity: combinedActivity, diagnosticSink: sink)
+        var received: [VoiceCommand] = []
+
+        gated.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+
+        // Backend sends audio: this makes playback.isPlaying = true via enqueue,
+        // which triggers CombinedSpeechActivity -> SpeechGatedVoice -> pauseListening.
+        // The response must NOT be cancelled or flushed.
+        let chunk1 = VoiceAudioChunk(data: Data([1, 2, 3, 4]),
+                                      format: .pcm16Mono24k, timestamp: 1)
+        backend.emit(.audio(chunk1))
+
+        XCTAssertTrue(playback.isPlaying,
+                      "playback must stay busy — the audio must not be flushed")
+        XCTAssertEqual(playback.stopAndFlushCount, 0,
+                       "stopAndFlush must NOT be called by the activity-driven pause")
+        XCTAssertFalse(backend.calls.contains(.cancelResponse),
+                       "cancelResponse must NOT be called — the response is the answer")
+        XCTAssertEqual(playback.enqueued.count, 1, "the first chunk must be enqueued")
+
+        // More chunks should still reach the player despite the pause.
+        let chunk2 = VoiceAudioChunk(data: Data([5, 6, 7, 8]),
+                                      format: .pcm16Mono24k, timestamp: 2)
+        backend.emit(.audio(chunk2))
+        XCTAssertEqual(playback.enqueued.count, 2,
+                       "subsequent chunks must route to the player during the pause")
+
+        // Response completes: finishStream called, then playback drains.
+        backend.emit(.responseCompleted)
+        XCTAssertEqual(playback.finishStreamCount, 1)
+
+        // Simulate playback drain (all buffers completed).
+        // This triggers CombinedSpeechActivity -> SpeechGatedVoice.speakingChanged(false)
+        // -> startInner() -> provider.start().
+        playback.completeDrain()
+        await settle()
+
+        // A fresh turn should have started on the still-open session.
+        XCTAssertTrue(backend.isOpen, "session must stay open")
+        XCTAssertTrue(backend.isTurnActive, "fresh turn started after playback drain")
+        XCTAssertFalse(backend.calls.contains(.cancelResponse),
+                       "still no cancelResponse — the response completed naturally")
+    }
+
+    /// Same composition as above, but with WearerGatedVoice in the chain:
+    ///   SpeechGatedVoice(WearerGatedVoice(provider))
+    /// Verifies that pauseListening propagates through the full gate stack.
+    func testPlaybackActivityPropagatesThroughWearerGate() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let sink = RecordingSink()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            responseAudio: playback,
+            idleSleep: { _ in },
+            diagnosticSink: sink)
+        let fakeSignal = FakeWearerSpeechSignal()
+        let wearerGated = WearerGatedVoice(
+            wrapping: provider, signal: fakeSignal, diagnosticSink: sink)
+        let tts = FakeSpeechActivity()
+        let combinedActivity = CombinedSpeechActivity(tts: tts, playback: playback)
+        let gated = SpeechGatedVoice(
+            wrapping: wearerGated, activity: combinedActivity, diagnosticSink: sink)
+        var received: [VoiceCommand] = []
+
+        gated.start { received.append($0) }
+        await settle()
+
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2, 3, 4]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+
+        XCTAssertTrue(playback.isPlaying, "playback must stay busy through the gate stack")
+        XCTAssertEqual(playback.stopAndFlushCount, 0,
+                       "stopAndFlush must not be called through WearerGatedVoice")
+        XCTAssertFalse(backend.calls.contains(.cancelResponse))
+    }
+
+    /// When TTS speaks during an open turn (e.g. notification), pauseListening must still
+    /// end the turn — the "turn never spans a TTS-busy interval" invariant must hold even
+    /// with the new pauseListening path. This test uses the conversation-mode provider with
+    /// a FakePlayback (not playing) to verify the TTS case.
+    func testPauseListeningEndsTurnWhenTTSNotPlayback() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let sink = RecordingSink()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            responseAudio: playback,
+            idleSleep: { _ in },
+            diagnosticSink: sink)
+        let tts = FakeSpeechActivity()
+        let combinedActivity = CombinedSpeechActivity(tts: tts, playback: playback)
+        let gated = SpeechGatedVoice(
+            wrapping: provider, activity: combinedActivity, diagnosticSink: sink)
+        var received: [VoiceCommand] = []
+
+        gated.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+
+        // TTS starts (notification). Playback is NOT active — the pause should end the turn.
+        tts.setSpeaking(true)
+        XCTAssertFalse(backend.isTurnActive,
+                       "turn must end when TTS starts (not playback)")
+        XCTAssertTrue(backend.isOpen, "session stays open")
+        XCTAssertTrue(sink.names.contains("listening.paused"))
+
+        // TTS finishes: a fresh turn starts.
+        tts.setSpeaking(false)
+        await settle()
+        XCTAssertTrue(backend.isTurnActive, "fresh turn after TTS drain")
+
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.no])
+    }
+
+    /// A fake WearerSpeechSignaling for composition tests. Always reports signal
+    /// unavailable so the gate fails open (all commands pass through).
+    @MainActor
+    private final class FakeWearerSpeechSignal: WearerSpeechSignaling {
+        var isWearerSpeaking = false
+        var isSignalAvailable = false
+        var onWearerSpeakingChange: (@MainActor (Bool) -> Void)?
     }
 }

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -1229,33 +1229,62 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             diagnosticSink: sink)
     }
 
-    func testConversationModeStartDuringResponseCancelsWhenBargeInSupported() async {
+    func testConversationModeMatchResolvedSuppressesResponse() async {
         let backend = RespondingAwareBackend()
         let sink = RecordingSink()
         let provider = makeConversationProviderWithRespondingBackend(
             backend: backend, supportsBargeIn: true, sink: sink)
         var received: [VoiceCommand] = []
 
-        // Window 1: open, speak, match -> turn ends, response starts
+        // Window 1: open, speak, match -> turn ends, response suppressed immediately.
+        // With supportsBargeIn and conversation mode, a match-resolved endUserTurn
+        // is followed by cancelResponse, so the backend never stays in the responding
+        // state between windows.
         provider.start { received.append($0) }
         await settle()
         backend.emit(.transcriptPartial("yes"))
         XCTAssertEqual(received, [.yes])
         XCTAssertTrue(backend.isOpen, "session stays open")
-        XCTAssertTrue(backend.isResponding, "endUserTurn triggered a response")
+        XCTAssertFalse(backend.isResponding, "match-resolved response suppressed")
+        XCTAssertTrue(backend.calls.contains(.cancelResponse),
+                      "cancelResponse must follow endUserTurn for match-resolved windows")
+        XCTAssertTrue(sink.names.contains("response.suppressed_match_resolved"))
 
-        // Between windows, the backend emits audio (response in flight).
-        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]), format: .pcm16Mono24k, timestamp: 1)))
-
-        // Window 2: start() must cancel the response instead of crashing.
+        // Window 2: no response in flight, start() begins a new turn directly.
         provider.start { received.append($0) }
         await settle()
 
-        XCTAssertTrue(backend.calls.contains(.cancelResponse),
-                      "response must be cancelled before beginning a new turn")
-        XCTAssertFalse(backend.isResponding, "response cancelled")
         XCTAssertTrue(backend.isTurnActive, "new turn started successfully")
-        XCTAssertTrue(backend.isOpen, "session survived — not torn down by a violation")
+        XCTAssertTrue(backend.isOpen, "session survived")
+    }
+
+    /// When an unsuppressed response is still in flight at the next start(), barge-in-capable
+    /// providers cancel it there. This can happen when stop() ends a window (no match → no
+    /// suppress) and the adapter created a response anyway.
+    func testConversationModeStartDuringUnsuppressedResponseCancels() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, sink: sink)
+
+        // Window 1: open, then stop() without matching (no suppress).
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        // The stop-path endWindowKeepSession does NOT call cancelResponse (no match),
+        // so a response from endUserTurn is still in flight.
+        XCTAssertTrue(backend.isResponding, "stop() does not suppress the response")
+
+        // Between windows, audio arrives.
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]), format: .pcm16Mono24k, timestamp: 1)))
+
+        // Window 2: start() sees the response in flight and cancels it.
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertTrue(backend.calls.contains(.cancelResponse))
+        XCTAssertFalse(backend.isResponding, "response cancelled at window 2 start")
+        XCTAssertTrue(backend.isTurnActive, "new turn started")
         XCTAssertTrue(sink.names.contains("response.cancelled_for_new_window"))
     }
 
@@ -1464,5 +1493,101 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
 
         XCTAssertTrue(backend.isOpen, "session stayed open — idle timer was cancelled")
         XCTAssertFalse(sink.names.contains("session.idle_closed"))
+    }
+
+    // MARK: - Conversation reopened callback (WP6)
+
+    func testConversationReopenedCallbackFiresOnceAfterIdleClose() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, idleClose: 60,
+                                                instantIdle: true, sink: sink)
+        var reopenCount = 0
+        provider.onConversationReopened = { reopenCount += 1 }
+
+        // Conversation 1: open, stop, idle-close.
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        await settle() // idle-close fires (instant sleep)
+        XCTAssertFalse(backend.isOpen, "session closed by idle timer")
+        XCTAssertEqual(reopenCount, 0, "no reopen yet — this was the first conversation")
+
+        // Conversation 2: reopen after idle-close.
+        provider.start { _ in }
+        await settle()
+        XCTAssertTrue(backend.isOpen, "session reopened")
+        XCTAssertEqual(reopenCount, 1, "callback fires exactly once on reopen after idle-close")
+        XCTAssertTrue(sink.names.contains("session.reopened_after_idle"))
+    }
+
+    func testConversationReopenedCallbackDoesNotFireOnFirstOpen() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend, idleClose: 60)
+        var reopenCount = 0
+        provider.onConversationReopened = { reopenCount += 1 }
+
+        // First open is not a reopen.
+        provider.start { _ in }
+        await settle()
+        XCTAssertEqual(reopenCount, 0,
+                       "the very first session open is not a conversation reopen")
+    }
+
+    func testConversationReopenedCallbackDoesNotFireOnSessionFailureReopen() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend, idleClose: 60)
+        var reopenCount = 0
+        provider.onConversationReopened = { reopenCount += 1 }
+
+        // Open, then fail the session.
+        provider.start { _ in }
+        await settle()
+        backend.emit(.sessionFailed(.network("dropped")))
+
+        // Next start() reopens from sessionFailed, not from idle-close.
+        provider.start { _ in }
+        await settle()
+        XCTAssertEqual(reopenCount, 0,
+                       "session-failure reopen is not idle-close reopen")
+    }
+
+    // MARK: - Match-resolved response suppression scripted test (WP6)
+
+    /// When stop() ends a conversation-mode window (no match), endUserTurn is called
+    /// but cancelResponse is NOT called. The response is left in flight for the
+    /// backend to drain naturally.
+    func testConversationModeStopDoesNotSuppressResponse() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+
+        XCTAssertTrue(backend.isResponding,
+                      "stop() must not suppress the response — only match resolution does")
+        XCTAssertFalse(sink.names.contains("response.suppressed_match_resolved"))
+    }
+
+    /// Without supportsBargeIn, a match-resolved window does not attempt to suppress
+    /// the response (cancelResponse is not valid on such backends).
+    func testMatchResolvedDoesNotSuppressWithoutBargeIn() async {
+        let backend = RespondingAwareBackend(capabilities: .transcriptOnly)
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: false, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+        XCTAssertTrue(backend.isResponding,
+                      "without barge-in, the response is left to drain")
+        XCTAssertFalse(backend.calls.contains(.cancelResponse))
+        XCTAssertFalse(sink.names.contains("response.suppressed_match_resolved"))
     }
 }

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -1312,6 +1312,120 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertFalse(provider.isResponseInFlight)
     }
 
+    // MARK: - Stale response-in-flight across conversations (defect 3)
+
+    /// Regression for defect 3: audio arrives with no window open, idle-close
+    /// fires (closing the session), then the next conversation's start() must
+    /// beginUserTurn immediately with no cancelResponse call.
+    ///
+    /// Before the fix, _responseInFlight and pendingUserTurn were not cleared in
+    /// fireIdleClose or on a fresh openWindow, so:
+    ///   - A stale _responseInFlight from a previous conversation made the next
+    ///     start() send a spurious cancelResponse (or defer the turn forever if
+    ///     supportsBargeIn was false).
+    ///   - A stale pendingUserTurn would wait on a responseCompleted that never
+    ///     comes because the session was closed.
+    func testStaleResponseInFlightClearedByIdleClose() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, sink: sink)
+        var received: [VoiceCommand] = []
+
+        // Conversation 1: open, speak, match -> response starts
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+
+        // Audio arrives between windows (response in flight from the prior commit).
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        XCTAssertTrue(provider.isResponseInFlight)
+
+        // Idle-close fires (the sleep returns instantly in this fixture).
+        await settle()
+        XCTAssertFalse(backend.isOpen, "session closed by idle-close")
+        XCTAssertFalse(provider.isResponseInFlight,
+                       "idle-close must clear the stale response-in-flight flag")
+
+        // Conversation 2: start() must beginUserTurn immediately, no cancelResponse.
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertTrue(backend.isOpen, "a fresh session opened for conversation 2")
+        XCTAssertTrue(backend.isTurnActive, "turn started immediately")
+        XCTAssertFalse(backend.calls.suffix(3).contains(.cancelResponse),
+                       "no spurious cancelResponse on the new conversation")
+
+        // The new conversation works normally.
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.yes, .no])
+    }
+
+    /// Same scenario but for pendingUserTurn: if barge-in is unsupported, a stale
+    /// _responseInFlight would have caused start() to defer the turn forever.
+    func testStaleResponseInFlightDoesNotWedgeTurnAfterIdleClose() async {
+        let backend = RespondingAwareBackend(capabilities: .transcriptOnly)
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: false, sink: sink)
+        var received: [VoiceCommand] = []
+
+        // Conversation 1: open, speak, match
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+
+        // Audio between windows.
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+
+        // Idle-close fires.
+        await settle()
+        XCTAssertFalse(backend.isOpen)
+
+        // Conversation 2: must not wedge on pendingUserTurn.
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive,
+                      "turn must start immediately, not wait for a responseCompleted that will never come")
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.yes, .no])
+    }
+
+    /// Verifies the openWindow success path clears stale state when the session
+    /// was lost (e.g. sessionFailed while _responseInFlight was true) and a new
+    /// openWindow is required.
+    func testStaleResponseInFlightClearedByFreshOpenWindow() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, sink: sink)
+        var received: [VoiceCommand] = []
+
+        // Conversation 1
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+
+        // Audio arrives, then the session fails.
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        // sessionFailed clears _responseInFlight already (line 289), but let's
+        // verify the openWindow path is also safe by going through it.
+        backend.emit(.sessionFailed(.network("socket dropped")))
+
+        // Conversation 2: needs a fresh open because the session died.
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+        XCTAssertFalse(provider.isResponseInFlight,
+                       "fresh openWindow must clear stale response-in-flight")
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.yes, .no])
+    }
+
     // MARK: - Idle timer with injectable sleep (defect 3)
 
     func testIdleTimerFiresWithoutRealSleep() async {

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -1227,6 +1227,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
     private func makeConversationProviderWithRespondingBackend(
         backend: RespondingAwareBackend,
         supportsBargeIn: Bool = true,
+        instantIdle: Bool = true,
         sink: RecordingSink = RecordingSink()
     ) -> VoiceBackendCommandProvider {
         VoiceBackendCommandProvider(
@@ -1234,7 +1235,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             match: Self.match,
             sessionPolicy: .conversation(idleClose: 60),
             supportsBargeIn: supportsBargeIn,
-            idleSleep: { _ in },
+            idleSleep: instantIdle ? { _ in } : { try? await Task.sleep(for: .seconds($0)) },
             diagnosticSink: sink)
     }
 
@@ -1354,6 +1355,142 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         // responseCompleted clears it.
         backend.emit(.responseCompleted)
         XCTAssertFalse(provider.isResponseInFlight)
+    }
+
+    // MARK: - Session-death race: no-audio-yet gap (defect 1)
+
+    /// Regression for defect 1: session-death race on the conversation-mode resume path.
+    ///
+    /// When endUserTurn triggers a response on the adapter (commit + response.create on
+    /// the OpenAI path), the provider must know a response is pending even before the first
+    /// .audio event confirms it. Without this, start() calls beginUserTurn while the adapter
+    /// is in .responding, causing a protocol violation -> session death -> sticky fallback.
+    ///
+    /// The shipped test testConversationModeStartDuringUnsuppressedResponseCancels passes
+    /// only because it emits .audio before the second start. This test omits the .audio to
+    /// exercise the gap.
+    func testConversationModeStartDuringResponseGapDefersWithoutSessionDeath() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, instantIdle: false, sink: sink)
+        var received: [VoiceCommand] = []
+
+        // Window 1: open, then stop() -- backend enters .responding from endUserTurn.
+        provider.start { received.append($0) }
+        await settle()
+        provider.stop()
+        XCTAssertTrue(backend.isResponding, "endUserTurn enters .responding")
+
+        // NO .audio emitted -- this is the gap between commit and first audio delta.
+
+        // Window 2: start() must NOT call beginUserTurn (that would be a protocol
+        // violation -> session death). Instead it must defer until responseCompleted.
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertFalse(backend.isTurnActive,
+                       "turn must not start -- a response is pending from the prior commit")
+        XCTAssertTrue(backend.isOpen, "session must survive (no protocol violation)")
+        XCTAssertFalse(sink.names.contains("session.failed"),
+                       "no session failure -- the race was handled")
+        XCTAssertTrue(sink.names.contains("turn.deferred_response_in_flight"))
+
+        // The response completes: the deferred turn fires.
+        backend.emit(.responseCompleted)
+        XCTAssertTrue(backend.isTurnActive, "deferred turn started after responseCompleted")
+
+        // The new turn works normally.
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.no])
+    }
+
+    /// Same race triggered by the coordinator's endActiveTurn instead of stop().
+    /// The coordinator commits the turn, the adapter enters .responding, and the next
+    /// start() must defer rather than crashing into beginUserTurn.
+    func testConversationModeStartAfterCoordinatorCommitGapDefersWithoutSessionDeath() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, instantIdle: false, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+
+        // The coordinator commits the turn (wearer stopped speaking).
+        provider.endActiveTurn()
+        XCTAssertTrue(backend.isResponding, "endActiveTurn triggers a response on the adapter")
+
+        // The window closes (arbiter resolves or times out).
+        provider.stop()
+
+        // NO .audio emitted yet -- the response is cooking but has not produced audio.
+
+        // Next window: must defer.
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertFalse(backend.isTurnActive, "turn must not start -- response pending")
+        XCTAssertTrue(backend.isOpen, "session survived")
+        XCTAssertTrue(sink.names.contains("turn.deferred_response_in_flight"))
+
+        // Response completes.
+        backend.emit(.responseCompleted)
+        XCTAssertTrue(backend.isTurnActive, "deferred turn started")
+
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+    }
+
+    /// The pauseListening path: TTS starts while a turn is open, the turn is committed,
+    /// TTS finishes, start() resumes. In the gap, no .audio has arrived yet.
+    func testConversationModeResumeAfterTTSPauseCommitDefersWithoutSessionDeath() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let playback = FakePlayback()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            responseAudio: playback,
+            idleSleep: { try? await Task.sleep(for: .seconds($0)) },
+            diagnosticSink: sink)
+        let tts = FakeSpeechActivity()
+        let combinedActivity = CombinedSpeechActivity(tts: tts, playback: playback)
+        let gated = SpeechGatedVoice(
+            wrapping: provider, activity: combinedActivity, diagnosticSink: sink)
+        var received: [VoiceCommand] = []
+
+        gated.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+
+        // TTS starts (a notification prompt). This calls pauseListening, which ends the
+        // turn (because playback is NOT active -- it is TTS, not backend audio).
+        tts.setSpeaking(true)
+        XCTAssertFalse(backend.isTurnActive, "turn ended by TTS pause")
+        XCTAssertTrue(backend.isResponding, "endUserTurn entered .responding")
+
+        // NO .audio emitted -- the response is cooking.
+
+        // TTS finishes: SpeechGatedVoice restarts the inner provider.
+        tts.setSpeaking(false)
+        await settle()
+
+        // The resume path in start() must defer rather than crashing.
+        XCTAssertFalse(backend.isTurnActive,
+                       "turn must not start -- response pending (resume deferred)")
+        XCTAssertTrue(backend.isOpen, "session survived")
+        XCTAssertTrue(sink.names.contains("turn.deferred_resume_response_in_flight"))
+
+        // Response completes: deferred turn fires.
+        backend.emit(.responseCompleted)
+        XCTAssertTrue(backend.isTurnActive, "deferred turn started")
+
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.no])
     }
 
     // MARK: - Stale response-in-flight across conversations (defect 3)
@@ -2008,6 +2145,13 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
                        "turn must end when TTS starts (not playback)")
         XCTAssertTrue(backend.isOpen, "session stays open")
         XCTAssertTrue(sink.names.contains("listening.paused"))
+
+        // The backend completes the response that endUserTurn triggered. On the real
+        // OpenAI path, commit + response.create run when the turn is ended, and
+        // responseCompleted arrives after the model finishes — typically while TTS is
+        // still speaking. Modeling it here keeps the test honest about the turn-end →
+        // response lifecycle that the session-death-race fix tracks.
+        backend.emit(.responseCompleted)
 
         // TTS finishes: a fresh turn starts.
         tts.setSpeaking(false)

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -85,11 +85,14 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             isTurnActive = true
         }
 
-        func endUserTurn() {
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool {
             calls.append(.endUserTurn)
             XCTAssertTrue(isOpen, "endUserTurn on a closed session")
             XCTAssertTrue(isTurnActive, "endUserTurn with no turn open")
             isTurnActive = false
+            // Transcript-only backend: never creates a response.
+            return false
         }
 
         func sendAudio(_ chunk: VoiceAudioChunk) {
@@ -1197,12 +1200,18 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             isTurnActive = true
         }
 
-        func endUserTurn() {
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool {
             calls.append(.endUserTurn)
             isTurnActive = false
-            // Simulates the OpenAI adapter: endUserTurn commits + requestResponse, entering
-            // the responding state.
-            isResponding = true
+            if expectingResponse {
+                // Simulates the OpenAI adapter: endUserTurn commits + requestResponse,
+                // entering the responding state.
+                isResponding = true
+                return true
+            }
+            // Commit only, no response created.
+            return false
         }
 
         func sendAudio(_ chunk: VoiceAudioChunk) {
@@ -1274,22 +1283,23 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertTrue(backend.isOpen, "session survived")
     }
 
-    /// When an unsuppressed response is still in flight at the next start(), barge-in-capable
-    /// providers cancel it there. This can happen when stop() ends a window (no match → no
-    /// suppress) and the adapter created a response anyway.
+    /// When a coordinator-created response is still in flight at the next start(),
+    /// barge-in-capable providers cancel it there. The coordinator called endActiveTurn
+    /// (expectingResponse: true), creating a response; stop() closed the window without
+    /// a match; the response is still pending; the next start() cancels it.
     func testConversationModeStartDuringUnsuppressedResponseCancels() async {
         let backend = RespondingAwareBackend()
         let sink = RecordingSink()
         let provider = makeConversationProviderWithRespondingBackend(
             backend: backend, supportsBargeIn: true, sink: sink)
 
-        // Window 1: open, then stop() without matching (no suppress).
+        // Window 1: open, coordinator commits the turn, then stop() closes the window.
         provider.start { _ in }
         await settle()
+        provider.endActiveTurn()
+        XCTAssertTrue(backend.isResponding, "endActiveTurn creates a response")
         provider.stop()
-        // The stop-path endWindowKeepSession does NOT call cancelResponse (no match),
-        // so a response from endUserTurn is still in flight.
-        XCTAssertTrue(backend.isResponding, "stop() does not suppress the response")
+        // stop() does not suppress because suppressResponse is false.
 
         // Between windows, audio arrives.
         backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]), format: .pcm16Mono24k, timestamp: 1)))
@@ -1359,48 +1369,33 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
 
     // MARK: - Session-death race: no-audio-yet gap (defect 1)
 
-    /// Regression for defect 1: session-death race on the conversation-mode resume path.
-    ///
-    /// When endUserTurn triggers a response on the adapter (commit + response.create on
-    /// the OpenAI path), the provider must know a response is pending even before the first
-    /// .audio event confirms it. Without this, start() calls beginUserTurn while the adapter
-    /// is in .responding, causing a protocol violation -> session death -> sticky fallback.
-    ///
-    /// The shipped test testConversationModeStartDuringUnsuppressedResponseCancels passes
-    /// only because it emits .audio before the second start. This test omits the .audio to
-    /// exercise the gap.
-    func testConversationModeStartDuringResponseGapDefersWithoutSessionDeath() async {
+    /// With the ground-truth contract, stop() passes expectingResponse: false, so no
+    /// response is created and no gap-deferral is needed. The turn starts immediately.
+    /// This is the correct fix for the original defect 1 race: stop() no longer creates
+    /// spurious responses.
+    func testConversationModeStopWithNoResponseStartsTurnImmediately() async {
         let backend = RespondingAwareBackend()
         let sink = RecordingSink()
         let provider = makeConversationProviderWithRespondingBackend(
             backend: backend, supportsBargeIn: true, instantIdle: false, sink: sink)
         var received: [VoiceCommand] = []
 
-        // Window 1: open, then stop() -- backend enters .responding from endUserTurn.
+        // Window 1: open, then stop() — no response created (expectingResponse: false).
         provider.start { received.append($0) }
         await settle()
         provider.stop()
-        XCTAssertTrue(backend.isResponding, "endUserTurn enters .responding")
+        XCTAssertFalse(backend.isResponding,
+                       "stop passes expectingResponse: false — no response created")
 
-        // NO .audio emitted -- this is the gap between commit and first audio delta.
-
-        // Window 2: start() must NOT call beginUserTurn (that would be a protocol
-        // violation -> session death). Instead it must defer until responseCompleted.
+        // Window 2: start() can begin a turn immediately (no gap to defer on).
         provider.start { received.append($0) }
         await settle()
 
-        XCTAssertFalse(backend.isTurnActive,
-                       "turn must not start -- a response is pending from the prior commit")
-        XCTAssertTrue(backend.isOpen, "session must survive (no protocol violation)")
-        XCTAssertFalse(sink.names.contains("session.failed"),
-                       "no session failure -- the race was handled")
-        XCTAssertTrue(sink.names.contains("turn.deferred_response_in_flight"))
+        XCTAssertTrue(backend.isTurnActive, "turn starts immediately — no response pending")
+        XCTAssertTrue(backend.isOpen, "session survived")
+        XCTAssertFalse(sink.names.contains("turn.deferred_response_in_flight"),
+                       "no deferral needed — no response was created")
 
-        // The response completes: the deferred turn fires.
-        backend.emit(.responseCompleted)
-        XCTAssertTrue(backend.isTurnActive, "deferred turn started after responseCompleted")
-
-        // The new turn works normally.
         backend.emit(.transcriptPartial("no"))
         XCTAssertEqual(received, [.no])
     }
@@ -1443,9 +1438,10 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertEqual(received, [.yes])
     }
 
-    /// The pauseListening path: TTS starts while a turn is open, the turn is committed,
-    /// TTS finishes, start() resumes. In the gap, no .audio has arrived yet.
-    func testConversationModeResumeAfterTTSPauseCommitDefersWithoutSessionDeath() async {
+    /// The pauseListening path: TTS starts while a turn is open, the turn is committed
+    /// with expectingResponse: false (TTS pause does not want a model reply), TTS
+    /// finishes, start() resumes. No response was created, so the turn starts immediately.
+    func testConversationModeResumeAfterTTSPauseStartsTurnImmediately() async {
         let backend = RespondingAwareBackend()
         let sink = RecordingSink()
         let playback = FakePlayback()
@@ -1468,26 +1464,19 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertTrue(backend.isTurnActive)
 
         // TTS starts (a notification prompt). This calls pauseListening, which ends the
-        // turn (because playback is NOT active -- it is TTS, not backend audio).
+        // turn with expectingResponse: false — no response is created.
         tts.setSpeaking(true)
         XCTAssertFalse(backend.isTurnActive, "turn ended by TTS pause")
-        XCTAssertTrue(backend.isResponding, "endUserTurn entered .responding")
-
-        // NO .audio emitted -- the response is cooking.
+        XCTAssertFalse(backend.isResponding,
+                       "pauseListening passes expectingResponse: false — no response created")
 
         // TTS finishes: SpeechGatedVoice restarts the inner provider.
         tts.setSpeaking(false)
         await settle()
 
-        // The resume path in start() must defer rather than crashing.
-        XCTAssertFalse(backend.isTurnActive,
-                       "turn must not start -- response pending (resume deferred)")
+        // The turn starts immediately because no response is pending.
+        XCTAssertTrue(backend.isTurnActive, "fresh turn after TTS drain — no deferral needed")
         XCTAssertTrue(backend.isOpen, "session survived")
-        XCTAssertTrue(sink.names.contains("turn.deferred_resume_response_in_flight"))
-
-        // Response completes: deferred turn fires.
-        backend.emit(.responseCompleted)
-        XCTAssertTrue(backend.isTurnActive, "deferred turn started")
 
         backend.emit(.transcriptPartial("no"))
         XCTAssertEqual(received, [.no])
@@ -1748,10 +1737,10 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
 
     // MARK: - Match-resolved response suppression scripted test (WP6)
 
-    /// When stop() ends a conversation-mode window (no match), endUserTurn is called
-    /// but cancelResponse is NOT called. The response is left in flight for the
-    /// backend to drain naturally.
-    func testConversationModeStopDoesNotSuppressResponse() async {
+    /// When stop() ends a conversation-mode window (no match), endUserTurn passes
+    /// expectingResponse: false — no response is created. The backend stays in .committed
+    /// (not .responding), and no cancelResponse is called.
+    func testConversationModeStopCreatesNoResponse() async {
         let backend = RespondingAwareBackend()
         let sink = RecordingSink()
         let provider = makeConversationProviderWithRespondingBackend(
@@ -1761,8 +1750,10 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         await settle()
         provider.stop()
 
-        XCTAssertTrue(backend.isResponding,
-                      "stop() must not suppress the response — only match resolution does")
+        XCTAssertFalse(backend.isResponding,
+                       "stop() passes expectingResponse: false — no response created")
+        XCTAssertFalse(backend.calls.contains(.cancelResponse),
+                       "no response to cancel")
         XCTAssertFalse(sink.names.contains("response.suppressed_match_resolved"))
     }
 
@@ -1831,7 +1822,8 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
     }
 
     /// Without supportsBargeIn, a match-resolved window does not attempt to suppress
-    /// the response (cancelResponse is not valid on such backends).
+    /// the response (cancelResponse is not valid on such backends). The response was
+    /// created by endActiveTurn (coordinator endpoint); match resolves after transcript.
     func testMatchResolvedDoesNotSuppressWithoutBargeIn() async {
         let backend = RespondingAwareBackend(capabilities: .transcriptOnly)
         let sink = RecordingSink()
@@ -1841,12 +1833,214 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
 
         provider.start { received.append($0) }
         await settle()
-        backend.emit(.transcriptPartial("yes"))
+        // Coordinator commits the turn, creating a response.
+        provider.endActiveTurn()
+        // Transcript arrives post-commit and matches.
+        backend.emit(.transcriptFinal("yes"))
         XCTAssertEqual(received, [.yes])
-        XCTAssertTrue(backend.isResponding,
-                      "without barge-in, the response is left to drain")
+        // Without barge-in, the response cannot be cancelled — it is left to drain.
         XCTAssertFalse(backend.calls.contains(.cancelResponse))
         XCTAssertFalse(sink.names.contains("response.suppressed_match_resolved"))
+    }
+
+    // MARK: - Real OpenAI ordering: suppression via armed mark (defect 1 fix, defect 5)
+
+    /// The real OpenAI flow for a match-resolved window after the coordinator committed:
+    /// beginUserTurn -> sendAudio -> endActiveTurn (commit+response.create) ->
+    /// transcriptFinal(match) -> first .audio arriving after resolution.
+    /// The provider must cancel the response on first audio, with zero enqueues.
+    func testRealOpenAIOrderingMatchAfterCommitSuppressesOnFirstAudio() async {
+        let backend = RespondingAwareBackend()
+        let playback = FakePlayback()
+        let sink = RecordingSink()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            responseAudio: playback,
+            idleSleep: { _ in },
+            diagnosticSink: sink)
+        var received: [VoiceCommand] = []
+
+        // 1. Open and begin turn.
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+
+        // 2. Coordinator commits the turn (wearer stopped speaking).
+        provider.endActiveTurn()
+        XCTAssertTrue(backend.isResponding, "endActiveTurn creates a response")
+
+        // 3. Transcript arrives post-commit and matches.
+        backend.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(received, [.yes])
+        XCTAssertFalse(provider.isWindowOpenForTesting, "window resolved by match")
+        XCTAssertTrue(sink.names.contains("response.suppression_armed"),
+                      "response pending but no audio yet — suppression armed")
+
+        // 4. First .audio arrives AFTER the window is resolved.
+        let chunk = VoiceAudioChunk(data: Data([1, 2, 3, 4]),
+                                     format: .pcm16Mono24k, timestamp: 1)
+        backend.emit(.audio(chunk))
+
+        // The audio must trigger cancelResponse, not enqueue.
+        XCTAssertTrue(backend.calls.contains(.cancelResponse),
+                      "cancelResponse must fire on first audio of a suppressed response")
+        XCTAssertEqual(playback.enqueued.count, 0,
+                       "zero audio enqueues — the response was suppressed")
+        XCTAssertFalse(provider.isResponseInFlight,
+                       "response-in-flight must not be set for a cancelled response")
+        XCTAssertTrue(sink.names.contains("response.suppressed_on_first_audio"))
+
+        // 5. Next window starts immediately (no stale state).
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive, "fresh turn started")
+    }
+
+    /// Same real OpenAI ordering, but the response completes (responseCompleted) before
+    /// any audio arrives. The suppression mark is cleared without a cancel.
+    func testRealOpenAIOrderingResponseCompletedClearsSuppression() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        provider.endActiveTurn()
+        backend.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(received, [.yes])
+        XCTAssertTrue(sink.names.contains("response.suppression_armed"))
+
+        // responseCompleted arrives before any audio.
+        backend.emit(.responseCompleted)
+        XCTAssertFalse(provider.isResponseInFlight)
+
+        // Next window starts without issue.
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+    }
+
+    // MARK: - No-response-created backend: next start() not wedged (defect 2 fix)
+
+    /// A backend whose endUserTurn creates no response (e.g. the empty-turn guard on
+    /// OpenAI skipped commit, or a transcript-only backend). The provider must derive
+    /// _responsePendingFromTurn from the ground-truth return value. The next start()
+    /// must begin a user turn immediately, not defer waiting for a responseCompleted
+    /// that will never come.
+    @MainActor
+    private final class NoResponseBackend: VoiceBackend {
+        enum Call: Equatable {
+            case open, close, beginUserTurn, endUserTurn
+            case sendAudio(Int), requestResponse(String), cancelResponse
+        }
+        let capabilities = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                     duplex: true)
+        private(set) var calls: [Call] = []
+        private(set) var isOpen = false
+        private(set) var isTurnActive = false
+        private var handler: (@MainActor (VoiceBackendEvent) -> Void)?
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            calls.append(.open)
+            isOpen = true
+            handler = onEvent
+        }
+        func close() { calls.append(.close); isOpen = false; isTurnActive = false; handler = nil }
+        func beginUserTurn() { calls.append(.beginUserTurn); isTurnActive = true }
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool {
+            calls.append(.endUserTurn)
+            isTurnActive = false
+            // This backend NEVER creates a response — simulates the empty-turn guard,
+            // or a transcript-only backend.
+            return false
+        }
+        func sendAudio(_ chunk: VoiceAudioChunk) { calls.append(.sendAudio(chunk.data.count)) }
+        func requestResponse(text: String) { calls.append(.requestResponse(text)) }
+        func cancelResponse() { calls.append(.cancelResponse) }
+
+        func emit(_ event: VoiceBackendEvent) { handler?(event) }
+    }
+
+    func testNoResponseCreatedNextStartBeginsTurnImmediately() async {
+        let backend = NoResponseBackend()
+        let sink = RecordingSink()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            idleSleep: { _ in },
+            diagnosticSink: sink)
+        var received: [VoiceCommand] = []
+
+        // Window 1: coordinator commits the turn, but the backend creates no response
+        // (e.g. the OpenAI empty-turn guard fires).
+        provider.start { received.append($0) }
+        await settle()
+        provider.endActiveTurn()
+        XCTAssertTrue(sink.names.contains("turn.committed_by_coordinator"))
+
+        // Close the window.
+        provider.stop()
+
+        // Window 2: must start immediately — no response was created, so no deferral.
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertTrue(backend.isTurnActive,
+                      "turn must start immediately — endUserTurn reported no response created")
+        XCTAssertTrue(backend.isOpen, "session survived")
+        XCTAssertFalse(sink.names.contains("turn.deferred_response_in_flight"),
+                       "no deferral — the backend reported no response")
+
+        backend.emit(.transcriptFinal("no"))
+        XCTAssertEqual(received, [.no])
+    }
+
+    // MARK: - windowPaused cleared on stop/endWindowKeepSession (defect 4)
+
+    func testWindowPausedClearedByStopSoNewWindowIsNotTreatedAsResume() async {
+        let backend = RespondingAwareBackend()
+        let playback = FakePlayback()
+        let sink = RecordingSink()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            responseAudio: playback,
+            idleSleep: { try? await Task.sleep(for: .seconds($0)) },
+            diagnosticSink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+
+        // pauseListening sets windowPaused = true.
+        provider.pauseListening()
+        XCTAssertTrue(sink.names.contains("listening.paused"))
+
+        // stop() must clear windowPaused.
+        provider.stop()
+
+        // A genuinely new window: must be a fresh start (beginUserTurn), not a
+        // resume of the paused one (which would check for in-flight responses).
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertTrue(backend.isTurnActive,
+                      "a genuinely new window must begin a turn, not defer as a resume")
+        XCTAssertTrue(backend.isOpen)
+
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.no])
     }
 
     // MARK: - Free-form (WP8)

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -486,6 +486,390 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertEqual(received, [.yes])
     }
 
+    // MARK: - Conversation mode
+
+    /// Virtual clock for idle-close testing.
+    @MainActor
+    private final class VirtualClock {
+        var time: TimeInterval = 0
+        func advance(by interval: TimeInterval) { time += interval }
+    }
+
+    private func makeConversationProvider(
+        backend: ScriptedVoiceBackend,
+        idleClose: TimeInterval = 60,
+        supportsBargeIn: Bool = false,
+        clock: VirtualClock? = nil,
+        sink: RecordingSink = RecordingSink()
+    ) -> VoiceBackendCommandProvider {
+        let resolvedClock = clock ?? VirtualClock()
+        return VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: idleClose),
+            supportsBargeIn: supportsBargeIn,
+            monotonicNow: { resolvedClock.time },
+            diagnosticSink: sink)
+    }
+
+    func testConversationModeOneOpenAcrossMultipleStartStopCycles() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        // First window
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn])
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+        // Match resolves the window, ends the turn, session stays open
+        XCTAssertTrue(backend.isOpen, "the session must stay open in conversation mode")
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn, .endUserTurn])
+
+        // Second window: no new open, just a fresh turn
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn, .endUserTurn, .beginUserTurn])
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.yes, .no])
+        XCTAssertTrue(backend.isOpen)
+    }
+
+    func testConversationModeExactlyOneBeginUserTurnPerStart() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+
+        // Cycle three start/stop pairs.
+        for _ in 0..<3 {
+            provider.start { _ in }
+            await settle()
+            provider.stop()
+        }
+        let beginCount = backend.calls.filter { $0 == .beginUserTurn }.count
+        XCTAssertEqual(beginCount, 3, "each start opens exactly one turn")
+        let openCount = backend.calls.filter { $0 == .open }.count
+        XCTAssertEqual(openCount, 1, "one open for the whole conversation")
+    }
+
+    func testConversationModeMatchDeliversOnceThenEndsTheTurn() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+
+        XCTAssertEqual(received, [.yes])
+        XCTAssertFalse(backend.isTurnActive, "the turn ends on match")
+        XCTAssertTrue(backend.isOpen, "the session stays open")
+        XCTAssertFalse(provider.isWindowOpenForTesting, "the window is closed")
+    }
+
+    func testConversationModeSecondStartAfterMatchYieldsTurnTwoOnSameSession() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+
+        // Second start: same session, fresh turn, clean transcript slate
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+        backend.emit(.transcriptFinal("no"))
+        XCTAssertEqual(received, [.yes, .no])
+    }
+
+    func testConversationModeIdleTimerClosesSessionAfterIdleClose() async {
+        let clock = VirtualClock()
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, idleClose: 0.01,
+                                                clock: clock, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        XCTAssertTrue(backend.isOpen, "session stays open right after stop")
+
+        // Let the idle timer fire
+        clock.advance(by: 0.02)
+        await settle()
+        // Sleep long enough for the Task.sleep to complete
+        try? await Task.sleep(for: .seconds(0.05))
+
+        XCTAssertFalse(backend.isOpen, "session closed by idle timer")
+        XCTAssertTrue(sink.names.contains("session.idle_closed"))
+    }
+
+    func testConversationModeStartAfterIdleCloseReopens() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend, idleClose: 0.01)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        provider.stop()
+        // Wait for idle close
+        try? await Task.sleep(for: .seconds(0.05))
+
+        XCTAssertFalse(backend.isOpen)
+        // New start should reopen
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isOpen)
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+        let openCount = backend.calls.filter { $0 == .open }.count
+        XCTAssertEqual(openCount, 2, "idle-close forces a reopen")
+    }
+
+    func testConversationModeStopDuringAsyncOpenStillClosesExactlyOnce() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        backend.openGate = { await Task.yield() }
+
+        provider.start { _ in XCTFail("the window was abandoned") }
+        provider.stop()
+        await settle()
+
+        XCTAssertEqual(backend.calls, [.open, .close],
+                       "a session finishing its open after stop must be closed")
+        XCTAssertFalse(backend.isOpen)
+    }
+
+    func testConversationModeSessionFailedMidConversation() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.sessionFailed(.network("socket dropped")))
+
+        XCTAssertFalse(provider.isWindowOpenForTesting)
+        XCTAssertFalse(provider.isSessionOpenForTesting)
+
+        // Next start reopens from scratch
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isOpen)
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+    }
+
+    func testConversationModeShutdownIsIdempotent() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+
+        provider.start { _ in }
+        await settle()
+        provider.shutdown()
+        provider.shutdown()
+        provider.shutdown()
+
+        XCTAssertFalse(backend.isOpen)
+        let closeCount = backend.calls.filter { $0 == .close }.count
+        XCTAssertEqual(closeCount, 1, "shutdown closes exactly once")
+    }
+
+    func testConversationModeStartAfterShutdownIsIgnored() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.shutdown()
+
+        provider.start { _ in XCTFail("a shut-down provider must not start") }
+        await settle()
+
+        XCTAssertTrue(sink.names.contains("start.skipped"))
+    }
+
+    // MARK: - endActiveTurn
+
+    func testEndActiveTurnCommitsExactlyOnce() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+
+        provider.endActiveTurn()
+
+        XCTAssertFalse(backend.isTurnActive)
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn, .endUserTurn])
+        XCTAssertTrue(sink.names.contains("turn.committed_by_coordinator"))
+    }
+
+    func testEndActiveTurnTranscriptAfterCommitStillMatchesAndResolves() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        provider.endActiveTurn()
+
+        // Transcript arriving after the commit (the OpenAI flow)
+        backend.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(received, [.yes], "post-commit transcript must still resolve")
+    }
+
+    func testEndActiveTurnWithNoActiveTurnIsRecordedNoOp() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, sink: sink)
+
+        // No window open
+        provider.endActiveTurn()
+        XCTAssertTrue(sink.names.contains("endActiveTurn.skipped"))
+        XCTAssertEqual(backend.calls, [])
+    }
+
+    func testEndActiveTurnNeverCausesAProtocolViolation() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, sink: sink)
+
+        // With a window but turn already ended by stop
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        provider.endActiveTurn()
+
+        // No crash, no protocol violation
+        XCTAssertTrue(sink.names.contains("endActiveTurn.skipped"))
+    }
+
+    // MARK: - cancelActiveResponse
+
+    func testCancelActiveResponseSkipsWhenNoResponse() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, supportsBargeIn: true,
+                                                sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.cancelActiveResponse()
+
+        XCTAssertTrue(sink.names.contains("cancelActiveResponse.skipped"))
+        XCTAssertFalse(backend.calls.contains(.cancelResponse))
+    }
+
+    func testCancelActiveResponseSkipsWhenBargeInUnsupported() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, supportsBargeIn: false,
+                                                sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.cancelActiveResponse()
+
+        XCTAssertTrue(sink.names.contains("cancelActiveResponse.skipped"))
+    }
+
+    // MARK: - onTranscriptFinal
+
+    func testOnTranscriptFinalFiresForMatchedFinalTranscript() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var finals: [(String, Bool)] = []
+        provider.onTranscriptFinal = { text, matched in finals.append((text, matched)) }
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(.transcriptFinal("yes"))
+
+        XCTAssertEqual(finals.count, 1)
+        XCTAssertEqual(finals[0].0, "yes")
+        XCTAssertTrue(finals[0].1, "matched must be true for a command match")
+    }
+
+    func testOnTranscriptFinalFiresForUnmatchedFinalTranscript() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var finals: [(String, Bool)] = []
+        provider.onTranscriptFinal = { text, matched in finals.append((text, matched)) }
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(.transcriptFinal("what time is the standup"))
+
+        XCTAssertEqual(finals.count, 1)
+        XCTAssertEqual(finals[0].0, "what time is the standup")
+        XCTAssertFalse(finals[0].1, "matched must be false for unmatched")
+    }
+
+    func testOnTranscriptFinalDoesNotFireForPartials() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var finals: [(String, Bool)] = []
+        provider.onTranscriptFinal = { text, matched in finals.append((text, matched)) }
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(.transcriptPartial("um"))
+
+        XCTAssertEqual(finals.count, 0, "partials never fire onTranscriptFinal")
+    }
+
+    func testOnTranscriptFinalFiresForMatchOnPartial() async {
+        // A partial that matches fires onTranscriptFinal only if it is not marked as a final.
+        // In the current design, only .transcriptFinal triggers onTranscriptFinal. A match on a
+        // partial resolves the window but does not fire onTranscriptFinal (partials are not final).
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        var finals: [(String, Bool)] = []
+        provider.onTranscriptFinal = { text, matched in finals.append((text, matched)) }
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+
+        XCTAssertEqual(received, [.yes], "the match resolves the window")
+        XCTAssertEqual(finals.count, 0, "partials do not fire onTranscriptFinal even when matched")
+    }
+
+    // MARK: - Turn never spans a TTS-busy interval (composition test)
+
+    func testTurnNeverSpansATTSBusyInterval() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeConversationProvider(backend: backend)
+        let activity = FakeSpeechActivity()
+        let gated = SpeechGatedVoice(wrapping: provider, activity: activity)
+        var received: [VoiceCommand] = []
+
+        // TTS starts speaking during an open window
+        gated.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+
+        // TTS becomes busy: SpeechGatedVoice stops the provider, ending the turn
+        activity.setSpeaking(true)
+        XCTAssertFalse(backend.isTurnActive, "turn must end when TTS starts")
+        XCTAssertTrue(backend.isOpen, "session stays open in conversation mode")
+
+        // TTS finishes: SpeechGatedVoice restarts the provider, beginning a new turn
+        activity.setSpeaking(false)
+        await settle()
+        XCTAssertTrue(backend.isTurnActive, "a fresh turn opens after TTS drains")
+
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.no])
+    }
+
     @MainActor
     private final class FakeSpeechActivity: SpeechActivitySignaling {
         private(set) var isSpeaking = false

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -1590,4 +1590,155 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertFalse(backend.calls.contains(.cancelResponse))
         XCTAssertFalse(sink.names.contains("response.suppressed_match_resolved"))
     }
+
+    // MARK: - Free-form (WP8)
+
+    private func makeFreeformProvider(
+        backend: ScriptedVoiceBackend,
+        freeformEnabled: Bool = true,
+        sink: RecordingSink = RecordingSink()
+    ) -> VoiceBackendCommandProvider {
+        VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            freeformEnabled: freeformEnabled,
+            idleSleep: { _ in },
+            diagnosticSink: sink)
+    }
+
+    func testFreeformDeliveredForUnmatchedFinalWhenEnabled() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeFreeformProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("deploy the blue canary"))
+
+        XCTAssertEqual(received, [.freeform("deploy the blue canary")])
+        XCTAssertTrue(sink.names.contains("freeform.delivered"))
+    }
+
+    func testFreeformNotDeliveredWhenDisabled() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeFreeformProvider(backend: backend, freeformEnabled: false, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("deploy the blue canary"))
+
+        XCTAssertEqual(received, [],
+                       "freeform must not be delivered when disabled")
+        XCTAssertFalse(sink.names.contains("freeform.delivered"))
+    }
+
+    func testFreeformNotDeliveredForMatchedFinal() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeFreeformProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("yes"))
+
+        XCTAssertEqual(received, [.yes],
+                       "a matching transcript must produce the command, never freeform")
+    }
+
+    func testFreeformNotDeliveredForPartials() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeFreeformProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("hello world"))
+
+        XCTAssertEqual(received, [],
+                       "partials never produce freeform even when enabled")
+    }
+
+    func testFreeformEmptyWhitespaceTranscriptNotDelivered() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeFreeformProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("   \n  "))
+
+        XCTAssertEqual(received, [],
+                       "empty/whitespace-only transcripts must not produce freeform")
+        XCTAssertFalse(sink.names.contains("freeform.delivered"))
+    }
+
+    func testFreeformDeliveredOnlyOncePerTurn() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeFreeformProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("first answer"))
+        backend.emit(.transcriptFinal("second answer"))
+
+        XCTAssertEqual(received, [.freeform("first answer")],
+                       "freeform must be delivered exactly once per turn")
+        XCTAssertEqual(sink.names.filter { $0 == "freeform.delivered" }.count, 1)
+    }
+
+    func testFreeformResetOnNewTurn() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeFreeformProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        // First turn
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("answer one"))
+        XCTAssertEqual(received, [.freeform("answer one")])
+        // Close the window (arbiter resolves or times out -> stop)
+        provider.stop()
+
+        // Second turn
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("answer two"))
+        XCTAssertEqual(received, [.freeform("answer one"), .freeform("answer two")],
+                       "freeform must be available again on the next turn")
+    }
+
+    func testFreeformTrimsWhitespace() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeFreeformProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("  padded answer  "))
+
+        XCTAssertEqual(received, [.freeform("padded answer")],
+                       "freeform text must be trimmed")
+    }
+
+    func testFreeformOnTranscriptFinalStillFires() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeFreeformProvider(backend: backend)
+        var finals: [(String, Bool)] = []
+        provider.onTranscriptFinal = { text, matched in finals.append((text, matched)) }
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(.transcriptFinal("freeform text"))
+
+        XCTAssertEqual(finals.count, 1)
+        XCTAssertEqual(finals[0].0, "freeform text")
+        XCTAssertFalse(finals[0].1, "freeform text is unmatched")
+    }
 }

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -881,4 +881,248 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             onSpeakingChange?(speaking)
         }
     }
+
+    // MARK: - FakePlayback (VoiceResponseAudioPlaying)
+
+    @MainActor
+    private final class FakePlayback: VoiceResponseAudioPlaying {
+        private(set) var isPlaying = false
+        var onPlayingChange: (@MainActor (Bool) -> Void)?
+
+        private(set) var enqueued: [VoiceAudioChunk] = []
+        private(set) var finishStreamCount = 0
+        private(set) var stopAndFlushCount = 0
+
+        func enqueue(_ chunk: VoiceAudioChunk) {
+            enqueued.append(chunk)
+            if !isPlaying {
+                isPlaying = true
+                onPlayingChange?(true)
+            }
+        }
+
+        func finishStream() {
+            finishStreamCount += 1
+        }
+
+        func stopAndFlush() {
+            stopAndFlushCount += 1
+            guard isPlaying else { return }
+            isPlaying = false
+            onPlayingChange?(false)
+        }
+    }
+
+    private func makeProviderWithPlayback(
+        backend: ScriptedVoiceBackend,
+        playback: FakePlayback,
+        sessionPolicy: SessionPolicy = .perWindow,
+        supportsBargeIn: Bool = false,
+        sink: RecordingSink = RecordingSink()
+    ) -> VoiceBackendCommandProvider {
+        VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: sessionPolicy,
+            supportsBargeIn: supportsBargeIn,
+            responseAudio: playback,
+            diagnosticSink: sink)
+    }
+
+    // MARK: - Response audio routing (WP2)
+
+    func testAudioChunksAreRoutedToPlayerInOrder() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let provider = makeProviderWithPlayback(backend: backend, playback: playback)
+
+        provider.start { _ in }
+        await settle()
+
+        let chunk1 = VoiceAudioChunk(data: Data([1, 2, 3, 4]),
+                                      format: .pcm16Mono24k, timestamp: 1)
+        let chunk2 = VoiceAudioChunk(data: Data([5, 6, 7, 8]),
+                                      format: .pcm16Mono24k, timestamp: 2)
+        backend.emit(.audio(chunk1))
+        backend.emit(.audio(chunk2))
+
+        XCTAssertEqual(playback.enqueued.count, 2)
+        XCTAssertEqual(playback.enqueued[0], chunk1)
+        XCTAssertEqual(playback.enqueued[1], chunk2)
+    }
+
+    func testResponseCompletedCallsFinishStream() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let provider = makeProviderWithPlayback(backend: backend, playback: playback)
+
+        provider.start { _ in }
+        await settle()
+
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        backend.emit(.responseCompleted)
+
+        XCTAssertEqual(playback.finishStreamCount, 1)
+    }
+
+    func testWindowTeardownCallsStopAndFlush() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let provider = makeProviderWithPlayback(backend: backend, playback: playback)
+
+        provider.start { _ in }
+        await settle()
+
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        provider.stop()
+
+        XCTAssertEqual(playback.stopAndFlushCount, 1)
+    }
+
+    func testSessionFailedCallsStopAndFlush() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let provider = makeProviderWithPlayback(backend: backend, playback: playback)
+
+        provider.start { _ in }
+        await settle()
+
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        backend.emit(.sessionFailed(.network("socket dropped")))
+
+        XCTAssertEqual(playback.stopAndFlushCount, 1)
+    }
+
+    func testCancelActiveResponseCallsStopAndFlush() async {
+        let backend = ScriptedVoiceBackend(
+            capabilities: VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true))
+        let playback = FakePlayback()
+        let sink = RecordingSink()
+        let provider = makeProviderWithPlayback(
+            backend: backend, playback: playback,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+
+        // An .audio event sets _responseInFlight = true (event-stream gating).
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        XCTAssertTrue(provider.isResponseInFlight)
+
+        provider.cancelActiveResponse()
+
+        XCTAssertTrue(backend.calls.contains(.cancelResponse))
+        XCTAssertEqual(playback.stopAndFlushCount, 1,
+                       "cancelActiveResponse must flush the audio player")
+        XCTAssertFalse(provider.isResponseInFlight)
+        XCTAssertTrue(sink.names.contains("response.cancelled_by_coordinator"))
+    }
+
+    func testWithNoPlayerAudioIsIgnoredAndDiagnosticRecorded() async {
+        // This tests the existing behavior is preserved when no player is provided.
+        let backend = ScriptedVoiceBackend(
+            capabilities: VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                   duplex: true))
+        let sink = RecordingSink()
+        let provider = makeProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.audio(VoiceAudioChunk(data: Data(repeating: 7, count: 64),
+                                            format: .pcm16Mono24k, timestamp: 2)))
+
+        XCTAssertEqual(received, [])
+        XCTAssertTrue(sink.names.contains("audio.ignored"))
+    }
+
+    func testWithPlayerAudioIsNotRecordedAsIgnored() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let sink = RecordingSink()
+        let provider = makeProviderWithPlayback(backend: backend, playback: playback, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+
+        XCTAssertFalse(sink.names.contains("audio.ignored"),
+                       "audio routed to a player is not logged as ignored")
+    }
+
+    func testConversationModeTeardownOnMatchCallsStopAndFlush() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let provider = makeProviderWithPlayback(
+            backend: backend, playback: playback,
+            sessionPolicy: .conversation(idleClose: 60))
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        backend.emit(.transcriptPartial("yes"))
+
+        XCTAssertEqual(received, [.yes])
+        XCTAssertEqual(playback.stopAndFlushCount, 1,
+                       "match resolution calls stopAndFlush in conversation mode")
+    }
+
+    func testShutdownCallsStopAndFlush() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let provider = makeProviderWithPlayback(
+            backend: backend, playback: playback,
+            sessionPolicy: .conversation(idleClose: 60))
+
+        provider.start { _ in }
+        await settle()
+
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        provider.shutdown()
+
+        XCTAssertEqual(playback.stopAndFlushCount, 1)
+    }
+
+    func testAudioEventsAfterWindowCloseAreDropped() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let provider = makeProviderWithPlayback(backend: backend, playback: playback)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+
+        // Audio arriving after the window is closed
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+
+        XCTAssertEqual(playback.enqueued.count, 0,
+                       "audio events after window close must not reach the player")
+    }
+
+    func testResponseCompletedClearsResponseInFlight() async {
+        let backend = ScriptedVoiceBackend()
+        let playback = FakePlayback()
+        let provider = makeProviderWithPlayback(
+            backend: backend, playback: playback,
+            sessionPolicy: .conversation(idleClose: 60))
+
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertFalse(provider.isResponseInFlight)
+        backend.emit(.responseCompleted)
+        XCTAssertFalse(provider.isResponseInFlight, "responseCompleted clears the flag")
+        XCTAssertEqual(playback.finishStreamCount, 1)
+    }
 }

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -1,0 +1,500 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+@MainActor
+final class VoiceBackendCommandProviderTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    /// A backend that records the exact call sequence and replays scripted events on
+    /// demand.
+    ///
+    /// It also polices the turn protocol from the backend's side: an `endUserTurn` with no
+    /// turn open, a second `beginUserTurn`, or any turn call after `close` fails the test
+    /// where it happens. The fake never ends a turn itself — that is the invariant these
+    /// tests exist to defend, and a fake that quietly did it would hide the bug.
+    @MainActor
+    final class ScriptedVoiceBackend: VoiceBackend {
+        enum Call: Equatable {
+            case open
+            case close
+            case beginUserTurn
+            case endUserTurn
+            case sendAudio(Int)
+            case requestResponse(String)
+            case cancelResponse
+        }
+
+        let capabilities: VoiceBackendCapabilities
+        private(set) var calls: [Call] = []
+        private(set) var handlers: [(@MainActor (VoiceBackendEvent) -> Void)] = []
+        private(set) var isOpen = false
+        private(set) var isTurnActive = false
+        /// Set to make the handshake fail; cleared by the test to let a retry succeed.
+        var openFailure: VoiceBackendFailure?
+        /// When set, `open` suspends on it so a test can stop the window mid-handshake.
+        var openGate: (() async -> Void)?
+
+        init(capabilities: VoiceBackendCapabilities = .transcriptOnly) {
+            self.capabilities = capabilities
+        }
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            calls.append(.open)
+            if let openGate {
+                await openGate()
+            }
+            if let openFailure {
+                throw openFailure
+            }
+            isOpen = true
+            handlers.append(onEvent)
+        }
+
+        func close() {
+            calls.append(.close)
+            isOpen = false
+            isTurnActive = false
+        }
+
+        func beginUserTurn() {
+            calls.append(.beginUserTurn)
+            XCTAssertTrue(isOpen, "beginUserTurn on a closed session")
+            XCTAssertFalse(isTurnActive, "double beginUserTurn")
+            isTurnActive = true
+        }
+
+        func endUserTurn() {
+            calls.append(.endUserTurn)
+            XCTAssertTrue(isOpen, "endUserTurn on a closed session")
+            XCTAssertTrue(isTurnActive, "endUserTurn with no turn open")
+            isTurnActive = false
+        }
+
+        func sendAudio(_ chunk: VoiceAudioChunk) {
+            calls.append(.sendAudio(chunk.data.count))
+        }
+
+        func requestResponse(text: String) {
+            calls.append(.requestResponse(text))
+        }
+
+        func cancelResponse() {
+            calls.append(.cancelResponse)
+        }
+
+        /// Delivers an event to the newest window, or to an older one when a test needs to
+        /// prove stale callbacks are dropped.
+        func emit(_ event: VoiceBackendEvent, toHandler index: Int? = nil) {
+            guard !handlers.isEmpty else { return XCTFail("no window is listening") }
+            handlers[index ?? handlers.count - 1](event)
+        }
+    }
+
+    /// Stands in for `VoiceCommandMatcher`, which lives in a module this one does not
+    /// depend on. Deliberately substring-based so cumulative transcripts behave the way the
+    /// real grammar's whole-utterance matching does.
+    private static let match: VoiceBackendCommandProvider.TranscriptMatching = { text in
+        let lowered = text.lowercased()
+        if lowered.contains("yes") { return .yes }
+        if lowered.contains("no") { return .no }
+        return nil
+    }
+
+    private func makeProvider(backend: ScriptedVoiceBackend,
+                              sink: RecordingSink = RecordingSink())
+        -> VoiceBackendCommandProvider {
+        VoiceBackendCommandProvider(backend: backend, match: Self.match, diagnosticSink: sink)
+    }
+
+    /// The window opens across an `await`, so tests hand the main actor back before
+    /// asserting on it.
+    private func settle() async {
+        for _ in 0..<4 { await Task.yield() }
+    }
+
+    // MARK: - Window lifecycle
+
+    func testStartOpensTheSessionAndBeginsExactlyOneUserTurn() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+
+        provider.start { _ in XCTFail("nothing was transcribed") }
+        XCTAssertEqual(backend.calls, [], "the handshake is async; nothing happens inline")
+        await settle()
+
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn])
+        XCTAssertTrue(backend.isTurnActive)
+        XCTAssertTrue(provider.isWindowOpenForTesting)
+    }
+
+    func testDuplicateStartIsIgnored() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeProvider(backend: backend, sink: sink)
+
+        provider.start { _ in }
+        provider.start { _ in XCTFail("a second start must not replace the window") }
+        await settle()
+
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn])
+        XCTAssertEqual(sink.events.first { $0.name == "start.skipped" }?.fields["reason"],
+                       "already_running")
+    }
+
+    func testStopEndsTheTurnAndClosesTheSession() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn, .endUserTurn, .close])
+        XCTAssertFalse(provider.isWindowOpenForTesting)
+    }
+
+    func testStopIsIdempotent() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        provider.stop()
+        provider.stop()
+
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn, .endUserTurn, .close])
+    }
+
+    func testStopBeforeTheHandshakeCompletesStillClosesTheSession() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+        backend.openGate = { await Task.yield() }
+
+        provider.start { _ in XCTFail("the window was abandoned") }
+        provider.stop()
+        await settle()
+
+        XCTAssertEqual(backend.calls, [.open, .close],
+                       "a session that finishes opening after stop must not be left running")
+        XCTAssertFalse(backend.isOpen)
+        XCTAssertFalse(backend.isTurnActive)
+    }
+
+    // MARK: - Matching
+
+    func testMatchOnPartialTranscriptDeliversOnceAndEndsTheTurn() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+
+        XCTAssertEqual(received, [.yes])
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn, .endUserTurn, .close])
+        XCTAssertFalse(provider.isWindowOpenForTesting)
+        XCTAssertEqual(sink.events.last { $0.name == "command.matched" }?.fields["command"],
+                       "yes")
+    }
+
+    func testCumulativeTranscriptIsMatchedAsAWhole() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        // Cumulative, exactly as SFSpeechRecognizer reports it: each partial repeats the
+        // whole utterance so far.
+        backend.emit(.transcriptPartial("um"))
+        XCTAssertEqual(received, [])
+        backend.emit(.transcriptPartial("um yes"))
+
+        XCTAssertEqual(received, [.yes])
+    }
+
+    func testTranscriptsAfterAMatchDeliverNothing() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+        // In-flight transcripts landing after the window resolved.
+        backend.emit(.transcriptPartial("yes"))
+        backend.emit(.transcriptFinal("no"))
+
+        XCTAssertEqual(received, [.yes], "a window resolves exactly once")
+    }
+
+    func testUnmatchedFinalTranscriptDeliversNothingAndLeavesTheTurnOpen() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("what time is the standup"))
+
+        XCTAssertEqual(received, [])
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn],
+                       "a backend's final transcript is not a turn boundary")
+        XCTAssertTrue(backend.isTurnActive)
+        XCTAssertTrue(provider.isWindowOpenForTesting)
+        let rejection = sink.events.last { $0.name == "transcript.rejected" }
+        XCTAssertEqual(rejection?.fields["reason"], "unmatched")
+        XCTAssertEqual(rejection?.fields["length"], "24")
+    }
+
+    func testUnmatchedPartialTranscriptIsNotLoggedAsRejected() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeProvider(backend: backend, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(.transcriptPartial("um"))
+
+        XCTAssertFalse(sink.names.contains("transcript.rejected"),
+                       "every partial is unmatched until it isn't; logging each is noise")
+    }
+
+    // MARK: - Turn ownership
+
+    func testTheBackendNeverEndsATurnOnItsOwn() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+
+        provider.start { _ in }
+        await settle()
+        // Everything a backend can say that is not a match: none of it may commit a turn.
+        backend.emit(.transcriptPartial("hello"))
+        backend.emit(.transcriptFinal("hello"))
+        backend.emit(.responseCompleted)
+        backend.emit(.audio(VoiceAudioChunk(data: Data([0, 1, 2, 3]),
+                                            format: .pcm16Mono16k, timestamp: 1)))
+
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn])
+        XCTAssertTrue(backend.isTurnActive)
+        provider.stop()
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn, .endUserTurn, .close],
+                       "only the caller ends the turn")
+    }
+
+    func testResponseAudioIsIgnoredAndRecorded() async {
+        let backend = ScriptedVoiceBackend(
+            capabilities: VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                   duplex: true))
+        let sink = RecordingSink()
+        let provider = makeProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.audio(VoiceAudioChunk(data: Data(repeating: 7, count: 64),
+                                            format: .pcm16Mono24k, timestamp: 2)))
+
+        XCTAssertEqual(received, [])
+        XCTAssertTrue(sink.names.contains("audio.ignored"))
+    }
+
+    func testProviderNeverPushesAudioIntoABackendThatRecordsItself() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+
+        XCTAssertFalse(backend.calls.contains { if case .sendAudio = $0 { return true }
+                                                return false })
+        XCTAssertFalse(backend.calls.contains(.requestResponse("")))
+        XCTAssertFalse(backend.calls.contains(.cancelResponse))
+    }
+
+    // MARK: - Failure paths (all fail open)
+
+    func testSessionFailedMidWindowTearsDownWithoutDelivering() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.sessionFailed(.network("socket dropped")))
+
+        XCTAssertEqual(received, [], "a dead session resolves nothing")
+        XCTAssertFalse(provider.isWindowOpenForTesting)
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn, .close],
+                       "no endUserTurn into a session that is already gone")
+        let failure = sink.events.last { $0.name == "session.failed" }
+        XCTAssertEqual(failure?.level, .warning)
+        XCTAssertTrue(failure?.fields["detail"]?.contains("socket dropped") == true)
+    }
+
+    func testTranscriptsAfterSessionFailureAreDropped() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.sessionFailed(.closed("peer hung up")))
+        backend.emit(.transcriptFinal("yes"))
+
+        XCTAssertEqual(received, [])
+    }
+
+    func testOpenFailureFailsOpenSilently() async {
+        let backend = ScriptedVoiceBackend()
+        backend.openFailure = .authorization("no credentials")
+        let sink = RecordingSink()
+        let provider = makeProvider(backend: backend, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertEqual(received, [])
+        XCTAssertEqual(backend.calls, [.open], "a session that never opened is not closed")
+        XCTAssertFalse(provider.isWindowOpenForTesting)
+        let failed = sink.events.last { $0.name == "window.open_failed" }
+        XCTAssertEqual(failed?.level, .warning)
+        XCTAssertTrue(failed?.fields["error"]?.contains("credentials") == true)
+    }
+
+    func testSecondStartAfterFailureOpensAFreshTurn() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.sessionFailed(.network("route changed")))
+
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertEqual(backend.calls,
+                       [.open, .beginUserTurn, .close, .open, .beginUserTurn])
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes], "the next window recovers on a fresh session")
+    }
+
+    func testSecondStartAfterAnOpenFailureRecovers() async {
+        let backend = ScriptedVoiceBackend()
+        backend.openFailure = .network("first handshake timed out")
+        let provider = makeProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.openFailure = nil
+
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptFinal("yes"))
+
+        XCTAssertEqual(received, [.yes])
+        XCTAssertEqual(backend.calls, [.open, .open, .beginUserTurn, .endUserTurn, .close])
+    }
+
+    // MARK: - Stale callbacks
+
+    func testEventsFromAPriorWindowAreDropped() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        provider.stop()
+
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertEqual(backend.handlers.count, 2)
+
+        backend.emit(.transcriptFinal("yes"), toHandler: 0)
+        XCTAssertEqual(received, [], "a transcript from the closed window resolves nothing")
+
+        backend.emit(.transcriptFinal("yes"), toHandler: 1)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    func testFailureFromAPriorWindowDoesNotTearDownTheLiveOne() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        provider.stop()
+        provider.start { received.append($0) }
+        await settle()
+
+        backend.emit(.sessionFailed(.network("late failure from window 1")), toHandler: 0)
+        XCTAssertTrue(provider.isWindowOpenForTesting)
+        backend.emit(.transcriptPartial("yes"), toHandler: 1)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    // MARK: - Composition
+
+    func testStacksUnderSpeechGatedVoice() async {
+        let backend = ScriptedVoiceBackend()
+        let provider = makeProvider(backend: backend)
+        let activity = FakeSpeechActivity()
+        let gated = SpeechGatedVoice(wrapping: provider, activity: activity)
+        var received: [VoiceCommand] = []
+
+        activity.setSpeaking(true)
+        gated.start { received.append($0) }
+        await settle()
+        XCTAssertEqual(backend.calls, [], "the mic stays shut while the synthesizer talks")
+
+        activity.setSpeaking(false)
+        await settle()
+        XCTAssertEqual(backend.calls, [.open, .beginUserTurn])
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+    }
+
+    @MainActor
+    private final class FakeSpeechActivity: SpeechActivitySignaling {
+        private(set) var isSpeaking = false
+        var onSpeakingChange: (@MainActor (Bool) -> Void)?
+
+        func setSpeaking(_ speaking: Bool) {
+            guard speaking != isSpeaking else { return }
+            isSpeaking = speaking
+            onSpeakingChange?(speaking)
+        }
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -500,6 +500,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         idleClose: TimeInterval = 60,
         supportsBargeIn: Bool = false,
         clock: VirtualClock? = nil,
+        instantIdle: Bool = false,
         sink: RecordingSink = RecordingSink()
     ) -> VoiceBackendCommandProvider {
         let resolvedClock = clock ?? VirtualClock()
@@ -509,6 +510,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             sessionPolicy: .conversation(idleClose: idleClose),
             supportsBargeIn: supportsBargeIn,
             monotonicNow: { resolvedClock.time },
+            idleSleep: instantIdle ? { _ in } : { try? await Task.sleep(for: .seconds($0)) },
             diagnosticSink: sink)
     }
 
@@ -585,22 +587,18 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
     }
 
     func testConversationModeIdleTimerClosesSessionAfterIdleClose() async {
-        let clock = VirtualClock()
         let backend = ScriptedVoiceBackend()
         let sink = RecordingSink()
-        let provider = makeConversationProvider(backend: backend, idleClose: 0.01,
-                                                clock: clock, sink: sink)
+        let provider = makeConversationProvider(backend: backend, idleClose: 60,
+                                                instantIdle: true, sink: sink)
 
         provider.start { _ in }
         await settle()
         provider.stop()
         XCTAssertTrue(backend.isOpen, "session stays open right after stop")
 
-        // Let the idle timer fire
-        clock.advance(by: 0.02)
+        // The injectable sleep returns instantly; settle lets the Task deliver.
         await settle()
-        // Sleep long enough for the Task.sleep to complete
-        try? await Task.sleep(for: .seconds(0.05))
 
         XCTAssertFalse(backend.isOpen, "session closed by idle timer")
         XCTAssertTrue(sink.names.contains("session.idle_closed"))
@@ -608,14 +606,15 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
 
     func testConversationModeStartAfterIdleCloseReopens() async {
         let backend = ScriptedVoiceBackend()
-        let provider = makeConversationProvider(backend: backend, idleClose: 0.01)
+        let provider = makeConversationProvider(backend: backend, idleClose: 60,
+                                                instantIdle: true)
         var received: [VoiceCommand] = []
 
         provider.start { received.append($0) }
         await settle()
         provider.stop()
-        // Wait for idle close
-        try? await Task.sleep(for: .seconds(0.05))
+        // The injectable sleep returns instantly; settle lets the idle fire.
+        await settle()
 
         XCTAssertFalse(backend.isOpen)
         // New start should reopen
@@ -1124,5 +1123,232 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         backend.emit(.responseCompleted)
         XCTAssertFalse(provider.isResponseInFlight, "responseCompleted clears the flag")
         XCTAssertEqual(playback.finishStreamCount, 1)
+    }
+
+    // MARK: - Response-in-flight tracking at session scope (defect 1)
+
+    /// A backend that polices the responding state: calling `beginUserTurn` while a
+    /// response is in flight fails the session, exactly as `VoiceTurnStateMachine` does in
+    /// `OpenAIRealtimeVoiceBackend`. `ScriptedVoiceBackend` does not model the responding
+    /// state, which is why the original tests passed.
+    @MainActor
+    private final class RespondingAwareBackend: VoiceBackend {
+        enum Call: Equatable {
+            case open
+            case close
+            case beginUserTurn
+            case endUserTurn
+            case sendAudio(Int)
+            case requestResponse(String)
+            case cancelResponse
+        }
+
+        let capabilities: VoiceBackendCapabilities
+        private(set) var calls: [Call] = []
+        private(set) var isOpen = false
+        private(set) var isTurnActive = false
+        private(set) var isResponding = false
+        private var handler: (@MainActor (VoiceBackendEvent) -> Void)?
+
+        init(capabilities: VoiceBackendCapabilities = VoiceBackendCapabilities(
+            supportsBargeIn: true, producesAudio: true, duplex: true
+        )) {
+            self.capabilities = capabilities
+        }
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            calls.append(.open)
+            isOpen = true
+            handler = onEvent
+        }
+
+        func close() {
+            calls.append(.close)
+            isOpen = false
+            isTurnActive = false
+            isResponding = false
+            handler = nil
+        }
+
+        func beginUserTurn() {
+            calls.append(.beginUserTurn)
+            if isResponding {
+                // This is the exact behavior OpenAIRealtimeVoiceBackend exhibits:
+                // VoiceTurnStateMachine.beginUserTurn from .responding throws
+                // responseAlreadyInFlight, which is surfaced via violated() -> failSession.
+                let callback = handler
+                isOpen = false
+                isTurnActive = false
+                isResponding = false
+                handler = nil
+                callback?(.sessionFailed(.protocolViolation(
+                    "A response is already in flight.")))
+                return
+            }
+            isTurnActive = true
+        }
+
+        func endUserTurn() {
+            calls.append(.endUserTurn)
+            isTurnActive = false
+            // Simulates the OpenAI adapter: endUserTurn commits + requestResponse, entering
+            // the responding state.
+            isResponding = true
+        }
+
+        func sendAudio(_ chunk: VoiceAudioChunk) {
+            calls.append(.sendAudio(chunk.data.count))
+        }
+
+        func requestResponse(text: String) {
+            calls.append(.requestResponse(text))
+        }
+
+        func cancelResponse() {
+            calls.append(.cancelResponse)
+            isResponding = false
+        }
+
+        func emit(_ event: VoiceBackendEvent) {
+            if case .responseCompleted = event { isResponding = false }
+            handler?(event)
+        }
+    }
+
+    private func makeConversationProviderWithRespondingBackend(
+        backend: RespondingAwareBackend,
+        supportsBargeIn: Bool = true,
+        sink: RecordingSink = RecordingSink()
+    ) -> VoiceBackendCommandProvider {
+        VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: supportsBargeIn,
+            idleSleep: { _ in },
+            diagnosticSink: sink)
+    }
+
+    func testConversationModeStartDuringResponseCancelsWhenBargeInSupported() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, sink: sink)
+        var received: [VoiceCommand] = []
+
+        // Window 1: open, speak, match -> turn ends, response starts
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+        XCTAssertTrue(backend.isOpen, "session stays open")
+        XCTAssertTrue(backend.isResponding, "endUserTurn triggered a response")
+
+        // Between windows, the backend emits audio (response in flight).
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]), format: .pcm16Mono24k, timestamp: 1)))
+
+        // Window 2: start() must cancel the response instead of crashing.
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertTrue(backend.calls.contains(.cancelResponse),
+                      "response must be cancelled before beginning a new turn")
+        XCTAssertFalse(backend.isResponding, "response cancelled")
+        XCTAssertTrue(backend.isTurnActive, "new turn started successfully")
+        XCTAssertTrue(backend.isOpen, "session survived — not torn down by a violation")
+        XCTAssertTrue(sink.names.contains("response.cancelled_for_new_window"))
+    }
+
+    func testConversationModeStartDuringResponseDefersWhenBargeInUnsupported() async {
+        let backend = RespondingAwareBackend(capabilities: .transcriptOnly)
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: false, sink: sink)
+        var received: [VoiceCommand] = []
+
+        // Window 1: trigger a response
+        provider.start { received.append($0) }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+
+        // Between windows, mark response in flight.
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]), format: .pcm16Mono24k, timestamp: 1)))
+
+        // Window 2: cannot barge in, so the turn is deferred.
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertFalse(backend.isTurnActive, "turn not started yet — deferred")
+        XCTAssertTrue(sink.names.contains("turn.deferred_response_in_flight"))
+
+        // Response completes: the deferred turn should now fire.
+        backend.emit(.responseCompleted)
+        XCTAssertTrue(backend.isTurnActive, "deferred turn started after responseCompleted")
+        XCTAssertTrue(sink.names.contains("turn.started_after_deferred"))
+
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.yes, .no])
+    }
+
+    func testResponseInFlightTrackedAtSessionScopeBetweenWindows() async {
+        let backend = RespondingAwareBackend()
+        let provider = makeConversationProviderWithRespondingBackend(backend: backend)
+
+        // Window 1: start, match, end window
+        provider.start { _ in }
+        await settle()
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertFalse(provider.isWindowOpenForTesting)
+
+        // Between windows, audio arrives (response in flight from the prior commit).
+        // handler is nil, but isResponseInFlight must still track this.
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]), format: .pcm16Mono24k, timestamp: 1)))
+        XCTAssertTrue(provider.isResponseInFlight,
+                      "response-in-flight must be tracked even without a window")
+
+        // responseCompleted clears it.
+        backend.emit(.responseCompleted)
+        XCTAssertFalse(provider.isResponseInFlight)
+    }
+
+    // MARK: - Idle timer with injectable sleep (defect 3)
+
+    func testIdleTimerFiresWithoutRealSleep() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        // Uses instantIdle: the idle sleep returns immediately, so no real delay needed.
+        let provider = makeConversationProvider(backend: backend, idleClose: 3600,
+                                                instantIdle: true, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        XCTAssertTrue(backend.isOpen, "session open right after stop")
+
+        // Settle lets the Task with the instant sleep deliver.
+        await settle()
+
+        XCTAssertFalse(backend.isOpen, "session closed by idle timer (no real sleep)")
+        XCTAssertTrue(sink.names.contains("session.idle_closed"))
+    }
+
+    func testIdleTimerCancelledByNewWindow() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        // instantIdle makes the sleep return immediately; but if a new window opens first
+        // (bumping idleGeneration), the fire should be suppressed.
+        let provider = makeConversationProvider(backend: backend, idleClose: 3600,
+                                                instantIdle: true, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        // Immediately reopen before the idle Task delivers.
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertTrue(backend.isOpen, "session stayed open — idle timer was cancelled")
+        XCTAssertFalse(sink.names.contains("session.idle_closed"))
     }
 }

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -1283,11 +1283,10 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertTrue(backend.isOpen, "session survived")
     }
 
-    /// When a coordinator-created response is still in flight at the next start(),
-    /// barge-in-capable providers cancel it there. The coordinator called endActiveTurn
-    /// (expectingResponse: true), creating a response; stop() closed the window without
-    /// a match; the response is still pending; the next start() cancels it.
-    func testConversationModeStartDuringUnsuppressedResponseCancels() async {
+    /// When a coordinator-created response is still pending at stop(), stop() now arms
+    /// suppression. The first audio arriving between windows triggers the cancel. The next
+    /// start() finds no response in flight and begins a turn immediately.
+    func testConversationModeStopAfterCoordinatorEndpointSuppressesResponse() async {
         let backend = RespondingAwareBackend()
         let sink = RecordingSink()
         let provider = makeConversationProviderWithRespondingBackend(
@@ -1299,19 +1298,24 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         provider.endActiveTurn()
         XCTAssertTrue(backend.isResponding, "endActiveTurn creates a response")
         provider.stop()
-        // stop() does not suppress because suppressResponse is false.
+        // stop() now passes suppressResponse: true, arming the suppression mark.
+        XCTAssertTrue(sink.names.contains("response.suppression_armed"),
+                      "stop() must arm suppression for the pending response")
 
-        // Between windows, audio arrives.
+        // Between windows, audio arrives — suppression fires.
         backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]), format: .pcm16Mono24k, timestamp: 1)))
 
-        // Window 2: start() sees the response in flight and cancels it.
+        XCTAssertTrue(backend.calls.contains(.cancelResponse),
+                      "the pending response must be cancelled on first audio")
+        XCTAssertFalse(backend.isResponding, "response cancelled by suppression")
+        XCTAssertTrue(sink.names.contains("response.suppressed_on_first_audio"))
+
+        // Window 2: no response in flight, start() begins a new turn directly.
         provider.start { _ in }
         await settle()
 
-        XCTAssertTrue(backend.calls.contains(.cancelResponse))
-        XCTAssertFalse(backend.isResponding, "response cancelled at window 2 start")
-        XCTAssertTrue(backend.isTurnActive, "new turn started")
-        XCTAssertTrue(sink.names.contains("response.cancelled_for_new_window"))
+        XCTAssertTrue(backend.isTurnActive, "new turn started immediately")
+        XCTAssertTrue(backend.isOpen, "session survived")
     }
 
     func testConversationModeStartDuringResponseDefersWhenBargeInUnsupported() async {
@@ -1841,6 +1845,50 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         // Without barge-in, the response cannot be cancelled — it is left to drain.
         XCTAssertFalse(backend.calls.contains(.cancelResponse))
         XCTAssertFalse(sink.names.contains("response.suppressed_match_resolved"))
+    }
+
+    // MARK: - Gesture/timeout stop suppresses endpoint-created response (fixup defect 3)
+
+    /// The coordinator commits the turn (wearer stopped speaking), creating a response on
+    /// the backend. Then the window resolves by gesture or timeout (stop()). With
+    /// suppressResponse: true, the pending response is suppressed so it is not left to be
+    /// dropped between windows. The next start() begins a turn immediately.
+    func testStopAfterEndpointSuppressesPendingResponseAndNextStartIsImmediate() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, instantIdle: false, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+
+        // Coordinator commits the turn (wearer stopped speaking).
+        provider.endActiveTurn()
+        XCTAssertTrue(backend.isResponding, "endActiveTurn creates a response")
+
+        // Gesture resolution: stop() is called.
+        provider.stop()
+
+        // stop() arms suppression for the pending response.
+        XCTAssertTrue(sink.names.contains("response.suppression_armed"),
+                      "stop() must arm suppression for the endpoint-created response")
+
+        // The response completes (responseCompleted clears all flags).
+        backend.emit(.responseCompleted)
+
+        // Next window: no stale response state, turn starts immediately.
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertTrue(backend.isTurnActive,
+                      "the next start() must begin a turn immediately")
+        XCTAssertTrue(backend.isOpen, "session survived")
+        XCTAssertFalse(sink.names.contains("turn.deferred_response_in_flight"),
+                       "no deferral — the response was suppressed at stop()")
+
+        backend.emit(.transcriptPartial("no"))
+        XCTAssertEqual(received, [.no])
     }
 
     // MARK: - Real OpenAI ordering: suppression via armed mark (defect 1 fix, defect 5)

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -1236,12 +1236,16 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             backend: backend, supportsBargeIn: true, sink: sink)
         var received: [VoiceCommand] = []
 
-        // Window 1: open, speak, match -> turn ends, response suppressed immediately.
-        // With supportsBargeIn and conversation mode, a match-resolved endUserTurn
-        // is followed by cancelResponse, so the backend never stays in the responding
-        // state between windows.
+        // Window 1: open, begin turn, backend starts responding with audio, then match.
+        // The response must be suppressed via cancelResponse because _responseInFlight
+        // is true (set by the audio event).
         provider.start { received.append($0) }
         await settle()
+        // Simulate audio arriving from the backend response (sets _responseInFlight).
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        XCTAssertTrue(provider.isResponseInFlight)
+
         backend.emit(.transcriptPartial("yes"))
         XCTAssertEqual(received, [.yes])
         XCTAssertTrue(backend.isOpen, "session stays open")
@@ -1249,6 +1253,8 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertTrue(backend.calls.contains(.cancelResponse),
                       "cancelResponse must follow endUserTurn for match-resolved windows")
         XCTAssertTrue(sink.names.contains("response.suppressed_match_resolved"))
+        XCTAssertFalse(provider.isResponseInFlight,
+                       "suppression must clear the response-in-flight flag")
 
         // Window 2: no response in flight, start() begins a new turn directly.
         provider.start { received.append($0) }
@@ -1521,6 +1527,48 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertTrue(sink.names.contains("session.reopened_after_idle"))
     }
 
+    /// Regression for defect 3 (decision 3): the onConversationReopened callback must
+    /// fire BEFORE backend.open so that FailThroughVoiceBackend.resetStickiness() clears
+    /// sticky fallback state and the new conversation re-probes the primary. Before the
+    /// fix, the callback fired after open, binding the reopened conversation to the stale
+    /// fallback.
+    func testConversationReopenedCallbackPrecedesOpenCall() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend, idleClose: 60,
+                                                instantIdle: true, sink: sink)
+
+        var callbackFiredBeforeOpen = false
+        var callbackCallCount = 0
+        provider.onConversationReopened = {
+            callbackCallCount += 1
+            // At the time the callback fires, backend.isOpen must still be false
+            // (the open hasn't happened yet).
+            callbackFiredBeforeOpen = !backend.isOpen
+        }
+
+        // Conversation 1: open, stop, idle-close.
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        await settle()
+        XCTAssertFalse(backend.isOpen)
+
+        // Record open count before conversation 2.
+        let openCountBefore = backend.calls.filter { $0 == .open }.count
+
+        // Conversation 2: reopen after idle-close.
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertEqual(callbackCallCount, 1, "callback fired exactly once")
+        XCTAssertTrue(callbackFiredBeforeOpen,
+                      "onConversationReopened must fire BEFORE backend.open (decision 3)")
+        let openCountAfter = backend.calls.filter { $0 == .open }.count
+        XCTAssertEqual(openCountAfter, openCountBefore + 1,
+                       "backend.open was called after the callback")
+    }
+
     func testConversationReopenedCallbackDoesNotFireOnFirstOpen() async {
         let backend = ScriptedVoiceBackend()
         let provider = makeConversationProvider(backend: backend, idleClose: 60)
@@ -1570,6 +1618,70 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         XCTAssertTrue(backend.isResponding,
                       "stop() must not suppress the response — only match resolution does")
         XCTAssertFalse(sink.names.contains("response.suppressed_match_resolved"))
+    }
+
+    /// Regression for defect 2: match-resolved response suppression must not call
+    /// cancelResponse when no response is actually in flight. On the OpenAI path, the
+    /// empty-turn guard can leave the adapter in .committed (not .responding) after
+    /// endUserTurn, and on the Apple fallback, cancelResponse always throws
+    /// bargeInUnsupported. The _responseInFlight guard prevents both session-killing paths.
+    func testMatchResolvedDoesNotCallCancelResponseWhenNoResponseInFlight() async {
+        // A backend that enforces VoiceTurnStateMachine legality (like the real adapters).
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+
+        // The backend is in .userTurn -> endUserTurn moves to .committed.
+        // RespondingAwareBackend.endUserTurn sets isResponding = true (simulating OpenAI's
+        // commit + response.create). But if we match on a partial BEFORE any audio event
+        // marks _responseInFlight = true, the provider must NOT call cancelResponse.
+        // The response-in-flight flag is set by .audio events, not by endUserTurn.
+        XCTAssertFalse(provider.isResponseInFlight,
+                       "no audio events yet — response not in flight")
+
+        // Match on the partial: this calls endWindowKeepSession(suppressResponse: true).
+        // endUserTurn will set isResponding = true on the backend, but the provider's
+        // _responseInFlight is still false, so cancelResponse must NOT be called.
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+
+        // The backend survived — no session death from an illegal cancelResponse.
+        XCTAssertTrue(backend.isOpen,
+                      "session must survive — no illegal cancelResponse")
+        XCTAssertFalse(sink.names.contains("response.suppressed_match_resolved"),
+                       "suppression must not fire when no response is in flight")
+    }
+
+    /// Regression for defect 2b: when a response IS in flight at match time,
+    /// the suppression path should still fire and clear _responseInFlight.
+    func testMatchResolvedSuppressesWhenResponseActuallyInFlight() async {
+        let backend = RespondingAwareBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProviderWithRespondingBackend(
+            backend: backend, supportsBargeIn: true, sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+
+        // Mark response in flight via an audio event.
+        backend.emit(.audio(VoiceAudioChunk(data: Data([1, 2]),
+                                             format: .pcm16Mono24k, timestamp: 1)))
+        XCTAssertTrue(provider.isResponseInFlight)
+
+        // Match: should suppress the response.
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes])
+
+        XCTAssertTrue(backend.isOpen, "session survived")
+        XCTAssertFalse(provider.isResponseInFlight,
+                       "suppression must clear the response-in-flight flag")
+        XCTAssertTrue(sink.names.contains("response.suppressed_match_resolved"))
     }
 
     /// Without supportsBargeIn, a match-resolved window does not attempt to suppress

--- a/Tests/TapQInteractionBaselineTests/WearerGatedVoiceTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerGatedVoiceTests.swift
@@ -346,4 +346,38 @@ final class WearerGatedVoiceTests: XCTestCase {
         inner.fire(.yes)
         XCTAssertEqual(received, [.yes], "degraded attribution must not change shipped behavior")
     }
+
+    /// The fail-open regression sentinel for the live composition: SpeechGatedVoice wrapping
+    /// WearerGatedVoice wrapping the raw voice, with a *stale* signal (isSignalAvailable
+    /// false). The gate must pass every command through verbatim — the exact behavior of a
+    /// serve without --wearer-gate.
+    func testFullStackWithStaleSignalIsVerbatimPassthrough() {
+        let inner = FakeVoice()
+        let signal = FakeSignal(available: false)
+        let activity = FakeActivity()
+        let clock = Clock()
+        let sink = RecordingSink()
+        let attributed = makeGate(inner: inner, signal: signal, clock: clock, sink: sink)
+        let gated = SpeechGatedVoice(wrapping: attributed, activity: activity)
+        var received: [VoiceCommand] = []
+        gated.start { received.append($0) }
+
+        // Every command passes through without the wearer speaking.
+        inner.fire(.yes)
+        inner.fire(.no)
+        XCTAssertEqual(received, [.yes, .no])
+
+        // TTS gating still works on top of the stale attribution.
+        activity.setSpeaking(true)
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes, .no], "TTS gate still closes the mic")
+
+        activity.setSpeaking(false)
+        inner.fire(.no)
+        XCTAssertEqual(received, [.yes, .no, .no], "mic reopens after TTS drains")
+
+        // Every passed-through command records the fail-open diagnostic.
+        let passCount = sink.names.filter { $0 == "command.passed_signal_unavailable" }.count
+        XCTAssertEqual(passCount, 3, "each pass-through must be diagnostically visible")
+    }
 }

--- a/Tests/TapQInteractionBaselineTests/WearerGatedVoiceTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerGatedVoiceTests.swift
@@ -97,7 +97,7 @@ final class WearerGatedVoiceTests: XCTestCase {
 
     // MARK: - Fail open
 
-    func testPassesThroughWhenSignalUnavailable() {
+    func testPassesThroughWhenSignalUnavailable() async {
         let inner = FakeVoice()
         let signal = FakeSignal(available: false)
         let clock = Clock()
@@ -110,7 +110,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(sink.names, ["command.passed_signal_unavailable"])
     }
 
-    func testWedgedSignalStillDeliversWhenUnavailable() {
+    func testWedgedSignalStillDeliversWhenUnavailable() async {
         let inner = FakeVoice()
         let signal = FakeSignal(available: false)
         let clock = Clock()
@@ -125,7 +125,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(received, [.no, .yes])
     }
 
-    func testAvailabilityLostMidWindowReopensTheGate() {
+    func testAvailabilityLostMidWindowReopensTheGate() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -141,7 +141,7 @@ final class WearerGatedVoiceTests: XCTestCase {
 
     // MARK: - Attribution
 
-    func testPassesWhileWearerIsSpeaking() {
+    func testPassesWhileWearerIsSpeaking() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -153,7 +153,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(received, [.yes])
     }
 
-    func testPassesWithinTrailingAttributionWindow() {
+    func testPassesWithinTrailingAttributionWindow() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -168,7 +168,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(received, [.yes])
     }
 
-    func testRejectsWhenWearerNeverSpoke() {
+    func testRejectsWhenWearerNeverSpoke() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -182,7 +182,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(sink.events.first?.fields["since_wearer_speech_seconds"], "never")
     }
 
-    func testRejectsAfterWindowExpiry() {
+    func testRejectsAfterWindowExpiry() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -199,7 +199,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(sink.events.first?.fields["attribution_window_seconds"], "2.000")
     }
 
-    func testWindowBoundaryIsInclusive() {
+    func testWindowBoundaryIsInclusive() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -213,7 +213,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(received, [.yes])
     }
 
-    func testSpeechBeforeTheWindowOpenedStillAttributes() {
+    func testSpeechBeforeTheWindowOpenedStillAttributes() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -227,7 +227,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(received, [.yes])
     }
 
-    func testComposedMidUtteranceAnchorsTheClock() {
+    func testComposedMidUtteranceAnchorsTheClock() async {
         let inner = FakeVoice()
         let signal = FakeSignal(speaking: true) // already talking when composed
         let clock = Clock()
@@ -242,7 +242,7 @@ final class WearerGatedVoiceTests: XCTestCase {
 
     // MARK: - Ownership and lifecycle
 
-    func testClaimsTheSpeakingChangeObserver() {
+    func testClaimsTheSpeakingChangeObserver() async {
         let signal = FakeSignal()
         XCTAssertNil(signal.onWearerSpeakingChange)
         let clock = Clock()
@@ -252,7 +252,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         withExtendedLifetime(gate) {}
     }
 
-    func testStartAndStopForwardToInner() {
+    func testStartAndStopForwardToInner() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -263,7 +263,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(inner.stops, 1)
     }
 
-    func testNeverTouchesTheMicrophoneOnSignalTransitions() {
+    func testNeverTouchesTheMicrophoneOnSignalTransitions() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -276,7 +276,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(inner.stops, 0)
     }
 
-    func testCommandAfterStopIsDropped() {
+    func testCommandAfterStopIsDropped() async {
         let inner = FakeVoice()
         let signal = FakeSignal(available: false)
         let clock = Clock()
@@ -288,7 +288,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(received, [])
     }
 
-    func testAttributionSurvivesAcrossWindows() {
+    func testAttributionSurvivesAcrossWindows() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let clock = Clock()
@@ -306,7 +306,7 @@ final class WearerGatedVoiceTests: XCTestCase {
 
     // MARK: - Composition with SpeechGatedVoice
 
-    func testStackedWithSpeechGateBothPoliciesApply() {
+    func testStackedWithSpeechGateBothPoliciesApply() async {
         let inner = FakeVoice()
         let signal = FakeSignal()
         let activity = FakeActivity()
@@ -334,7 +334,7 @@ final class WearerGatedVoiceTests: XCTestCase {
         XCTAssertEqual(received, [.yes])
     }
 
-    func testStackedWithSpeechGateFailsOpenWhenSignalUnavailable() {
+    func testStackedWithSpeechGateFailsOpenWhenSignalUnavailable() async {
         let inner = FakeVoice()
         let signal = FakeSignal(available: false)
         let activity = FakeActivity()
@@ -351,7 +351,7 @@ final class WearerGatedVoiceTests: XCTestCase {
     /// WearerGatedVoice wrapping the raw voice, with a *stale* signal (isSignalAvailable
     /// false). The gate must pass every command through verbatim — the exact behavior of a
     /// serve without --wearer-gate.
-    func testFullStackWithStaleSignalIsVerbatimPassthrough() {
+    func testFullStackWithStaleSignalIsVerbatimPassthrough() async {
         let inner = FakeVoice()
         let signal = FakeSignal(available: false)
         let activity = FakeActivity()

--- a/Tests/TapQInteractionBaselineTests/WearerGatedVoiceTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerGatedVoiceTests.swift
@@ -1,0 +1,349 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+@MainActor
+final class WearerGatedVoiceTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    /// A wearer-speech signal whose transitions and availability the test drives by hand.
+    @MainActor
+    final class FakeSignal: WearerSpeechSignaling {
+        private(set) var isWearerSpeaking = false
+        var isSignalAvailable = true
+        var onWearerSpeakingChange: (@MainActor (Bool) -> Void)?
+
+        init(speaking: Bool = false, available: Bool = true) {
+            isWearerSpeaking = speaking
+            isSignalAvailable = available
+        }
+
+        func setSpeaking(_ speaking: Bool) {
+            guard speaking != isWearerSpeaking else { return }
+            isWearerSpeaking = speaking
+            onWearerSpeakingChange?(speaking)
+        }
+
+        /// A detector that believes the wearer is silent and never changes its mind —
+        /// the shape a wedged analyzer takes while still reporting itself available.
+        func wedgeQuiet() {
+            isWearerSpeaking = false
+            isSignalAvailable = true
+        }
+    }
+
+    /// stop() deliberately does NOT clear onCommand: it simulates the recognizer's
+    /// main-actor Task hop, where a match can reach the decorator after teardown began.
+    @MainActor
+    final class FakeVoice: VoiceCommandProviding {
+        var onCommand: (@MainActor (VoiceCommand) -> Void)?
+        private(set) var starts = 0
+        private(set) var stops = 0
+        func start(onCommand: @escaping @MainActor (VoiceCommand) -> Void) {
+            starts += 1
+            self.onCommand = onCommand
+        }
+        func stop() { stops += 1 }
+        func fire(_ command: VoiceCommand) { onCommand?(command) }
+    }
+
+    @MainActor
+    final class FakeActivity: SpeechActivitySignaling {
+        private(set) var isSpeaking = false
+        var onSpeakingChange: (@MainActor (Bool) -> Void)?
+        func setSpeaking(_ speaking: Bool) {
+            guard speaking != isSpeaking else { return }
+            isSpeaking = speaking
+            onSpeakingChange?(speaking)
+        }
+    }
+
+    /// Test-controlled monotonic clock; the attribution window looks backwards from
+    /// delivery time, so tests must own "now".
+    private final class Clock {
+        var now: TimeInterval = 100
+        func advance(_ seconds: TimeInterval) { now += seconds }
+    }
+
+    private func makeGate(inner: FakeVoice,
+                          signal: FakeSignal,
+                          clock: Clock,
+                          window: TimeInterval = 2.0,
+                          sink: RecordingSink = RecordingSink()) -> WearerGatedVoice {
+        WearerGatedVoice(wrapping: inner, signal: signal, attributionWindow: window,
+                         monotonicNow: { clock.now }, diagnosticSink: sink)
+    }
+
+    // MARK: - Fail open
+
+    func testPassesThroughWhenSignalUnavailable() {
+        let inner = FakeVoice()
+        let signal = FakeSignal(available: false)
+        let clock = Clock()
+        let sink = RecordingSink()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock, sink: sink)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes], "no signal must reproduce today's shipped behavior")
+        XCTAssertEqual(sink.names, ["command.passed_signal_unavailable"])
+    }
+
+    func testWedgedSignalStillDeliversWhenUnavailable() {
+        let inner = FakeVoice()
+        let signal = FakeSignal(available: false)
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        // The analyzer never fires a single transition — the failure mode that would
+        // otherwise silently swallow every command.
+        clock.advance(600)
+        inner.fire(.no)
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.no, .yes])
+    }
+
+    func testAvailabilityLostMidWindowReopensTheGate() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        inner.fire(.yes)
+        XCTAssertEqual(received, [], "silent wearer, signal healthy")
+        signal.isSignalAvailable = false // AirPods sleep, stream goes stale
+        inner.fire(.no)
+        XCTAssertEqual(received, [.no], "degradation must fail open immediately")
+    }
+
+    // MARK: - Attribution
+
+    func testPassesWhileWearerIsSpeaking() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        signal.setSpeaking(true)
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    func testPassesWithinTrailingAttributionWindow() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock, window: 2.0)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        signal.setSpeaking(true)
+        clock.advance(0.4)
+        signal.setSpeaking(false)
+        clock.advance(0.5) // recognizer latency: the match lands after the utterance ends
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    func testRejectsWhenWearerNeverSpoke() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let sink = RecordingSink()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock, sink: sink)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        inner.fire(.yes) // a colleague across the desk said "yes"
+        XCTAssertEqual(received, [])
+        XCTAssertEqual(sink.names, ["command.rejected_nonwearer"])
+        XCTAssertEqual(sink.events.first?.fields["since_wearer_speech_seconds"], "never")
+    }
+
+    func testRejectsAfterWindowExpiry() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let sink = RecordingSink()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock, window: 2.0, sink: sink)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        clock.advance(2.5)
+        inner.fire(.yes)
+        XCTAssertEqual(received, [])
+        XCTAssertEqual(sink.events.first?.fields["since_wearer_speech_seconds"], "2.500")
+        XCTAssertEqual(sink.events.first?.fields["attribution_window_seconds"], "2.000")
+    }
+
+    func testWindowBoundaryIsInclusive() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock, window: 2.0)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        clock.advance(2.0)
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    func testSpeechBeforeTheWindowOpenedStillAttributes() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock, window: 2.0)
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        clock.advance(0.3)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) } // window opens after the wearer already spoke
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    func testComposedMidUtteranceAnchorsTheClock() {
+        let inner = FakeVoice()
+        let signal = FakeSignal(speaking: true) // already talking when composed
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock, window: 2.0)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        signal.setSpeaking(false)
+        clock.advance(0.1)
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    // MARK: - Ownership and lifecycle
+
+    func testClaimsTheSpeakingChangeObserver() {
+        let signal = FakeSignal()
+        XCTAssertNil(signal.onWearerSpeakingChange)
+        let clock = Clock()
+        let gate = makeGate(inner: FakeVoice(), signal: signal, clock: clock)
+        XCTAssertNotNil(signal.onWearerSpeakingChange,
+                        "the wrapper must own the single-observer signal")
+        withExtendedLifetime(gate) {}
+    }
+
+    func testStartAndStopForwardToInner() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock)
+        gate.start { _ in }
+        XCTAssertEqual(inner.starts, 1)
+        gate.stop()
+        XCTAssertEqual(inner.stops, 1)
+    }
+
+    func testNeverTouchesTheMicrophoneOnSignalTransitions() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock)
+        gate.start { _ in }
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        signal.isSignalAvailable = false
+        XCTAssertEqual(inner.starts, 1, "mic lifecycle belongs to SpeechGatedVoice")
+        XCTAssertEqual(inner.stops, 0)
+    }
+
+    func testCommandAfterStopIsDropped() {
+        let inner = FakeVoice()
+        let signal = FakeSignal(available: false)
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        gate.stop()
+        inner.fire(.yes) // in-flight match landing after teardown
+        XCTAssertEqual(received, [])
+    }
+
+    func testAttributionSurvivesAcrossWindows() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let clock = Clock()
+        let gate = makeGate(inner: inner, signal: signal, clock: clock, window: 2.0)
+        gate.start { _ in }
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        gate.stop()
+        clock.advance(0.2)
+        var received: [VoiceCommand] = []
+        gate.start { received.append($0) }
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    // MARK: - Composition with SpeechGatedVoice
+
+    func testStackedWithSpeechGateBothPoliciesApply() {
+        let inner = FakeVoice()
+        let signal = FakeSignal()
+        let activity = FakeActivity()
+        let clock = Clock()
+        let attributed = makeGate(inner: inner, signal: signal, clock: clock, window: 2.0)
+        let gated = SpeechGatedVoice(wrapping: attributed, activity: activity)
+        var received: [VoiceCommand] = []
+        gated.start { received.append($0) }
+        XCTAssertEqual(inner.starts, 1, "outer gate opens the mic through the inner filter")
+
+        // 1. Wearer silent: attribution rejects even though TTS is idle.
+        inner.fire(.yes)
+        XCTAssertEqual(received, [])
+
+        // 2. Wearer speaks: the command survives both layers.
+        signal.setSpeaking(true)
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes])
+
+        // 3. TTS starts: the outer gate tears the session down and drops in-flight matches
+        //    even though attribution would have accepted them.
+        activity.setSpeaking(true)
+        XCTAssertEqual(inner.stops, 1)
+        inner.fire(.no)
+        XCTAssertEqual(received, [.yes])
+    }
+
+    func testStackedWithSpeechGateFailsOpenWhenSignalUnavailable() {
+        let inner = FakeVoice()
+        let signal = FakeSignal(available: false)
+        let activity = FakeActivity()
+        let clock = Clock()
+        let attributed = makeGate(inner: inner, signal: signal, clock: clock)
+        let gated = SpeechGatedVoice(wrapping: attributed, activity: activity)
+        var received: [VoiceCommand] = []
+        gated.start { received.append($0) }
+        inner.fire(.yes)
+        XCTAssertEqual(received, [.yes], "degraded attribution must not change shipped behavior")
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
@@ -1,0 +1,654 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+@MainActor
+final class WearerTurnCoordinatorTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    /// A wearer-speech signal whose transitions and availability the test drives by hand.
+    @MainActor
+    private final class FakeSignal: WearerSpeechSignaling {
+        private(set) var isWearerSpeaking = false
+        var isSignalAvailable = true
+        var onWearerSpeakingChange: (@MainActor (Bool) -> Void)?
+
+        init(speaking: Bool = false, available: Bool = true) {
+            isWearerSpeaking = speaking
+            isSignalAvailable = available
+        }
+
+        func setSpeaking(_ speaking: Bool) {
+            guard speaking != isWearerSpeaking else { return }
+            isWearerSpeaking = speaking
+            onWearerSpeakingChange?(speaking)
+        }
+    }
+
+    /// Recording closure that counts invocations and tracks per-call details.
+    @MainActor
+    private final class CallRecorder {
+        private(set) var endpointCount = 0
+        private(set) var interruptCount = 0
+
+        var endpoint: @MainActor () -> Void {
+            { [weak self] in self?.endpointCount += 1 }
+        }
+
+        var interruptPlayback: @MainActor () -> Void {
+            { [weak self] in self?.interruptCount += 1 }
+        }
+    }
+
+    // MARK: - Factory
+
+    private func makeCoordinator(
+        signal: FakeSignal,
+        recorder: CallRecorder,
+        responsePlaying: @escaping @MainActor () -> Bool = { false },
+        turnActive: @escaping @MainActor () -> Bool = { true },
+        endpointDelay: TimeInterval = 0.01,
+        delaySleep: @escaping @MainActor (TimeInterval) async -> Void = { _ in }
+    ) -> WearerTurnCoordinator {
+        WearerTurnCoordinator(
+            signal: signal,
+            endpoint: recorder.endpoint,
+            interruptPlayback: recorder.interruptPlayback,
+            isResponsePlaying: responsePlaying,
+            isUserTurnActive: turnActive,
+            endpointDelay: endpointDelay,
+            delaySleep: delaySleep
+        )
+    }
+
+    /// Yields the main actor enough for async timer tasks to settle.
+    private func settle() async {
+        for _ in 0..<4 { await Task.yield() }
+    }
+
+    // MARK: - Endpointing basics
+
+    func testEndpointFiresOnceAfterDelay() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(signal: signal, recorder: recorder)
+        coordinator.start()
+
+        // Onset: wearer starts speaking.
+        signal.setSpeaking(true)
+        // Offset: wearer stops speaking.
+        signal.setSpeaking(false)
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 1, "endpoint should fire once after delay")
+    }
+
+    func testEndpointFiresOnlyOncePerTurn() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(signal: signal, recorder: recorder)
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        // A second onset/offset in the same turn should NOT fire again.
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 1,
+                       "endpoint fires only once per turn (per start())")
+    }
+
+    func testResumeWithinDelayCancelsEndpoint() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        var sleepContinuation: CheckedContinuation<Void, Never>?
+
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            delaySleep: { _ in
+                await withCheckedContinuation { continuation in
+                    sleepContinuation = continuation
+                }
+            }
+        )
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        // The sleep is suspended (timer running). Resume speaking.
+        signal.setSpeaking(true)
+        // Now let the sleep finish.
+        sleepContinuation?.resume()
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 0,
+                       "resuming speech before delay expires cancels the endpoint")
+    }
+
+    // MARK: - Warm-up guard
+
+    func testNoEndpointWithoutPriorOnsetInTurn() async {
+        let signal = FakeSignal(speaking: true)
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(signal: signal, recorder: recorder)
+        coordinator.start()
+
+        // Stop speaking without a prior startedSpeaking transition in this turn.
+        // The signal was already speaking when start() was called, so no onset
+        // transition fired.
+        signal.setSpeaking(false)
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 0,
+                       "no endpoint without a prior onset in-turn (warm-up guard)")
+    }
+
+    func testOnsetThenOffsetInTurnDoesEndpoint() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(signal: signal, recorder: recorder)
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 1)
+    }
+
+    // MARK: - Signal unavailable
+
+    func testNoEndpointWhenSignalUnavailable() async {
+        let signal = FakeSignal(available: false)
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(signal: signal, recorder: recorder)
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 0,
+                       "coordinator ignores transitions when signal is unavailable")
+    }
+
+    func testNoEndpointWhenSignalBecomesUnavailableDuringDelay() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        var sleepContinuation: CheckedContinuation<Void, Never>?
+
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            delaySleep: { _ in
+                await withCheckedContinuation { continuation in
+                    sleepContinuation = continuation
+                }
+            }
+        )
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        // While the delay is in flight, the signal becomes unavailable.
+        signal.isSignalAvailable = false
+        sleepContinuation?.resume()
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 0,
+                       "stale signal during delay prevents endpoint (fail open)")
+    }
+
+    // MARK: - Turn active guard
+
+    func testNoEndpointWhenTurnNotActive() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            turnActive: { false }
+        )
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 0,
+                       "no endpoint when user turn is not active")
+    }
+
+    func testNoEndpointWhenTurnResolvedDuringDelay() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        var turnActive = true
+        var sleepContinuation: CheckedContinuation<Void, Never>?
+
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            turnActive: { turnActive },
+            delaySleep: { _ in
+                await withCheckedContinuation { continuation in
+                    sleepContinuation = continuation
+                }
+            }
+        )
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        // Turn resolved by a match while delay is in flight.
+        turnActive = false
+        sleepContinuation?.resume()
+        await settle()
+
+        XCTAssertEqual(recorder.endpointCount, 0,
+                       "no endpoint when the turn resolved during delay")
+    }
+
+    // MARK: - Barge-in
+
+    func testBargeInFiresOncePerPlayingResponse() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        var responsePlaying = true
+
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            responsePlaying: { responsePlaying }
+        )
+        coordinator.start()
+
+        // Speech onset while response is playing -> barge-in.
+        signal.setSpeaking(true)
+        XCTAssertEqual(recorder.interruptCount, 1)
+
+        // A second onset during the same response should NOT fire again.
+        signal.setSpeaking(false)
+        signal.setSpeaking(true)
+        XCTAssertEqual(recorder.interruptCount, 1,
+                       "barge-in fires once per response")
+    }
+
+    func testBargeInResetsForNewResponse() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        var responsePlaying = true
+
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            responsePlaying: { responsePlaying }
+        )
+        coordinator.start()
+
+        // First response: barge-in fires.
+        signal.setSpeaking(true)
+        XCTAssertEqual(recorder.interruptCount, 1)
+
+        // Response ends.
+        responsePlaying = false
+        signal.setSpeaking(false)
+
+        // New response: barge-in should fire again.
+        responsePlaying = true
+        signal.setSpeaking(true)
+        XCTAssertEqual(recorder.interruptCount, 2)
+    }
+
+    func testBargeInDoesNotFireWhenIdle() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            responsePlaying: { false }
+        )
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        XCTAssertEqual(recorder.interruptCount, 0,
+                       "no barge-in when no response is playing")
+    }
+
+    // MARK: - Armed/disarmed
+
+    func testNoCallsAfterStop() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        var responsePlaying = true
+
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            responsePlaying: { responsePlaying }
+        )
+        coordinator.start()
+        coordinator.stop()
+
+        // Try endpoint path.
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        // Try barge-in path.
+        signal.setSpeaking(true)
+
+        XCTAssertEqual(recorder.endpointCount, 0,
+                       "no endpoint after stop()")
+        XCTAssertEqual(recorder.interruptCount, 0,
+                       "no barge-in after stop()")
+    }
+
+    func testNoCallsBeforeStart() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        var responsePlaying = true
+
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            responsePlaying: { responsePlaying }
+        )
+        // Note: start() NOT called.
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        signal.setSpeaking(true)
+
+        XCTAssertEqual(recorder.endpointCount, 0)
+        XCTAssertEqual(recorder.interruptCount, 0)
+    }
+
+    func testRestartResetsState() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(signal: signal, recorder: recorder)
+
+        coordinator.start()
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+        XCTAssertEqual(recorder.endpointCount, 1)
+
+        // Second start resets everything.
+        coordinator.start()
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+        XCTAssertEqual(recorder.endpointCount, 2,
+                       "restart() allows endpoint to fire again for the new turn")
+    }
+
+    // MARK: - Wedged signal: coordinator never blocks existing paths
+
+    /// Composing the coordinator with a full provider and ScriptedVoiceBackend: match-on-
+    /// transcript and window timeout behave identically with the coordinator attached and
+    /// the signal dead.
+    func testWedgedSignalDoesNotBlockMatchResolution() async {
+        let signal = FakeSignal()
+        signal.isSignalAvailable = true
+        // Wedge: signal reports quiet and never changes.
+
+        let backend = ScriptedVoiceBackend()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: { text in
+                text.lowercased().contains("yes") ? .yes : nil
+            },
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            idleSleep: { _ in },
+            diagnosticSink: NoOpTapQDiagnosticSink()
+        )
+
+        let recorder = CallRecorder()
+        let coordinator = WearerTurnCoordinator(
+            signal: signal,
+            endpoint: { provider.endActiveTurn() },
+            interruptPlayback: { provider.cancelActiveResponse() },
+            isResponsePlaying: { provider.isResponseInFlight },
+            isUserTurnActive: { provider.isUserTurnActiveForCoordination },
+            delaySleep: { _ in }
+        )
+        coordinator.start()
+
+        var received: [VoiceCommand] = []
+        provider.start { received.append($0) }
+        await settle()
+
+        // Match-on-transcript resolves the window normally.
+        backend.emit(.transcriptPartial("yes"))
+        XCTAssertEqual(received, [.yes],
+                       "match resolution works with coordinator attached and signal wedged")
+
+        // The coordinator should not have fired anything.
+        XCTAssertEqual(recorder.endpointCount, 0)
+        XCTAssertEqual(recorder.interruptCount, 0)
+    }
+
+    // MARK: - End-to-end shaped test: scripted pipe backend + coordinator
+
+    /// Simulates the OpenAI-shaped flow from the findings: wearer speaks -> endpoint
+    /// commits -> post-commit transcript -> command matched.
+    func testEndToEndEndpointingFlow() async {
+        let signal = FakeSignal()
+        let backend = ScriptedVoiceBackend()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: { text in
+                text.lowercased().contains("yes") ? .yes : nil
+            },
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            idleSleep: { _ in },
+            diagnosticSink: NoOpTapQDiagnosticSink()
+        )
+
+        let coordinator = WearerTurnCoordinator(
+            signal: signal,
+            endpoint: { provider.endActiveTurn() },
+            interruptPlayback: { provider.cancelActiveResponse() },
+            isResponsePlaying: { provider.isResponseInFlight },
+            isUserTurnActive: { provider.isUserTurnActiveForCoordination },
+            delaySleep: { _ in }
+        )
+        coordinator.start()
+
+        var received: [VoiceCommand] = []
+        provider.start { received.append($0) }
+        await settle()
+
+        XCTAssertTrue(provider.isUserTurnActiveForCoordination)
+
+        // Wearer starts speaking.
+        signal.setSpeaking(true)
+        // Wearer stops speaking -> endpoint fires after delay (instant in test).
+        signal.setSpeaking(false)
+        await settle()
+
+        // The endpoint committed the turn.
+        XCTAssertFalse(provider.isUserTurnActiveForCoordination,
+                       "endActiveTurn was called by the endpoint")
+        XCTAssertTrue(backend.calls.contains(.endUserTurn))
+
+        // Post-commit transcript arrives (the OpenAI path: transcripts exist only after
+        // commit). The handler is still armed, so a match resolves the window.
+        backend.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(received, [.yes],
+                       "post-commit transcript resolves the window")
+    }
+
+    /// Simulates barge-in during response audio: onset -> flush + cancel -> next turn
+    /// resolves by transcript.
+    func testEndToEndBargeInFlow() async {
+        let signal = FakeSignal()
+        let backend = ScriptedVoiceBackend()
+        let fakePlayback = FakePlaybackForCoordinator()
+
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: { text in
+                text.lowercased().contains("yes") ? .yes : nil
+            },
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            responseAudio: fakePlayback,
+            idleSleep: { _ in },
+            diagnosticSink: NoOpTapQDiagnosticSink()
+        )
+
+        var speechStopAllCount = 0
+        let coordinator = WearerTurnCoordinator(
+            signal: signal,
+            endpoint: { provider.endActiveTurn() },
+            interruptPlayback: {
+                fakePlayback.stopAndFlush()
+                provider.cancelActiveResponse()
+                speechStopAllCount += 1
+            },
+            isResponsePlaying: { fakePlayback.isPlaying },
+            isUserTurnActive: { provider.isUserTurnActiveForCoordination },
+            delaySleep: { _ in }
+        )
+        coordinator.start()
+
+        var received: [VoiceCommand] = []
+        provider.start { received.append($0) }
+        await settle()
+
+        // Backend starts sending response audio.
+        let chunk = VoiceAudioChunk(data: Data([1, 2, 3, 4]),
+                                     format: .pcm16Mono24k, timestamp: 1.0)
+        backend.emit(.audio(chunk))
+        XCTAssertTrue(fakePlayback.isPlaying)
+        XCTAssertTrue(provider.isResponseInFlight)
+
+        // Wearer starts speaking during response -> barge-in.
+        signal.setSpeaking(true)
+        XCTAssertEqual(speechStopAllCount, 1, "speech.stopAll() called on barge-in")
+        XCTAssertTrue(backend.calls.contains(.cancelResponse),
+                      "cancelActiveResponse sends cancelResponse to backend")
+        XCTAssertFalse(fakePlayback.isPlaying,
+                       "playback flushed on barge-in")
+    }
+
+    // MARK: - Default endpoint delay
+
+    func testDefaultEndpointDelayIs04Seconds() {
+        XCTAssertEqual(WearerTurnCoordinator.defaultEndpointDelay, 0.4,
+                       "the provisional endpoint delay constant is 0.4 s")
+    }
+
+    // MARK: - Speech.stopAll() documented as deliberately blunt
+
+    func testBargeInCallsInterruptPlaybackClosure() async {
+        let signal = FakeSignal()
+        let recorder = CallRecorder()
+        let coordinator = makeCoordinator(
+            signal: signal,
+            recorder: recorder,
+            responsePlaying: { true }
+        )
+        coordinator.start()
+
+        signal.setSpeaking(true)
+        XCTAssertEqual(recorder.interruptCount, 1,
+                       "interruptPlayback closure is called on barge-in (speech.stopAll() is " +
+                       "the documented blunt implementation)")
+    }
+
+    // MARK: - ScriptedVoiceBackend (shared with provider tests, duplicated for isolation)
+
+    /// Minimal scripted backend for end-to-end tests.
+    @MainActor
+    private final class ScriptedVoiceBackend: VoiceBackend {
+        enum Call: Equatable {
+            case open, close, beginUserTurn, endUserTurn
+            case sendAudio(Int), requestResponse(String), cancelResponse
+        }
+
+        let capabilities: VoiceBackendCapabilities
+        private(set) var calls: [Call] = []
+        private(set) var handlers: [(@MainActor (VoiceBackendEvent) -> Void)] = []
+        private(set) var isOpen = false
+        private(set) var isTurnActive = false
+
+        init(capabilities: VoiceBackendCapabilities = .transcriptOnly) {
+            self.capabilities = capabilities
+        }
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            calls.append(.open)
+            isOpen = true
+            handlers.append(onEvent)
+        }
+
+        func close() {
+            calls.append(.close)
+            isOpen = false
+            isTurnActive = false
+        }
+
+        func beginUserTurn() {
+            calls.append(.beginUserTurn)
+            isTurnActive = true
+        }
+
+        func endUserTurn() {
+            calls.append(.endUserTurn)
+            isTurnActive = false
+        }
+
+        func sendAudio(_ chunk: VoiceAudioChunk) {
+            calls.append(.sendAudio(chunk.data.count))
+        }
+
+        func requestResponse(text: String) {
+            calls.append(.requestResponse(text))
+        }
+
+        func cancelResponse() {
+            calls.append(.cancelResponse)
+        }
+
+        func emit(_ event: VoiceBackendEvent, toHandler index: Int? = nil) {
+            guard !handlers.isEmpty else { return }
+            handlers[index ?? handlers.count - 1](event)
+        }
+    }
+
+    /// Minimal fake playback for end-to-end tests.
+    @MainActor
+    private final class FakePlaybackForCoordinator: VoiceResponseAudioPlaying {
+        private(set) var isPlaying = false
+        var onPlayingChange: (@MainActor (Bool) -> Void)?
+
+        func enqueue(_ chunk: VoiceAudioChunk) {
+            if !isPlaying {
+                isPlaying = true
+                onPlayingChange?(true)
+            }
+        }
+
+        func finishStream() {}
+
+        func stopAndFlush() {
+            guard isPlaying else { return }
+            isPlaying = false
+            onPlayingChange?(false)
+        }
+    }
+
+}

--- a/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
@@ -259,7 +259,7 @@ final class WearerTurnCoordinatorTests: XCTestCase {
     func testBargeInFiresOncePerPlayingResponse() async {
         let signal = FakeSignal()
         let recorder = CallRecorder()
-        var responsePlaying = true
+        let responsePlaying = true
 
         let coordinator = makeCoordinator(
             signal: signal,
@@ -325,7 +325,7 @@ final class WearerTurnCoordinatorTests: XCTestCase {
     func testNoCallsAfterStop() async {
         let signal = FakeSignal()
         let recorder = CallRecorder()
-        var responsePlaying = true
+        let responsePlaying = true
 
         let coordinator = makeCoordinator(
             signal: signal,
@@ -352,7 +352,7 @@ final class WearerTurnCoordinatorTests: XCTestCase {
     func testNoCallsBeforeStart() async {
         let signal = FakeSignal()
         let recorder = CallRecorder()
-        var responsePlaying = true
+        let responsePlaying = true
 
         let coordinator = makeCoordinator(
             signal: signal,
@@ -369,6 +369,7 @@ final class WearerTurnCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(recorder.endpointCount, 0)
         XCTAssertEqual(recorder.interruptCount, 0)
+        withExtendedLifetime(coordinator) {}
     }
 
     func testRestartResetsState() async {
@@ -662,7 +663,7 @@ final class WearerTurnCoordinatorTests: XCTestCase {
 
     // MARK: - Default endpoint delay
 
-    func testDefaultEndpointDelayIs04Seconds() {
+    func testDefaultEndpointDelayIs04Seconds() async {
         XCTAssertEqual(WearerTurnCoordinator.defaultEndpointDelay, 0.4,
                        "the provisional endpoint delay constant is 0.4 s")
     }

--- a/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
@@ -722,9 +722,11 @@ final class WearerTurnCoordinatorTests: XCTestCase {
             isTurnActive = true
         }
 
-        func endUserTurn() {
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool {
             calls.append(.endUserTurn)
             isTurnActive = false
+            return false
         }
 
         func sendAudio(_ chunk: VoiceAudioChunk) {

--- a/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
@@ -599,6 +599,12 @@ final class WearerTurnCoordinatorTests: XCTestCase {
         backend.emit(.transcriptFinal("yes"))
         XCTAssertEqual(received, [.yes])
 
+        // The response triggered by endActiveTurn's endUserTurn completes. On the real
+        // OpenAI path, commit + response.create run synchronously in endUserTurn, and
+        // responseCompleted arrives after the model finishes. The provider tracks this
+        // lifecycle to avoid calling beginUserTurn into a responding adapter.
+        backend.emit(.responseCompleted)
+
         // --- Window 2 (no coordinator.stop()/start() in between) ---
         provider.start { received.append($0) }
         await settle()

--- a/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
@@ -544,6 +544,116 @@ final class WearerTurnCoordinatorTests: XCTestCase {
                        "playback flushed on barge-in")
     }
 
+    // MARK: - Per-turn re-arm across windows without stop()/start()
+
+    /// Regression for the serve-lifetime bug: the coordinator is start()-ed once at serve
+    /// startup and never stop()/start()-ed per window. After the first endpoint fires,
+    /// endpointFired blocks all later endpoints. This test fires two endpoints across two
+    /// windows without an intervening coordinator.stop() — the coordinator must re-arm
+    /// automatically when it detects a new turn via a rising edge of isUserTurnActive().
+    func testEndpointFiresAcrossMultipleWindowsWithoutCoordinatorStop() async {
+        let signal = FakeSignal()
+        let backend = ScriptedVoiceBackend()
+        let provider = VoiceBackendCommandProvider(
+            backend: backend,
+            match: { text in
+                text.lowercased().contains("yes") ? .yes : nil
+            },
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            idleSleep: { _ in },
+            diagnosticSink: NoOpTapQDiagnosticSink()
+        )
+
+        var endpointCount = 0
+        let coordinator = WearerTurnCoordinator(
+            signal: signal,
+            endpoint: {
+                endpointCount += 1
+                provider.endActiveTurn()
+            },
+            interruptPlayback: { provider.cancelActiveResponse() },
+            isResponsePlaying: { provider.isResponseInFlight },
+            isUserTurnActive: { provider.isUserTurnActiveForCoordination },
+            delaySleep: { _ in }
+        )
+
+        // Armed once for the serve lifetime — no stop()/start() per window.
+        coordinator.start()
+
+        var received: [VoiceCommand] = []
+
+        // --- Window 1 ---
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(provider.isUserTurnActiveForCoordination)
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        XCTAssertEqual(endpointCount, 1, "first window endpoint fires")
+        XCTAssertFalse(provider.isUserTurnActiveForCoordination)
+
+        // Post-commit transcript resolves window 1.
+        backend.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(received, [.yes])
+
+        // --- Window 2 (no coordinator.stop()/start() in between) ---
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(provider.isUserTurnActiveForCoordination)
+
+        signal.setSpeaking(true)
+        signal.setSpeaking(false)
+        await settle()
+
+        XCTAssertEqual(endpointCount, 2,
+                       "second window endpoint must fire — the coordinator re-arms per turn")
+        XCTAssertFalse(provider.isUserTurnActiveForCoordination)
+
+        backend.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(received, [.yes, .yes])
+    }
+
+    /// Same scenario but three windows deep, proving the re-arm is not a one-shot fix.
+    /// Uses a manual turnActive variable with an endpoint closure that simulates the
+    /// real endActiveTurn behavior (setting turnActive to false on endpoint fire).
+    func testEndpointFiresAcrossThreeWindowsWithoutCoordinatorStop() async {
+        let signal = FakeSignal()
+        var turnActive = false
+        var endpointCount = 0
+
+        let coord = WearerTurnCoordinator(
+            signal: signal,
+            endpoint: {
+                endpointCount += 1
+                // Simulate endActiveTurn: the endpoint commits the turn.
+                turnActive = false
+            },
+            interruptPlayback: {},
+            isResponsePlaying: { false },
+            isUserTurnActive: { turnActive },
+            endpointDelay: 0.01,
+            delaySleep: { _ in }
+        )
+        coord.start()
+
+        for window in 1...3 {
+            // Simulate a new turn opening.
+            turnActive = true
+            // Trigger transitions: onset (re-arm + warm-up), offset (endpoint timer).
+            signal.setSpeaking(true)
+            signal.setSpeaking(false)
+            await settle()
+
+            XCTAssertEqual(endpointCount, window,
+                           "endpoint must fire in window \(window)")
+            XCTAssertFalse(turnActive,
+                           "endpoint must have committed the turn in window \(window)")
+        }
+    }
+
     // MARK: - Default endpoint delay
 
     func testDefaultEndpointDelayIs04Seconds() {

--- a/Tests/TapQPOSIXBridgeClientTests/BrokerDiscoveryTests.swift
+++ b/Tests/TapQPOSIXBridgeClientTests/BrokerDiscoveryTests.swift
@@ -21,7 +21,7 @@ final class BrokerDiscoveryTests: XCTestCase {
 
     func testReadsServerOwnedRecordIncludingProtocolVersion() throws {
         let record = """
-        {"socket":"/tmp/tapq.sock","token":"tok","protocol_version":3,\
+        {"socket":"/tmp/tapq.sock","token":"tok","protocol_version":\(WireProtocol.version),\
         "steering_enabled":true,"process_id":\(ProcessInfo.processInfo.processIdentifier)}
         """
         try Data(record.utf8).write(to: discovery.discoveryURL)

--- a/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
@@ -1,0 +1,377 @@
+import XCTest
+@testable import TapQVoiceBackends
+import TapQContracts
+
+@MainActor
+final class FailThroughVoiceBackendTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        var names: [String] { events.map(\.name) }
+    }
+
+    @MainActor
+    final class EventLog {
+        private(set) var events: [VoiceBackendEvent] = []
+        func append(_ event: VoiceBackendEvent) { events.append(event) }
+        var failures: [VoiceBackendFailure] {
+            events.compactMap { if case .sessionFailed(let f) = $0 { return f } else { return nil } }
+        }
+    }
+
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    private let chunk = VoiceAudioChunk(data: Data(repeating: 3, count: 64),
+                                        format: .pcm16Mono24k, timestamp: 0)
+
+    private func makeBackends(sink: RecordingSink = RecordingSink())
+        -> (ScriptedVoiceBackend, ScriptedVoiceBackend, FailThroughVoiceBackend) {
+        let primary = ScriptedVoiceBackend(
+            name: "primary",
+            capabilities: VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                   duplex: true))
+        let fallback = ScriptedVoiceBackend(name: "fallback")
+        return (primary, fallback,
+                FailThroughVoiceBackend(primary: primary, fallback: fallback,
+                                        diagnosticSink: sink))
+    }
+
+    // MARK: - Healthy primary
+
+    func testAHealthyPrimaryCostsTheFallbackNothing() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        let events = EventLog()
+
+        try await wrapper.open { events.append($0) }
+        wrapper.beginUserTurn()
+        wrapper.sendAudio(chunk)
+        primary.emit(.transcriptPartial("yes"))
+        wrapper.endUserTurn()
+        wrapper.close()
+
+        XCTAssertEqual(primary.calls,
+                       [.open, .beginUserTurn, .sendAudio(64), .endUserTurn, .close])
+        XCTAssertEqual(fallback.calls, [], "the fallback must be entirely inert until needed")
+        XCTAssertEqual(events.events, [.transcriptPartial("yes")])
+    }
+
+    func testEveryCallIsForwardedToThePrimary() async throws {
+        let (primary, _, wrapper) = makeBackends()
+        try await wrapper.open { _ in }
+
+        wrapper.requestResponse(text: "done")
+        wrapper.cancelResponse()
+
+        XCTAssertEqual(primary.calls, [.open, .requestResponse("done"), .cancelResponse])
+    }
+
+    func testCapabilitiesAreTheIntersectionOfBoth() {
+        let (_, _, wrapper) = makeBackends()
+        XCTAssertEqual(wrapper.capabilities, .transcriptOnly,
+                       "a caller must not be handed a capability the fallback lacks")
+
+        let duplex = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                              duplex: true)
+        let both = FailThroughVoiceBackend(
+            primary: ScriptedVoiceBackend(capabilities: duplex),
+            fallback: ScriptedVoiceBackend(capabilities: duplex))
+        XCTAssertEqual(both.capabilities, duplex)
+    }
+
+    // MARK: - Open-time failover
+
+    func testPrimaryOpenFailureFallsThroughTransparently() async throws {
+        let sink = RecordingSink()
+        let (primary, fallback, wrapper) = makeBackends(sink: sink)
+        primary.openFailure = .network("no route to host")
+        let events = EventLog()
+
+        try await wrapper.open { events.append($0) }
+        wrapper.beginUserTurn()
+        fallback.emit(.transcriptFinal("yes"))
+
+        XCTAssertEqual(primary.calls, [.open], "a session that never opened is not closed")
+        XCTAssertEqual(fallback.calls, [.open, .beginUserTurn])
+        XCTAssertEqual(events.events, [.transcriptFinal("yes")],
+                       "the caller never learns which pipe answered")
+        XCTAssertTrue(sink.names.contains("primary.open_failed"))
+        XCTAssertTrue(sink.names.contains("fallback.opened"))
+    }
+
+    func testBothOpenFailuresSurfaceTheFallbacksFailure() async {
+        let (primary, fallback, wrapper) = makeBackends()
+        primary.openFailure = .network("no route to host")
+        fallback.openFailure = .authorization("speech recognition unavailable")
+
+        do {
+            try await wrapper.open { _ in XCTFail("no session was ever established") }
+            XCTFail("there is nothing left to fall through to")
+        } catch {
+            XCTAssertEqual(error as? VoiceBackendFailure,
+                           .authorization("speech recognition unavailable"))
+        }
+        XCTAssertEqual(primary.calls, [.open])
+        XCTAssertEqual(fallback.calls, [.open])
+    }
+
+    func testAFailedOpenLeavesNothingBehindForTheNextAttempt() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        primary.openFailure = .network("first attempt")
+        fallback.openFailure = .network("first attempt")
+        try? await wrapper.open { _ in }
+
+        primary.openFailure = nil
+        fallback.openFailure = nil
+        try await wrapper.open { _ in }
+
+        XCTAssertEqual(primary.calls, [.open, .open])
+        XCTAssertEqual(fallback.calls, [.open], "the retry starts from the primary again")
+    }
+
+    func testOpeningTwiceIsAProtocolViolation() async throws {
+        let (_, _, wrapper) = makeBackends()
+        try await wrapper.open { _ in }
+
+        do {
+            try await wrapper.open { _ in }
+            XCTFail("a second open on a live session is a programming error")
+        } catch {
+            guard case .protocolViolation? = error as? VoiceBackendFailure else {
+                return XCTFail("expected a protocol violation, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Mid-session failover
+
+    func testMidSessionFailureReopensTheFallbackWithTheActiveTurn() async throws {
+        let sink = RecordingSink()
+        let (primary, fallback, wrapper) = makeBackends(sink: sink)
+        let events = EventLog()
+        try await wrapper.open { events.append($0) }
+        wrapper.beginUserTurn()
+        wrapper.sendAudio(chunk)
+
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        await settle()
+
+        XCTAssertEqual(primary.calls, [.open, .beginUserTurn, .sendAudio(64), .close])
+        XCTAssertEqual(fallback.calls, [.open, .beginUserTurn],
+                       "the wearer is mid-sentence; the window must survive the switch")
+        XCTAssertEqual(events.failures, [], "a recovered session is not a failed one")
+        XCTAssertTrue(sink.names.contains("fallback.turn_resumed"))
+
+        fallback.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(events.events, [.transcriptFinal("yes")])
+    }
+
+    func testMidSessionFailureWithNoTurnOpenDoesNotOpenOne() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        try await wrapper.open { _ in }
+
+        primary.emit(.sessionFailed(.closed("peer hung up")))
+        await settle()
+
+        XCTAssertEqual(fallback.calls, [.open], "state is replayed, not invented")
+    }
+
+    func testAudioArrivingDuringTheSwitchIsDroppedNotMisrouted() async throws {
+        let sink = RecordingSink()
+        let (primary, fallback, wrapper) = makeBackends(sink: sink)
+        fallback.openGate = { await Task.yield() }
+        try await wrapper.open { _ in }
+        wrapper.beginUserTurn()
+
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        wrapper.sendAudio(chunk)
+        await settle()
+
+        XCTAssertFalse(primary.calls.contains(.sendAudio(64)),
+                       "no audio into a backend that is already gone")
+        XCTAssertFalse(fallback.calls.contains(.sendAudio(64)),
+                       "and none into one whose turn has not started")
+        XCTAssertTrue(sink.names.contains("audio.dropped"))
+        XCTAssertEqual(fallback.calls, [.open, .beginUserTurn])
+    }
+
+    func testATurnEndedDuringTheSwitchIsNotResumed() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        fallback.openGate = { await Task.yield() }
+        try await wrapper.open { _ in }
+        wrapper.beginUserTurn()
+
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        wrapper.endUserTurn()
+        await settle()
+
+        XCTAssertEqual(fallback.calls, [.open],
+                       "the window closed while switching; reopening it would reopen the mic")
+    }
+
+    func testFallbackFailureAfterAFailoverSurfacesToTheCaller() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        fallback.openFailure = .authorization("speech recognition unavailable")
+        let events = EventLog()
+        try await wrapper.open { events.append($0) }
+        wrapper.beginUserTurn()
+
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        await settle()
+
+        XCTAssertEqual(events.failures, [.authorization("speech recognition unavailable")],
+                       "with nothing left underneath, the caller has to be told")
+    }
+
+    func testAFallbackSessionFailureIsSurfacedRatherThanFailedOverAgain() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        primary.openFailure = .network("no route to host")
+        let events = EventLog()
+        try await wrapper.open { events.append($0) }
+
+        fallback.emit(.sessionFailed(.network("microphone route changed")))
+        await settle()
+
+        XCTAssertEqual(events.failures, [.network("microphone route changed")])
+        XCTAssertEqual(primary.calls, [.open], "failover happens once, not in a loop")
+    }
+
+    func testLateEventsFromTheDeadPrimaryAreIgnored() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        let events = EventLog()
+        try await wrapper.open { events.append($0) }
+        wrapper.beginUserTurn()
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        await settle()
+
+        primary.emit(.transcriptFinal("yes"), toHandler: 0)
+
+        XCTAssertEqual(events.events, [], "a transcript from the dead pipe resolves nothing")
+        fallback.emit(.transcriptFinal("no"))
+        XCTAssertEqual(events.events, [.transcriptFinal("no")])
+    }
+
+    // MARK: - Teardown
+
+    func testCloseIsIdempotentAndClosesOnlyWhatWasOpened() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        try await wrapper.open { _ in }
+
+        wrapper.close()
+        wrapper.close()
+
+        XCTAssertEqual(primary.calls, [.open, .close])
+        XCTAssertEqual(fallback.calls, [])
+    }
+
+    func testCloseAfterAFailoverClosesTheFallbackOnly() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        try await wrapper.open { _ in }
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        await settle()
+
+        wrapper.close()
+
+        XCTAssertEqual(primary.calls, [.open, .close], "closed once, when it failed")
+        XCTAssertEqual(fallback.calls, [.open, .close])
+    }
+
+    func testCloseDuringAFailoverAbandonsTheFallback() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        let gate = AsyncGate()
+        fallback.openGate = { await gate.wait() }
+        let events = EventLog()
+        try await wrapper.open { events.append($0) }
+        wrapper.beginUserTurn()
+
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        await settle()
+        wrapper.close()
+        gate.open()
+        await settle()
+
+        XCTAssertEqual(fallback.calls, [.open, .close],
+                       "a fallback that finishes opening after close must not be left running")
+        XCTAssertEqual(events.events, [])
+    }
+
+    func testResponseTrafficDuringTheSwitchIsDropped() async throws {
+        let sink = RecordingSink()
+        let (primary, fallback, wrapper) = makeBackends(sink: sink)
+        fallback.openGate = { await Task.yield() }
+        try await wrapper.open { _ in }
+
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        wrapper.requestResponse(text: "into the void")
+        wrapper.cancelResponse()
+        await settle()
+
+        XCTAssertEqual(fallback.calls, [.open],
+                       "a response addressed to a pipe that no longer exists goes nowhere")
+        XCTAssertTrue(sink.names.contains("response.dropped"))
+        XCTAssertTrue(sink.names.contains("cancel.dropped"))
+    }
+
+    func testCloseWithoutOpenTouchesNeitherBackend() {
+        let (primary, fallback, wrapper) = makeBackends()
+
+        wrapper.close()
+
+        XCTAssertEqual(primary.calls, [])
+        XCTAssertEqual(fallback.calls, [])
+    }
+
+    func testEventsAfterCloseAreDropped() async throws {
+        let (primary, _, wrapper) = makeBackends()
+        let events = EventLog()
+        try await wrapper.open { events.append($0) }
+        wrapper.close()
+
+        primary.emit(.transcriptFinal("yes"), toHandler: 0)
+
+        XCTAssertEqual(events.events, [])
+    }
+
+    // MARK: - Composition with the realtime adapter
+
+    /// The shape WP9 composes: a realtime primary that dies mid-window, an on-device
+    /// fallback that answers. Proven above the adapter seam, with a scripted socket.
+    func testARealtimeSessionThatDiesMidWindowResolvesOnTheFallback() async throws {
+        let server = ScriptedRealtimeServer()
+        let primary = OpenAIRealtimeVoiceBackend(transport: server, timeout: 1)
+        let fallback = ScriptedVoiceBackend(name: "apple")
+        let wrapper = FailThroughVoiceBackend(primary: primary, fallback: fallback)
+        let events = EventLog()
+
+        try await wrapper.open { events.append($0) }
+        wrapper.beginUserTurn()
+        wrapper.sendAudio(VoiceAudioChunk(data: Data(repeating: 5, count: 480),
+                                          format: OpenAIRealtimeVoiceBackend.audioFormat,
+                                          timestamp: 0))
+        await settle()
+        XCTAssertEqual(server.sentTypes, ["session.update", "input_audio_buffer.append"])
+
+        server.disconnect()
+        await settle()
+
+        XCTAssertEqual(fallback.calls, [.open, .beginUserTurn])
+        fallback.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(events.events, [.transcriptFinal("yes")])
+        XCTAssertEqual(events.failures, [],
+                       "a dropped socket must never leave the wearer with a dead window")
+    }
+}

--- a/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
@@ -374,4 +374,122 @@ final class FailThroughVoiceBackendTests: XCTestCase {
         XCTAssertEqual(events.failures, [],
                        "a dropped socket must never leave the wearer with a dead window")
     }
+
+    // MARK: - Sticky fail-through
+
+    private func makeStickyBackends(sink: RecordingSink = RecordingSink())
+        -> (ScriptedVoiceBackend, ScriptedVoiceBackend, FailThroughVoiceBackend) {
+        let primary = ScriptedVoiceBackend(
+            name: "primary",
+            capabilities: VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                   duplex: true))
+        let fallback = ScriptedVoiceBackend(name: "fallback")
+        return (primary, fallback,
+                FailThroughVoiceBackend(primary: primary, fallback: fallback,
+                                        stickiness: .stickyAfterFailure,
+                                        diagnosticSink: sink))
+    }
+
+    func testStickyAfterOpenFailureSkipsPrimaryOnNextOpen() async throws {
+        let sink = RecordingSink()
+        let (primary, fallback, wrapper) = makeStickyBackends(sink: sink)
+        primary.openFailure = .network("dead wifi")
+
+        try await wrapper.open { _ in }
+        wrapper.close()
+
+        // Second open: primary should be skipped entirely
+        primary.openFailure = nil
+        try await wrapper.open { _ in }
+
+        XCTAssertEqual(primary.calls, [.open],
+                       "the primary was tried once and then skipped")
+        XCTAssertEqual(fallback.calls, [.open, .close, .open],
+                       "the fallback is used directly after primary failure")
+        XCTAssertTrue(wrapper.isPrimaryStuckForTesting)
+        XCTAssertTrue(sink.names.contains("primary.skipped_sticky"))
+    }
+
+    func testStickyAfterMidSessionFailureSkipsPrimaryOnNextOpen() async throws {
+        let sink = RecordingSink()
+        let (primary, fallback, wrapper) = makeStickyBackends(sink: sink)
+        let events = EventLog()
+        try await wrapper.open { events.append($0) }
+        wrapper.beginUserTurn()
+
+        // Mid-session failure
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        await settle()
+
+        wrapper.close()
+
+        // Next open: primary should be skipped
+        try await wrapper.open { _ in }
+
+        // Primary was tried once (the first open), then the mid-session failure stuck it
+        let primaryOpens = primary.calls.filter { $0 == .open }.count
+        XCTAssertEqual(primaryOpens, 1)
+        // Fallback opens: once from failover, once from the second wrapper.open
+        let fallbackOpens = fallback.calls.filter { $0 == .open }.count
+        XCTAssertEqual(fallbackOpens, 2,
+                       "subsequent opens go straight to fallback")
+        XCTAssertTrue(wrapper.isPrimaryStuckForTesting)
+        XCTAssertTrue(sink.names.contains("primary.skipped_sticky"))
+    }
+
+    func testResetStickinessRestoresPrimaryFirst() async throws {
+        let (primary, fallback, wrapper) = makeStickyBackends()
+        primary.openFailure = .network("dead wifi")
+
+        try await wrapper.open { _ in }
+        wrapper.close()
+        XCTAssertTrue(wrapper.isPrimaryStuckForTesting)
+
+        wrapper.resetStickiness()
+        XCTAssertFalse(wrapper.isPrimaryStuckForTesting)
+
+        // The primary should be tried again
+        primary.openFailure = nil
+        try await wrapper.open { _ in }
+
+        let primaryOpens = primary.calls.filter { $0 == .open }.count
+        XCTAssertEqual(primaryOpens, 2, "resetStickiness restores primary-first behavior")
+    }
+
+    func testStickyBothFailStillSurfacesSessionFailed() async throws {
+        let (primary, fallback, wrapper) = makeStickyBackends()
+        primary.openFailure = .network("primary dead")
+
+        try await wrapper.open { _ in }
+        wrapper.close()
+
+        // Now both fail
+        fallback.openFailure = .authorization("speech unavailable")
+        do {
+            try await wrapper.open { _ in XCTFail("no session should be established") }
+            XCTFail("both-fail must throw")
+        } catch {
+            XCTAssertEqual(error as? VoiceBackendFailure,
+                           .authorization("speech unavailable"))
+        }
+    }
+
+    func testRetryEachOpenStickinessNeverSticks() async throws {
+        // The default stickiness should never stick
+        let (primary, fallback, wrapper) = makeBackends()
+        primary.openFailure = .network("dead wifi")
+
+        try await wrapper.open { _ in }
+        wrapper.close()
+
+        // Second open: primary should be tried again (default behavior)
+        primary.openFailure = nil
+        try await wrapper.open { _ in }
+
+        let primaryOpens = primary.calls.filter { $0 == .open }.count
+        XCTAssertEqual(primaryOpens, 2,
+                       "retryEachOpen always starts with the primary")
+        XCTAssertEqual(fallback.calls.filter { $0 == .open }.count, 1,
+                       "fallback was only needed once")
+    }
 }

--- a/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
@@ -61,7 +61,7 @@ final class FailThroughVoiceBackendTests: XCTestCase {
         wrapper.beginUserTurn()
         wrapper.sendAudio(chunk)
         primary.emit(.transcriptPartial("yes"))
-        wrapper.endUserTurn()
+        wrapper.endUserTurn(expectingResponse: true)
         wrapper.close()
 
         XCTAssertEqual(primary.calls,
@@ -216,7 +216,7 @@ final class FailThroughVoiceBackendTests: XCTestCase {
         wrapper.beginUserTurn()
 
         primary.emit(.sessionFailed(.network("socket dropped")))
-        wrapper.endUserTurn()
+        wrapper.endUserTurn(expectingResponse: true)
         await settle()
 
         XCTAssertEqual(fallback.calls, [.open],

--- a/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
@@ -80,7 +80,7 @@ final class FailThroughVoiceBackendTests: XCTestCase {
         XCTAssertEqual(primary.calls, [.open, .requestResponse("done"), .cancelResponse])
     }
 
-    func testCapabilitiesAreTheIntersectionOfBoth() {
+    func testCapabilitiesAreTheIntersectionOfBoth() async {
         let (_, _, wrapper) = makeBackends()
         XCTAssertEqual(wrapper.capabilities, .transcriptOnly,
                        "a caller must not be handed a capability the fallback lacks")
@@ -326,7 +326,7 @@ final class FailThroughVoiceBackendTests: XCTestCase {
         XCTAssertTrue(sink.names.contains("cancel.dropped"))
     }
 
-    func testCloseWithoutOpenTouchesNeitherBackend() {
+    func testCloseWithoutOpenTouchesNeitherBackend() async {
         let (primary, fallback, wrapper) = makeBackends()
 
         wrapper.close()
@@ -438,7 +438,7 @@ final class FailThroughVoiceBackendTests: XCTestCase {
     }
 
     func testResetStickinessRestoresPrimaryFirst() async throws {
-        let (primary, fallback, wrapper) = makeStickyBackends()
+        let (primary, _, wrapper) = makeStickyBackends()
         primary.openFailure = .network("dead wifi")
 
         try await wrapper.open { _ in }

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -202,7 +202,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         await settle()
         XCTAssertEqual(server.sentTypes, ["session.update", "input_audio_buffer.append"])
 
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
         XCTAssertEqual(server.sentTypes, ["session.update", "input_audio_buffer.append",
                                           "input_audio_buffer.commit", "response.create"])
@@ -268,13 +268,13 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let events = EventLog()
         try await openTurn(backend, collecting: events)
         backend.sendAudio(pcm16(240))
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         server.push(RealtimeFrame.responseDone)
         await settle()
 
         backend.beginUserTurn()
         backend.sendAudio(pcm16(240))
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         XCTAssertEqual(server.sentTypes,
@@ -305,7 +305,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let backend = makeBackend(server)
         let events = EventLog()
         try await openTurn(backend, collecting: events)
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         backend.sendAudio(pcm16(240))
@@ -356,7 +356,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let events = EventLog()
         try await backend.open { events.append($0) }
 
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         XCTAssertFalse(server.sentTypes.contains("input_audio_buffer.commit"))
@@ -451,7 +451,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         try await openTurn(backend, collecting: events)
         server.push(RealtimeFrame.transcriptDelta("yes"))
         await settle()
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         server.push(RealtimeFrame.responseDone)
         await settle()
 
@@ -468,7 +468,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let backend = makeBackend(server)
         let events = EventLog()
         try await openTurn(backend, collecting: events)
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         let audio = Data(repeating: 0x33, count: 480)
@@ -486,7 +486,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let backend = makeBackend(server)
         let events = EventLog()
         try await openTurn(backend, collecting: events)
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         server.push(RealtimeFrame.responseDone)
@@ -563,7 +563,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let events = EventLog()
         try await openTurn(backend, collecting: events)
         backend.sendAudio(pcm16(240))
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         backend.cancelResponse()
@@ -782,7 +782,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         try await openTurn(backend, collecting: events)
 
         // End the turn without sending any audio.
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         XCTAssertFalse(server.sentTypes.contains("input_audio_buffer.commit"),
@@ -801,7 +801,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         try await openTurn(backend, collecting: events)
 
         backend.sendAudio(pcm16(240))
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         XCTAssertEqual(server.sentTypes, ["session.update", "input_audio_buffer.append",
@@ -816,14 +816,14 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         try await openTurn(backend, collecting: events)
 
         // First turn: empty
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         server.push(RealtimeFrame.responseDone)
         await settle()
 
         // Second turn: with audio
         backend.beginUserTurn()
         backend.sendAudio(pcm16(240))
-        backend.endUserTurn()
+        backend.endUserTurn(expectingResponse: true)
         await settle()
 
         XCTAssertTrue(server.sentTypes.contains("input_audio_buffer.commit"))

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -559,7 +559,8 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
 
     func testCancelResponseSendsAResponseCancel() async throws {
         let server = ScriptedRealtimeServer()
-        let backend = makeBackend(server)
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
         let events = EventLog()
         try await openTurn(backend, collecting: events)
         backend.sendAudio(pcm16(240))
@@ -571,7 +572,71 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
 
         XCTAssertEqual(server.sentTypes.last, "response.cancel")
         XCTAssertEqual(backend.turnStateForTesting, .open)
-        XCTAssertEqual(events.failures, [])
+        XCTAssertEqual(events.failures, [],
+                       "the cancel ack (response.done cancelled) must not fail the session")
+        // The scripted server now models the documented cancel semantics: a response.cancel
+        // is acked with response.done (cancelled). The adapter must emit responseCompleted
+        // so the provider clears any response-in-flight tracking.
+        XCTAssertTrue(events.events.contains(.responseCompleted),
+                      "the cancel ack must be forwarded as responseCompleted")
+        XCTAssertTrue(sink.names.contains("cancel_ack.received"))
+    }
+
+    func testCancelAckDoesNotFailSessionAndEmitsResponseCompleted() async throws {
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.sendAudio(pcm16(240))
+        backend.endUserTurn(expectingResponse: true)
+        await settle()
+
+        // Straggler audio before the cancel ack.
+        let audio = Data(repeating: 0x42, count: 480)
+        server.push(RealtimeFrame.audioDelta(audio))
+        await settle()
+
+        backend.cancelResponse()
+        await settle()
+
+        // The scripted server acks with response.done (cancelled). The adapter handles it
+        // via expectCancelAck rather than calling turns.responseCompleted() from .open.
+        XCTAssertEqual(backend.turnStateForTesting, .open)
+        XCTAssertEqual(events.failures, [],
+                       "the cancel ack must not fail the session")
+        XCTAssertTrue(events.events.contains(.responseCompleted),
+                      "responseCompleted must be emitted so the provider clears tracking state")
+        // The next turn must work.
+        backend.beginUserTurn()
+        XCTAssertEqual(backend.turnStateForTesting, .userTurn)
+    }
+
+    func testCancelRacingCompletedResponseTreatsErrorAsBenign() async throws {
+        let server = ScriptedRealtimeServer()
+        // Disable the auto-ack: simulate the server returning only an error for the cancel
+        // because the response had already completed when the cancel arrived.
+        server.acknowledgesCancelWithDone = false
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.sendAudio(pcm16(240))
+        backend.endUserTurn(expectingResponse: true)
+        await settle()
+
+        backend.cancelResponse()
+        await settle()
+
+        // The cancel was sent; now the server returns an error instead of response.done.
+        server.push(RealtimeFrame.error(message: "response already completed",
+                                         code: "cancel_failed"))
+        await settle()
+
+        XCTAssertEqual(events.failures, [],
+                       "an error from a cancel race must not fail the session")
+        XCTAssertEqual(backend.turnStateForTesting, .open)
+        XCTAssertTrue(sink.names.contains("cancel_ack.race_error"))
     }
 
     func testCancelWithNothingInFlightIsRejected() async throws {

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -226,7 +226,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
                        "splitting must not lose or duplicate a byte")
     }
 
-    func testSplitPreservesOrderAndSampleFrames() {
+    func testSplitPreservesOrderAndSampleFrames() async {
         let chunk = VoiceAudioChunk(data: Data((0..<10).map { UInt8($0) }),
                                     format: VoiceAudioFormat(sampleRate: 20, channels: 1),
                                     timestamp: 0)
@@ -238,7 +238,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
                       "a block that ends mid-sample is a click in the wearer's audio")
     }
 
-    func testSmallChunksAreSentWhole() {
+    func testSmallChunksAreSentWhole() async {
         let blocks = OpenAIRealtimeVoiceBackend.split(pcm16(10), maxSeconds: 0.1)
         XCTAssertEqual(blocks.count, 1)
         XCTAssertEqual(OpenAIRealtimeVoiceBackend.split(pcm16(0), maxSeconds: 0.1), [])
@@ -654,7 +654,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         }
     }
 
-    func testCapabilitiesDescribeTheTransportNotThePolicy() {
+    func testCapabilitiesDescribeTheTransportNotThePolicy() async {
         let backend = makeBackend(ScriptedRealtimeServer())
         XCTAssertEqual(backend.capabilities,
                        VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
@@ -796,7 +796,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         XCTAssertFalse(server.isConnected, "a connection nobody wanted must not be left up")
     }
 
-    func testCloseWithoutOpenIsHarmless() {
+    func testCloseWithoutOpenIsHarmless() async {
         let server = ScriptedRealtimeServer()
         let backend = makeBackend(server)
 

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -1,0 +1,771 @@
+import XCTest
+@testable import TapQVoiceBackends
+import TapQContracts
+
+@MainActor
+final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        var names: [String] { events.map(\.name) }
+    }
+
+    /// Fixed clock so audio timestamps are assertable.
+    private nonisolated static let now: TimeInterval = 1_234.5
+
+    private func makeBackend(_ server: ScriptedRealtimeServer,
+                             timeout: TimeInterval = 1,
+                             sink: RecordingSink = RecordingSink())
+        -> OpenAIRealtimeVoiceBackend {
+        OpenAIRealtimeVoiceBackend(transport: server,
+                                   timeout: timeout,
+                                   monotonicNow: { Self.now },
+                                   diagnosticSink: sink)
+    }
+
+    /// Frames cross two task hops (the outbound pump and the receive loop), so tests hand
+    /// the main actor back before asserting.
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    /// Opens a session with a live turn, which is where most of these tests start.
+    private func openTurn(_ backend: OpenAIRealtimeVoiceBackend,
+                          collecting events: EventLog) async throws {
+        try await backend.open { events.append($0) }
+        backend.beginUserTurn()
+        await settle()
+    }
+
+    /// Reference type so the capture in `open`'s handler and the assertions see the same
+    /// list without fighting exclusivity.
+    @MainActor
+    final class EventLog {
+        private(set) var events: [VoiceBackendEvent] = []
+        func append(_ event: VoiceBackendEvent) { events.append(event) }
+        var failures: [VoiceBackendFailure] {
+            events.compactMap { if case .sessionFailed(let f) = $0 { return f } else { return nil } }
+        }
+        var transcripts: [String] {
+            events.compactMap {
+                switch $0 {
+                case .transcriptPartial(let t), .transcriptFinal(let t): return t
+                default: return nil
+                }
+            }
+        }
+    }
+
+    private func pcm16(_ frames: Int, byte: UInt8 = 0x11) -> VoiceAudioChunk {
+        VoiceAudioChunk(data: Data(repeating: byte, count: frames * 2),
+                        format: OpenAIRealtimeVoiceBackend.audioFormat,
+                        timestamp: 0)
+    }
+
+    // MARK: - Handshake
+
+    func testOpenConfiguresManualTurnsBeforeAnythingElse() async throws {
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
+
+        try await backend.open { _ in }
+
+        XCTAssertEqual(server.sentTypes, ["session.update"])
+        let detection = server.sessionConfiguration?["turn_detection"] as? [String: Any]
+        XCTAssertEqual(detection?["type"] as? String, "none")
+        XCTAssertTrue(sink.names.contains("session.opened"))
+    }
+
+    func testCallerSuppliedTurnDetectionIsOverridden() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = OpenAIRealtimeVoiceBackend(
+            transport: server,
+            configuration: RealtimeSessionConfiguration(
+                turnDetection: RealtimeTurnDetection(type: "server_vad")),
+            timeout: 1)
+
+        try await backend.open { _ in }
+
+        let detection = server.sessionConfiguration?["turn_detection"] as? [String: Any]
+        XCTAssertEqual(detection?["type"] as? String, "none",
+                       "the adapter refuses to run a session the service can end itself")
+    }
+
+    func testSessionCreatedAloneDoesNotCompleteTheHandshake() async {
+        let server = ScriptedRealtimeServer()
+        server.acknowledgesSessionUpdate = false
+        server.announcesSessionCreated = true
+        let backend = makeBackend(server, timeout: 0.05)
+
+        do {
+            try await backend.open { _ in }
+            XCTFail("session.created is not confirmation that turn detection is off")
+        } catch {
+            guard case .network(let detail)? = error as? VoiceBackendFailure else {
+                return XCTFail("expected a network failure, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("timed out"))
+        }
+        XCTAssertEqual(server.closeCount, 1, "a session that never opened leaves no socket")
+    }
+
+    func testConnectFailureSurfacesAsATypedOpenError() async {
+        let server = ScriptedRealtimeServer()
+        server.connectFailure = .connectFailed("dns lookup failed")
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
+
+        do {
+            try await backend.open { _ in }
+            XCTFail("the handshake cannot succeed without a connection")
+        } catch {
+            guard case .network(let detail)? = error as? VoiceBackendFailure else {
+                return XCTFail("expected a network failure, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("dns lookup failed"))
+        }
+        XCTAssertEqual(server.sentTypes, [])
+        XCTAssertEqual(sink.events.first { $0.name == "connect.failed" }?.level, .warning)
+    }
+
+    func testHandshakeFailureIsReportedByThrowingRatherThanAsAnEvent() async {
+        let server = ScriptedRealtimeServer()
+        server.acknowledgesSessionUpdate = false
+        let events = EventLog()
+        let backend = makeBackend(server, timeout: 0.05)
+
+        do {
+            try await backend.open { events.append($0) }
+            XCTFail("the handshake timed out")
+        } catch {
+            XCTAssertTrue(error is VoiceBackendFailure)
+        }
+        await settle()
+
+        XCTAssertEqual(events.events, [],
+                       "a caller whose open threw never installed a window to fail")
+    }
+
+    func testASecondOpenAfterAFailedHandshakeSucceeds() async throws {
+        let server = ScriptedRealtimeServer()
+        server.acknowledgesSessionUpdate = false
+        let backend = makeBackend(server, timeout: 0.05)
+
+        try? await backend.open { _ in }
+        server.acknowledgesSessionUpdate = true
+        try await backend.open { _ in }
+
+        XCTAssertEqual(backend.turnStateForTesting, .open)
+    }
+
+    func testOpeningAnAlreadyOpenSessionIsAProtocolViolation() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        try await backend.open { _ in }
+
+        do {
+            try await backend.open { _ in }
+            XCTFail("a second open on a live session is a programming error")
+        } catch {
+            guard case .protocolViolation? = error as? VoiceBackendFailure else {
+                return XCTFail("expected a protocol violation, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Manual turn cycle
+
+    func testTurnCycleAppendsThenCommitsThenCreates() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+
+        try await openTurn(backend, collecting: events)
+        XCTAssertEqual(server.sentTypes, ["session.update"],
+                       "beginning a turn is a local state change; nothing is on the wire yet")
+
+        backend.sendAudio(pcm16(240))
+        await settle()
+        XCTAssertEqual(server.sentTypes, ["session.update", "input_audio_buffer.append"])
+
+        backend.endUserTurn()
+        await settle()
+        XCTAssertEqual(server.sentTypes, ["session.update", "input_audio_buffer.append",
+                                          "input_audio_buffer.commit", "response.create"])
+        XCTAssertEqual(backend.turnStateForTesting, .responding)
+        XCTAssertEqual(events.events, [])
+    }
+
+    func testAudioIsFramedIntoBlocksOfAtMostOneHundredMilliseconds() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        // Half a second at 24 kHz mono: five 100 ms blocks.
+        backend.sendAudio(pcm16(12_000))
+        await settle()
+
+        XCTAssertEqual(server.appendedAudio.count, 5)
+        XCTAssertEqual(server.appendedAudio.map(\.count), Array(repeating: 4_800, count: 5))
+        XCTAssertEqual(server.appendedAudio.reduce(Data(), +).count, 24_000,
+                       "splitting must not lose or duplicate a byte")
+    }
+
+    func testSplitPreservesOrderAndSampleFrames() {
+        let chunk = VoiceAudioChunk(data: Data((0..<10).map { UInt8($0) }),
+                                    format: VoiceAudioFormat(sampleRate: 20, channels: 1),
+                                    timestamp: 0)
+        // 100 ms at 20 Hz is two frames — four bytes a block.
+        let blocks = OpenAIRealtimeVoiceBackend.split(chunk, maxSeconds: 0.1)
+
+        XCTAssertEqual(blocks, [Data([0, 1, 2, 3]), Data([4, 5, 6, 7]), Data([8, 9])])
+        XCTAssertTrue(blocks.dropLast().allSatisfy { $0.count % 2 == 0 },
+                      "a block that ends mid-sample is a click in the wearer's audio")
+    }
+
+    func testSmallChunksAreSentWhole() {
+        let blocks = OpenAIRealtimeVoiceBackend.split(pcm16(10), maxSeconds: 0.1)
+        XCTAssertEqual(blocks.count, 1)
+        XCTAssertEqual(OpenAIRealtimeVoiceBackend.split(pcm16(0), maxSeconds: 0.1), [])
+    }
+
+    func testAppendsReachThePeerInOrder() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        // Three 100 ms blocks, each stamped with its own byte value.
+        var audio = Data()
+        for block in 0..<3 { audio.append(Data(repeating: UInt8(block), count: 4_800)) }
+        backend.sendAudio(VoiceAudioChunk(data: audio,
+                                          format: OpenAIRealtimeVoiceBackend.audioFormat,
+                                          timestamp: 0))
+        await settle()
+
+        XCTAssertEqual(server.appendedAudio.map { $0.first }, [0, 1, 2],
+                       "a reordered append is scrambled audio in the transcript")
+    }
+
+    func testASecondTurnRunsOnTheSameSession() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.endUserTurn()
+        server.push(RealtimeFrame.responseDone)
+        await settle()
+
+        backend.beginUserTurn()
+        backend.sendAudio(pcm16(240))
+        backend.endUserTurn()
+        await settle()
+
+        XCTAssertEqual(server.sentTypes,
+                       ["session.update",
+                        "input_audio_buffer.commit", "response.create",
+                        "input_audio_buffer.append",
+                        "input_audio_buffer.commit", "response.create"])
+        XCTAssertEqual(events.failures, [], "one session serves many windows")
+    }
+
+    func testBeginningATurnTwiceIsAProtocolViolation() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        backend.beginUserTurn()
+        await settle()
+
+        guard case .protocolViolation? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+    }
+
+    func testAudioAfterTheCommitIsRejected() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.endUserTurn()
+        await settle()
+
+        backend.sendAudio(pcm16(240))
+        await settle()
+
+        XCTAssertEqual(server.appendedAudio, [],
+                       "audio after the commit belongs to a turn that is already gone")
+        guard case .protocolViolation? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+    }
+
+    func testAudioBeforeATurnIsAProtocolViolation() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await backend.open { events.append($0) }
+
+        backend.sendAudio(pcm16(240))
+        await settle()
+
+        XCTAssertEqual(server.sentTypes, ["session.update"], "no audio reaches an unopened turn")
+        guard case .protocolViolation? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+    }
+
+    func testAudioInTheWrongFormatIsRejectedLoudly() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        backend.sendAudio(VoiceAudioChunk(data: Data(repeating: 1, count: 320),
+                                          format: .pcm16Mono16k, timestamp: 0))
+        await settle()
+
+        guard case .protocolViolation(let detail)? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+        XCTAssertTrue(detail.contains("16000"), detail)
+        XCTAssertEqual(server.appendedAudio, [], "mis-encoded audio transcribes as noise")
+    }
+
+    func testEndingATurnThatNeverBeganIsAProtocolViolation() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await backend.open { events.append($0) }
+
+        backend.endUserTurn()
+        await settle()
+
+        XCTAssertFalse(server.sentTypes.contains("input_audio_buffer.commit"))
+        guard case .protocolViolation? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+    }
+
+    func testTheServerNeverEndsATurn() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.sendAudio(pcm16(240))
+        await settle()
+
+        // Everything a chatty service can say mid-turn. None of it may commit the buffer.
+        server.push(sequence: [RealtimeFrame.transcriptDelta("yes"),
+                               RealtimeFrame.transcriptCompleted("yes"),
+                               RealtimeFrame.unknownEvent,
+                               #"{"type":"input_audio_buffer.speech_stopped"}"#])
+        await settle()
+
+        XCTAssertEqual(server.sentTypes, ["session.update", "input_audio_buffer.append"],
+                       "only TapQ commits")
+        XCTAssertEqual(backend.turnStateForTesting, .userTurn)
+        XCTAssertEqual(events.failures, [])
+    }
+
+    func testAnUnrequestedResponseCompletionEndsTheSession() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.push(RealtimeFrame.responseDone)
+        await settle()
+
+        guard case .protocolViolation(let detail)? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+        XCTAssertTrue(detail.contains("never requested"), detail)
+    }
+
+    // MARK: - Event mapping
+
+    func testTranscriptDeltasAccumulateIntoCumulativePartials() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.push(sequence: [RealtimeFrame.transcriptDelta("yes"),
+                               RealtimeFrame.transcriptDelta(" go"),
+                               RealtimeFrame.transcriptDelta(" ahead")])
+        await settle()
+
+        XCTAssertEqual(events.transcripts, ["yes", "yes go", "yes go ahead"],
+                       "matchers see the whole utterance each time, exactly as with Apple's")
+    }
+
+    func testTranscriptCompletionEmitsAFinalTranscript() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.push(sequence: [RealtimeFrame.transcriptDelta("yes go"),
+                               RealtimeFrame.transcriptCompleted("yes, go ahead")])
+        await settle()
+
+        XCTAssertEqual(events.events.last, .transcriptFinal("yes, go ahead"))
+    }
+
+    func testAnEmptyCompletionKeepsTheAccumulatedTranscript() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.push(sequence: [RealtimeFrame.transcriptDelta("yes"),
+                               RealtimeFrame.transcriptCompleted("")])
+        await settle()
+
+        XCTAssertEqual(events.events.last, .transcriptFinal("yes"))
+    }
+
+    func testANewTurnStartsFromAnEmptyTranscript() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        server.push(RealtimeFrame.transcriptDelta("yes"))
+        await settle()
+        backend.endUserTurn()
+        server.push(RealtimeFrame.responseDone)
+        await settle()
+
+        backend.beginUserTurn()
+        server.push(RealtimeFrame.transcriptDelta("no"))
+        await settle()
+
+        XCTAssertEqual(events.transcripts, ["yes", "no"],
+                       "one turn's words must not bleed into the next")
+    }
+
+    func testResponseAudioIsMappedWithTheSessionFormatAndClock() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.endUserTurn()
+        await settle()
+
+        let audio = Data(repeating: 0x33, count: 480)
+        server.push(RealtimeFrame.audioDelta(audio))
+        await settle()
+
+        XCTAssertEqual(events.events.last,
+                       .audio(VoiceAudioChunk(data: audio,
+                                              format: OpenAIRealtimeVoiceBackend.audioFormat,
+                                              timestamp: Self.now)))
+    }
+
+    func testResponseCompletionReturnsTheSessionToIdleAndIsForwarded() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.endUserTurn()
+        await settle()
+
+        server.push(RealtimeFrame.responseDone)
+        await settle()
+
+        XCTAssertEqual(events.events.last, .responseCompleted)
+        XCTAssertEqual(backend.turnStateForTesting, .open)
+    }
+
+    func testUnknownServerEventsAreIgnoredNotFatal() async throws {
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.push(sequence: [RealtimeFrame.unknownEvent, RealtimeFrame.transcriptDelta("yes")])
+        await settle()
+
+        XCTAssertEqual(events.transcripts, ["yes"])
+        XCTAssertEqual(sink.events.last { $0.name == "event.ignored" }?.fields["type"],
+                       "rate_limits.updated")
+    }
+
+    func testAMalformedFrameEndsTheSession() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.push("{ this is not json")
+        await settle()
+
+        guard case .protocolViolation? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+    }
+
+    // MARK: - Responses and barge-in
+
+    func testRequestResponseCarriesTheText() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await backend.open { events.append($0) }
+
+        backend.requestResponse(text: "the build finished")
+        await settle()
+
+        XCTAssertEqual(server.sentTypes, ["session.update", "response.create"])
+        XCTAssertEqual(server.instructions(ofResponseAt: 0), "the build finished")
+    }
+
+    func testRequestResponseDuringAUserTurnIsRejected() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        backend.requestResponse(text: "talking over the wearer")
+        await settle()
+
+        XCTAssertFalse(server.sentTypes.contains("response.create"),
+                       "half-duplex is TapQ policy even against a duplex transport")
+        guard case .protocolViolation(let detail)? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+        XCTAssertTrue(detail.contains("half-duplex"), detail)
+    }
+
+    func testCancelResponseSendsAResponseCancel() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.endUserTurn()
+        await settle()
+
+        backend.cancelResponse()
+        await settle()
+
+        XCTAssertEqual(server.sentTypes.last, "response.cancel")
+        XCTAssertEqual(backend.turnStateForTesting, .open)
+        XCTAssertEqual(events.failures, [])
+    }
+
+    func testCancelWithNothingInFlightIsRejected() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await backend.open { events.append($0) }
+
+        backend.cancelResponse()
+        await settle()
+
+        XCTAssertFalse(server.sentTypes.contains("response.cancel"))
+        guard case .protocolViolation? = events.failures.first else {
+            return XCTFail("expected a protocol violation, got \(events.events)")
+        }
+    }
+
+    func testCapabilitiesDescribeTheTransportNotThePolicy() {
+        let backend = makeBackend(ScriptedRealtimeServer())
+        XCTAssertEqual(backend.capabilities,
+                       VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                duplex: true))
+    }
+
+    // MARK: - Failure paths
+
+    func testAnErrorEventEndsTheSession() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.push(RealtimeFrame.error(message: "session expired", code: "server_error"))
+        await settle()
+
+        XCTAssertEqual(events.failures, [.protocolViolation("session expired")])
+        XCTAssertEqual(server.closeCount, 1)
+    }
+
+    func testAnAuthorizationErrorIsTypedAsSuch() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.push(RealtimeFrame.error(message: "bad key", code: "invalid_api_key"))
+        await settle()
+
+        XCTAssertEqual(events.failures, [.authorization("bad key")],
+                       "reconnecting against a rejected key is a loop, not a recovery")
+    }
+
+    func testAMidStreamDisconnectSurfacesAsSessionFailed() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.disconnect()
+        await settle()
+
+        guard case .network(let detail)? = events.failures.first else {
+            return XCTFail("expected a network failure, got \(events.events)")
+        }
+        XCTAssertTrue(detail.contains("socket dropped"), detail)
+    }
+
+    func testACleanHangUpSurfacesAsAClosedSession() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.hangUp()
+        await settle()
+
+        guard case .closed? = events.failures.first else {
+            return XCTFail("expected a closed failure, got \(events.events)")
+        }
+    }
+
+    func testASendFailureEndsTheSession() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.sendFailure = .sendFailed("broken pipe")
+        backend.sendAudio(pcm16(240))
+        await settle()
+
+        guard case .network(let detail)? = events.failures.first else {
+            return XCTFail("expected a network failure, got \(events.events)")
+        }
+        XCTAssertTrue(detail.contains("broken pipe"), detail)
+    }
+
+    func testNoEventsArriveAfterAFailure() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        server.disconnect()
+        await settle()
+        let afterFailure = events.events.count
+        server.push(RealtimeFrame.transcriptDelta("too late"))
+        await settle()
+
+        XCTAssertEqual(events.events.count, afterFailure,
+                       "frames from a dead session resolve nothing")
+    }
+
+    // MARK: - Teardown
+
+    func testCloseIsIdempotentAndSilencesTheSession() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        backend.close()
+        backend.close()
+        backend.close()
+        server.push(RealtimeFrame.transcriptDelta("after close"))
+        await settle()
+
+        XCTAssertEqual(events.events, [])
+        XCTAssertEqual(backend.turnStateForTesting, .idle)
+        XCTAssertGreaterThanOrEqual(server.closeCount, 1)
+    }
+
+    func testCloseDuringTheConnectHandshakeLeavesNothingRunning() async {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let gate = AsyncGate()
+        server.connectGate = { await gate.wait() }
+
+        let opening = Task { @MainActor in
+            try await backend.open { _ in XCTFail("the window was abandoned") }
+        }
+        await settle()
+        backend.close()
+        gate.open()
+
+        do {
+            try await opening.value
+            XCTFail("a torn-down session cannot finish opening")
+        } catch {
+            guard case .closed? = error as? VoiceBackendFailure else {
+                return XCTFail("expected a closed failure, got \(error)")
+            }
+        }
+        await settle()
+
+        XCTAssertEqual(server.sentTypes, [], "nothing is configured on an abandoned session")
+        XCTAssertFalse(server.isConnected, "a connection nobody wanted must not be left up")
+    }
+
+    func testCloseWithoutOpenIsHarmless() {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+
+        backend.close()
+        backend.close()
+
+        XCTAssertEqual(backend.turnStateForTesting, .idle)
+        XCTAssertEqual(server.sentTypes, [])
+    }
+
+    func testALateAckAfterATimedOutHandshakeChangesNothing() async {
+        let server = ScriptedRealtimeServer()
+        server.acknowledgesSessionUpdate = false
+        let backend = makeBackend(server, timeout: 0.05)
+        try? await backend.open { _ in XCTFail("the handshake never completed") }
+
+        server.push(RealtimeFrame.sessionUpdated)
+        await settle()
+
+        XCTAssertEqual(backend.turnStateForTesting, .idle,
+                       "an ack for a session that gave up must not revive it")
+        XCTAssertEqual(server.closeCount, 1)
+    }
+
+    func testAFullSessionCanBeReopenedAfterClose() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.close()
+
+        let second = EventLog()
+        try await openTurn(backend, collecting: second)
+        server.push(RealtimeFrame.transcriptDelta("yes"))
+        await settle()
+
+        XCTAssertEqual(second.transcripts, ["yes"])
+        XCTAssertEqual(events.events, [], "the first window stays closed")
+    }
+}

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -267,6 +267,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let backend = makeBackend(server)
         let events = EventLog()
         try await openTurn(backend, collecting: events)
+        backend.sendAudio(pcm16(240))
         backend.endUserTurn()
         server.push(RealtimeFrame.responseDone)
         await settle()
@@ -278,6 +279,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
 
         XCTAssertEqual(server.sentTypes,
                        ["session.update",
+                        "input_audio_buffer.append",
                         "input_audio_buffer.commit", "response.create",
                         "input_audio_buffer.append",
                         "input_audio_buffer.commit", "response.create"])
@@ -560,6 +562,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let backend = makeBackend(server)
         let events = EventLog()
         try await openTurn(backend, collecting: events)
+        backend.sendAudio(pcm16(240))
         backend.endUserTurn()
         await settle()
 
@@ -767,5 +770,64 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
 
         XCTAssertEqual(second.transcripts, ["yes"])
         XCTAssertEqual(events.events, [], "the first window stays closed")
+    }
+
+    // MARK: - Empty-turn guard
+
+    func testEmptyTurnSendsNeitherCommitNorResponseCreate() async throws {
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        // End the turn without sending any audio.
+        backend.endUserTurn()
+        await settle()
+
+        XCTAssertFalse(server.sentTypes.contains("input_audio_buffer.commit"),
+                       "an empty turn must not commit")
+        XCTAssertFalse(server.sentTypes.contains("response.create"),
+                       "an empty turn must not request a response")
+        XCTAssertEqual(server.sentTypes, ["session.update"],
+                       "only the handshake frame was sent")
+        XCTAssertTrue(sink.names.contains("turn.empty_skipped"))
+    }
+
+    func testNormalTurnWithAudioIsUnchangedByEmptyGuard() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        backend.sendAudio(pcm16(240))
+        backend.endUserTurn()
+        await settle()
+
+        XCTAssertEqual(server.sentTypes, ["session.update", "input_audio_buffer.append",
+                                          "input_audio_buffer.commit", "response.create"],
+                       "a turn with audio commits and requests normally")
+    }
+
+    func testEmptyTurnFollowedByNormalTurnWorks() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        // First turn: empty
+        backend.endUserTurn()
+        server.push(RealtimeFrame.responseDone)
+        await settle()
+
+        // Second turn: with audio
+        backend.beginUserTurn()
+        backend.sendAudio(pcm16(240))
+        backend.endUserTurn()
+        await settle()
+
+        XCTAssertTrue(server.sentTypes.contains("input_audio_buffer.commit"))
+        XCTAssertTrue(server.sentTypes.contains("response.create"))
+        XCTAssertEqual(events.failures, [], "the empty turn must not corrupt later turns")
     }
 }

--- a/Tests/TapQVoiceBackendsTests/RealtimeMessagesTests.swift
+++ b/Tests/TapQVoiceBackendsTests/RealtimeMessagesTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import TapQVoiceBackends
+
+final class RealtimeMessagesTests: XCTestCase {
+
+    private func object(_ frame: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(frame.data(using: .utf8))
+        return try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - Client events
+
+    func testSessionUpdateDisablesServerTurnDetection() throws {
+        let frame = try RealtimeClientEvent.sessionUpdate(RealtimeSessionConfiguration())
+            .encodedFrame()
+        let json = try object(frame)
+
+        XCTAssertEqual(json["type"] as? String, "session.update")
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        let detection = try XCTUnwrap(session["turn_detection"] as? [String: Any])
+        XCTAssertEqual(detection["type"] as? String, "none",
+                       "manual-turn mode is the whole reason this adapter exists")
+    }
+
+    func testSessionUpdateCarriesTheAudioAndTranscriptionSlice() throws {
+        let configuration = RealtimeSessionConfiguration(model: "gpt-realtime-mini",
+                                                         instructions: "be brief",
+                                                         voice: "cedar")
+        let json = try object(try RealtimeClientEvent.sessionUpdate(configuration).encodedFrame())
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+
+        XCTAssertEqual(session["model"] as? String, "gpt-realtime-mini")
+        XCTAssertEqual(session["input_audio_format"] as? String, "pcm16")
+        XCTAssertEqual(session["output_audio_format"] as? String, "pcm16")
+        XCTAssertEqual(session["instructions"] as? String, "be brief")
+        XCTAssertEqual(session["voice"] as? String, "cedar")
+        let transcription = try XCTUnwrap(session["input_audio_transcription"] as? [String: Any])
+        XCTAssertEqual(transcription["model"] as? String,
+                       RealtimeDefaults.inputTranscriptionModel,
+                       "without input transcription the grammar has nothing to match")
+    }
+
+    func testSessionUpdateOmitsUnsetOptionalFields() throws {
+        let json = try object(
+            try RealtimeClientEvent.sessionUpdate(RealtimeSessionConfiguration()).encodedFrame())
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+
+        XCTAssertNil(session["instructions"])
+        XCTAssertNil(session["voice"], "unset settings stay at the service default")
+    }
+
+    func testAppendFramesBase64EncodeTheAudio() throws {
+        let audio = Data([0x00, 0x01, 0xFE, 0xFF, 0x10, 0x20])
+        let json = try object(try RealtimeClientEvent.appendInputAudio(audio).encodedFrame())
+
+        XCTAssertEqual(json["type"] as? String, "input_audio_buffer.append")
+        let encoded = try XCTUnwrap(json["audio"] as? String)
+        XCTAssertEqual(Data(base64Encoded: encoded), audio, "audio survives the framing round-trip")
+    }
+
+    func testCommitAndCancelAreBareFrames() throws {
+        XCTAssertEqual(try object(try RealtimeClientEvent.commitInputAudio.encodedFrame())["type"]
+                        as? String, "input_audio_buffer.commit")
+        XCTAssertEqual(try object(try RealtimeClientEvent.cancelResponse.encodedFrame())["type"]
+                        as? String, "response.cancel")
+    }
+
+    func testResponseCreateCarriesInstructionsOnlyWhenGiven() throws {
+        let bare = try object(try RealtimeClientEvent.createResponse(instructions: nil)
+            .encodedFrame())
+        XCTAssertEqual(bare["type"] as? String, "response.create")
+        XCTAssertNil(bare["response"])
+
+        let directed = try object(try RealtimeClientEvent
+            .createResponse(instructions: "say yes").encodedFrame())
+        let response = try XCTUnwrap(directed["response"] as? [String: Any])
+        XCTAssertEqual(response["instructions"] as? String, "say yes")
+    }
+
+    func testWireTypesMatchTheEncodedFrames() throws {
+        let events: [RealtimeClientEvent] = [
+            .sessionUpdate(RealtimeSessionConfiguration()),
+            .appendInputAudio(Data([1, 2])),
+            .commitInputAudio,
+            .createResponse(instructions: nil),
+            .cancelResponse,
+        ]
+        for event in events {
+            XCTAssertEqual(try object(try event.encodedFrame())["type"] as? String, event.wireType)
+        }
+    }
+
+    func testFramesAreByteStable() throws {
+        let event = RealtimeClientEvent.sessionUpdate(RealtimeSessionConfiguration())
+        XCTAssertEqual(try event.encodedFrame(), try event.encodedFrame(),
+                       "sorted keys keep frames diffable in logs and test failures")
+    }
+
+    // MARK: - Server events
+
+    func testDecodesTheSessionLifecycle() throws {
+        XCTAssertEqual(try RealtimeServerEvent.decode(#"{"type":"session.created"}"#),
+                       .sessionCreated)
+        XCTAssertEqual(try RealtimeServerEvent.decode(#"{"type":"session.updated"}"#),
+                       .sessionUpdated)
+    }
+
+    func testDecodesTranscriptDeltasAndCompletions() throws {
+        XCTAssertEqual(
+            try RealtimeServerEvent.decode(RealtimeFrame.transcriptDelta("yes")),
+            .transcriptDelta("yes"))
+        XCTAssertEqual(
+            try RealtimeServerEvent.decode(RealtimeFrame.transcriptCompleted("yes go")),
+            .transcriptCompleted("yes go"))
+    }
+
+    func testDecodesAudioDeltaFromBase64() throws {
+        let audio = Data(repeating: 0x7F, count: 96)
+        XCTAssertEqual(try RealtimeServerEvent.decode(RealtimeFrame.audioDelta(audio)),
+                       .audioDelta(audio))
+    }
+
+    func testAudioDeltaThatIsNotBase64IsMalformed() {
+        let frame = #"{"type":"response.output_audio.delta","delta":"not base64 !!"}"#
+        XCTAssertThrowsError(try RealtimeServerEvent.decode(frame)) { error in
+            guard case .malformedFrame(let detail)? = error as? RealtimeMessageError else {
+                return XCTFail("expected a malformed-frame error, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("base64"))
+        }
+    }
+
+    func testDecodesResponseCompletionUnderBothSpellings() throws {
+        XCTAssertEqual(try RealtimeServerEvent.decode(RealtimeFrame.responseDone),
+                       .responseCompleted)
+        XCTAssertEqual(try RealtimeServerEvent.decode(#"{"type":"response.completed"}"#),
+                       .responseCompleted)
+    }
+
+    func testDecodesErrorEvents() throws {
+        let event = try RealtimeServerEvent.decode(
+            RealtimeFrame.error(message: "boom", code: "server_error"))
+        guard case .failure(let failure) = event else {
+            return XCTFail("expected a failure event, got \(event)")
+        }
+        XCTAssertEqual(failure.message, "boom")
+        XCTAssertEqual(failure.code, "server_error")
+        XCTAssertFalse(failure.isAuthorization)
+    }
+
+    func testAuthorizationErrorsAreRecognized() throws {
+        let codes = ["invalid_api_key", "unauthorized"]
+        for code in codes {
+            let event = try RealtimeServerEvent.decode(
+                RealtimeFrame.error(message: "rejected", code: code))
+            guard case .failure(let failure) = event else {
+                return XCTFail("expected a failure event for \(code)")
+            }
+            XCTAssertTrue(failure.isAuthorization,
+                          "\(code) must not be retried as if it were a network blip")
+        }
+    }
+
+    // MARK: - Tolerance
+
+    func testUnknownEventTypesDecodeAsUnsupported() throws {
+        XCTAssertEqual(try RealtimeServerEvent.decode(RealtimeFrame.unknownEvent),
+                       .unsupported("rate_limits.updated"),
+                       "a new upstream event must not be able to kill a session")
+    }
+
+    func testUnknownFieldsAreIgnored() throws {
+        let frame = """
+        {"type":"conversation.item.input_audio_transcription.delta","delta":"ok",\
+        "event_id":"ev_9","item_id":"item_3","content_index":0,"logprobs":[{"token":"ok"}]}
+        """
+        XCTAssertEqual(try RealtimeServerEvent.decode(frame), .transcriptDelta("ok"))
+    }
+
+    func testMissingPayloadFieldsDegradeRatherThanThrow() throws {
+        XCTAssertEqual(
+            try RealtimeServerEvent.decode(
+                #"{"type":"conversation.item.input_audio_transcription.delta"}"#),
+            .transcriptDelta(""))
+        XCTAssertEqual(
+            try RealtimeServerEvent.decode(
+                #"{"type":"conversation.item.input_audio_transcription.completed"}"#),
+            .transcriptCompleted(""))
+    }
+
+    func testFramesWithoutATypeAreMalformed() {
+        for frame in [#"{"delta":"yes"}"#, "not json at all", ""] {
+            XCTAssertThrowsError(try RealtimeServerEvent.decode(frame),
+                                 "a frame with no type is unreadable, not unsupported")
+        }
+    }
+
+    func testErrorEventWithoutAnErrorBodyIsMalformed() {
+        XCTAssertThrowsError(try RealtimeServerEvent.decode(#"{"type":"error"}"#))
+    }
+}

--- a/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
@@ -38,6 +38,9 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
     var acknowledgesSessionUpdate = true
     /// Emit `session.created` before the ack, as the live service does.
     var announcesSessionCreated = true
+    /// Reply to `response.cancel` with `response.done (cancelled)`. Cleared to test a
+    /// cancel racing a just-completed response (the server sends an error instead).
+    var acknowledgesCancelWithDone = true
 
     private var continuation: AsyncThrowingStream<String, any Error>.Continuation?
     /// Rebuilt on every connect: a reconnect after a drop is a new stream, exactly as it
@@ -96,6 +99,12 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
         if type == "session.update" {
             if announcesSessionCreated { push(#"{"type":"session.created","session":{"id":"sess_1"}}"#) }
             if acknowledgesSessionUpdate { push(#"{"type":"session.updated"}"#) }
+        }
+
+        if type == "response.cancel", acknowledgesCancelWithDone {
+            // Model the documented cancel semantics: the real OpenAI Realtime service acks
+            // a response.cancel with response.done (status "cancelled").
+            push(RealtimeFrame.responseDoneCancelled)
         }
     }
 
@@ -204,6 +213,9 @@ enum RealtimeFrame {
 
     static let responseDone = frame(["type": "response.done",
                                      "response": ["status": "completed"]])
+
+    static let responseDoneCancelled = frame(["type": "response.done",
+                                               "response": ["status": "cancelled"]])
 
     static let sessionUpdated = #"{"type":"session.updated"}"#
 

--- a/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
@@ -1,0 +1,225 @@
+import XCTest
+import Foundation
+@testable import TapQVoiceBackends
+
+/// An in-process realtime peer: it records every client frame, polices the manual-turn
+/// protocol from the far side, and replays scripted server events on demand.
+///
+/// The point of this fake is that it is *hostile*. A permissive stub would let the adapter
+/// commit turns out of order, send audio before configuring the session, or ask for a
+/// response over an uncommitted buffer, and every one of those bugs would surface only
+/// against the live service. So the invariants are asserted here, at the moment the frame
+/// is sent:
+///
+/// 1. The first frame on a connection is `session.update` with turn detection disabled.
+///    Everything before that ack is a session running the service's own VAD.
+/// 2. No frame at all before `connect()`.
+/// 3. No `response.create` while audio sits in the buffer uncommitted — the manual turn
+///    cycle is append → commit → create, and a response over live audio is the server-VAD
+///    behavior TapQ exists to prevent.
+///
+/// It also never ends a turn on its own initiative. Nothing in `push` can commit a buffer;
+/// the only way a turn ends is a client frame, which is the invariant the adapter's tests
+/// assert against `sentTypes`.
+@MainActor
+final class ScriptedRealtimeServer: RealtimeTransporting {
+    /// Frames the client sent, decoded, in order.
+    private(set) var sent: [[String: Any]] = []
+    private(set) var isConnected = false
+    private(set) var closeCount = 0
+
+    /// Set to make `connect()` throw.
+    var connectFailure: RealtimeTransportFailure?
+    /// Set to make the *next* `send` throw.
+    var sendFailure: RealtimeTransportFailure?
+    /// When set, `connect()` suspends on it, so a test can tear down mid-handshake.
+    var connectGate: (@MainActor () async -> Void)?
+    /// Reply to `session.update` with `session.updated`. Cleared to test handshake timeout.
+    var acknowledgesSessionUpdate = true
+    /// Emit `session.created` before the ack, as the live service does.
+    var announcesSessionCreated = true
+
+    private var continuation: AsyncThrowingStream<String, any Error>.Continuation?
+    /// Rebuilt on every connect: a reconnect after a drop is a new stream, exactly as it
+    /// would be against a real socket.
+    private var frames: AsyncThrowingStream<String, any Error>?
+    private var uncommittedAudio = false
+
+    // MARK: - RealtimeTransporting
+
+    func connect() async throws {
+        if let connectGate { await connectGate() }
+        if let connectFailure { throw connectFailure }
+        isConnected = true
+        frames = AsyncThrowingStream { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func send(_ frame: String) async throws {
+        XCTAssertTrue(isConnected, "a frame was sent before the transport connected")
+        if let sendFailure {
+            self.sendFailure = nil
+            throw sendFailure
+        }
+        guard let data = frame.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = object["type"] as? String else {
+            return XCTFail("a client frame was not a JSON object with a type: \(frame)")
+        }
+
+        if sent.isEmpty {
+            XCTAssertEqual(type, "session.update",
+                           "the session must be configured before anything else is sent")
+            let session = object["session"] as? [String: Any]
+            let detection = session?["turn_detection"] as? [String: Any]
+            XCTAssertEqual(detection?["type"] as? String, "none",
+                           "server-side turn detection must be disabled on the first frame")
+        }
+
+        switch type {
+        case "input_audio_buffer.append":
+            uncommittedAudio = true
+        case "input_audio_buffer.commit":
+            XCTAssertTrue(uncommittedAudio || allowsEmptyCommit,
+                          "the buffer was committed with nothing in it")
+            uncommittedAudio = false
+        case "response.create":
+            XCTAssertFalse(uncommittedAudio,
+                           "a response was requested over an uncommitted audio buffer")
+        default:
+            break
+        }
+
+        sent.append(object)
+
+        if type == "session.update" {
+            if announcesSessionCreated { push(#"{"type":"session.created","session":{"id":"sess_1"}}"#) }
+            if acknowledgesSessionUpdate { push(#"{"type":"session.updated"}"#) }
+        }
+    }
+
+    func receiveFrames() -> AsyncThrowingStream<String, any Error> {
+        frames ?? AsyncThrowingStream { continuation in
+            continuation.finish(throwing: RealtimeTransportFailure.closed("never connected"))
+        }
+    }
+
+    func close() {
+        closeCount += 1
+        isConnected = false
+        continuation?.finish()
+        continuation = nil
+        frames = nil
+    }
+
+    // MARK: - Scripting
+
+    /// A commit with no preceding append is normally a bug; a few tests exercise the empty
+    /// window deliberately.
+    var allowsEmptyCommit = true
+
+    /// Delivers a raw server frame.
+    func push(_ frame: String) {
+        continuation?.yield(frame)
+    }
+
+    /// Delivers a whole scripted sequence in order.
+    func push(sequence: [String]) {
+        for frame in sequence { push(frame) }
+    }
+
+    /// The peer drops the connection mid-stream.
+    func disconnect(_ failure: RealtimeTransportFailure = .receiveFailed("socket dropped")) {
+        continuation?.finish(throwing: failure)
+        continuation = nil
+    }
+
+    /// The peer hangs up cleanly.
+    func hangUp() {
+        continuation?.finish()
+        continuation = nil
+    }
+
+    // MARK: - Assertions
+
+    var sentTypes: [String] { sent.compactMap { $0["type"] as? String } }
+
+    /// Base64 payloads of every `input_audio_buffer.append`, decoded.
+    var appendedAudio: [Data] {
+        sent.filter { $0["type"] as? String == "input_audio_buffer.append" }
+            .compactMap { $0["audio"] as? String }
+            .compactMap { Data(base64Encoded: $0) }
+    }
+
+    var sessionConfiguration: [String: Any]? {
+        sent.first { $0["type"] as? String == "session.update" }?["session"] as? [String: Any]
+    }
+
+    func instructions(ofResponseAt index: Int) -> String? {
+        let creates = sent.filter { $0["type"] as? String == "response.create" }
+        guard index < creates.count else { return nil }
+        return (creates[index]["response"] as? [String: Any])?["instructions"] as? String
+    }
+
+}
+
+/// A one-shot latch, so a test can hold an async call open at a chosen suspension point
+/// and act while it is parked there.
+@MainActor
+final class AsyncGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let continuation = self.continuation
+        self.continuation = nil
+        continuation?.resume()
+    }
+}
+
+/// Server frames as the service sends them, built once so the codec tests and the adapter
+/// tests are arguing about the same bytes.
+enum RealtimeFrame {
+    static func transcriptDelta(_ text: String) -> String {
+        frame(["type": "conversation.item.input_audio_transcription.delta", "delta": text])
+    }
+
+    static func transcriptCompleted(_ text: String) -> String {
+        frame(["type": "conversation.item.input_audio_transcription.completed",
+               "transcript": text])
+    }
+
+    static func audioDelta(_ audio: Data) -> String {
+        frame(["type": "response.output_audio.delta", "delta": audio.base64EncodedString()])
+    }
+
+    static let responseDone = frame(["type": "response.done",
+                                     "response": ["status": "completed"]])
+
+    static let sessionUpdated = #"{"type":"session.updated"}"#
+
+    static func error(message: String, code: String? = nil,
+                      type: String = "invalid_request_error") -> String {
+        var error: [String: Any] = ["type": type, "message": message]
+        if let code { error["code"] = code }
+        return frame(["type": "error", "error": error])
+    }
+
+    /// An event type this adapter does not model — the service adds them regularly.
+    static let unknownEvent = frame(["type": "rate_limits.updated",
+                                     "rate_limits": [["name": "requests", "remaining": 9]]])
+
+    private static func frame(_ object: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift
@@ -1,0 +1,86 @@
+import XCTest
+import Foundation
+import TapQContracts
+
+/// A `VoiceBackend` that records its call sequence and replays scripted events.
+///
+/// Like the realtime fake, it polices the turn protocol from the backend's side — a turn
+/// call on a closed session, a double begin, or an end with nothing open fails the test
+/// where it happens rather than somewhere downstream. It never ends a turn on its own.
+@MainActor
+final class ScriptedVoiceBackend: VoiceBackend {
+    enum Call: Equatable {
+        case open
+        case close
+        case beginUserTurn
+        case endUserTurn
+        case sendAudio(Int)
+        case requestResponse(String)
+        case cancelResponse
+    }
+
+    let capabilities: VoiceBackendCapabilities
+    let name: String
+    private(set) var calls: [Call] = []
+    private(set) var handlers: [(@MainActor (VoiceBackendEvent) -> Void)] = []
+    private(set) var isOpen = false
+    private(set) var isTurnActive = false
+    /// Set to make `open` throw; cleared to let a retry succeed.
+    var openFailure: VoiceBackendFailure?
+    /// When set, `open` suspends on it.
+    var openGate: (@MainActor () async -> Void)?
+
+    init(name: String = "backend",
+         capabilities: VoiceBackendCapabilities = .transcriptOnly) {
+        self.name = name
+        self.capabilities = capabilities
+    }
+
+    func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+        calls.append(.open)
+        if let openGate { await openGate() }
+        if let openFailure { throw openFailure }
+        isOpen = true
+        handlers.append(onEvent)
+    }
+
+    func close() {
+        calls.append(.close)
+        isOpen = false
+        isTurnActive = false
+    }
+
+    func beginUserTurn() {
+        calls.append(.beginUserTurn)
+        XCTAssertTrue(isOpen, "\(name): beginUserTurn on a closed session")
+        XCTAssertFalse(isTurnActive, "\(name): double beginUserTurn")
+        isTurnActive = true
+    }
+
+    func endUserTurn() {
+        calls.append(.endUserTurn)
+        XCTAssertTrue(isOpen, "\(name): endUserTurn on a closed session")
+        XCTAssertTrue(isTurnActive, "\(name): endUserTurn with no turn open")
+        isTurnActive = false
+    }
+
+    func sendAudio(_ chunk: VoiceAudioChunk) {
+        calls.append(.sendAudio(chunk.data.count))
+        XCTAssertTrue(isTurnActive, "\(name): audio outside a turn")
+    }
+
+    func requestResponse(text: String) {
+        calls.append(.requestResponse(text))
+    }
+
+    func cancelResponse() {
+        calls.append(.cancelResponse)
+    }
+
+    /// Delivers an event to the newest window, or to an older one when a test needs to
+    /// prove stale callbacks are dropped.
+    func emit(_ event: VoiceBackendEvent, toHandler index: Int? = nil) {
+        guard !handlers.isEmpty else { return XCTFail("\(name): no window is listening") }
+        handlers[index ?? handlers.count - 1](event)
+    }
+}

--- a/Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift
@@ -57,11 +57,13 @@ final class ScriptedVoiceBackend: VoiceBackend {
         isTurnActive = true
     }
 
-    func endUserTurn() {
+    @discardableResult
+    func endUserTurn(expectingResponse: Bool) -> Bool {
         calls.append(.endUserTurn)
         XCTAssertTrue(isOpen, "\(name): endUserTurn on a closed session")
         XCTAssertTrue(isTurnActive, "\(name): endUserTurn with no turn open")
         isTurnActive = false
+        return false
     }
 
     func sendAudio(_ chunk: VoiceAudioChunk) {

--- a/Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift
@@ -77,6 +77,12 @@ final class ScriptedVoiceBackend: VoiceBackend {
 
     func cancelResponse() {
         calls.append(.cancelResponse)
+        // Model the documented cancel semantics: the real service acks a cancel with a
+        // responseCompleted event, so test compositions that include this backend see the
+        // same ordering the live path produces.
+        if !handlers.isEmpty {
+            handlers[handlers.count - 1](.responseCompleted)
+        }
     }
 
     /// Delivers an event to the newest window, or to an older one when a test needs to

--- a/Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests.swift
+++ b/Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests.swift
@@ -1,0 +1,230 @@
+import XCTest
+@testable import TapQVoiceBackends
+import TapQContracts
+
+/// What the factory promises, in the order the promises matter:
+///
+/// 1. The default provider is a pass-through — no wrapper, no policy, no cost.
+/// 2. An explicitly requested cloud backend with no credentials fails at startup rather
+///    than quietly serving the on-device one.
+/// 3. Everything the cloud path composes has the on-device stack underneath it.
+@MainActor
+final class VoiceBackendFactoryTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+    }
+
+    /// Records what the realtime seam was handed, and hands back a fake so no test builds a
+    /// WebSocket transport.
+    @MainActor
+    private final class RealtimeSpy {
+        private(set) var apiKeys: [String] = []
+        private(set) var sinks: [any TapQDiagnosticSink] = []
+        let backend: ScriptedVoiceBackend
+
+        init(backend: ScriptedVoiceBackend? = nil) {
+            self.backend = backend ?? ScriptedVoiceBackend(name: "realtime")
+        }
+
+        func make(apiKey: String, sink: any TapQDiagnosticSink) throws -> any VoiceBackend {
+            apiKeys.append(apiKey)
+            sinks.append(sink)
+            return backend
+        }
+    }
+
+    // MARK: - Provider vocabulary
+
+    /// The raw values are the CLI spellings, so a renamed case is a renamed flag and this
+    /// test is the thing that says so out loud.
+    func testProviderRawValuesAreTheFlagSpellings() {
+        XCTAssertEqual(VoiceBackendProvider.allCases.map(\.rawValue),
+                       ["apple", "openai-realtime"])
+        XCTAssertEqual(VoiceBackendProvider(rawValue: "openai-realtime"), .openaiRealtime)
+        XCTAssertNil(VoiceBackendProvider(rawValue: "openai_realtime"))
+    }
+
+    func testOnlyTheNonDefaultProviderReportsAStatusLine() {
+        XCTAssertNil(VoiceBackendProvider.apple.statusDescription)
+        XCTAssertEqual(VoiceBackendProvider.openaiRealtime.statusDescription,
+                       "openai-realtime (fail-through: apple)")
+    }
+
+    // MARK: - Apple
+
+    func testAppleProviderReturnsTheClosuresProductDirectly() throws {
+        let apple = ScriptedVoiceBackend(name: "apple")
+        var builds = 0
+
+        let selection = try VoiceBackendFactory.select(provider: .apple) {
+            builds += 1
+            return apple
+        }
+
+        XCTAssertTrue(selection.backend === apple,
+                      "the default path must not be wrapped in anything")
+        XCTAssertEqual(selection.provider, .apple)
+        XCTAssertNil(selection.statusDescription)
+        XCTAssertEqual(builds, 1)
+    }
+
+    /// The Apple provider is the one path that must work with no credentials at all.
+    func testAppleProviderIgnoresTheAPIKeyEntirely() throws {
+        let selection = try VoiceBackendFactory.select(provider: .apple, openAIAPIKey: nil) {
+            ScriptedVoiceBackend(name: "apple")
+        }
+        XCTAssertEqual(selection.provider, .apple)
+    }
+
+    // MARK: - Missing credentials
+
+    func testRealtimeWithoutAnAPIKeyThrowsAtStartup() {
+        let spy = RealtimeSpy()
+        var appleBuilds = 0
+
+        for key in [nil, "", "   \n"] as [String?] {
+            XCTAssertThrowsError(
+                try select(.openaiRealtime, key: key, spy: spy,
+                           onAppleBuild: { appleBuilds += 1 })
+            ) { error in
+                XCTAssertEqual(error as? VoiceBackendConfigurationError, .missingOpenAIAPIKey)
+            }
+        }
+
+        XCTAssertEqual(
+            VoiceBackendConfigurationError.missingOpenAIAPIKey.localizedDescription,
+            "OpenAI Realtime voice requires OPENAI_API_KEY in the TapQ process environment."
+        )
+        XCTAssertEqual(appleBuilds, 0,
+                       "a doomed startup must not open a recognizer on the way out")
+        XCTAssertEqual(spy.apiKeys, [], "no session is built for a request that cannot run")
+    }
+
+    func testASurroundingWhitespaceKeyIsTrimmedRatherThanRejected() throws {
+        let spy = RealtimeSpy()
+        _ = try select(.openaiRealtime, key: "  sk-live-key\n", spy: spy)
+        XCTAssertEqual(spy.apiKeys, ["sk-live-key"])
+    }
+
+    // MARK: - Composition
+
+    func testRealtimeComposesFailThroughOverTheAppleBackend() throws {
+        let spy = RealtimeSpy()
+        let apple = ScriptedVoiceBackend(name: "apple")
+
+        let selection = try select(.openaiRealtime, key: "sk-key", spy: spy, apple: apple)
+
+        XCTAssertTrue(selection.backend is FailThroughVoiceBackend)
+        XCTAssertEqual(selection.provider, .openaiRealtime)
+        XCTAssertEqual(selection.statusDescription, "openai-realtime (fail-through: apple)")
+        XCTAssertEqual(spy.apiKeys.count, 1)
+        XCTAssertEqual(apple.calls, [], "composition alone must not open the microphone")
+    }
+
+    func testTheDiagnosticSinkReachesTheComposedBackends() async throws {
+        let sink = RecordingSink()
+        let spy = RealtimeSpy()
+
+        let selection = try VoiceBackendFactory.select(
+            provider: .openaiRealtime,
+            openAIAPIKey: "sk-key",
+            diagnosticSink: sink,
+            makeAppleBackend: { ScriptedVoiceBackend(name: "apple") },
+            makeRealtimeBackend: { key, sink in try spy.make(apiKey: key, sink: sink) }
+        )
+        XCTAssertTrue(spy.sinks.first as? RecordingSink === sink,
+                      "the realtime session must log through the host's sink")
+
+        try await selection.backend.open { _ in }
+        selection.backend.close()
+
+        // Only `FailThroughVoiceBackend` records these, so the wrapper got the sink too.
+        XCTAssertEqual(sink.names, ["primary.opened", "session.closed"])
+    }
+
+    /// The composition is only worth anything if the fallback is actually reachable, so the
+    /// factory's product is driven through a primary failure rather than merely inspected.
+    func testTheComposedFallbackIsTheAppleBackend() async throws {
+        let spy = RealtimeSpy()
+        let apple = ScriptedVoiceBackend(name: "apple")
+        spy.backend.openFailure = .network("no route to host")
+
+        let selection = try select(.openaiRealtime, key: "sk-key", spy: spy, apple: apple)
+        var received: [VoiceBackendEvent] = []
+        try await selection.backend.open { received.append($0) }
+        selection.backend.beginUserTurn()
+        apple.emit(.transcriptFinal("yes"))
+
+        XCTAssertEqual(apple.calls, [.open, .beginUserTurn])
+        XCTAssertEqual(received, [.transcriptFinal("yes")])
+    }
+
+    func testAHealthyRealtimeSessionLeavesTheAppleFallbackInert() async throws {
+        let spy = RealtimeSpy()
+        let apple = ScriptedVoiceBackend(name: "apple")
+
+        let selection = try select(.openaiRealtime, key: "sk-key", spy: spy, apple: apple)
+        try await selection.backend.open { _ in }
+        selection.backend.beginUserTurn()
+        spy.backend.emit(.transcriptPartial("yes"))
+        selection.backend.endUserTurn()
+        selection.backend.close()
+
+        XCTAssertEqual(spy.backend.calls,
+                       [.open, .beginUserTurn, .endUserTurn, .close])
+        XCTAssertEqual(apple.calls, [],
+                       "a working cloud session must cost the on-device stack nothing")
+    }
+
+    #if canImport(Darwin)
+    /// The one test that takes the real construction path. It proves the live branch
+    /// compiles and composes; it opens nothing, because nothing in this file calls `open`
+    /// on it and the transport connects no earlier than that.
+    func testTheLiveRealtimePathComposesWithoutTouchingTheNetwork() throws {
+        let apple = ScriptedVoiceBackend(name: "apple")
+        let selection = try VoiceBackendFactory.select(
+            provider: .openaiRealtime,
+            openAIAPIKey: "sk-key"
+        ) { apple }
+
+        XCTAssertTrue(selection.backend is FailThroughVoiceBackend)
+        XCTAssertEqual(apple.calls, [])
+    }
+    #endif
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func select(
+        _ provider: VoiceBackendProvider,
+        key: String?,
+        spy: RealtimeSpy,
+        apple: ScriptedVoiceBackend? = nil,
+        onAppleBuild: () -> Void = {}
+    ) throws -> VoiceBackendSelection {
+        let fallback = apple ?? ScriptedVoiceBackend(name: "apple")
+        return try VoiceBackendFactory.select(
+            provider: provider,
+            openAIAPIKey: key,
+            diagnosticSink: NoOpTapQDiagnosticSink(),
+            makeAppleBackend: {
+                onAppleBuild()
+                return fallback
+            },
+            makeRealtimeBackend: { apiKey, sink in try spy.make(apiKey: apiKey, sink: sink) }
+        )
+    }
+}

--- a/Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests.swift
+++ b/Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests.swift
@@ -205,6 +205,64 @@ final class VoiceBackendFactoryTests: XCTestCase {
     }
     #endif
 
+    // MARK: - Decorator
+
+    /// The decorator wraps only the realtime primary, never the Apple path.
+    func testDecoratorIsAppliedToRealtimePrimaryOnly() throws {
+        let spy = RealtimeSpy()
+        var decorated: (any VoiceBackend)?
+        let selection = try VoiceBackendFactory.select(
+            provider: .openaiRealtime,
+            openAIAPIKey: "sk-key",
+            decorateRealtimePrimary: { primary in
+                decorated = primary
+                return ScriptedVoiceBackend(name: "decorated")
+            },
+            diagnosticSink: NoOpTapQDiagnosticSink(),
+            makeAppleBackend: { ScriptedVoiceBackend(name: "apple") },
+            makeRealtimeBackend: { apiKey, sink in try spy.make(apiKey: apiKey, sink: sink) }
+        )
+
+        XCTAssertTrue(decorated === spy.backend,
+                      "the decorator receives the raw realtime primary")
+        XCTAssertTrue(selection.backend is FailThroughVoiceBackend)
+    }
+
+    func testDecoratorIsNotInvokedForAppleProvider() throws {
+        var decoratorCalled = false
+        let selection = try VoiceBackendFactory.select(
+            provider: .apple,
+            openAIAPIKey: nil,
+            decorateRealtimePrimary: { backend in
+                decoratorCalled = true
+                return backend
+            },
+            diagnosticSink: NoOpTapQDiagnosticSink(),
+            makeAppleBackend: { ScriptedVoiceBackend(name: "apple") },
+            makeRealtimeBackend: { _, _ in ScriptedVoiceBackend(name: "realtime") }
+        )
+
+        XCTAssertFalse(decoratorCalled,
+                       "the Apple path must not invoke the realtime decorator")
+        XCTAssertTrue(selection.backend is ScriptedVoiceBackend)
+        XCTAssertEqual(selection.provider, .apple)
+    }
+
+    func testNilDecoratorLeavesThePrimaryUnwrapped() throws {
+        let spy = RealtimeSpy()
+        let selection = try VoiceBackendFactory.select(
+            provider: .openaiRealtime,
+            openAIAPIKey: "sk-key",
+            decorateRealtimePrimary: nil,
+            diagnosticSink: NoOpTapQDiagnosticSink(),
+            makeAppleBackend: { ScriptedVoiceBackend(name: "apple") },
+            makeRealtimeBackend: { apiKey, sink in try spy.make(apiKey: apiKey, sink: sink) }
+        )
+
+        XCTAssertTrue(selection.backend is FailThroughVoiceBackend,
+                      "with no decorator the composition is unchanged")
+    }
+
     // MARK: - Helpers
 
     @discardableResult

--- a/Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests.swift
+++ b/Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests.swift
@@ -180,7 +180,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
         try await selection.backend.open { _ in }
         selection.backend.beginUserTurn()
         spy.backend.emit(.transcriptPartial("yes"))
-        selection.backend.endUserTurn()
+        selection.backend.endUserTurn(expectingResponse: true)
         selection.backend.close()
 
         XCTAssertEqual(spy.backend.calls,

--- a/Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests.swift
+++ b/Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests.swift
@@ -50,14 +50,14 @@ final class VoiceBackendFactoryTests: XCTestCase {
 
     /// The raw values are the CLI spellings, so a renamed case is a renamed flag and this
     /// test is the thing that says so out loud.
-    func testProviderRawValuesAreTheFlagSpellings() {
+    func testProviderRawValuesAreTheFlagSpellings() async {
         XCTAssertEqual(VoiceBackendProvider.allCases.map(\.rawValue),
                        ["apple", "openai-realtime"])
         XCTAssertEqual(VoiceBackendProvider(rawValue: "openai-realtime"), .openaiRealtime)
         XCTAssertNil(VoiceBackendProvider(rawValue: "openai_realtime"))
     }
 
-    func testOnlyTheNonDefaultProviderReportsAStatusLine() {
+    func testOnlyTheNonDefaultProviderReportsAStatusLine() async {
         XCTAssertNil(VoiceBackendProvider.apple.statusDescription)
         XCTAssertEqual(VoiceBackendProvider.openaiRealtime.statusDescription,
                        "openai-realtime (fail-through: apple)")
@@ -65,7 +65,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
 
     // MARK: - Apple
 
-    func testAppleProviderReturnsTheClosuresProductDirectly() throws {
+    func testAppleProviderReturnsTheClosuresProductDirectly() async throws {
         let apple = ScriptedVoiceBackend(name: "apple")
         var builds = 0
 
@@ -82,7 +82,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
     }
 
     /// The Apple provider is the one path that must work with no credentials at all.
-    func testAppleProviderIgnoresTheAPIKeyEntirely() throws {
+    func testAppleProviderIgnoresTheAPIKeyEntirely() async throws {
         let selection = try VoiceBackendFactory.select(provider: .apple, openAIAPIKey: nil) {
             ScriptedVoiceBackend(name: "apple")
         }
@@ -91,7 +91,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
 
     // MARK: - Missing credentials
 
-    func testRealtimeWithoutAnAPIKeyThrowsAtStartup() {
+    func testRealtimeWithoutAnAPIKeyThrowsAtStartup() async {
         let spy = RealtimeSpy()
         var appleBuilds = 0
 
@@ -113,7 +113,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
         XCTAssertEqual(spy.apiKeys, [], "no session is built for a request that cannot run")
     }
 
-    func testASurroundingWhitespaceKeyIsTrimmedRatherThanRejected() throws {
+    func testASurroundingWhitespaceKeyIsTrimmedRatherThanRejected() async throws {
         let spy = RealtimeSpy()
         _ = try select(.openaiRealtime, key: "  sk-live-key\n", spy: spy)
         XCTAssertEqual(spy.apiKeys, ["sk-live-key"])
@@ -121,7 +121,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
 
     // MARK: - Composition
 
-    func testRealtimeComposesFailThroughOverTheAppleBackend() throws {
+    func testRealtimeComposesFailThroughOverTheAppleBackend() async throws {
         let spy = RealtimeSpy()
         let apple = ScriptedVoiceBackend(name: "apple")
 
@@ -193,7 +193,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
     /// The one test that takes the real construction path. It proves the live branch
     /// compiles and composes; it opens nothing, because nothing in this file calls `open`
     /// on it and the transport connects no earlier than that.
-    func testTheLiveRealtimePathComposesWithoutTouchingTheNetwork() throws {
+    func testTheLiveRealtimePathComposesWithoutTouchingTheNetwork() async throws {
         let apple = ScriptedVoiceBackend(name: "apple")
         let selection = try VoiceBackendFactory.select(
             provider: .openaiRealtime,
@@ -208,7 +208,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
     // MARK: - Decorator
 
     /// The decorator wraps only the realtime primary, never the Apple path.
-    func testDecoratorIsAppliedToRealtimePrimaryOnly() throws {
+    func testDecoratorIsAppliedToRealtimePrimaryOnly() async throws {
         let spy = RealtimeSpy()
         var decorated: (any VoiceBackend)?
         let selection = try VoiceBackendFactory.select(
@@ -228,7 +228,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
         XCTAssertTrue(selection.backend is FailThroughVoiceBackend)
     }
 
-    func testDecoratorIsNotInvokedForAppleProvider() throws {
+    func testDecoratorIsNotInvokedForAppleProvider() async throws {
         var decoratorCalled = false
         let selection = try VoiceBackendFactory.select(
             provider: .apple,
@@ -248,7 +248,7 @@ final class VoiceBackendFactoryTests: XCTestCase {
         XCTAssertEqual(selection.provider, .apple)
     }
 
-    func testNilDecoratorLeavesThePrimaryUnwrapped() throws {
+    func testNilDecoratorLeavesThePrimaryUnwrapped() async throws {
         let spy = RealtimeSpy()
         let selection = try VoiceBackendFactory.select(
             provider: .openaiRealtime,

--- a/Tests/TapQVoiceBackendsTests/VoiceBackendFailThroughWindowTests.swift
+++ b/Tests/TapQVoiceBackendsTests/VoiceBackendFailThroughWindowTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import TapQVoiceBackends
+import TapQContracts
+@testable import TapQInteractionBaseline
+
+/// The whole point of the milestone's voice work, exercised as one stack: a command
+/// provider on top of a fail-through wrapper on top of the real OpenAI Realtime adapter
+/// talking to a scripted server, with the Apple stack underneath as the fallback.
+///
+/// Every layer below has its own tests; these are the ones that would catch a composition
+/// that is individually correct and jointly useless — a socket that dies mid-window and
+/// takes the wearer's approval with it.
+///
+/// The fallback is a `ScriptedVoiceBackend` rather than `AppleVoiceBackend` deliberately:
+/// this target is portable, and what matters here is that the *composition* recovers, not
+/// which recognizer answers.
+@MainActor
+final class VoiceBackendFailThroughWindowTests: XCTestCase {
+    private func settle() async {
+        for _ in 0..<12 { await Task.yield() }
+    }
+
+    /// Stands in for `VoiceCommandMatcher.match`, which lives in a target this one does not
+    /// depend on. The grammar is not what is under test; cumulative-transcript matching is.
+    private nonisolated func match(_ transcript: String) -> VoiceCommand? {
+        let text = transcript.lowercased()
+        if text.contains("yes") { return .yes }
+        if text.contains("no") { return .no }
+        return nil
+    }
+
+    private struct Stack {
+        let server: ScriptedRealtimeServer
+        let realtime: OpenAIRealtimeVoiceBackend
+        let apple: ScriptedVoiceBackend
+        let failThrough: FailThroughVoiceBackend
+        let provider: VoiceBackendCommandProvider
+    }
+
+    private func makeStack() -> Stack {
+        let server = ScriptedRealtimeServer()
+        let realtime = OpenAIRealtimeVoiceBackend(transport: server, monotonicNow: { 0 })
+        let apple = ScriptedVoiceBackend(name: "apple")
+        let failThrough = FailThroughVoiceBackend(primary: realtime, fallback: apple)
+        return Stack(
+            server: server,
+            realtime: realtime,
+            apple: apple,
+            failThrough: failThrough,
+            provider: VoiceBackendCommandProvider(backend: failThrough,
+                                                  match: { self.match($0) })
+        )
+    }
+
+    func testATransportDeathMidWindowStillResolvesTheWindowOnTheFallback() async {
+        let stack = makeStack()
+        var delivered: [VoiceCommand] = []
+
+        stack.provider.start { delivered.append($0) }
+        await settle()
+        XCTAssertEqual(stack.server.sentTypes.first, "session.update",
+                       "the realtime session must be the one that opened")
+        XCTAssertEqual(stack.apple.calls, [], "the fallback stays inert while the cloud works")
+
+        // The wearer is mid-sentence and the socket dies.
+        stack.server.disconnect()
+        await settle()
+
+        XCTAssertEqual(stack.apple.calls, [.open, .beginUserTurn],
+                       "the window moves to the on-device stack with its turn intact")
+        XCTAssertTrue(delivered.isEmpty, "nothing is delivered by the failure itself")
+
+        // The wearer answers into the recovered window.
+        stack.apple.emit(.transcriptPartial("yes"))
+
+        XCTAssertEqual(delivered, [.yes],
+                       "the approval still resolves by voice; the caller never learns why")
+        XCTAssertEqual(stack.apple.calls,
+                       [.open, .beginUserTurn, .endUserTurn, .close],
+                       "the recovered window tears down exactly like a healthy one")
+        XCTAssertFalse(stack.provider.isWindowOpenForTesting)
+    }
+
+    /// The failure has to be invisible above the seam: no window is torn down, and no
+    /// second `start` is needed to keep listening.
+    func testTheCommandProviderNeverSeesTheFailure() async {
+        let stack = makeStack()
+        stack.provider.start { _ in }
+        await settle()
+
+        stack.server.disconnect()
+        await settle()
+
+        XCTAssertTrue(stack.provider.isWindowOpenForTesting,
+                      "a dead primary must not resolve or abandon the wearer's window")
+    }
+
+    func testAHealthyRealtimeWindowResolvesWithoutTouchingTheFallback() async {
+        let stack = makeStack()
+        var delivered: [VoiceCommand] = []
+
+        stack.provider.start { delivered.append($0) }
+        await settle()
+        stack.server.push(RealtimeFrame.transcriptDelta("yes"))
+        await settle()
+
+        XCTAssertEqual(delivered, [.yes])
+        XCTAssertEqual(stack.apple.calls, [],
+                       "a working cloud window must cost the on-device stack nothing")
+        await settle()
+        // Nothing but the manual-turn configuration ever left: the match resolved the
+        // window, so the session was torn down before anything could ask for a response.
+        // The invariant that matters is the negative one — no `response.create` was sent,
+        // and the peer had no way to produce one on its own.
+        XCTAssertEqual(stack.server.sentTypes, ["session.update"])
+        XCTAssertEqual(stack.server.closeCount, 1,
+                       "a resolved window closes the realtime session")
+    }
+
+    /// Both pipes gone is the one case that surfaces: the window then resolves by gesture,
+    /// tap, or timeout, which is exactly what a torn-down provider leaves it free to do.
+    func testWhenTheFallbackAlsoFailsTheWindowClosesQuietly() async {
+        let stack = makeStack()
+        stack.apple.openFailure = .authorization("speech recognition is unavailable")
+        var delivered: [VoiceCommand] = []
+
+        stack.provider.start { delivered.append($0) }
+        await settle()
+        stack.server.disconnect()
+        await settle()
+
+        XCTAssertTrue(delivered.isEmpty)
+        XCTAssertFalse(stack.provider.isWindowOpenForTesting,
+                       "with nothing left underneath, the voice window gives up rather than hanging")
+    }
+}

--- a/Tests/TapQWireProtocolTests/SelectionWireTests.swift
+++ b/Tests/TapQWireProtocolTests/SelectionWireTests.swift
@@ -28,4 +28,47 @@ final class SelectionWireTests: XCTestCase {
         let decoded = try JSONDecoder().decode(BrokerResponse.self, from: data)
         XCTAssertEqual(decoded, response)
     }
+
+    // MARK: - free_text selection responses
+
+    func testSelectionWithFreeTextEncodes() throws {
+        let response = BrokerResponse.selection(indices: [], labels: [], freeText: "deploy to staging")
+        let data = response.encoded()
+        let decoded = try JSONDecoder().decode([String: JSONValue].self, from: data)
+        XCTAssertEqual(decoded["selected_indices"]?.arrayValue?.count, 0)
+        XCTAssertEqual(decoded["selected_labels"]?.arrayValue?.count, 0)
+        XCTAssertEqual(decoded["free_text"]?.stringValue, "deploy to staging")
+    }
+
+    func testSelectionWithFreeTextRoundTrips() throws {
+        let response = BrokerResponse.selection(indices: [], labels: [], freeText: "deploy to staging")
+        let data = response.encoded()
+        let decoded = try JSONDecoder().decode(BrokerResponse.self, from: data)
+        XCTAssertEqual(decoded, response)
+    }
+
+    func testSelectionWithoutFreeTextIsByteIdenticalToV3() throws {
+        // When freeText is nil, the encoded bytes must match the v3 shape exactly
+        // (no free_text key present).
+        let response = BrokerResponse.selection(indices: [1], labels: ["Blue"])
+        let data = response.encoded()
+        let decoded = try JSONDecoder().decode([String: JSONValue].self, from: data)
+        XCTAssertNil(decoded["free_text"], "absent freeText must not produce a free_text key")
+        XCTAssertEqual(decoded.count, 2, "only selected_indices and selected_labels")
+    }
+
+    func testSelectionWithBothLabelsAndFreeTextRoundTrips() throws {
+        // Defensive: a response with both labels and freeText preserves both.
+        let response = BrokerResponse.selection(indices: [0], labels: ["Red"], freeText: "red please")
+        let data = response.encoded()
+        let decoded = try JSONDecoder().decode(BrokerResponse.self, from: data)
+        XCTAssertEqual(decoded, response)
+    }
+
+    func testV3SelectionBytesDecodeWithNilFreeText() throws {
+        // Simulate a v3 broker response (no free_text key) and verify it decodes.
+        let v3JSON = #"{"selected_indices":[0],"selected_labels":["Red"]}"#
+        let decoded = try JSONDecoder().decode(BrokerResponse.self, from: Data(v3JSON.utf8))
+        XCTAssertEqual(decoded, .selection(indices: [0], labels: ["Red"]))
+    }
 }

--- a/Tests/TapQWireProtocolTests/WireProtocolTests.swift
+++ b/Tests/TapQWireProtocolTests/WireProtocolTests.swift
@@ -84,7 +84,13 @@ final class WireProtocolTests: XCTestCase {
     }
 
     func testResponseRoundTrips() throws {
-        for response: BrokerResponse in [.decision(.ask, reason: nil), .ok, .error("nope")] {
+        for response: BrokerResponse in [
+            .decision(.ask, reason: nil),
+            .ok,
+            .error("nope"),
+            .selection(indices: [0], labels: ["A"]),
+            .selection(indices: [], labels: [], freeText: "typed answer"),
+        ] {
             let data = response.encoded()
             let decoded = try JSONDecoder().decode(BrokerResponse.self, from: data)
             XCTAssertEqual(decoded, response)
@@ -106,16 +112,44 @@ final class WireProtocolTests: XCTestCase {
     }
 
     func testCompatibilityRule() {
-        XCTAssertFalse(WireProtocol.isCompatible(nil), "v1-de-facto peers must fail a v3 check")
+        XCTAssertFalse(WireProtocol.isCompatible(nil), "v1-de-facto peers must fail a v4 check")
         XCTAssertTrue(WireProtocol.isCompatible(WireProtocol.version))
         XCTAssertFalse(WireProtocol.isCompatible(WireProtocol.version + 1))
     }
 
+    func testVersionAcceptanceMatrix() {
+        // nil (v1 de facto): rejected
+        XCTAssertFalse(WireProtocol.isCompatible(nil))
+        // 1: rejected
+        XCTAssertFalse(WireProtocol.isCompatible(1))
+        // 2: rejected (was already rejected in v3)
+        XCTAssertFalse(WireProtocol.isCompatible(2))
+        // 3: accepted (backward compat — request shapes identical to v4)
+        XCTAssertTrue(WireProtocol.isCompatible(3))
+        // 4: accepted (current)
+        XCTAssertTrue(WireProtocol.isCompatible(4))
+    }
+
     func testShimNegotiatesV2OnlyForLegacySafeMessages() {
+        // v4 shim → v4 broker: speak v4
+        XCTAssertEqual(
+            WireProtocol.outboundVersion(for: 4, approvalSource: .permissionRequest),
+            4
+        )
+        // v4 shim → v3 broker: speak v3 (request shapes identical)
         XCTAssertEqual(
             WireProtocol.outboundVersion(for: 3, approvalSource: .permissionRequest),
             3
         )
+        XCTAssertEqual(
+            WireProtocol.outboundVersion(for: 3, approvalSource: .preToolUse),
+            3
+        )
+        XCTAssertEqual(
+            WireProtocol.outboundVersion(for: 3, approvalSource: nil),
+            3
+        )
+        // v2 bridge rules unchanged
         XCTAssertEqual(
             WireProtocol.outboundVersion(for: 2, approvalSource: .preToolUse),
             2
@@ -128,7 +162,8 @@ final class WireProtocolTests: XCTestCase {
             WireProtocol.outboundVersion(for: 2, approvalSource: .permissionRequest)
         )
         XCTAssertNil(WireProtocol.outboundVersion(for: nil, approvalSource: nil))
-        XCTAssertNil(WireProtocol.outboundVersion(for: 4, approvalSource: nil))
+        // Unknown future version: nil
+        XCTAssertNil(WireProtocol.outboundVersion(for: 5, approvalSource: nil))
     }
 
     func testNilPeerIncompatibleOnceVersionBumps() {
@@ -138,8 +173,8 @@ final class WireProtocolTests: XCTestCase {
         XCTAssertFalse(WireProtocol.isCompatible(1, current: 2))
     }
 
-    func testVersionIsThreeAndRejectsPreApprovalSourcePeers() {
-        XCTAssertEqual(WireProtocol.version, 3)
+    func testVersionIsFourAndRejectsPreApprovalSourcePeers() {
+        XCTAssertEqual(WireProtocol.version, 4)
         XCTAssertFalse(WireProtocol.isCompatible(2),
                        "v2 peers do not understand policy-significant approval_source")
     }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -56,6 +56,7 @@ scripts/run-runtime-app.sh serve --steering
 scripts/run-runtime-app.sh serve --question-classifier anthropic
 # With OPENAI_API_KEY already present in the launcher environment:
 scripts/run-runtime-app.sh serve --question-classifier openai
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime
 ```
 
 The underlying command syntax is `tapq serve [options]`.
@@ -77,6 +78,7 @@ The underlying command syntax is `tapq serve [options]`.
 | `--reasoner PROVIDER` | Stage-2 risk reasoner backend: `off` (default) or `apple`, Apple's on-device Foundation Model |
 | `--reasoner-mode shadow\|primary` | `shadow` (default) records reasoner decisions as diagnostics while confirmation requirements stay as the deterministic policy set them; `primary` lets a decision strengthen the requirement for that request. A reasoner can only ask for *more* confirmation — it can never approve, deny, or resolve a request, so every failure, timeout, or absent model leaves behavior exactly as it is today. Requires `--reasoner`; a device without the model keeps serving without risk escalation and reports it |
 | `--question-classifier PROVIDER` | Select `auto`, `apple`, `anthropic`, `openai`, or `local`; default is `auto` |
+| `--voice-backend PROVIDER` | Speech pipe for voice commands: `apple` (default) or `openai-realtime` |
 
 Selecting a reasoner also starts a local decision log at
 `<broker-dir>/reasoner-log.jsonl` — one JSON line per reasoner-observed approval,
@@ -111,6 +113,30 @@ Question classifier modes:
 - `local` uses only the deterministic structured-option heuristic.
 
 The selected mode applies to every agent adapter connected to that runtime instance.
+
+### Voice backend
+
+`--voice-backend` selects the speech pipe behind voice commands. It is independent of
+`--question-classifier`, which chooses how a *written* agent question is interpreted.
+
+- `apple` is the default and is exactly the shipped composition: Apple's on-device
+  recognizer, opened only inside a bounded response window. No status line is printed,
+  because nothing changed.
+- `openai-realtime` requires `OPENAI_API_KEY` in the runtime's environment and refuses to
+  start without it, the same way `--question-classifier openai` does. It uses OpenAI's
+  Realtime API in manual-turn mode. The ready block reports
+  `Voice backend: openai-realtime (fail-through: apple)`.
+
+There is no OpenAI-only mode. The realtime backend is always composed with the Apple stack
+underneath it, so a session that cannot be opened — or that drops mid-window — continues
+on-device rather than leaving the window without a voice channel. Gesture, tap, and
+timeout resolution are unaffected in every case.
+
+Turn arbitration stays on TapQ's side in both modes: server-side voice activity detection
+is disabled (`turn_detection: none`) and TapQ commits each turn itself, so a remote
+endpoint can never decide the wearer has finished speaking. Audio leaves the machine only
+while a response window is open, and the API key is sent as a request header and is not
+logged.
 
 On macOS, `tapq serve`:
 
@@ -175,6 +201,7 @@ before sharing.
 tapq capture --duration 10 --output capture.jsonl
 tapq capture --duration 10 --format csv --output capture.csv
 tapq capture --duration 5 --output -
+tapq capture --duration 30 -o imu.jsonl --mic-envelope imu.envelope.jsonl
 ```
 
 | Option | Default or behavior |
@@ -182,7 +209,8 @@ tapq capture --duration 5 --output -
 | `--duration SECONDS` | `10` |
 | `--format jsonl\|csv` | `jsonl` |
 | `--output PATH`, `-o PATH` | `-` for stdout |
-| `--force`, `-f` | Off; existing files are preserved |
+| `--force`, `-f` | Off; existing files are preserved; also applies to `--mic-envelope` |
+| `--mic-envelope PATH` | Off; co-record a microphone loudness envelope sidecar |
 
 Progress and the final sample count go to stderr, keeping stdout pipe-safe. CSV
 output begins with a header. Each record contains:
@@ -200,6 +228,42 @@ against earlier captures keeps working; per-axis columns are appended.
 
 Capture does not run gesture classification. It requires macOS, compatible
 connected AirPods, and Motion permission. Linux returns an unavailable error.
+
+### Microphone envelope sidecar
+
+`--mic-envelope PATH` co-records a microphone loudness envelope alongside the motion
+track. It is capture-study tooling for labeling wearer speech, not a runtime input: it
+answers *when* someone was talking so an IMU-based wearer-speech detector can be scored
+against something that actually heard the room.
+
+No audio is retained. Each audio block is reduced to a root-mean-square and a peak value
+and the samples themselves are discarded, so the sidecar cannot reconstruct what was said.
+Using the flag requires Microphone permission and adds a microphone open to a command
+that is otherwise motion-only.
+
+The sidecar is always line-delimited JSON regardless of the motion track's `--format`,
+because its header line has no CSV equivalent. The first line is the track header and
+every following line is one block:
+
+```json
+{"block_frames":4800,"clock":"boottime","sample_rate":48000,"schema":"tapq-mic-envelope-v1"}
+{"peak":0.0121,"rms":0.0034,"timestamp":13485.221}
+```
+
+`timestamp` is on the same seconds-since-boot clock CoreMotion stamps motion samples
+with, so the two tracks overlay directly with no second alignment step. The envelope's own
+rate is `sample_rate / block_frames` points per second. A reader that meets an unfamiliar
+`schema` rejects the file rather than guessing at its samples.
+
+Failure policy is deliberately fail-closed, unlike TapQ's runtime paths. A study session
+whose label track never opened is not worth keeping, so if the microphone cannot start the
+command exits `69` before any motion is recorded. If the audio route is invalidated
+mid-capture — switching input devices, for instance — the motion capture still finishes
+and is written, stderr reports that the sidecar is truncated, and the command exits `1`.
+
+Select the Mac's built-in microphone as the system input before co-recording. Opening the
+AirPods microphone switches Bluetooth into its headset mode, which degrades the audio
+route mid-session and changes the very motion signal the study is trying to measure.
 
 ## Replay and evaluation
 
@@ -224,6 +288,8 @@ change against the same data.
 | `--encoder-model PATH` | Also replay through a TapQ-1 encoder model (macOS only) |
 | `--gesture-profile PATH` | Replay with a calibrated gesture profile instead of defaults |
 | `--tap-profile PATH` | Replay with a calibrated tap profile instead of defaults |
+| `--wearer-speech-profile PATH` | Replay with a calibrated wearer-speech profile instead of defaults |
+| `--mic-envelope PATH` | Envelope sidecar to derive wearer-speech ground truth from |
 | `--json` | Emit the machine-readable report |
 
 Without labels, replay lists every emitted event with its offset. With labels,
@@ -246,6 +312,42 @@ enabled during replay even though it ships disabled live, so experimental
 channels can be evaluated from the same recordings. Magnitude-only captures from
 before per-axis capture replay through the heuristic backend; the encoder
 backend needs per-axis data.
+
+### Wearer speech
+
+Replay also scores wearer-speech detection — whether the IMU can tell that the person
+wearing the earbuds is the one talking. Unlike a gesture, speech is interval-valued rather
+than event-valued, so it is reported separately and scored by frame overlap rather than by
+the event evaluator.
+
+Ground truth comes from one of two places:
+
+- a `wearer_speech` label segment, which marks a span the wearer was talking:
+
+  ```json
+  {"start": 3.0, "end": 8.5, "label": "wearer_speech"}
+  ```
+
+- or `--mic-envelope PATH`, a sidecar from `tapq capture --mic-envelope`, from which
+  speech spans are derived by thresholding the envelope against the recording's own noise
+  floor with hysteresis and a short-gap merge.
+
+Labels win when both are supplied, and a note is printed to stderr. Without either, the
+section is omitted entirely and the report is exactly the shape it had before wearer
+speech existed. `--tolerance` doubles as the edge slack allowed on both sides of a
+wearer-speech span, since the edges of an utterance are approximate in a way a nod's are
+not.
+
+The text report prints frame-level true/false positives and negatives, precision, recall,
+and F1 at the capture's own sample rate, plus mean onset latency over matched segments and
+false activations per minute. Under `--json` the same numbers appear as a `wearer_speech`
+object with the keys `truth_source` (`labels` or `mic_envelope`), `frame_precision`,
+`frame_recall`, `f1`, `onset_latency_mean_seconds`, `false_activations`,
+`false_activations_per_minute`, `detected_intervals`, `truth_intervals`, and
+`matched_intervals`.
+
+Threshold defaults are provisional until the capture study, which is why the detector's
+configuration lives in a calibration profile rather than in code.
 
 ## Reasoner bench
 
@@ -325,13 +427,16 @@ report a score for a corpus it did not run.
 tapq calibration run
 tapq calibration run gesture
 tapq calibration run tap
+tapq calibration run wearer-speech
 tapq calibrate
 tapq calibration show
 tapq calibration show gesture
 tapq calibration show tap
+tapq calibration show wearer-speech
 tapq calibration show --json
 tapq calibration reset
 tapq calibration reset tap
+tapq calibration reset wearer-speech
 ```
 
 For source development on macOS, substitute
@@ -345,16 +450,26 @@ For source development on macOS, substitute
 | `--nod-seconds N` | 4 seconds |
 | `--shake-seconds N` | 4 seconds |
 | `--tap-seconds N` | 4 seconds |
+| `--speak-seconds N` | 6 seconds |
 | `--non-interactive` | Off; when supplied, skips the initial Return prompt |
 
-The default `all` run advances through connection warmup, rest, nod, shake, and
-tap in one continuous motion session. A gesture-only run is 14 seconds by
+The default `all` run advances through connection warmup, rest, nod, shake, tap,
+and speak in one continuous motion session. A gesture-only run is 14 seconds by
 default; a tap-only retry is 9 seconds. The timeline discards a one-second
 connection warmup and one-second transitions.
 
-Gesture and tap results are saved as independent profiles. If tap fails after a
-valid gesture sequence, the gesture profile remains saved; rerun only
-`tapq calibration run tap`.
+Gesture, tap, and wearer-speech results are saved as three independent profiles.
+Each usable profile is saved as soon as its phase is assessed, so a later failure
+never discards an earlier success: if tap fails after a valid gesture sequence,
+the gesture profile remains saved and only `tapq calibration run tap` needs
+rerunning. The same holds for the speak phase.
+
+The speak phase asks the wearer to read aloud at a normal volume with the head
+still. It measures the jaw- and skull-borne vibration the earbud IMU picks up
+during speech, which is a different quantity from anything the microphone hears
+and is only meaningful against a resting baseline recorded in the same session.
+It is longer than the other phases by default because the statistic is a median
+over sustained vibration rather than a peak over discrete events.
 
 Tap calibration evaluates a sharp acceleration spike against the resting
 baseline. It accepts lower-amplitude hardware only when the captured peak is at
@@ -364,7 +479,9 @@ requires a brief spike, quiet head rotation, a return toward baseline, and two
 distinct impacts inside the pairing window.
 
 Profiles contain tuned configuration, timestamps, sample counts, and aggregate
-quality metrics. They do not retain raw motion values.
+quality metrics. They do not retain raw motion values. `calibration show --json`
+emits one object keyed `gesture`, `tap`, and `wearer_speech`, with only the
+profiles that exist present.
 
 ### Profile locations
 
@@ -374,12 +491,15 @@ quality metrics. They do not retain raw motion values.
 | Linux | `$XDG_CONFIG_HOME/tapq/`, or `~/.config/tapq/` |
 | Override | `$TAPQ_CONFIG_DIR/` |
 
-The filenames are `gesture-calibration.json` and `tap-calibration.json`.
+The filenames are `gesture-calibration.json`, `tap-calibration.json`, and
+`wearer-speech-calibration.json`.
 
-For a selected `gesture` or `tap` target, `--profile PATH` overrides that
-profile. `--gesture-profile PATH` and `--tap-profile PATH` can override both
-paths for an `all` run, show, or reset. `calibration reset` prompts unless
-`--yes` or `-y` is supplied.
+For a selected `gesture`, `tap`, or `wearer-speech` target, `--profile PATH`
+overrides that one profile; it is rejected under `all`, where three documents are
+in play. `--gesture-profile PATH`, `--tap-profile PATH`, and
+`--wearer-speech-profile PATH` can override the paths individually for an `all`
+run, show, or reset. `calibration reset` prompts unless `--yes` or `-y` is
+supplied, and resetting one target never touches the other two.
 
 Profile inspection and reset work on Linux; live acquisition does not.
 
@@ -601,7 +721,7 @@ tasks.
 | `TAPQ_CONFIG_DIR` | Override calibration profile storage |
 | `CODEX_HOME` | Select the Codex state directory whose `hooks.json` the integration command manages |
 | `ANTHROPIC_API_KEY` | Authenticate classification requests selected with `--question-classifier anthropic` |
-| `OPENAI_API_KEY` | Authenticate classification requests selected with `--question-classifier openai` |
+| `OPENAI_API_KEY` | Authenticate classification requests selected with `--question-classifier openai`, and realtime voice sessions selected with `--voice-backend openai-realtime` |
 | `TAPQ_SIGN_IDENTITY` | Select a signing identity for the packaging script |
 
 Default broker directories:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -37,7 +37,7 @@ tapq version --json
 The JSON form includes the CLI version and wire protocol version:
 
 ```json
-{"name":"tapq","version":"0.4.0-beta.1","wire_protocol":3}
+{"name":"tapq","version":"0.4.0-beta.1","wire_protocol":4}
 ```
 
 The project is pre-1.0. Machine-readable formats are designed for automation,
@@ -79,6 +79,9 @@ The underlying command syntax is `tapq serve [options]`.
 | `--reasoner-mode shadow\|primary` | `shadow` (default) records reasoner decisions as diagnostics while confirmation requirements stay as the deterministic policy set them; `primary` lets a decision strengthen the requirement for that request. A reasoner can only ask for *more* confirmation — it can never approve, deny, or resolve a request, so every failure, timeout, or absent model leaves behavior exactly as it is today. Requires `--reasoner`; a device without the model keeps serving without risk escalation and reports it |
 | `--question-classifier PROVIDER` | Select `auto`, `apple`, `anthropic`, `openai`, or `local`; default is `auto` |
 | `--voice-backend PROVIDER` | Speech pipe for voice commands: `apple` (default) or `openai-realtime` |
+| `--wearer-gate` | IMU-based wearer-speech attribution gate (default: off). Voice commands must be attributed to the wearer's own jaw vibration; commands from bystanders or other audio sources are rejected. Fails open when the signal is unavailable or degraded. Uses `wearer-speech-calibration.json` when present, provisional thresholds otherwise |
+| `--imu-turn-control` | IMU-based turn control (default: off). Endpointing: wearer speech-end commits the user turn after a short delay. Barge-in: wearer speech-onset during response audio interrupts playback. Both are additive to gesture/tap/timeout resolution. Shares one signal source with `--wearer-gate` |
+| `--voice-freeform` | Free-form voice answers for selections and multi-option stop questions (default: off). Requires `--voice-backend openai-realtime`. An unmatched final transcript is offered as a free-text reply with mandatory read-back confirmation. Tool approvals and yes/no stop questions stay binary |
 
 Selecting a reasoner also starts a local decision log at
 `<broker-dir>/reasoner-log.jsonl` — one JSON line per reasoner-observed approval,
@@ -138,6 +141,114 @@ endpoint can never decide the wearer has finished speaking. Audio leaves the mac
 while a response window is open, and the API key is sent as a request header and is not
 logged.
 
+#### Conversation sessions
+
+On the `openai-realtime` path, the backend session uses conversation-scoped persistence:
+one WebSocket session outlives multiple response windows. A per-window session policy
+(milestone one's behavior) would open and close a full WebSocket session on every mic
+reopen — several times per approval — because `SpeechGatedVoice` stops and restarts the
+voice provider every time TTS becomes busy. Conversation sessions eliminate that churn.
+
+The session stays open across windows and is closed by an idle timer (60 seconds with no
+window open) or by a serve shutdown. A new window opens a fresh user turn on the existing
+session. Fail-through is sticky per conversation: once the primary backend fails (network
+death, handshake timeout), subsequent windows go straight to the Apple fallback with no
+primary traffic until the conversation resets on idle-close reopen. This prevents a 5-second
+handshake timeout at every mic reopen when the network is down.
+
+The `apple` path is unchanged: `VoiceListener` opens and closes its recognizer per window,
+exactly as before.
+
+#### Microphone pump and playback
+
+The `openai-realtime` backend is a pipe: it transmits and receives audio but does not own
+the microphone or the speaker. Two macOS adapters bridge the gap:
+
+- **Microphone pump** (`MicrophonePumpVoiceBackend`): opens the Mac's audio input on each
+  user turn, converts captured buffers to the pipe's wire format (mono 24 kHz PCM16), and
+  streams them through `sendAudio`. The microphone is opened only inside a user turn and
+  never between windows. A mid-turn audio route change (e.g. Bluetooth disconnect) closes
+  the mic and triggers fail-through to the Apple backend.
+
+- **Backend audio playback** (`BackendAudioPlayback`): receives response audio chunks from
+  the cloud, converts them to `AVAudioPCMBuffer`, and plays them through `AVAudioEngine`.
+  The engine starts lazily on the first chunk of each response and stops when drained. Any
+  playback failure drops audio for the rest of the response and fails open: the transcript
+  and the window are unaffected.
+
+The combined speech activity signal merges TTS activity and backend playback, so
+`SpeechGatedVoice` holds the microphone closed while *either* the local synthesizer or
+the cloud voice is speaking. This is the self-hearing guarantee: the mic and the speaker
+are never simultaneously live.
+
+#### Transcript timing on the OpenAI path
+
+On the OpenAI Realtime path, transcripts are not available until the audio buffer is
+committed. Under `turn_detection: none`, the server creates the user conversation item —
+and starts input transcription — only on commit. This means there are no mid-turn partial
+transcripts, and the milestone-one "match on partial transcript" resolution path never
+fires before a commit.
+
+Without `--imu-turn-control`, the only turn-ending events are a command match after the
+window-teardown commit, gesture, tap, or timeout. **`--imu-turn-control` is effectively
+required for natural voice resolution on the `openai-realtime` path**, because it commits
+the turn when the wearer stops speaking, which is what makes transcripts — and therefore
+voice resolution — possible before the window timeout.
+
+#### Wearer-speech features
+
+`--wearer-gate` and `--imu-turn-control` share one `WearerSpeechSignalSource` when both
+are active. The source is fed by the headphone motion stream (samples flow only while a
+response window is open) and produces a speaking/quiet signal from the jaw- and
+skull-borne vibration.
+
+- **Wearer gate** (`--wearer-gate`): filters voice commands through IMU-based attribution.
+  A command is passed through when the wearer spoke within a trailing attribution window;
+  commands from bystanders or other audio sources are rejected. Fails open in every
+  degraded state: no signal, a magnitude-only stream, or a stale analyzer reproduces
+  today's behavior verbatim. Uses `wearer-speech-calibration.json` when present,
+  provisional thresholds otherwise. With provisional thresholds the gate may pass bystander
+  speech — the attribution window is generous by design until the capture study lands.
+
+- **IMU turn control** (`--imu-turn-control`): two additive features on top of the normal
+  gesture/tap/timeout resolution.
+
+  - *Endpointing*: when the wearer stops speaking, the user turn is committed after a
+    short delay (0.4 seconds on top of the detector's 0.6-second hangover). If the wearer
+    resumes within the delay, the commit is cancelled. A false endpoint (jaw motion that is
+    not speech) commits the turn early; the consequence is an unmatched transcript and a
+    re-armed turn — degraded, not broken.
+  - *Barge-in*: when the wearer starts speaking during response audio (TTS or backend
+    playback), all playback is stopped immediately. The microphone then reopens through the
+    normal gate machinery and the wearer speaks their answer on the next turn. The first
+    ~0.3-0.5 seconds of the barge-in utterance are not captured (IMU onset latency plus
+    mic-open latency); the UX answer is that barge-in stops the agent so the user can
+    speak, not that it salvages the interrupting syllables. Barge-in uses `stopAll()`,
+    which also drops any queued cross-session notifications.
+
+  A dead or absent signal means neither feature fires: the window resolves by gesture,
+  tap, timeout, or command match exactly as without the flag.
+
+#### Free-form voice answers
+
+`--voice-freeform` enables free-form spoken answers for selections and multi-option stop
+questions. It requires `--voice-backend openai-realtime` because the Apple recognizer does
+not produce transcripts through the backend command provider; passing `--voice-freeform`
+with the Apple backend is a startup error.
+
+When enabled, an unmatched final transcript (one that does not match any keyword in the
+grammar) is offered as a free-text reply with mandatory read-back confirmation:
+
+1. The wearer speaks an answer that matches no command.
+2. TapQ reads back: "You said: '<text>'. Nod to send, shake to discard."
+3. The wearer nods to confirm or shakes to discard and re-listen.
+
+A confirmed free-text answer resolves the selection and reaches the agent through the wire
+protocol (see below). Tool approvals and yes/no stop questions stay binary — a spoken
+free-text answer can never authorize an agent action. The read-back confirmation is a
+deliberate safety measure: a stray sentence becoming an agent instruction is worse than one
+extra nod.
+
 On macOS, `tapq serve`:
 
 1. Loads independent gesture and tap calibration profiles.
@@ -184,11 +295,12 @@ when samples do not recover. When a new prompt opens without motion, the runtime
 retries for a bounded period.
 
 Warnings and errors are printed by default. `TAPQ_DEBUG=1` adds broker, speech,
-gesture, tap, selection, and lifecycle events. Tap diagnostics include peak and
-threshold acceleration, rotation limits, elevated-sample width, baseline return,
-candidate duration, pairing gap, pending expiration, and listening-window reset.
-After `tap.pending`, a bounded 600 ms trace records every delivered acceleration
-and rotation sample with its hardware timestamp.
+gesture, tap, selection, voice backend, playback, microphone pump, wearer gate, and
+lifecycle events. Tap diagnostics include peak and threshold acceleration, rotation
+limits, elevated-sample width, baseline return, candidate duration, pairing gap,
+pending expiration, and listening-window reset. After `tap.pending`, a bounded 600 ms
+trace records every delivered acceleration and rotation sample with its hardware
+timestamp.
 
 These diagnostics do not change detection policy. The bundled sink can record
 tool names, request identifiers, option labels, lifecycle events, and motion
@@ -546,10 +658,19 @@ Only one ordinary approval path is installed at a time. `AskUserQuestion`
 currently supports exactly one single-select question. Multiple questions and
 multi-select requests fail through to Claude Code’s interface.
 
-Wire protocol v3 records whether an approval came from `PreToolUse` or
-`PermissionRequest`. Strict and shared messages can temporarily use a discovered
-legacy wire protocol v2 runtime. Native permission requests never downgrade to v2
-and remain in Claude’s normal dialog when no wire protocol v3 runtime is available.
+When `--voice-freeform` is enabled, a free-text voice answer to an `AskUserQuestion`
+selection is delivered to Claude as a deny reason containing the wearer’s spoken text:
+the model sees the original question and the wearer’s own-words answer, and is asked to
+proceed accordingly without re-asking. This is a best-effort delivery — Claude Code
+receives the text as feedback, not as a structured selection, and may interpret it at its
+discretion.
+
+Wire protocol v4 records whether an approval came from `PreToolUse` or
+`PermissionRequest`. The broker accepts both v4 and v3 requests; v3 shims continue to
+work and simply never see the `free_text` response field. Strict and shared messages can
+temporarily use a discovered legacy wire protocol v2 runtime. Native permission requests
+never downgrade to v2 and remain in Claude’s normal dialog when no compatible runtime is
+available.
 
 ### Structured-question steering
 
@@ -649,6 +770,13 @@ open. Multiple questions, auto-resolving questions, unsupported option shapes,
 secret questions, subagent calls, unanswered interactions, broker failures, and missing
 runtimes emit no hook output; Codex then retains its native behavior, including its
 free-form `Other` choice.
+
+When `--voice-freeform` is enabled, a free-text voice answer to a `request_user_input`
+question is delivered as a single-element `answers` array containing the wearer’s spoken
+text. Whether Codex’s `request_user_input` tool accepts non-option answer strings is not
+verifiable from this repository — the response JSON is a TapQ-fabricated model-visible
+claim — so the model will see the text, but native-UI expectations may differ. The
+milestone-two smoke checklist gates this with an explicit verification item.
 
 In Codex CLI `0.146.0`, Plan mode is the reliable surface for
 `request_user_input`. Default-mode exposure depends on Codex's

--- a/docs/MILESTONE1_MANUAL_TEST_PLAN.md
+++ b/docs/MILESTONE1_MANUAL_TEST_PLAN.md
@@ -1,0 +1,181 @@
+# Milestone one — manual test plan
+
+Structured, sessioned test plan for a human with AirPods, a Mac, and (for session 5) an
+OpenAI key. It organizes and extends [MILESTONE1_SMOKE_CHECKLIST.md](MILESTONE1_SMOKE_CHECKLIST.md):
+the checklist is the per-item reference for exact commands and expected output; this plan
+adds execution order, stop/continue gates, the discrimination scenarios that probe the
+science risk, and the results log the capture study needs.
+
+**Scope.** Everything the automated suite (1,169 tests) cannot verify: real IMU signal,
+real clock alignment, real permissions, real network failure. **Out of scope:** the Linux
+portable build (CI's job) and anything already covered by `swift test`.
+
+**Total time:** roughly 2 hours across five sessions. Sessions 1–4 need no network or
+OpenAI account. Sessions can run on different days; each is self-contained.
+
+---
+
+## Environment (once, before session 1)
+
+Follow "Before you start" in the smoke checklist. In short:
+
+- `scripts/package-runtime-app.sh debug`; AirPods connected; `serve` reports
+  `AirPods motion: available`.
+- System audio input = **built-in microphone** (sessions 2–4 depend on it).
+- `mkdir -p /tmp/tapq-smoke`.
+- Remember the launcher rules: stdin is EOF (`--non-interactive` / `--yes` everywhere),
+  paths must be absolute, and exit codes only survive when running
+  `build/TapQRuntime.app/Contents/MacOS/tapq` directly.
+
+Record once at the top of your results log: macOS version, AirPods model + firmware,
+Mac model.
+
+---
+
+## Session 1 — Regression baseline (~15 min, run first)
+
+*Why first: if the default path moved, nothing else matters, and every later session is
+easier to debug knowing the baseline was clean.*
+
+Run smoke item 7 in full:
+
+| # | Check | Pass criterion |
+|---|-------|----------------|
+| 1.1 | `serve` (no flags): approval by voice, double nod, double shake, double tap, volume-swipe navigation | Identical to pre-milestone behavior; **no** `Voice backend:` line in the ready block |
+| 1.2 | `capture` without `--mic-envelope` | Microphone never opens (no macOS mic indicator); output shape identical to a pre-milestone capture |
+| 1.3 | `replay` without new flags | No wearer-speech section in text; no `wearer_speech` key in `--json` |
+| 1.4 | `calibration show` with only gesture/tap saved | Prints those two; wearer-speech block reads as not calibrated; nothing errors |
+
+**Gate G1 — any regression here is a stop-ship defect.** File it and stop; do not
+continue on a moved baseline.
+
+---
+
+## Session 2 — Capture tooling integrity (~25 min)
+
+Smoke items 1, 2, 3 in order. The one result that gates everything downstream:
+
+| # | Check | Pass criterion |
+|---|-------|----------------|
+| 2.1 | Item 1: co-recorded capture, 30 s, speak two sentences mid-run | Both files written; envelope header correct; **first/last timestamps of `env.jsonl` and `imu.jsonl` agree within a few hundred ms**; speech clearly visible in `rms` |
+| 2.2 | Item 2: repeat with AirPods mic as input | Completes; audible HFP degradation confirms the documented guidance; input restored to built-in mic afterwards |
+| 2.3 | Item 3a: mid-capture route change | IMU track complete, sidecar truncated, truncation message, `exit=1` |
+| 2.4 | Item 3b: mic permission revoked | **Record which behavior occurs** — abort with exit 69 and nothing recorded (intended), or a "successful" run with a full-length near-zero-rms sidecar (the silent-buffer hole) |
+
+**Gate G2 — clock alignment (2.1).** A constant offset between the two clocks means the
+host-time→boot-time anchor is wrong; sessions 3–4 metrics would be meaningless. Stop and
+report the offset.
+
+**Gate G3 — the authorization question (2.4).** This is a genuine open question from the
+implementation review, not a formality. If you observe the silent-buffer outcome, the
+fail-closed policy needs an explicit mic-authorization check ahead of engine start —
+record it as a required fix before the capture study runs, because a study session
+recorded under a denied mic would be silently worthless. Re-grant mic access afterwards.
+
+---
+
+## Session 3 — Calibration lifecycle (~20 min)
+
+Smoke item 4 in full:
+
+| # | Check | Pass criterion |
+|---|-------|----------------|
+| 3.1 | `calibration run wearer-speech --non-interactive`, speaking normally through the 6 s speak phase | Saves; prints sustained envelope, resting peak, and required threshold — **record all three numbers** |
+| 3.2 | Deliberately silent speak phase | Fails with the documented separation message; saves nothing; any existing gesture/tap profiles untouched |
+| 3.3 | `show` / `show --json` | Three blocks; `wearer_speech` key present in JSON |
+| 3.4 | `reset wearer-speech --yes` then `show` | Only the wearer-speech document is gone; gesture and tap survive |
+| 3.5 | Re-run 3.1 so a calibrated profile exists for session 4 | Saves again |
+
+A speak phase that cannot separate speech from rest on your hardware is *data, not
+necessarily a bug* — the defaults are provisional until the capture study. Record the
+numbers; do not tune code.
+
+---
+
+## Session 4 — Detection quality and discrimination (~40 min, the science session)
+
+This is the session the milestone exists for. Part A is smoke item 5; part B extends it
+with the confusion cases that decide whether the 25 Hz signal is real. Every replay run
+is hardware-free (`tapq replay` directly is fine).
+
+### Part A — baseline metrics (smoke item 5)
+
+| # | Check | Pass criterion |
+|---|-------|----------------|
+| 4.1 | Replay item-1 capture, default config | Sane: detected span overlaps the spoken span; onset latency well under a second; **record precision / recall / F1 / onset latency** |
+| 4.2 | Same, `--wearer-speech-profile` from 3.5 | Not dramatically worse than defaults; ideally better — record both for comparison |
+| 4.3 | Silent control capture (30 s, no speech) | **Zero false activations** — this is a target, not a measurement |
+| 4.4 | Optional: hand-labeled truth vs envelope-derived truth | `truth: labels`, stderr note that labels won; metrics roughly agree — cross-validates the envelope derivation |
+
+### Part B — discrimination matrix
+
+Record one 30 s co-recorded capture per row (same command as 2.1), then replay each.
+Rows 4.5–4.9 are silent-mouth scenarios: the envelope sidecar should show near-silence
+while the IMU carries the confounder, so any detection is a false activation. These are
+exactly the confounders the analyzer's gates claim to reject — this is their first
+contact with reality.
+
+| # | Scenario (30 s each) | Target | What a failure means |
+|---|----------------------|--------|----------------------|
+| 4.5 | Chewing (gum or food), head still, silent | 0 false activations | Jaw-motion confusion — the classic bone-conduction confounder; thresholds or breadth gate need study data |
+| 4.6 | Walking around the room, silent | 0–low false activations | Gait energy leaking through the envelope; rotation gate insufficient alone |
+| 4.7 | Nodding and shaking deliberately, silent | 0 false activations | Rotation-quiet gate failing on real gestures — would misattribute during gesture use |
+| 4.8 | Bystander speech: someone else talks (or TV/speaker at conversational volume), wearer silent and still | 0 false activations | **The wearer-attribution claim itself** — acoustic sound must not shake the wearer's skull enough to fire |
+| 4.9 | Music in the AirPods at normal listening volume, wearer silent | 0 false activations | Speaker vibration bleeding into the IMU at 25 Hz |
+| 4.10 | Speaking while slowly walking | Detection comparable to 4.1 | Real usage isn't statue-still; heavy recall loss here bounds the feature to desk use |
+| 4.11 | Whispering two sentences | Record whatever happens | Expected weak/no detection — establishes the floor of the modality; data, not pass/fail |
+
+**Gate G4 — go/no-go input for `WearerGatedVoice`.** The wrapper stays out of the live
+composition until the capture study validates the signal. These numbers are that study's
+pilot: 4.3, 4.5, 4.7 and 4.8 at zero (or near) false activations is the minimum bar for
+ever wiring attribution into live approvals — a detector that fires on a bystander's
+voice would attribute their command to the wearer, which is worse than no attribution at
+all. Keep every capture file: they seed the study corpus either way.
+
+---
+
+## Session 5 — Cloud backend and fail-through (~20 min, needs network + OpenAI key)
+
+Smoke item 6 in full. Note a live Realtime session bills to your OpenAI account
+(cents, not dollars, at this duration).
+
+| # | Check | Pass criterion |
+|---|-------|----------------|
+| 5.1 | `serve --voice-backend openai-realtime` with key exported | Ready block prints `Voice backend: openai-realtime (fail-through: apple)`; a live approval answered by voice takes effect |
+| 5.2 | Wi-Fi off while a response window is open | **Window resolves** (Apple-stack voice, gesture, tap, or timeout) — never hangs; later windows work on-device; mic never stuck open between windows |
+| 5.3 | Key unset, same flag, direct executable | Exact error `OpenAI Realtime voice requires OPENAI_API_KEY…`, `exit=1` — refuses rather than silently serving on-device |
+| 5.4 | Wi-Fi restored, new serve | Cloud path works again |
+
+**Gate G5 — a hung window in 5.2 is the serious failure.** Fail-through exists so a
+network problem costs latency, never the interaction. A window that cannot be resolved
+is worse than having no cloud backend; that outcome blocks shipping the flag.
+
+---
+
+## Results log
+
+Copy this skeleton into your run notes; a bad number is data, a missing number is not.
+
+```
+Hardware: macOS ____ / AirPods ____ (fw ____) / Mac ____          Date: ____
+
+S1 regression:            PASS / FAIL (detail: ____)
+S2 clock offset (2.1):    first ____ ms, last ____ ms
+S2 auth behavior (2.4):   abort-69 / silent-buffers        ← G3
+S3 calibration (3.1):     sustained ____ g, resting ____ g, required ____ g
+S4 baseline (4.1/4.2):    P ____ R ____ F1 ____ onset ____ s   (default / calibrated)
+S4 silent control (4.3):  ____ false activations
+S4 matrix (4.5–4.11):     chew ____  walk ____  gesture ____  bystander ____
+                          music ____  walk+speak P/R ____/____  whisper ____
+S5 fail-through (5.2):    resolved by ____ ; mic released: Y/N
+Verdict per gate:         G1 __ G2 __ G3 __ G4 __ G5 __
+```
+
+## What the outcomes decide
+
+- **All gates pass, matrix clean** → proceed to the full capture study with this exact
+  tooling; `WearerGatedVoice` live wiring becomes a thresholds-and-review decision.
+- **G3 silent-buffers** → add the mic-authorization gate before any study recording.
+- **Matrix rows fail** → the study's job is now threshold retuning against the recorded
+  corpus (config change, no code change); keep all captures.
+- **G2 or G5 fail** → code defects; fix before anything else consumes the tooling.

--- a/docs/MILESTONE1_MANUAL_TEST_PLAN.md
+++ b/docs/MILESTONE1_MANUAL_TEST_PLAN.md
@@ -10,6 +10,24 @@ calling the milestone *done*; run this to see it *work*.
 **built-in mic**. Launcher quirks: pass `--non-interactive`/`--yes` to calibration
 commands, use absolute paths everywhere.
 
+**Triggering approvals (steps 4–5):** run `claude` in a scratch directory in **default
+permission mode** (not accept-edits or bypass — prompts must actually appear), then paste
+one of these:
+
+- *Yes/no permission prompt:*
+  > Run `sw_vers` and show me the output.
+
+  (Any non-allowlisted Bash command works; swap in another if your allowlist covers this
+  one.)
+- *File-write prompt:*
+  > Create a file named hello.txt here containing the single word "hello".
+- *Multi-option question* (exercises stem-swipe navigation + select):
+  > Use the AskUserQuestion tool to ask me what greeting hello.txt should use. Offer
+  > exactly three options: casual, formal, pirate.
+
+Each is harmless to approve, deny, or answer either way — the point is the prompt, not
+the outcome.
+
 ---
 
 ## 1. Capture with ground truth (5 min)
@@ -55,9 +73,12 @@ scripts/run-runtime-app.sh serve --voice-backend openai-realtime
 ```
 
 **Pass:** ready block prints `Voice backend: openai-realtime (fail-through: apple)`.
-Trigger an approval from Claude Code and answer it by voice — it takes effect.
+Trigger the *yes/no* prompt from the setup list ("Run `sw_vers`…") and answer "yes" by
+voice — Claude Code proceeds. Then trigger the *multi-option* question and walk the three
+options by stem swipe, selecting one by tap or voice.
 
-Then the part that actually matters: with a response window open, **turn Wi-Fi off**.
+Then the part that actually matters: paste the *file-write* prompt, and while its response
+window is open, **turn Wi-Fi off**.
 
 **Pass:** the window resolves anyway (on-device voice, nod, or timeout) — it must never
 hang — and the next window works on-device. A hung window is the one serious failure here.
@@ -68,7 +89,8 @@ hang — and the next window works on-device. A hung window is the one serious f
 scripts/run-runtime-app.sh serve
 ```
 
-**Pass:** **no** `Voice backend:` line; voice approval and double-nod behave exactly as
+**Pass:** **no** `Voice backend:` line; re-run the *yes/no* prompt and approve by double
+nod, then the *multi-option* question navigated by stem swipe — both behave exactly as
 before the milestone. Everything new sits behind flags — if the default moved, that's a
 defect regardless of steps 1–4.
 

--- a/docs/MILESTONE1_MANUAL_TEST_PLAN.md
+++ b/docs/MILESTONE1_MANUAL_TEST_PLAN.md
@@ -1,181 +1,79 @@
-# Milestone one — manual test plan
+# Milestone one — essential manual test (~20 min)
 
-Structured, sessioned test plan for a human with AirPods, a Mac, and (for session 5) an
-OpenAI key. It organizes and extends [MILESTONE1_SMOKE_CHECKLIST.md](MILESTONE1_SMOKE_CHECKLIST.md):
-the checklist is the per-item reference for exact commands and expected output; this plan
-adds execution order, stop/continue gates, the discrimination scenarios that probe the
-science risk, and the results log the capture study needs.
+Five steps that touch every milestone surface once: capture tooling, detector, calibration,
+cloud voice backend (`gpt-realtime`, the built-in default model), and the unchanged default
+path. The exhaustive version (discrimination matrix, permission edge cases, full lifecycle)
+lives in [MILESTONE1_SMOKE_CHECKLIST.md](MILESTONE1_SMOKE_CHECKLIST.md) — run it before
+calling the milestone *done*; run this to see it *work*.
 
-**Scope.** Everything the automated suite (1,169 tests) cannot verify: real IMU signal,
-real clock alignment, real permissions, real network failure. **Out of scope:** the Linux
-portable build (CI's job) and anything already covered by `swift test`.
-
-**Total time:** roughly 2 hours across five sessions. Sessions 1–4 need no network or
-OpenAI account. Sessions can run on different days; each is self-contained.
+**Setup:** `scripts/package-runtime-app.sh debug`; AirPods connected; system audio input =
+**built-in mic**. Launcher quirks: pass `--non-interactive`/`--yes` to calibration
+commands, use absolute paths everywhere.
 
 ---
 
-## Environment (once, before session 1)
+## 1. Capture with ground truth (5 min)
 
-Follow "Before you start" in the smoke checklist. In short:
-
-- `scripts/package-runtime-app.sh debug`; AirPods connected; `serve` reports
-  `AirPods motion: available`.
-- System audio input = **built-in microphone** (sessions 2–4 depend on it).
-- `mkdir -p /tmp/tapq-smoke`.
-- Remember the launcher rules: stdin is EOF (`--non-interactive` / `--yes` everywhere),
-  paths must be absolute, and exit codes only survive when running
-  `build/TapQRuntime.app/Contents/MacOS/tapq` directly.
-
-Record once at the top of your results log: macOS version, AirPods model + firmware,
-Mac model.
-
----
-
-## Session 1 — Regression baseline (~15 min, run first)
-
-*Why first: if the default path moved, nothing else matters, and every later session is
-easier to debug knowing the baseline was clean.*
-
-Run smoke item 7 in full:
-
-| # | Check | Pass criterion |
-|---|-------|----------------|
-| 1.1 | `serve` (no flags): approval by voice, double nod, double shake, double tap, volume-swipe navigation | Identical to pre-milestone behavior; **no** `Voice backend:` line in the ready block |
-| 1.2 | `capture` without `--mic-envelope` | Microphone never opens (no macOS mic indicator); output shape identical to a pre-milestone capture |
-| 1.3 | `replay` without new flags | No wearer-speech section in text; no `wearer_speech` key in `--json` |
-| 1.4 | `calibration show` with only gesture/tap saved | Prints those two; wearer-speech block reads as not calibrated; nothing errors |
-
-**Gate G1 — any regression here is a stop-ship defect.** File it and stop; do not
-continue on a moved baseline.
-
----
-
-## Session 2 — Capture tooling integrity (~25 min)
-
-Smoke items 1, 2, 3 in order. The one result that gates everything downstream:
-
-| # | Check | Pass criterion |
-|---|-------|----------------|
-| 2.1 | Item 1: co-recorded capture, 30 s, speak two sentences mid-run | Both files written; envelope header correct; **first/last timestamps of `env.jsonl` and `imu.jsonl` agree within a few hundred ms**; speech clearly visible in `rms` |
-| 2.2 | Item 2: repeat with AirPods mic as input | Completes; audible HFP degradation confirms the documented guidance; input restored to built-in mic afterwards |
-| 2.3 | Item 3a: mid-capture route change | IMU track complete, sidecar truncated, truncation message, `exit=1` |
-| 2.4 | Item 3b: mic permission revoked | **Record which behavior occurs** — abort with exit 69 and nothing recorded (intended), or a "successful" run with a full-length near-zero-rms sidecar (the silent-buffer hole) |
-
-**Gate G2 — clock alignment (2.1).** A constant offset between the two clocks means the
-host-time→boot-time anchor is wrong; sessions 3–4 metrics would be meaningless. Stop and
-report the offset.
-
-**Gate G3 — the authorization question (2.4).** This is a genuine open question from the
-implementation review, not a formality. If you observe the silent-buffer outcome, the
-fail-closed policy needs an explicit mic-authorization check ahead of engine start —
-record it as a required fix before the capture study runs, because a study session
-recorded under a denied mic would be silently worthless. Re-grant mic access afterwards.
-
----
-
-## Session 3 — Calibration lifecycle (~20 min)
-
-Smoke item 4 in full:
-
-| # | Check | Pass criterion |
-|---|-------|----------------|
-| 3.1 | `calibration run wearer-speech --non-interactive`, speaking normally through the 6 s speak phase | Saves; prints sustained envelope, resting peak, and required threshold — **record all three numbers** |
-| 3.2 | Deliberately silent speak phase | Fails with the documented separation message; saves nothing; any existing gesture/tap profiles untouched |
-| 3.3 | `show` / `show --json` | Three blocks; `wearer_speech` key present in JSON |
-| 3.4 | `reset wearer-speech --yes` then `show` | Only the wearer-speech document is gone; gesture and tap survive |
-| 3.5 | Re-run 3.1 so a calibrated profile exists for session 4 | Saves again |
-
-A speak phase that cannot separate speech from rest on your hardware is *data, not
-necessarily a bug* — the defaults are provisional until the capture study. Record the
-numbers; do not tune code.
-
----
-
-## Session 4 — Detection quality and discrimination (~40 min, the science session)
-
-This is the session the milestone exists for. Part A is smoke item 5; part B extends it
-with the confusion cases that decide whether the 25 Hz signal is real. Every replay run
-is hardware-free (`tapq replay` directly is fine).
-
-### Part A — baseline metrics (smoke item 5)
-
-| # | Check | Pass criterion |
-|---|-------|----------------|
-| 4.1 | Replay item-1 capture, default config | Sane: detected span overlaps the spoken span; onset latency well under a second; **record precision / recall / F1 / onset latency** |
-| 4.2 | Same, `--wearer-speech-profile` from 3.5 | Not dramatically worse than defaults; ideally better — record both for comparison |
-| 4.3 | Silent control capture (30 s, no speech) | **Zero false activations** — this is a target, not a measurement |
-| 4.4 | Optional: hand-labeled truth vs envelope-derived truth | `truth: labels`, stderr note that labels won; metrics roughly agree — cross-validates the envelope derivation |
-
-### Part B — discrimination matrix
-
-Record one 30 s co-recorded capture per row (same command as 2.1), then replay each.
-Rows 4.5–4.9 are silent-mouth scenarios: the envelope sidecar should show near-silence
-while the IMU carries the confounder, so any detection is a false activation. These are
-exactly the confounders the analyzer's gates claim to reject — this is their first
-contact with reality.
-
-| # | Scenario (30 s each) | Target | What a failure means |
-|---|----------------------|--------|----------------------|
-| 4.5 | Chewing (gum or food), head still, silent | 0 false activations | Jaw-motion confusion — the classic bone-conduction confounder; thresholds or breadth gate need study data |
-| 4.6 | Walking around the room, silent | 0–low false activations | Gait energy leaking through the envelope; rotation gate insufficient alone |
-| 4.7 | Nodding and shaking deliberately, silent | 0 false activations | Rotation-quiet gate failing on real gestures — would misattribute during gesture use |
-| 4.8 | Bystander speech: someone else talks (or TV/speaker at conversational volume), wearer silent and still | 0 false activations | **The wearer-attribution claim itself** — acoustic sound must not shake the wearer's skull enough to fire |
-| 4.9 | Music in the AirPods at normal listening volume, wearer silent | 0 false activations | Speaker vibration bleeding into the IMU at 25 Hz |
-| 4.10 | Speaking while slowly walking | Detection comparable to 4.1 | Real usage isn't statue-still; heavy recall loss here bounds the feature to desk use |
-| 4.11 | Whispering two sentences | Record whatever happens | Expected weak/no detection — establishes the floor of the modality; data, not pass/fail |
-
-**Gate G4 — go/no-go input for `WearerGatedVoice`.** The wrapper stays out of the live
-composition until the capture study validates the signal. These numbers are that study's
-pilot: 4.3, 4.5, 4.7 and 4.8 at zero (or near) false activations is the minimum bar for
-ever wiring attribution into live approvals — a detector that fires on a bystander's
-voice would attribute their command to the wearer, which is worse than no attribution at
-all. Keep every capture file: they seed the study corpus either way.
-
----
-
-## Session 5 — Cloud backend and fail-through (~20 min, needs network + OpenAI key)
-
-Smoke item 6 in full. Note a live Realtime session bills to your OpenAI account
-(cents, not dollars, at this duration).
-
-| # | Check | Pass criterion |
-|---|-------|----------------|
-| 5.1 | `serve --voice-backend openai-realtime` with key exported | Ready block prints `Voice backend: openai-realtime (fail-through: apple)`; a live approval answered by voice takes effect |
-| 5.2 | Wi-Fi off while a response window is open | **Window resolves** (Apple-stack voice, gesture, tap, or timeout) — never hangs; later windows work on-device; mic never stuck open between windows |
-| 5.3 | Key unset, same flag, direct executable | Exact error `OpenAI Realtime voice requires OPENAI_API_KEY…`, `exit=1` — refuses rather than silently serving on-device |
-| 5.4 | Wi-Fi restored, new serve | Cloud path works again |
-
-**Gate G5 — a hung window in 5.2 is the serious failure.** Fail-through exists so a
-network problem costs latency, never the interaction. A window that cannot be resolved
-is worse than having no cloud backend; that outcome blocks shipping the flag.
-
----
-
-## Results log
-
-Copy this skeleton into your run notes; a bad number is data, a missing number is not.
-
-```
-Hardware: macOS ____ / AirPods ____ (fw ____) / Mac ____          Date: ____
-
-S1 regression:            PASS / FAIL (detail: ____)
-S2 clock offset (2.1):    first ____ ms, last ____ ms
-S2 auth behavior (2.4):   abort-69 / silent-buffers        ← G3
-S3 calibration (3.1):     sustained ____ g, resting ____ g, required ____ g
-S4 baseline (4.1/4.2):    P ____ R ____ F1 ____ onset ____ s   (default / calibrated)
-S4 silent control (4.3):  ____ false activations
-S4 matrix (4.5–4.11):     chew ____  walk ____  gesture ____  bystander ____
-                          music ____  walk+speak P/R ____/____  whisper ____
-S5 fail-through (5.2):    resolved by ____ ; mic released: Y/N
-Verdict per gate:         G1 __ G2 __ G3 __ G4 __ G5 __
+```bash
+scripts/run-runtime-app.sh capture --duration 30 \
+  -o /tmp/tapq-imu.jsonl --mic-envelope /tmp/tapq-env.jsonl
 ```
 
-## What the outcomes decide
+Head still. Silent ~10 s, read two sentences aloud, silent to the end.
 
-- **All gates pass, matrix clean** → proceed to the full capture study with this exact
-  tooling; `WearerGatedVoice` live wiring becomes a thresholds-and-review decision.
-- **G3 silent-buffers** → add the mic-authorization gate before any study recording.
-- **Matrix rows fail** → the study's job is now threshold retuning against the recorded
-  corpus (config change, no code change); keep all captures.
-- **G2 or G5 fail** → code defects; fix before anything else consumes the tooling.
+**Pass:** both files written; the first/last `timestamp` in the two files agree within a
+few hundred ms (this validates the audio→IMU clock anchor — the one thing no unit test
+could check); `rms` in `tapq-env.jsonl` is clearly higher while you spoke.
+
+## 2. Detector sees you — and only you (3 min)
+
+```bash
+tapq replay -i /tmp/tapq-imu.jsonl --mic-envelope /tmp/tapq-env.jsonl
+```
+
+**Pass:** a `Wearer speech (truth: mic_envelope)` section appears; the detected span
+overlaps when you actually spoke; **no activation during the silent stretches**. Absolute
+precision/recall numbers are study input, not pass/fail — but false activations while
+silent matter: that's the wearer-attribution claim.
+
+## 3. Calibration (2 min)
+
+```bash
+scripts/run-runtime-app.sh calibration run wearer-speech --non-interactive
+```
+
+Read aloud continuously through the 6-second speak phase, head still, hands off the earbuds.
+
+**Pass:** prints the envelope numbers and saves `wearer-speech-calibration.json`;
+`calibration show` prints three blocks (gesture, tap, wearer speech).
+
+## 4. Cloud backend on gpt-realtime, with the kill test (7 min)
+
+```bash
+export OPENAI_API_KEY=…   # then:
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime
+```
+
+**Pass:** ready block prints `Voice backend: openai-realtime (fail-through: apple)`.
+Trigger an approval from Claude Code and answer it by voice — it takes effect.
+
+Then the part that actually matters: with a response window open, **turn Wi-Fi off**.
+
+**Pass:** the window resolves anyway (on-device voice, nod, or timeout) — it must never
+hang — and the next window works on-device. A hung window is the one serious failure here.
+
+## 5. Default path untouched (3 min)
+
+```bash
+scripts/run-runtime-app.sh serve
+```
+
+**Pass:** **no** `Voice backend:` line; voice approval and double-nod behave exactly as
+before the milestone. Everything new sits behind flags — if the default moved, that's a
+defect regardless of steps 1–4.
+
+---
+
+Record: clock offset (step 1), false activations while silent (step 2), calibration
+envelope numbers (step 3), and how the killed window resolved (step 4). Keep the two
+capture files — they seed the study corpus.

--- a/docs/MILESTONE1_SMOKE_CHECKLIST.md
+++ b/docs/MILESTONE1_SMOKE_CHECKLIST.md
@@ -1,0 +1,293 @@
+# Milestone one — manual smoke checklist
+
+Wearer-speech detection and the `VoiceBackend` contract, verified against real hardware.
+
+Everything here needs a human, physical AirPods, macOS privacy permissions, and — for the
+last items — a live network and an OpenAI account. **Agents must not attempt these.** The
+automated suite covers every seam that can be faked; this file covers exactly the part it
+cannot: whether the earbud IMU can actually hear its wearer talk, whether the microphone
+and motion clocks really line up, and whether a cloud voice session degrades the way the
+tests say it does.
+
+Nothing in this milestone changes the shipped default paths. Item 7 is the regression
+check that proves it.
+
+## Before you start
+
+- Build the runtime bundle once: `scripts/package-runtime-app.sh debug`.
+- Connect AirPods and confirm head motion works at all: `scripts/run-runtime-app.sh serve`
+  should report `AirPods motion: available`. If it does not, stop — every item below
+  depends on it and a missing profile will read as a detection failure.
+- Set the Mac's **built-in microphone** as the system audio input (System Settings →
+  Sound → Input). Items 1 and 5 depend on this; item 2 deliberately changes it back.
+- Keep a scratch directory, e.g. `mkdir -p /tmp/tapq-smoke`.
+
+Three properties of the development launcher shape every command below. It runs the
+bundle through `open -n -W`, which means:
+
+- **stdin is closed.** Interactive prompts see EOF. Always pass `--non-interactive` to
+  `calibration run` and `--yes` to `calibration reset`.
+- **the working directory is `/`.** Every path argument must be absolute.
+- **the exit code is lost.** `open -W` returns `0` no matter what the app returned, so the
+  launcher cannot be used to check an exit status. Where an item asks for one, run the
+  bundle's executable directly instead:
+  `build/TapQRuntime.app/Contents/MacOS/tapq …`, and grant permission again if macOS
+  re-prompts.
+
+Environment variables *are* inherited, so `OPENAI_API_KEY` and `TAPQ_DEBUG=1` work through
+the launcher.
+
+---
+
+## 1. Envelope co-recording aligns with the IMU track
+
+```bash
+scripts/run-runtime-app.sh capture --duration 30 \
+  -o /tmp/tapq-smoke/imu.jsonl \
+  --mic-envelope /tmp/tapq-smoke/env.jsonl
+```
+
+Wear the AirPods, keep your head still, and during the 30 seconds: stay silent for about
+5 s, read two sentences aloud at a normal volume, then stay silent again to the end. Note
+roughly when you started and stopped talking.
+
+**Expect**
+
+- stderr says `Co-recording a microphone envelope to /tmp/tapq-smoke/env.jsonl…` *before*
+  the motion capture line — the microphone opens first by design.
+- Both files exist, and the run ends with a motion sample count and an envelope block
+  count.
+- `env.jsonl`'s first line is the header:
+  `{"block_frames":…,"clock":"boottime","sample_rate":…,"schema":"tapq-mic-envelope-v1"}`.
+- **The clocks overlay.** The first `timestamp` in `env.jsonl` is within a few hundred
+  milliseconds of the first `timestamp` in `imu.jsonl`, and the last of each likewise.
+  This is the item's real purpose: the audio host-time to boot-time anchor conversion is
+  the one piece of arithmetic no unit test can validate against actual hardware.
+- **Speech is visible in the envelope.** The `rms` values during your two sentences are
+  clearly above the silent stretches — an order of magnitude, not a few percent — and the
+  loud span lines up with when you were actually talking.
+
+**If it fails** — a constant offset between the two clocks means the anchor conversion is
+wrong and every metric in item 5 is meaningless; do not proceed past item 5 without
+resolving it. An envelope with no contrast between speech and silence usually means the
+wrong input device is selected.
+
+## 2. AirPods microphone as input: the HFP degradation story
+
+Set the system input to the **AirPods microphone**, then repeat item 1's command to a new
+pair of paths.
+
+**Expect**
+
+- The capture still completes; nothing crashes.
+- Audio quality audibly drops as Bluetooth switches into headset mode — this is the
+  documented reason `tapq capture --help` and
+  [CLI.md](CLI.md#microphone-envelope-sidecar) tell operators to select the built-in
+  microphone instead.
+- The motion track itself may look different from item 1's. That is the point of the
+  warning: opening the AirPods microphone changes the very signal the study measures.
+
+**Then set the system input back to the built-in microphone** before continuing.
+
+**If it fails** — if the AirPods path is *not* noticeably worse, the documented guidance
+is overstated and should be softened rather than left as folklore.
+
+## 3. Mid-capture route change truncates cleanly
+
+Start a long capture, and while it runs, change the system audio input device.
+
+```bash
+build/TapQRuntime.app/Contents/MacOS/tapq capture --duration 60 \
+  -o /tmp/tapq-smoke/imu-route.jsonl \
+  --mic-envelope /tmp/tapq-smoke/env-route.jsonl
+echo "exit=$?"
+```
+
+(Run the executable directly, not through the launcher — this item is about the exit
+code, which `open -W` discards.)
+
+**Expect**
+
+- The **motion capture finishes and is written**. Losing the IMU track because the
+  microphone had a problem would be the wrong trade.
+- stderr reports the truncated sidecar:
+  `The microphone envelope track ended early (…). The motion capture finished and was
+  written, but its envelope sidecar is truncated and covers only part of the session.`
+- `exit=1` — a failed run, not an unavailable service.
+- `env-route.jsonl` covers only the first part of the session; `imu-route.jsonl` covers all
+  of it.
+
+**Also check the fail-closed direction — and treat this one as an open question.** Revoke
+microphone access for the runtime bundle in System Settings → Privacy & Security →
+Microphone, then run the same command again.
+
+The intended behavior is an abort *before* any motion is recorded: exit `69`, a message
+ending `Nothing was recorded — a study session without its label track is not worth
+keeping`, and no output file. That is what happens when the audio engine refuses to start.
+
+But the envelope source has no explicit authorization check — it starts the engine and
+trusts the result — and a denied microphone on macOS may instead deliver *silent buffers*
+rather than an error. If that is what you observe, the run will look successful and write
+a full-length sidecar of near-zero `rms` values. **Record which of the two happens.** The
+silent-buffer outcome is exactly the failure the fail-closed policy was written to
+prevent, and would mean the policy needs an authorization gate ahead of the engine start
+rather than relying on it.
+
+## 4. Wearer-speech calibration profile lifecycle
+
+```bash
+scripts/run-runtime-app.sh calibration run wearer-speech --non-interactive
+```
+
+Follow the printed stage prompts. For the 6-second speak phase, read aloud continuously at
+a normal pace, keeping your head still and your hands away from the earbuds — the envelope
+uses the same acceleration channel a fingertip on the stem saturates, which is also why
+the speak phase runs last in an `all` session.
+
+**Expect**
+
+- The run reports `Wearer speech envelope: … g sustained (resting peak … g; required … g)`
+  and then `Wearer speech calibration saved to …/wearer-speech-calibration.json`.
+- A deliberately bad run — stay silent through the speak phase — fails with the documented
+  message about a vibration envelope not sufficiently separated from resting motion, and
+  saves nothing.
+
+Then walk the rest of the lifecycle:
+
+```bash
+scripts/run-runtime-app.sh calibration show
+scripts/run-runtime-app.sh calibration show --json
+scripts/run-runtime-app.sh calibration reset wearer-speech --yes
+scripts/run-runtime-app.sh calibration show
+```
+
+**Expect**
+
+- `show` prints three blocks: gesture, tap, and wearer speech.
+- `show --json` includes all three keys, the third being `wearer_speech`.
+- After the reset, **gesture and tap survive** and only the wearer-speech block is gone.
+  Three independent documents is the whole design; a reset that took the others with it
+  would cost a full recalibration session.
+
+**If it fails** — a speak phase that cannot separate speech from rest on your hardware is
+useful information, not necessarily a bug: the default thresholds are provisional until
+the capture study. Record the printed envelope numbers rather than adjusting code.
+
+## 5. Replay precision and recall on real recordings
+
+Score the detector against the recording from item 1:
+
+```bash
+tapq replay -i /tmp/tapq-smoke/imu.jsonl \
+  --mic-envelope /tmp/tapq-smoke/env.jsonl
+tapq replay -i /tmp/tapq-smoke/imu.jsonl \
+  --mic-envelope /tmp/tapq-smoke/env.jsonl \
+  --wearer-speech-profile ~/Library/Application\ Support/TapQ/wearer-speech-calibration.json
+```
+
+Replay needs no hardware or permissions, so a plain `swift run tapq` works here.
+
+**Expect**
+
+- A `Wearer speech (truth: mic_envelope)` section with frame precision and recall that are
+  at least *sane* — the detected span overlaps the span you actually spoke in, onset
+  latency is a fraction of a second rather than seconds, and the counts are not zero.
+- The calibrated profile does not make things dramatically worse than the defaults.
+- Numbers well below 1.0 are expected at this stage and are the study's input, not a
+  release blocker. Record them.
+
+Then the silent control:
+
+```bash
+# a 30 s capture with no speech at all, recorded the same way as item 1
+tapq replay -i /tmp/tapq-smoke/imu-silent.jsonl \
+  --mic-envelope /tmp/tapq-smoke/env-silent.jsonl
+```
+
+**Expect** — **zero false activations.** This is the one number in item 5 that is a
+target rather than a measurement. A detector that fires while nobody is talking would,
+once `WearerGatedVoice` goes live, attribute a bystander's command to the wearer.
+
+Optionally hand-label the same capture and compare:
+
+```bash
+printf '{"start": %s, "end": %s, "label": "wearer_speech"}\n' START END \
+  > /tmp/tapq-smoke/labels.jsonl
+tapq replay -i /tmp/tapq-smoke/imu.jsonl \
+  --labels /tmp/tapq-smoke/labels.jsonl \
+  --mic-envelope /tmp/tapq-smoke/env.jsonl
+```
+
+**Expect** — `truth: labels` and a stderr note that both sources were supplied and the
+labels won. Metrics close to the envelope-derived run cross-validates the derivation.
+
+## 6. OpenAI Realtime voice backend
+
+With `OPENAI_API_KEY` exported in the shell that launches the runtime:
+
+```bash
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime
+```
+
+**Expect**
+
+- The ready block prints `Voice backend: openai-realtime (fail-through: apple)`.
+- A live approval — trigger one from Claude Code or Codex — can be answered by voice, and
+  the answer takes effect exactly as it does on the Apple path.
+
+Then break it deliberately, mid-session: turn Wi-Fi off while a response window is open.
+
+**Expect**
+
+- The window does **not** hang. It resolves — by voice on the Apple stack, or by gesture,
+  tap, or timeout.
+- Voice keeps working on subsequent windows, on-device.
+- No stuck microphone: the mic must not stay open between windows.
+
+Finally, the misconfiguration:
+
+```bash
+env -u OPENAI_API_KEY build/TapQRuntime.app/Contents/MacOS/tapq serve \
+  --voice-backend openai-realtime
+echo "exit=$?"
+```
+
+**Expect** —
+`error: OpenAI Realtime voice requires OPENAI_API_KEY in the TapQ process environment.`
+and `exit=1`. Serving must refuse rather than quietly fall back to Apple: silently serving
+on-device after the operator asked for a cloud backend would hide the mistake behind
+working voice.
+
+**If it fails** — a hung window is the serious one. Fail-through exists so that a network
+problem costs latency and never the interaction; a window that cannot be resolved is worse
+than having no cloud backend at all.
+
+## 7. Regression: the default path is unchanged
+
+```bash
+scripts/run-runtime-app.sh serve
+```
+
+**Expect**
+
+- **No** `Voice backend:` line. The default prints nothing, because nothing changed.
+- Voice approvals, double nod, double shake, double tap, and volume-key option navigation
+  all behave exactly as they did before this milestone.
+- `tapq capture` without `--mic-envelope` never touches the microphone and produces a file
+  byte-identical in shape to a pre-milestone capture.
+- `tapq replay` without the new flags prints no wearer-speech section, and its `--json`
+  report has no `wearer_speech` key.
+
+This is the item that matters most. Everything in milestone one is either study tooling or
+sits behind an explicit flag; if any default behavior moved, that is a defect regardless of
+how well items 1 through 6 went.
+
+---
+
+## Recording results
+
+Wearer-speech thresholds are provisional by design — they live in a calibration profile
+precisely so the capture study can retune them without a code change. When reporting a
+run, include the envelope numbers from item 4, the precision/recall/F1 and false-activation
+figures from item 5, and the hardware and macOS version. A number that looks bad is data;
+a number that is missing is not.

--- a/docs/MILESTONE1_WEARER_VOICE_PLAN.md
+++ b/docs/MILESTONE1_WEARER_VOICE_PLAN.md
@@ -1,0 +1,266 @@
+# TapQ Milestone One — Implementation Plan (Wearer-Speech Detection + VoiceBackend Contract)
+
+*Authored by the Fable 5 planning agent, reviewed and approved by the orchestrator, 2026-08-03.*
+*Branch: `worktree-milestone1-wearer-voice`, based on `origin/main` at `373b498`.*
+
+## Orchestrator execution decisions
+
+- **Execution order is strictly sequential: WP1 → WP2 → WP3 → WP4 → WP5 → WP6 → WP7 → WP8 → WP9 → WP10.** This satisfies every declared dependency and the merge-hotspot order (WP2 → WP3 → WP4 → WP9 on `CLICommand.swift` / `TapQCLIApplication.swift`). Do not parallelize: all implementers share this worktree and its `.build` directory.
+- Each work package must leave `swift build` and `swift test` green, then be committed on this branch (no push) with message `milestone1 WPn: <short name>`.
+- `CHANGELOG.md` and `docs/CLI.md` are touched **only in WP10** to avoid conflicts.
+- Ratified judgment calls: WP3's fail-closed mic-capture policy for study tooling; WP5's WearerGatedVoice staying out of the live runtime composition this milestone; `calibration` target `all` expanding to include the wearer-speech profile (WP2).
+
+---
+
+## Codebase findings that shape the plan
+
+- **Portable/macOS split**: `Package.swift` keeps `TapQContracts`, `TapQDetectionBaseline`, `TapQInteractionBaseline`, `TapQContextBaseline`, `TapQCLI` identical on macOS/Linux; everything touching AVFoundation/Speech/CoreMotion lives in the `#if os(macOS)` block (`TapQAudioCaptureBridge`, `TapQAppleAdapters`) or the `tapq` executable. All new analyzers/contracts must stay in the portable half.
+- **Language mode is v5** (`.swiftLanguageMode(.v5)` on Swift 6 tools) — strict concurrency is not fully enforced, but the house discipline is `@MainActor` classes with closure callbacks, `Sendable` value types, and generation counters (`sessionGeneration`) to invalidate stale async callbacks. New streaming-audio code must follow that pattern, not actors.
+- **Injection seams already exist everywhere needed**: `TapQCLIApplication` takes injected `TapQMotionCapturing`, IO, env, home dir; `VoiceListener` has `VoiceSpeechRecognizing` + `makeAudioSource` test seams; `OpenAILunaQuestionClassifier` has an injected `HTTPSender`; CLI tests drive everything through `FakeCapture` + fake IO (`Tests/TapQCLITests/TapQCLIApplicationTests.swift:79`).
+- **Mic plumbing**: `VoiceAudioSource`/`VoiceAudioSourceController` (`Sources/TapQAppleAdapters/VoiceAudioSource.swift`) are `internal` to `TapQAppleAdapters` and already handle route-change invalidation (`AVAudioEngineConfigurationChange`), NSException→NSError conversion via the ObjC bridge, and generation-counted teardown. The capture-study mic co-record must reuse this, not open a second AVAudioEngine path.
+- **Calibration is two independent documents** (`gesture-calibration.json`, `tap-calibration.json`) with per-kind load/save/reset in `Sources/TapQCLI/CalibrationProfile.swift`; profile payloads live portably in `Sources/TapQDetectionBaseline/CalibrationProfile.swift`. The third profile follows this exactly.
+- **Replay** (`Sources/TapQCLI/CaptureReplay.swift`) is event-based (`ReplayEventLabel`, `ReplayEvaluator` with per-label TP/FN/FP). Wearer speech is *interval-valued*, so it needs a parallel segment evaluator, not a new case in the event enum (unknown labels currently throw `badLabelLine`, so the label reader needs a tolerant partition step).
+- **Provider-adapter precedent**: `QuestionClassifierProvider` + `QuestionClassifierFactory` (`Sources/TapQContextBaseline/ResponseQuestionClassifier.swift`) — explicit provider flags, missing API key throws at startup, runtime failures return nil and fall through. `--voice-backend` should mirror this shape.
+- **Fail-open reference**: `SpeechGatedVoice` (`Sources/TapQInteractionBaseline/SpeechGatedVoice.swift`) — single-owner `assert` on `activity.onSpeakingChange`, wedged-synthesizer failure mode leaves voice closed but never blocks gesture/tap/timeout resolution. `WearerGatedVoice` mirrors this but in the *pass-through* direction: no signal ⇒ deliver commands unchanged.
+- **Clocks**: `HeadMotionSample.timestamp` is CoreMotion's seconds-since-boot. Audio buffers carry `AVAudioTime` host time. Alignment must be anchor-based (capture one `(hostTime, systemUptime)` pair at start, convert via `mach_timebase_info`), packaged as a pure, injectable-constant function so it is unit-testable.
+
+---
+
+## Work packages
+
+Ordering key: **Track A** = wearer-speech detection, **Track B** = capture-study tooling, **Track C** = VoiceBackend contract + adapters.
+
+---
+
+### WP1 — WearerSpeechAnalyzer core (Track A)
+
+**Goal**: A pure, portable analyzer that turns the 25 Hz IMU stream into a wearer-speaking/quiet state signal using a jaw/skull vibration envelope heuristic, patterned on `TapAnalyzer` (pure windowed core) plus a small stateful wrapper (patterned on `MotionGesturePipeline`'s ownership of windows/debounce).
+
+**Files**
+- Create `Sources/TapQDetectionBaseline/WearerSpeechConfig.swift` — `Codable`, `Sendable`, `Equatable` config mirroring `TapConfig`: envelope enter/exit thresholds (hysteresis), minimum-duration-to-enter, hangover/hold time, rotation-quiet gate, window length. Tolerant decoding policy per `HeadGestureConfig`.
+- Create `Sources/TapQDetectionBaseline/WearerSpeechAnalyzer.swift` — two layers in one file:
+  - a pure `analyze(...)` over trailing windows returning an analysis struct with a `Rejection` enum (insufficient samples, below envelope, rotation-not-quiet, too-brief), like `TapAnalysis`;
+  - a stateful `WearerSpeechDetector` struct with `mutating func ingest(_ sample: HeadMotionSample) -> WearerSpeechState` (`.speaking`/`.quiet`, plus transition events), owning the differenced-acceleration envelope (jerk proxy — at 25 Hz the speech signature is sustained modest elevation of |Δ userAcceleration| with low rotation, distinguished from taps by duration and from gestures by the rotation gate), hysteresis, and hangover. Must treat magnitude-only samples (`hasPerAxisData == false` is acceptable — envelope can run on `accelerationMagnitude`) and define behavior for timestamp gaps (reset, like `MotionGesturePipeline.reset()`).
+
+**Dependencies**: none.
+
+**Acceptance criteria**
+- `Tests/TapQDetectionBaselineTests/WearerSpeechAnalyzerTests.swift` exists with, at minimum: synthetic sustained-vibration stream detected as speaking; resting jitter never detected; a `TapAnalyzer`-shaped single spike rejected (too brief); a nod/shake-shaped stream rejected (rotation gate); hysteresis (mid-band values do not chatter); hangover keeps state through short pauses; timestamp-gap reset; magnitude-only stream still works; config decode tolerance round-trip.
+- Doc comments explain the physical rationale (jaw/skull-borne vibration at 25 Hz) the way `TapAnalyzer`'s header does.
+- `swift test` green; no new dependencies; file compiles on Linux (no Foundation-macOS APIs).
+
+**Risk notes**: 25 Hz Nyquist is ~12.5 Hz — the "envelope" is a proxy (sample-to-sample jerk), not a real speech band; keep thresholds in config so the capture study can retune. Do not share window state with `MotionGesturePipeline`; the analyzer is a separate consumer of the same samples.
+
+---
+
+### WP2 — Wearer-speech calibration profile + CLI (Track A)
+
+**Goal**: Third calibration profile document with calibrator, store support, and `calibration run/show/reset` coverage, mirroring the gesture/tap pattern exactly.
+
+**Files**
+- Create `Sources/TapQDetectionBaseline/WearerSpeechCalibrator.swift` — pure, mirrors `TapCalibrator`: input = resting envelope samples + speaking-phase envelope samples; output = suggested `WearerSpeechConfig` thresholds + an `Assessment` (`isUsable` requires headroom multiple between speaking envelope and resting envelope; absolute floor/ceiling clamps).
+- Modify `Sources/TapQDetectionBaseline/CalibrationProfile.swift` — add `TapQWearerSpeechCalibrationProfile` (schemaVersion 1, calibratedAt, config, quality) + `WearerSpeechCalibrationQuality` (resting/speaking sample counts, resting/speaking envelope peaks).
+- Modify `Sources/TapQCLI/CalibrationProfile.swift` — `CalibrationProfileKind.wearerSpeech` (raw value `"wearer_speech"`), third URL `wearer-speech-calibration.json`, `loadWearerSpeech()/save(_:)`, `exists/reset/url` coverage.
+- Modify `Sources/TapQCLI/CLICommand.swift` — `CalibrationTarget` gains `.wearerSpeech` (CLI spelling `wearer-speech`); `--wearer-speech-profile PATH` on run/show/reset and `--profile` routing; `--speak-seconds N` run option; update usage strings.
+- Modify `Sources/TapQCLI/CalibrationTimeline.swift` — a "Speak" stage (instruction: read aloud, head still) appended when target includes wearer speech, with transition stage.
+- Modify `Sources/TapQCLI/TapQCLIApplication.swift` — `runCalibrationSession` collects the speak phase and saves/reports the third profile (independent failure text, like tap's); `showCalibration`/`resetCalibration`/`calibrationStore`/help text extended; `CalibrationProfileCollection` gains the third member.
+
+**Dependencies**: WP1 (config type; the calibrator must compute the envelope with the *same* code the detector uses — expose that as an internal static on the analyzer).
+
+**Acceptance criteria**
+- New `Tests/TapQDetectionBaselineTests/WearerSpeechCalibratorTests.swift` (usable/unusable separation, clamps, base-config preservation).
+- Extended `Tests/TapQCLITests/CalibrationProfileTests.swift` (round-trip, schema rejection, independent reset — resetting wearer-speech never touches gesture/tap), `CLICommandParserTests` (target parsing, `--profile` routing, `--speak-seconds`), `CalibrationTimelineTests` (phase boundaries per target), `TapQCLIApplicationTests` (run with `FakeCapture` streams saves the profile; show/reset text and `--json` output; unusable speak phase fails with the documented message while preserving other saved profiles).
+- `tapq calibration show` with all three profiles prints all three blocks; `show --json` for target `all` includes the third key.
+- `swift test` green after this package alone (WP1 + WP2 form a shippable unit).
+
+**Risk notes**: `CalibrationTarget.all` now includes wearer speech for run/show/reset (ratified) — call it out in help text. Keep the existing `--profile`-with-`all` rejection message updated for three kinds.
+
+---
+
+### WP3 — Capture-study arm: microphone-envelope co-recording (Track B)
+
+**Goal**: `tapq capture` can co-record a mic-envelope ground-truth label track time-aligned to the IMU stream, written as a sidecar JSONL file. Tooling only; no human protocol.
+
+**Files**
+- Modify `Sources/TapQCLI/CLICommand.swift` — `CaptureOptions.micEnvelopePath: String?` via `--mic-envelope PATH` (also honors `--force`); update capture help.
+- Create `Sources/TapQCLI/EnvelopeCapture.swift` (new sibling to `MotionCapture.swift`, keeping files small):
+  - `TapQAudioEnvelopeCapturing` protocol mirroring `TapQMotionCapturing`: capture with `onSample` callback, start/stop bracketing the motion capture;
+  - portable `MicEnvelopeSample` (timestamp in the IMU clock, rms, peak) and `MicEnvelopeTrackMeta` (schema `"tapq-mic-envelope-v1"`, clock `"boottime"`, sampleRate, blockFrames);
+  - `EnvelopeSampleFormatter` + `EnvelopeTrackReader` (writer/reader round-trip: meta line first, then sample lines; reader validates schema version) — the reader is consumed by WP4;
+  - typed errors (`TapQEnvelopeCaptureError`: unavailable, invalidated(route change), etc.).
+- Modify `Sources/TapQCLI/TapQCLIApplication.swift` — `runCapture` starts envelope capture before motion capture and stops after; sidecar written through a second `CaptureFileWriter`. Failure policy: if `--mic-envelope` was requested and the mic cannot start, the command **fails with a clear error before capturing** (a silently missing label track ruins a study session — this is tooling, not runtime input, so fail-closed is correct here); a mid-capture route-change invalidation finishes the IMU capture, reports the truncation on stderr, and exits nonzero.
+- Create `Sources/TapQAppleAdapters/MicrophoneEnvelopeSource.swift` — public `@MainActor` class reusing `VoiceAudioSourceController` + `AVAudioEngineVoiceAudioSource` (same module, so `internal` access works): computes per-buffer RMS/peak inside the tap callback (no allocation), forwards `(hostTime, rms, peak)` through an `AsyncStream` (buffering, order-preserving — do **not** spawn a `Task { @MainActor }` per buffer; Task scheduling does not guarantee order) to a MainActor consumer. Includes a pure `AudioClockAnchor` struct: constructed from one `(machHostTime, systemUptime, timebaseNumer/Denom)` anchor, converts buffer host times to the IMU clock; fully unit-testable with injected constants.
+- Modify `Executables/tapq/TapQMain.swift` — compose `AppleMicrophoneEnvelopeCapture` (thin executable-level adapter over `MicrophoneEnvelopeSource`, mirroring `AppleHeadphoneMotionCapture`) and pass it to `TapQCLIApplication` (new optional init parameter, default nil).
+
+**Dependencies**: none (but lands after WP2 for CLI-file hotspot ordering).
+
+**Acceptance criteria**
+- `Tests/TapQCLITests`: parser tests for `--mic-envelope`; formatter/reader round-trip incl. meta line, schema rejection, bad-line errors; `TapQCLIApplicationTests` with a `FakeEnvelopeCapture` — sidecar written alongside motion output, `--force` semantics, mic-start failure aborts before motion capture, mid-capture invalidation exits nonzero with truncation notice, and capture *without* the flag is byte-identical to today.
+- `Tests/TapQAppleAdaptersTests/MicrophoneEnvelopeSourceTests.swift`: RMS/peak math against synthetic `AVAudioPCMBuffer`s (constructible without hardware), `AudioClockAnchor` conversion math, stop is idempotent, route-change invalidation surfaces the typed error. No test opens real audio hardware.
+- `swift test` green on macOS; portable targets still build for Linux (`EnvelopeTrackReader` etc. have no AVFoundation imports).
+
+**Risk notes**: This is the package that hits the repo's historical pain. (1) Route changes: the controller's generation-counted invalidation already handles teardown — do not add a second observer; consume the existing `onInvalidation`. (2) OSStatus/NSError: `TapQAudioCaptureEngineStart/Stop` already convert exceptions and errors — check the `NSError` from Stop too (currently ignored in `AVAudioEngineVoiceAudioSource.stop()`; the envelope source should at least log it via diagnostics rather than discard it). (3) Opening the AirPods mic switches Bluetooth to HFP and can degrade the audio route mid-study — document in the capture help text that the **Mac's built-in mic** should be selected as system input for ground-truth recording; smoke-checked in WP10. (4) Tap callback runs on a realtime audio thread: no locks shared with MainActor state; AsyncStream continuation `yield` only.
+
+---
+
+### WP4 — Replay wiring + precision/recall for wearer speech (Track A)
+
+**Goal**: `tapq replay` runs `WearerSpeechDetector` over a capture and reports interval-level precision/recall against ground truth, where truth comes from either explicit `wearer_speech` label segments or a co-recorded envelope sidecar.
+
+**Files**
+- Create `Sources/TapQCLI/WearerSpeechReplay.swift`:
+  - tolerant label partition: extend label reading so lines whose `label` is `"wearer_speech"` are routed to `[ReplaySpeechSegment]` and all other lines continue through the existing `ReplayLabelReader` path unchanged (keep `ReplayEventLabel` event-only; do not add an enum case);
+  - `EnvelopeLabelDeriver` — pure: envelope track → speech truth segments via threshold + hysteresis + min-gap merge (thresholds either from CLI flags or derived from the track's noise floor; keep deterministic and documented);
+  - `WearerSpeechReplayRunner` — streams samples through the detector, produces speaking intervals;
+  - `SpeechIntervalEvaluator` — frame-level precision/recall/F1 at the IMU sample rate plus onset-latency mean and false-activation count per minute; tolerance parameter reusing replay's `--tolerance` for edge slack.
+- Modify `Sources/TapQCLI/CLICommand.swift` — `ReplayOptions` gains `micEnvelopePath: String?` (`--mic-envelope`) and `wearerSpeechProfilePath: String?` (`--wearer-speech-profile`); help text.
+- Modify `Sources/TapQCLI/TapQCLIApplication.swift` — `runReplay` loads the wearer-speech profile (default config when absent, matching gesture/tap behavior), resolves truth (labels take precedence over sidecar; both present = labels win with a stderr note), prints a "wearer speech" report section in text and `--json` (keys: `frame_precision`, `frame_recall`, `f1`, `onset_latency_mean_seconds`, `false_activations_per_minute`, `truth_source`).
+
+**Dependencies**: WP1 (detector), WP2 (profile flag), WP3 (`EnvelopeTrackReader`).
+
+**Acceptance criteria**
+- New `Tests/TapQCLITests/WearerSpeechReplayTests.swift`: evaluator math on hand-computed cases (perfect overlap, missed segment, spurious activation, edge tolerance); deriver hysteresis/merge; label partition keeps existing event labels working and old label files parsing byte-identically; unknown labels other than `wearer_speech` still throw `badLabelLine`.
+- `TapQCLIApplicationTests`/`ReplayCommandParsingTests` extensions: full replay over a synthetic capture with known speaking intervals produces expected metrics in text and JSON; replay without the new flags is output-identical to today.
+- One test deliberately offsets the envelope clock and asserts the metric degradation is visible (guards against silent misalignment).
+- `swift test` green.
+
+**Risk notes**: keep the event evaluator untouched — its consumed/tolerance semantics are load-bearing for existing gesture benchmarks.
+
+---
+
+### WP5 — WearerGatedVoice composition wrapper (Track A)
+
+**Goal**: A composition-time wrapper mirroring `SpeechGatedVoice` that attributes voice commands to the wearer using the IMU speech signal, failing open in every degraded state. **Not wired into the live runtime this milestone** (same precedent as `swipeDetectionEnabled: false` — live promotion awaits the capture study).
+
+**Files**
+- Create `Sources/TapQContracts/WearerSpeech.swift` — `@MainActor public protocol WearerSpeechSignaling: AnyObject`: `var isWearerSpeaking: Bool { get }`, `var isSignalAvailable: Bool { get }` (false = no motion stream / magnitude-only / stale), and single-observer `var onWearerSpeakingChange: (@MainActor (Bool) -> Void)? { get set }` with the same single-owner documentation as `SpeechActivitySignaling`.
+- Create `Sources/TapQInteractionBaseline/WearerGatedVoice.swift` — `@MainActor public final class WearerGatedVoice: VoiceCommandProviding`:
+  - `init(wrapping:signal:attributionWindow:diagnosticSink:)` with `assert(signal.onWearerSpeakingChange == nil, ...)` exactly like `SpeechGatedVoice.init`'s ownership assertion;
+  - delivery policy: pass a matched command through iff the wearer was speaking at any point within the trailing attribution window (default ~2 s, configurable) **or** `isSignalAvailable == false` (fail open — degraded analyzer must reproduce today's shipped behavior verbatim);
+  - never opens/closes the inner mic (that is `SpeechGatedVoice`'s job); it only filters delivery, recording `command.rejected_nonwearer` / `command.passed_signal_unavailable` diagnostics;
+  - documented stacking order: `WearerGatedVoice(wrapping: rawVoice)` inside, `SpeechGatedVoice` outside (TTS gating owns mic lifecycle; attribution filters what survives).
+- Create `Tests/TapQInteractionBaselineTests/WearerGatedVoiceTests.swift`.
+
+**Dependencies**: WP1 conceptually; compiles independently (contracts only).
+
+**Acceptance criteria**
+- Tests: pass-through when signal unavailable; pass when wearer spoke within window; reject when wearer silent; window expiry; ownership assertion (mirror `SpeechGatedVoiceTests`'s approach); a wedged signal (never fires) still lets commands through when `isSignalAvailable` is false and blocks nothing else; composition test stacking `SpeechGatedVoice(WearerGatedVoice(inner))` with fake activity + fake signal proving both behaviors compose; start/stop forwarding.
+- Test-to-code ratio at house standard (~4:1 — `SpeechGatedVoice` is 67 lines with a full test file; match that density).
+- `swift test` green; both new files portable.
+
+**Risk notes**: attribution timing races — a command's transcript match arrives after recognition latency (hundreds of ms), so the attribution window must look *backwards* from delivery time; make the clock injectable (`monotonicNow` closure, per `TapQCLIApplication` precedent) so tests control it.
+
+---
+
+### WP6 — VoiceBackend contract in TapQContracts (Track C)
+
+**Goal**: The slim, duplex-capable `VoiceBackend` protocol with half-duplex as policy; turn arbitration and wearer attribution permanently on TapQ's side.
+
+**Files**
+- Create `Sources/TapQContracts/VoiceBackend.swift`:
+  - value types: `VoiceAudioFormat` (sampleRate, channels, pcm16), `VoiceAudioChunk` (`Data` + format + timestamp; `Sendable`), `VoiceBackendCapabilities` (`supportsBargeIn: Bool`, `producesAudio: Bool`, `duplex: Bool`), `VoiceBackendEvent` enum (`transcriptPartial(String)`, `transcriptFinal(String)`, `audio(VoiceAudioChunk)`, `responseCompleted`, `sessionFailed(VoiceBackendFailure)`), `VoiceBackendFailure` (typed, `Equatable`, network/protocol/authorization/closed reasons);
+  - `@MainActor public protocol VoiceBackend: AnyObject`: `var capabilities: VoiceBackendCapabilities { get }`; `func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws`; `func close()`; **explicit turn control** `func beginUserTurn()`, `func endUserTurn()` (commit — only TapQ calls these; a backend's own VAD must never end a turn, and the doc comment states this as a contract invariant); `func sendAudio(_ chunk: VoiceAudioChunk)`; `func requestResponse(text: String)` (TTS/agent-response path for backends that produce audio); `func cancelResponse()` (barge-in, meaningful only when `supportsBargeIn`).
+- Create `Sources/TapQContracts/VoiceBackendSession.swift` — a small pure `VoiceTurnStateMachine` (idle → open → userTurn → committed → responding → open …, with legal-transition checking and typed violations). Adapters use it internally so "TapQ owns turns" is enforced mechanically, and it is the contract's primary test surface.
+
+**Dependencies**: none.
+
+**Acceptance criteria**
+- `Tests/TapQContractsTests/VoiceBackendContractTests.swift`: state-machine legality matrix (every illegal transition rejected with the right violation: sendAudio before open, endUserTurn before beginUserTurn, double-begin, requestResponse mid-user-turn under half-duplex policy, cancelResponse without barge-in capability); event/failure `Equatable` semantics; capability defaults.
+- Doc comments carry the two non-negotiables: turn arbitration lives on TapQ's side; backend is a dumb speech pipe.
+- `swift test` green; zero new imports beyond Foundation.
+
+**Risk notes**: resist adding convenience that pulls policy into the contract (e.g. auto-commit on silence) — that is exactly the backend-VAD hole the design rule forbids. Keep the protocol `@MainActor` + closure events to match `VoiceCommandProviding` idiom rather than introducing `AsyncSequence` requirements the rest of the codebase doesn't use.
+
+---
+
+### WP7 — Apple default VoiceBackend + command-provider adapter (Track C)
+
+**Goal**: Default `VoiceBackend` implementation over the existing Apple stack, plus the portable adapter that turns any `VoiceBackend` into a `VoiceCommandProviding` so it can slot into today's arbiter composition.
+
+**Files**
+- Create `Sources/TapQAppleAdapters/AppleVoiceBackend.swift` — `@MainActor public final class` implementing `VoiceBackend`: `beginUserTurn` opens a mic window through `VoiceAudioSourceController` + a fresh `SFSpeechAudioBufferRecognitionRequest` (reusing the `VoiceSpeechRecognizing` seam and generation-counter discipline from `VoiceListener` — factor shared logic only if it stays readable; duplication of ~40 lines is acceptable house style over a premature abstraction); `endUserTurn` calls `request.endAudio()` and finalizes; transcripts stream as `transcriptPartial/Final` events; TTS: `requestResponse(text:)` delegates to an injected `SpeechPresenting` (the shared `SpeechEngine` — never a second `AVSpeechSynthesizer`); `capabilities = (supportsBargeIn: false, producesAudio: false, duplex: false)`; route-change invalidation surfaces as `sessionFailed`.
+- Create `Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift` — portable `@MainActor final class` implementing `VoiceCommandProviding` over any `VoiceBackend` + `VoiceCommandMatcher`: `start(onCommand:)` opens (if needed) and begins a user turn; each transcript event runs the matcher (cumulative transcripts, matching `VoiceListener.handleRecognition` semantics); on match → end turn, deliver once, teardown window; `stop()` ends turn/closes window; `sessionFailed` → silent teardown (fail open — window resolves by gesture/tap/timeout, per `SpeechGatedVoice`'s documented behavior).
+
+**Dependencies**: WP6.
+
+**Acceptance criteria**
+- `Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift` with a `ScriptedVoiceBackend` fake: match on partial transcript fires exactly one command and ends the turn; unmatched final transcript delivers nothing; `sessionFailed` mid-window tears down without delivering; stop() is idempotent; a second start() after failure opens a fresh turn; **backend never ends a turn on its own** (fake asserts `endUserTurn` is only ever caller-initiated).
+- `Tests/TapQAppleAdaptersTests/AppleVoiceBackendTests.swift` using the existing `FakeRecognizer`/`FakeAudioSource` idioms from `VoiceListenerTests`: lifecycle, stale-generation callbacks ignored, route-change → `sessionFailed`, `requestResponse` reaches the injected `SpeechPresenting`, no recognition task created when recognizer unavailable (open throws typed failure).
+- `swift test` green on macOS and portable half on Linux.
+
+**Risk notes**: this must not perturb the shipped `VoiceListener` path — no refactor of `VoiceListener` itself in this package (WP9 keeps `apple` default on the existing composition). Generation counters everywhere a delayed recognizer callback could land after teardown; that is the concurrency bug class this file will attract.
+
+---
+
+### WP8 — OpenAI Realtime adapter + scripted fake server (Track C)
+
+**Goal**: `OpenAIRealtimeVoiceBackend` in manual-turn half-duplex mode (`turn_detection: none`; TapQ commits audio buffers), in a new small portable target, tested entirely against a scripted in-process fake server.
+
+**Files**
+- Modify `Package.swift` — new portable target + product `TapQVoiceBackends` (deps: `TapQContracts`), new test target `TapQVoiceBackendsTests`; `TapQCLI` and the `tapq` executable gain the dependency (executable wiring lands in WP9, but declare the target here so Package.swift is touched once).
+- Create `Sources/TapQVoiceBackends/RealtimeTransport.swift` — `RealtimeTransporting` protocol (connect, send text frame, receive stream of text frames, close, with typed failures) + `URLSessionWebSocketRealtimeTransport` live implementation guarded so the portable build still compiles where `URLSessionWebSocketTask` is unavailable (`#if canImport(FoundationNetworking)` care; the seam means Linux tests never need the live class).
+- Create `Sources/TapQVoiceBackends/RealtimeMessages.swift` — Codable client/server events for the slice used: `session.update` (with `turn_detection: none`, pcm16 formats, model), `input_audio_buffer.append` (base64 pcm16), `input_audio_buffer.commit`, `response.create`, `response.cancel`; server: session.created/updated, transcript deltas/completions, `response.output_audio.delta`, response.completed, error. Defaults (`defaultModel`, `defaultEndpoint`, `defaultTimeout`) as statics, per `OpenAILunaQuestionClassifier`. Version pinned in a doc comment; decoding tolerant of unknown event types (ignore, don't fail the session).
+- Create `Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift` — implements `VoiceBackend` over a `RealtimeTransporting` (injected; live transport by default): open = connect + configure session (fails typed on timeout/error); `beginUserTurn`/`sendAudio`/`endUserTurn` = buffer/append/commit + `response.create` per manual-turn mode; transcript/audio events mapped to `VoiceBackendEvent`; `capabilities = (supportsBargeIn: true, producesAudio: true, duplex: true)` with half-duplex enforced by TapQ policy, not the adapter; any transport error or server `error` event → `sessionFailed` (never a hang: all awaits bounded by the timeout pattern used in `OpenAILunaQuestionClassifier.classify`). API key only in headers, never logged. Chunk sizes bounded (~100 ms) so no single `sendAudio` stalls the MainActor.
+- Create `Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift` — wrapper `VoiceBackend` over (primary, fallback): open tries primary, falls back on typed failure; a mid-session `sessionFailed` from primary tears it down, opens fallback, replays only *state* (re-begins a user turn if one was active) and surfaces a diagnostic; fallback failure surfaces as the wrapper's own `sessionFailed`. This is the fail-open guarantee as code.
+- Create `Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift` — an in-process `RealtimeTransporting` that asserts the exact client frame sequence (session.update with `turn_detection: none` first; append/commit ordering; response.create only after commit) and replays scripted server event sequences, including mid-stream disconnects.
+
+**Dependencies**: WP6.
+
+**Acceptance criteria**
+- `Tests/TapQVoiceBackendsTests/`: message codec round-trips (incl. base64 audio framing and unknown-field tolerance); handshake failure → typed open error; the manual-turn invariant (fake server asserts no `response.create` before an explicit commit, and that no server VAD event ever ends a client turn); transcript and audio event mapping; error-event and disconnect → `sessionFailed`; `cancelResponse` sends `response.cancel`; `FailThroughVoiceBackendTests` — primary open failure falls back transparently, mid-session failure re-opens fallback with an active turn, both-fail surfaces failure, and zero fallback activity while primary is healthy.
+- No test opens a network socket; CI-safe on macOS and Linux.
+- `swift test` green; the portable graph builds (verify the `FoundationNetworking` guard compiles).
+
+**Risk notes**: `URLSessionWebSocketTask` on Linux corelibs is historically flaky: the transport seam is the mitigation; do not let any portable test depend on the live transport.
+
+---
+
+### WP9 — `--voice-backend` flag, factory, and runtime composition (Track C, integrative)
+
+**Goal**: `tapq serve --voice-backend apple|openai-realtime` following the `--question-classifier` precedent, with the OpenAI path composed behind fail-through to the Apple stack and the default path byte-for-byte today's behavior.
+
+**Files**
+- Create `Sources/TapQVoiceBackends/VoiceBackendProvider.swift` — `VoiceBackendProvider: String, CaseIterable` (`apple`, `openaiRealtime = "openai-realtime"`) + `VoiceBackendFactory.select(provider:openAIAPIKey:diagnosticSink:makeAppleBackend:)` mirroring `QuestionClassifierFactory.select`: explicit `openai-realtime` with missing/empty `OPENAI_API_KEY` **throws at startup** (`VoiceBackendConfigurationError.missingOpenAIAPIKey`, message shaped like the classifier's); returns the FailThrough(OpenAI → Apple) composition. `makeAppleBackend` is a closure so the portable factory never imports AVFoundation.
+- Modify `Sources/TapQCLI/CLICommand.swift` — `ServeOptions.voiceBackend: VoiceBackendProvider = .apple`, `--voice-backend` parsing with the exact error-message shape of `--question-classifier`; serve help text (state fail-through and the API-key requirement).
+- Modify `Sources/TapQCLI/RuntimeService.swift` — `TapQRuntimeConfiguration.voiceBackend` (default `.apple`); `TapQRuntimeEndpoint.voiceBackendStatus: String?` (nil for default; e.g. `"openai-realtime (fail-through: apple)"`).
+- Modify `Sources/TapQCLI/TapQCLIApplication.swift` — plumb option → configuration; print the status line in `runServe`'s onReady block.
+- Modify `Executables/tapq/AppleTapQRuntimeService.swift` — composition: when `.apple`, keep the existing `VoiceListener` path **unchanged** (zero risk to shipped behavior); when `.openaiRealtime`, build `AppleVoiceBackend` (sharing the one `SpeechEngine`), run the factory, wrap in `VoiceBackendCommandProvider`, then `SpeechGatedVoice` exactly where `rawVoice` sits today; startup configuration errors abort serve like classifier misconfiguration does.
+
+**Dependencies**: WP6, WP7, WP8 (strictly sequential after all three).
+
+**Acceptance criteria**
+- `Tests/TapQCLITests/CLICommandParserTests` + `TapQCLIApplicationTests`: flag parsing incl. rejection message listing valid providers; configuration passes through; serve with a fake runtime service receives the provider; status line rendering.
+- `Tests/TapQVoiceBackendsTests/VoiceBackendFactoryTests`: missing-key throws; key present composes FailThrough with Apple fallback; `apple` provider returns the Apple closure's product directly.
+- An end-to-end-shaped test at the `VoiceBackendCommandProvider` level: scripted OpenAI transport dies mid-window → command still resolvable through the Apple fake (fail-through proven above the adapter seam).
+- `--voice-backend apple` (and flag omitted) leaves every existing serve test output unchanged.
+- `swift test` green.
+
+**Risk notes**: the composition happens in the untested executable file (`AppleTapQRuntimeService.swift`) — keep the executable diff to a minimal `if/else` around already-tested components; anything with logic goes in the portable factory where it has tests. Do not let the OpenAI path capture the mic outside listen windows: `VoiceBackendCommandProvider` opening turns only inside `start()` preserves the "mic never always-on" invariant documented on `VoiceListener`.
+
+---
+
+### WP10 — Final verification and human smoke checklist
+
+**Goal**: whole-milestone verification and the handoff artifact for the human.
+
+**Work**
+- `swift build` (debug + release) and full `swift test` on macOS; compile-check the portable graph.
+- Docs: update `docs/CLI.md` (capture `--mic-envelope`, replay wearer-speech section, calibration `wearer-speech` target, serve `--voice-backend`), `docs/ROADMAP.md` checkbox updates if applicable, `CHANGELOG.md` entry. Verify all help-text strings match parser reality (the repo tests help output — check `CLICommandParserTests`).
+- Cross-package consistency pass: naming (`wearer_speech` raw values consistent across profile kind, labels, JSON keys), diagnostic category names, no portable target importing AVFoundation (grep gate).
+- Write the manual smoke checklist to `docs/MILESTONE1_SMOKE_CHECKLIST.md` (human + hardware; agents must not attempt):
+  1. AirPods connected: `tapq capture --duration 30 --mic-envelope /tmp/env.jsonl -o /tmp/imu.jsonl` while speaking two sentences and staying silent between — verify sidecar timestamps overlay IMU timestamps and speech is visible in the envelope.
+  2. Repeat with system input set to AirPods mic — confirm the documented HFP-degradation warning story and that route behavior matches docs.
+  3. Mid-capture route change (switch input device) — verify truncation message and nonzero exit.
+  4. `tapq calibration run wearer-speech`, then `calibration show`/`show --json`/`reset wearer-speech` — verify third profile lifecycle and that gesture/tap profiles survive the reset.
+  5. `tapq replay` on the recorded capture with `--mic-envelope` — sane precision/recall; then with a deliberate silent recording — zero false activations target.
+  6. `OPENAI_API_KEY` set: `tapq serve --voice-backend openai-realtime` — status line, a live approval answered by voice; then kill network mid-session — verify fail-through to Apple stack without a stuck window; then unset key — verify startup error message.
+  7. Regression: default `tapq serve` voice/gesture approval flow unchanged.
+
+**Dependencies**: all packages.
+
+---
+
+## Genuinely human/hardware-bound (no agent work planned)
+
+- All live recordings, the capture-study protocol itself, calibration sessions, live OpenAI Realtime sessions, and every item in the WP10 smoke checklist.
+- Threshold *values* in `WearerSpeechConfig` defaults are provisional until the human capture study; the plan treats them as config, so retuning is a data change, not a code change.

--- a/docs/MILESTONE2_SMOKE_CHECKLIST.md
+++ b/docs/MILESTONE2_SMOKE_CHECKLIST.md
@@ -1,0 +1,317 @@
+# Milestone two — manual smoke checklist
+
+Live voice loop: conversation sessions, microphone pump, response playback, wearer gate,
+IMU turn control, barge-in, and free-form voice answers, verified against real hardware.
+
+Everything here needs a human, physical AirPods, macOS privacy permissions, and — for most
+items — a live network and an OpenAI account. **Agents must not attempt these.** The
+automated suite covers every seam that can be faked; this file covers exactly the part it
+cannot: whether the cloud voice session actually works end-to-end, whether the wearer gate
+rejects a bystander, and whether free-form text reaches the agent.
+
+Nothing in this milestone changes the shipped default paths. Item 7 is the regression
+check that proves it.
+
+## Before you start
+
+- Build the runtime bundle once: `scripts/package-runtime-app.sh debug`.
+- Connect AirPods and confirm head motion works at all: `scripts/run-runtime-app.sh serve`
+  should report `AirPods motion: available`. If it does not, stop — every item below
+  depends on it.
+- Run the wearer-speech calibration if you have not already:
+  `scripts/run-runtime-app.sh calibration run wearer-speech --non-interactive`.
+  Items 2 and 3 require the IMU wearer-speech signal, which works with or without a
+  calibration profile but is more accurate with one.
+- Export `OPENAI_API_KEY` in the shell that launches the runtime. Items 1, 2, 4, and 5
+  require it.
+- Keep a scratch directory, e.g. `mkdir -p /tmp/tapq-smoke-m2`.
+
+Three properties of the development launcher shape every command below. It runs the
+bundle through `open -n -W`, which means:
+
+- **stdin is closed.** Interactive prompts see EOF. Always pass `--non-interactive` to
+  `calibration run` and `--yes` to `calibration reset`.
+- **the working directory is `/`.** Every path argument must be absolute.
+- **the exit code is lost.** `open -W` returns `0` no matter what the app returned, so the
+  launcher cannot be used to check an exit status. Where an item asks for one, run the
+  bundle's executable directly instead:
+  `build/TapQRuntime.app/Contents/MacOS/tapq ...`, and grant permission again if macOS
+  re-prompts.
+
+Environment variables *are* inherited, so `OPENAI_API_KEY`, `TAPQ_DEBUG=1`, and
+`TAPQ_SPEECH_VOICE` work through the launcher.
+
+---
+
+## 1. Cloud voice end-to-end: speak, hear, resolve
+
+```bash
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime
+```
+
+Trigger a live approval from Claude Code or Codex. When the prompt is spoken, answer by
+voice ("yes" or "no"). Then trigger a second approval.
+
+**Expect**
+
+- The ready block prints `Voice backend: openai-realtime (fail-through: apple)`.
+- The approval is answered by your spoken voice, and the decision takes effect exactly as
+  it does on the Apple path.
+- **You hear the cloud voice.** The agent's response audio — not the local `AVSpeech`
+  synthesizer — should be audible through the AirPods. This is the thing milestone one
+  could not do: the pipe now actually transmits audio (microphone pump), the cloud returns
+  audio, and TapQ plays it (backend playback).
+- The approval resolves by voice on the **primary** (OpenAI) path, not through
+  fail-through to Apple. With `TAPQ_DEBUG=1`, the diagnostic stream should show
+  `VoiceBackend` and `OpenAIRealtime` events, not `AppleVoiceBackend` events, for the
+  resolving window.
+- A second approval on the same session reuses the existing WebSocket session (no
+  reconnect churn). With `TAPQ_DEBUG=1`, you should not see a fresh `session.created`
+  between consecutive windows unless 60 seconds of idle time elapsed.
+
+**Also verify playback across devices.** If possible, repeat with different audio output
+configurations: AirPods only, Mac speakers only, an external audio interface. The
+`AVAudioPlayerNode` int16-interleaved connect/schedule/completion path was empirically
+verified on one Mac only; the smoke checklist must confirm playback across output devices
+and macOS versions. Record which macOS version and output device you used.
+
+**If it fails** — no audible cloud voice means the playback path is broken. No voice
+resolution means either the microphone pump is not transmitting or the transcript is not
+arriving. Check `TAPQ_DEBUG=1` output for `MicPump` and `Playback` diagnostics.
+
+## 2. IMU turn control: endpointing and barge-in
+
+```bash
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime --imu-turn-control
+```
+
+The ready block should print `Wearer speech: turn-control`.
+
+Trigger an approval. When the prompt is spoken, answer by voice. Stop talking and wait.
+
+**Expect — endpointing**
+
+- The turn commits within roughly 1 second of the wearer stopping speech (0.6 s detector
+  hangover + 0.4 s endpoint delay). The window resolves without waiting for the full
+  timeout.
+- Without `--imu-turn-control`, the same scenario would wait for the window timeout or a
+  gesture/tap before resolving.
+
+**Expect — barge-in**
+
+Trigger another approval. While the agent is speaking its response audio (the cloud voice
+or TTS), start talking.
+
+- **Playback stops immediately.** The agent's voice cuts off when the wearer starts
+  speaking.
+- The wearer's answer is heard on the next turn and the window resolves.
+- The first ~0.3-0.5 seconds of the barge-in utterance may be lost (IMU onset latency plus
+  mic-open latency). This is expected and documented.
+
+**If it fails** — endpointing not firing means the wearer-speech signal is not reaching the
+turn coordinator; check that AirPods motion is available and that per-axis data is present.
+Barge-in not firing means the `startedSpeaking` transition is not being observed during
+playback; check `TAPQ_DEBUG=1` for wearer-speech transitions.
+
+## 3. Wearer gate: attribution filtering
+
+```bash
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime --wearer-gate
+```
+
+The ready block should print `Wearer speech: gate`.
+
+**Expect — bystander rejection**
+
+Trigger an approval. While the window is open, play "yes" from a phone speaker or have
+another person say "yes" near the AirPods.
+
+- The bystander's "yes" should be **rejected**. The wearer-speech signal should not
+  attribute the command to the wearer. With `TAPQ_DEBUG=1`, you should see a `WearerGate`
+  diagnostic indicating the command was not attributed.
+- The window should remain open for the wearer to answer by gesture, tap, or their own
+  voice.
+
+**Expect — wearer acceptance**
+
+Then the wearer themselves says "yes".
+
+- The wearer's own "yes" should pass through. The approval resolves.
+
+**Expect — fail-open on signal loss**
+
+Pull the AirPods out of your ears (or wait for motion to disconnect) while a window is
+open.
+
+- The gate should degrade to pass-through. A voice command should resolve the window as if
+  the gate were not present (fail-open).
+- With `TAPQ_DEBUG=1`, you should see a `WearerGate` diagnostic indicating the signal is
+  unavailable and the command is being passed through.
+
+**If it fails** — the gate rejecting the wearer's own speech means the attribution window
+is too narrow or the detector is not sensitive enough on your hardware. Record the
+calibration profile numbers and the behavior. The thresholds are provisional.
+
+## 4. Free-form voice answers
+
+```bash
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime --imu-turn-control \
+  --voice-freeform
+```
+
+**Via Claude Code `AskUserQuestion`**
+
+Trigger a multi-option question from Claude Code (e.g. use `--steering` and prompt Claude
+to ask a question with options). When the options are spoken, instead of selecting one,
+speak an answer in your own words — something clearly different from any of the listed
+options.
+
+**Expect**
+
+- TapQ reads back your answer: "You said: '<your text>'. Nod to send, shake to discard."
+- Nod to confirm.
+- Claude receives the free text. Check the Claude Code transcript: the deny reason should
+  contain your spoken text. Claude should proceed with your answer rather than re-asking.
+
+**Via Codex `request_user_input`**
+
+Repeat the same test with a Codex `request_user_input` question.
+
+**Expect**
+
+- The same read-back confirmation flow.
+- **Record whether Codex accepts the free-text answer.** Whether `request_user_input`
+  tolerates non-option answer strings is not verifiable from this repository. If Codex
+  re-asks the same question, the free-text delivery is best-effort and the documented
+  fallback is that nothing worse than today's behavior happens. Record the observed
+  behavior.
+
+**Also verify discard**
+
+Speak a free-form answer, hear the read-back, then shake to discard.
+
+**Expect**
+
+- The answer is discarded and TapQ re-listens for the next command.
+
+**If it fails** — if the read-back never fires, check that `--voice-freeform` is passed and
+the backend is `openai-realtime`. If Claude does not see the text, check the wire protocol
+version in the debug output.
+
+## 5. Fail-through: network death mid-conversation
+
+```bash
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime
+```
+
+Trigger a live approval. After it resolves, **turn Wi-Fi off** while the session is idle
+(between windows).
+
+Then trigger another approval.
+
+**Expect**
+
+- The window does **not** hang. The primary backend fails to reopen (or the existing
+  session fails), and fail-through kicks in: voice continues on the Apple stack.
+- Fail-through is **sticky**: subsequent windows go directly to the Apple fallback with no
+  primary traffic and no per-window 5-second handshake timeout.
+- Voice keeps working on every subsequent window.
+- The microphone is **never stuck open** between windows.
+
+Turn Wi-Fi back on and wait at least 60 seconds (idle-close timeout) before triggering
+another approval.
+
+**Expect**
+
+- After the idle-close reopen, the primary is re-probed (stickiness is reset on a new
+  conversation). If the network is back, the primary should succeed.
+
+**If it fails** — a hung window is the serious case. Fail-through exists so that a network
+problem costs latency and never the interaction. A window that cannot be resolved is worse
+than having no cloud backend at all.
+
+## 6. Old shim against new broker
+
+Build the hook executable from the milestone-one tip (`0fc7474`) and leave it installed.
+Start the current milestone-two runtime.
+
+```bash
+# Build old shim (in a separate checkout or worktree)
+git checkout 0fc7474
+swift build
+# Note the path to the built tapq-hook / tapq-codex-hook
+
+# Start the current M2 runtime
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime
+```
+
+Trigger an approval from the old shim.
+
+**Expect**
+
+- The old shim (v3) connects to the new broker (which accepts v3). The approval resolves
+  normally — it fails open loudly to the on-screen prompt rather than silently breaking.
+- The old shim never sees `free_text` fields (it decodes them as absent), so free-form
+  voice answers are not delivered through the old shim. This is expected.
+
+Reinstall hooks with the current build (`tapq integration claude install` and/or
+`tapq integration codex install`).
+
+**Expect**
+
+- The new shim (v4) connects and all features including free-text work.
+
+**If it fails** — if the old shim is rejected entirely, the broker's version acceptance
+(`{3, 4}`) is not working. If the old shim hangs or crashes, there is a wire
+incompatibility in the request or response format.
+
+## 7. Regression: the default path is unchanged
+
+```bash
+scripts/run-runtime-app.sh serve
+```
+
+**Expect**
+
+- **No** `Voice backend:` line. The default prints nothing, because nothing changed.
+- **No** `Wearer speech:` line. Neither gate nor turn control is active by default.
+- Voice approvals, double nod, double shake, double tap, and volume-key option navigation
+  all behave exactly as they did before this milestone.
+- The default Apple voice path is unchanged: `VoiceListener` opens and closes its
+  recognizer per window, no conversation session, no playback, no microphone pump.
+
+Also verify that the new flags do not change behavior when not passed:
+
+```bash
+scripts/run-runtime-app.sh serve --voice-backend openai-realtime
+```
+
+**Expect**
+
+- Without `--wearer-gate`, `--imu-turn-control`, or `--voice-freeform`, the
+  `openai-realtime` path resolves windows by gesture, tap, or timeout exactly as before.
+  The only behavioral difference from milestone one is that the pipe now actually transmits
+  audio and the cloud voice is audible (items covered in item 1).
+- No new status lines beyond `Voice backend:`.
+
+This is the item that matters most. Everything in milestone two is either behind an
+explicit flag or an improvement to the existing `openai-realtime` flag path; if any
+unflagged default behavior moved, that is a defect regardless of how well items 1
+through 6 went.
+
+---
+
+## Recording results
+
+Record the following with every run:
+
+- macOS version and hardware (Mac model, AirPods model).
+- Audio output device used for item 1's playback verification.
+- Whether Codex accepts the free-text answer in item 4 (the one open question).
+- Calibration profile numbers from `tapq calibration show` for items 2 and 3.
+- Any `TAPQ_DEBUG=1` output that shows unexpected behavior.
+
+Wearer-speech thresholds are provisional by design — they live in a calibration profile
+precisely so the capture study can retune them without a code change. An endpoint that
+fires too early or a gate that passes a bystander on your hardware is data for the study,
+not necessarily a bug. Record the numbers.

--- a/docs/MILESTONE2_VOICE_LOOP_PLAN.md
+++ b/docs/MILESTONE2_VOICE_LOOP_PLAN.md
@@ -1,0 +1,376 @@
+# TapQ Milestone Two — Implementation Plan (Live Voice Loop)
+
+*Authored by the Fable 5 planning agent for orchestrator review, 2026-08-06.*
+*Branch: `worktree-milestone2-voice-loop`, based on milestone-1 tip `0fc7474`.*
+
+## Orchestrator decisions (ratified 2026-08-06)
+
+Answers to the open questions in §3; implementers treat these as settled.
+
+1. **WP3 (microphone pump) is in scope.** The confirmed M1 gap — no caller of `sendAudio` on the pipe path — is load-bearing; without WP3, scope items 1/4/5 are unreachable.
+2. **Playback and the mic pump ride the existing `--voice-backend openai-realtime` flag.** No new sub-flag; M1's silence on that path was an implementation gap, not a contract.
+3. **Conversation policy**: conversation = provider session lifetime with `idleClose` **60 s**; fail-through is sticky for the conversation lifetime, with `resetStickiness()` on idle-close reopen. The `openai-realtime` composition adopts `.conversation` immediately (WP3/WP6).
+4. **Free-form plumbing** widens `VoiceCommand`/`InputIntent` with `.freeform(String)`, with **mandatory read-back confirmation**, scoped to selections and multi-option stop questions only. Tool approvals and yes/no stop questions stay binary: spoken free text must never authorize an agent action.
+5. **Wire protocol bumps to version 4; the broker accepts {3, 4}**; `outboundVersion` bridges a v4 shim to a v3 broker, mirroring the existing v2 bridge.
+6. **Codex free-text**: implement per WP9; the verdict comes from smoke item 4. Documented fallback if Codex re-asks: fail open, nothing worse than today.
+7. **No acoustic endpointer this milestone.** Document honestly that `openai-realtime` without `--imu-turn-control` resolves windows by gesture/tap/timeout only; WP3's `onInputLevel` hook stays inert as the door to a future fallback.
+8. **Linux proof requires a push, and pushing this branch stays a user decision** (standing repo rule). WP10 lands the triggers and the boundary-list fix only.
+9. **Barge-in uses blunt `speech.stopAll()`** — accepted; document that queued cross-session notifications are dropped on barge-in.
+10. The §1 framing corrections are acknowledged; where the plan's citations disagree with the original scope wording, the plan wins.
+11. Per-WP calls ratified as recommended: idle-close 60 s with a virtual-clock seam; "a turn never spans a TTS-busy interval" must be an explicit test (WP1); the endpoint delay is a coordinator constant (default 0.4 s) with an init override, not a `WearerSpeechConfig` field (WP7).
+
+**Execution**: strictly sequential WP1 → WP11, one Opus implementation agent per WP, one commit per WP; Fable checkpoint reviews after WP4 and WP9. Implementers do not push, do not open PRs, and touch `CHANGELOG.md`/`docs/CLI.md` only in WP11.
+
+**Commit convention for implementers**: one commit per work package, message `milestone2 WPn: <short name>`, each leaving `swift build`, `swift test`, and `scripts/check-public-boundary.sh` green. Execution is strictly sequential (WP1 → … → WP11); all implementers share this worktree and its `.build`. `CHANGELOG.md` and `docs/CLI.md` are touched **only in WP11** to avoid rebase churn.
+
+## Design invariants (restated; non-negotiable)
+
+- **Half-duplex with fast interruption.** The backend is a dumb speech pipe. Only TapQ calls `beginUserTurn`/`endUserTurn`; backend VAD must never end a turn (`Sources/TapQContracts/VoiceBackend.swift:150-165` states this as contract; `VoiceTurnStateMachine` enforces it mechanically).
+- **Duplex transport, half-duplex policy.** Mic capture during agent playback is architecturally allowed, but this milestone deliberately keeps the microphone and the speaker mutually exclusive (see "Echo strategy" below). Barge-in arbitration is TapQ-side and IMU-driven, so it needs no open microphone at all.
+- **Fail-open everywhere at runtime.** A broken IMU signal, dead backend, dropped socket, or unavailable playback device degrades to milestone-1 behavior: the window still resolves by gesture, tap, or timeout; nothing ever blocks or hangs an approval.
+- **Default path byte-identical.** `tapq serve` with no new flags behaves exactly as milestone-1 tip: same composition (`Executables/tapq/AppleTapQRuntimeService.swift:131-151` keeps `VoiceListener` for `.apple`), same output, same wire bytes.
+- **Every IMU-live feature ships default-off behind explicit flags with provisional thresholds** (`swipeDetectionEnabled: false` precedent) — the human capture study is still pending.
+- **House idioms**: `@MainActor` classes + closure callbacks (no actors, no `AsyncSequence` API surface), generation counters for async invalidation, hardware-independent fakes, no live audio/network/hardware/CoreMotion in tests, ~4:1 test-to-code density, portable/macOS `Package.swift` split preserved (portable targets never import AVFoundation/CoreMotion/AppKit; `scripts/check-public-boundary.sh:134-151` is the grep gate).
+
+### Echo strategy (explicit, as required)
+
+No acoustic echo handling is needed in this milestone, and none should be built. The policy that already ships — `SpeechGatedVoice` closes the microphone whenever the speech engine is busy (`Sources/TapQInteractionBaseline/SpeechGatedVoice.swift:50-57`) — is extended to cover backend audio playback via a combined activity signal (WP2). The mic and the speaker are therefore never simultaneously live, so there is nothing to echo-cancel. Barge-in does not weaken this: the barge-in *trigger* is the jaw-vibration IMU signal, which the agent's speaker audio physically cannot reach, so interruption is detected with the mic closed; playback then stops, the activity signal drains, and `SpeechGatedVoice` reopens the mic. The accepted cost is that the first ~0.3–0.5 s of a barge-in utterance (IMU onset latency `minimumSpeakingSeconds` = 0.3 s default, `Sources/TapQDetectionBaseline/WearerSpeechConfig.swift:55`, plus mic-open latency) is not heard; the UX answer is that barge-in stops the agent and the user speaks their answer, it does not attempt to salvage the interrupting syllables. Cheapest adequate answer: strict half-duplex, zero echo code. True duplex-with-AEC would be a future milestone with its own hardware story.
+
+---
+
+## 1. Codebase findings
+
+All verified against this worktree at `0fc7474`. Where the scope framing disagreed with the code, the correction is marked **[correction]**.
+
+### Contract locations **[correction to framing]**
+There is no `TapQVoiceCore` target. The VoiceBackend contract lives in `TapQContracts`:
+- `Sources/TapQContracts/VoiceBackend.swift` — `VoiceAudioFormat`/`VoiceAudioChunk`/`VoiceBackendCapabilities`/`VoiceBackendEvent`/`VoiceBackendFailure` (lines 8–143), protocol at 169–209.
+- `Sources/TapQContracts/VoiceBackendSession.swift` — `VoiceTurnViolation` + `VoiceTurnStateMachine` (states idle/open/userTurn/committed/responding; `cancelResponse` legal only with `supportsBargeIn`, lines 143–151).
+- `Sources/TapQContracts/WearerSpeech.swift:16-32` — `WearerSpeechSignaling` (single-observer `onWearerSpeakingChange`; the doc comment at lines 27–31 explicitly anticipates "add a multicast on the implementation if a second consumer … ever needs the signal" — WP5 uses exactly that escape hatch, since M2 has two consumers: attribution and turn control).
+
+### Audio events are discarded; there is no playback path — confirmed
+`Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift:97-101`: `case .audio:` records `audio.ignored` and drops the chunk. No `AVAudioPlayerNode` (or any output path) exists anywhere in `Sources/`/`Executables/`; the ObjC bridge (`Sources/TapQAudioCaptureBridge/include/TapQAudioCaptureBridge.h`) exports only capture (`TapQAudioCaptureEngineStart/Stop` with an input-node tap).
+
+### **[correction — the biggest gap in the scope list] Nothing feeds microphone audio into a pipe backend.**
+The only caller of `VoiceBackend.sendAudio` in the whole tree is `FailThroughVoiceBackend`'s pass-through (`Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift:132`). `AppleVoiceBackend` owns its own mic (opens it inside `beginUserTurn`, `AppleVoiceBackend.swift:139-193`), but `OpenAIRealtimeVoiceBackend` is a pure pipe — and the live composition (`AppleTapQRuntimeService.swift:135-151`) wraps it in `VoiceBackendCommandProvider` with no microphone pump anywhere. Consequently, on `--voice-backend openai-realtime` today, a turn opens, **zero audio is ever appended**, no user transcript can ever arrive, and voice can only resolve a window if the primary session *fails* and fail-through lands on Apple. Milestone-1 smoke item 6 ("a live approval answered by voice") cannot pass on the primary path as built. M2 must add the mic pump (WP3) or items 1, 4, 5, 6 of the ratified scope are unreachable. Related: `OpenAIRealtimeVoiceBackend.endUserTurn()` (lines 198–216) sends `input_audio_buffer.commit` + `response.create` even for a turn that carried no audio — the server rejects an empty commit, so the empty-turn guard in WP1 matters.
+
+### A second OpenAI-path consequence: no transcripts until commit
+The adapter maps only `conversation.item.input_audio_transcription.delta/completed` to transcript events (`Sources/TapQVoiceBackends/RealtimeMessages.swift:256-259`). Under `turn_detection: none`, the service creates the user conversation item — and therefore starts input transcription — only when the buffer is **committed**. So on the OpenAI path there are no mid-turn partials, and the M1 "match on partial transcript" resolution never fires before a commit. Today the only commit is the one buried in teardown (`VoiceBackendCommandProvider.swift:133-145`, after the window is already being torn down). **IMU endpointing (WP7) is therefore not a nicety on the OpenAI path; it is what makes voice resolution possible there at all.** (Apple's recognizer emits partials continuously, so the shipped match-on-partial behavior is unaffected.)
+
+### Where turn end happens today — confirmed, with one addition
+`VoiceBackendCommandProvider`: turn ends only in `teardown()` (`:133-145`, `backend.endUserTurn()` at `:139`), reached from (a) a command match (`consume`, `:116-131`), (b) `stop()` (`:62-64`), (c) `sessionFailed` (`:104-110`, which skips the endUserTurn into a dead backend). `stop()` arrives from `InputArbiter.finish` (`Sources/TapQInteractionBaseline/InputArbiter.swift:78-89`) on any resolution/timeout, **and — the addition — from `SpeechGatedVoice.speakingChanged` every time TTS becomes busy** (`SpeechGatedVoice.swift:50-57`). Since every prompt/re-prompt makes TTS busy, the openai provider as composed would open and close a *full WebSocket session per mic reopen*, several times per approval. This churn is the real target of scope item 5 ("per conversation, not per window").
+
+### Fail-through granularity — confirmed per-open
+`FailThroughVoiceBackend` fails over exactly once per `open` and retries the primary on every new `open` (`FailThroughVoiceBackend.swift:19-21, 64-97`). Combined with the churn above, a dead network costs a 5 s handshake timeout (`OpenAIRealtimeVoiceBackend.defaultTimeout`) at every mic reopen. Conversation-scoped sessions (WP1) plus a sticky-fallback policy fix both.
+
+### HeadphoneMotionSource fan-out — exact answer to the posed question
+`HeadphoneMotionSource` is an **internal** protocol (`Sources/TapQAppleAdapters/HeadphoneMotionSource.swift:13-17`); the production `HeadphoneMotionManagerSource` owns the single `CMHeadphoneMotionManager` (a second manager would contend — doc comments `HeadphoneMotionSource.swift:37-39`, `HeadGestureDetector.swift:5-7`). The sole consumer is `HeadGestureDetector`, which holds the source privately (`HeadGestureDetector.swift:80`) and installs **one** callback per window (`beginMotionUpdates`, `:242-258`). Every live sample flows through exactly one of two branches: `ingest(sample)` in detection mode (`:349-371`, feeding `MotionGesturePipeline` + optional encoder) or `onSample` in capture mode (`:253-254`, used by `startCapture`, `:262-274`). **A second consumer cannot attach at the source level without disturbing the epoch/watchdog machinery; the correct attachment point is a fan-out hook inside `HeadGestureDetector.ingest`** (plus a reset notification from `teardown`/`resetSession`, `:309-338`). Crucially, the motion stream is **per-window**: `InputArbiter.begin` starts the detector, `finish` stops it, so samples flow only while an approval/selection window is open — which is exactly when attribution, endpointing, and barge-in are needed, because `BargeIn.listen` speaks the prompt *concurrently* with the open window (`Sources/TapQInteractionBaseline/BargeIn.swift:13-21`). Between windows the wearer-speech signal is simply stale ⇒ `isSignalAvailable == false` ⇒ fail open, by design.
+
+### WearerGatedVoice / WearerSpeechSignaling — confirmed not live
+`WearerSpeechSignaling` has no runtime producer: references exist only in contracts, `WearerGatedVoice`, and tests. `WearerGatedVoice` appears nowhere under `Executables/`. The serve composition root is `Executables/tapq/AppleTapQRuntimeService.swift` (`TapQMain.swift:33` constructs the service; `TapQCLIApplication` takes it injected, `Sources/TapQCLI/TapQCLIApplication.swift:42,68`). The runtime already constructs the calibration store with a wearer-speech URL "purely to satisfy the initializer" (`AppleTapQRuntimeService.swift:35-41`) — WP6 makes it real. Documented stacking order for the gate is already written: `SpeechGatedVoice(wrapping: WearerGatedVoice(wrapping: rawVoice, signal:), activity:)` (`WearerGatedVoice.swift:16-20`).
+
+### Wire protocol and where it is versioned — exact shape
+- Version constant: `Sources/TapQWireProtocol/WireMessages.swift:20` (`WireProtocol.version = 3`), with a worked precedent for cross-version bridging: `legacyBridgeVersion = 2` + `outboundVersion(for:approvalSource:)` (`:25-44`) — the *shim* downgrades its outbound version to the peer's, discovered from the broker's discovery record (`Sources/TapQBrokerRuntime/BrokerRuntimeDiscovery.swift:64,100`; read via `Sources/TapQPOSIXBridgeClient/BrokerDiscovery.swift:150`). The broker itself requires an exact match (`BrokerServer.swift:223-225`) and rejects with `error("protocol_version")` (`:227-238`), which shims treat as fail-open.
+- Decision path for approvals: broker → `onApproval` → `Decision` (allow/deny/ask only, `Sources/TapQContracts/Decision.swift`) → `BrokerResponse.decision(_, reason:)` (`WireMessages.swift:245-262`); the deny `reason` string already reaches both agents (Claude: `HookShim.swift:95,123`; Codex: `CodexHookShim.swift:314`).
+- Selections: broker → `onSelection` → `SelectionResult` (choices + `timedOut`; `timedOut` maps to `error("timeout")`, `BrokerServer.swift:154`) → `BrokerResponse.selection(indices:labels:)` (`WireMessages.swift:275-277`). The Claude shim turns the labels into a PreToolUse deny reason (`HookShim.swift:388-397`); the Codex shim turns them into a `request_user_input` response JSON inside a deny reason (`CodexHookShim.swift:214-245`).
+- **Stop questions already carry free text on the wire** (`action: "answer"` + `reply`, `WireMessages.swift:278-284`; consumed at `HookShim.swift:268-276` and `CodexHookShim.swift:483-494`, delivered to the agent as a Stop-block `reason`). What is missing is not wire capability but a *runtime producer* of free text: `StopQuestionCoordinator` only ever emits canned "Yes"/"No"/option-label replies (`Sources/TapQContextBaseline/StopQuestionCoordinator.swift:105,122,126,140-142`). So scope item 6 decomposes into: an interaction-layer free-text capture (WP8), an additive `free_text` field on the *selection* response + shim handling (WP9), and no change at all to the stop-question wire shape.
+- Both shims decode replies leniently (`[String: JSONValue]` + `decodeIfPresent`-style reads), so **additive response fields are wire-safe against installed shims**.
+
+### Linux CI **[correction to framing] — it already exists**
+`.github/workflows/ci.yml:42-59` has a `linux` job (ubuntu-24.04, `container: swift:6.0`) that builds and tests the portable graph, including the boundary script. It triggers only on push to `main`/tags and on PRs — milestone worktree branches have never run it, which is the true gap. Additionally, `scripts/check-public-boundary.sh:134-143` **omits `Sources/TapQVoiceBackends` from the portable-targets list**, so the M1 target has never been grep-gated against OS imports (it is currently clean: `RealtimeTransport.swift` guards the live WebSocket class with `#if canImport(Darwin)` at `:63` and `FoundationNetworking` at `:2-4`). WP10 fixes the list, adds trigger coverage, and audits the new M2 code.
+
+### Other load-bearing facts
+- `OpenAIRealtimeVoiceBackend`: default model `gpt-realtime`, input transcription `gpt-4o-transcribe` (`RealtimeMessages.swift:8,12`); wire format pinned mono 24 kHz PCM16 (`OpenAIRealtimeVoiceBackend.swift:38`, format check rejects anything else at `:183-190`); `capabilities = (bargeIn: true, audio: true, duplex: true)`; ordered outbound pump; `cancelResponse` sends `response.cancel` (`:228-236`).
+- `FailThroughVoiceBackend.capabilities` is the conservative **intersection** (`:50-56`) — with Apple (`transcriptOnly`) as fallback, the composed backend reports `producesAudio: false` and `supportsBargeIn: false`. WP2/WP7 must consult the *event stream and the inner call path*, not the composed capabilities, or playback and `cancelResponse` will be judged unavailable. This is a real design wrinkle; resolution proposed in WP2/WP7 and flagged in open questions.
+- Activity gating: `SpeechEngine` implements `SpeechActivitySignaling` (busy covers queued + speaking, `SpeechEngine.swift:200-208`); `SpeechGatedVoice` asserts sole ownership of `onSpeakingChange` (`:26-27`); the contract doc invites an implementation-side multicast (`Sources/TapQContracts/Inputs.swift:183-186`).
+- Existing fakes to reuse: `ScriptedVoiceBackend` (records call sequence, polices turn protocol, scripts events — `Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift`), `ScriptedRealtimeServer`, `FakeRecognizer`/`FakeAudioSource` idioms (`Tests/TapQAppleAdaptersTests`), `SpeechEngine.synthesisForTesting` seam, injectable `TapQRuntimeServing` for CLI serve tests, synthetic `AVAudioPCMBuffer` construction (`MicrophoneEnvelopeSourceTests`).
+- Realtime-audio-thread discipline to copy: `MicrophoneEnvelopeSource` reduces on the tap thread and crosses to MainActor through one ordered buffering `AsyncStream` — never a `Task { @MainActor }` per buffer (`Sources/TapQAppleAdapters/MicrophoneEnvelopeSource.swift:102-124`).
+- Budget chain: interaction total 245 s < shim socket 255 s < hook timeout 260 s (`Sources/TapQContracts/InteractionBudget.swift`).
+- Wearer-speech detector API for the live producer: `WearerSpeechDetector.ingestDetailed(_:) -> WearerSpeechUpdate` with `transition` (`started_speaking`/`stopped_speaking`), gap-reset built in (`Sources/TapQDetectionBaseline/WearerSpeechAnalyzer.swift:234-360`); provisional defaults: onset 0.3 s, hangover 0.6 s, window 0.6 s, `maxSampleGapSeconds` 0.5 s (`WearerSpeechConfig.swift:51-71`).
+
+---
+
+## 2. Work packages
+
+Ordering key: **Track P** = pipe plumbing (session/audio), **Track I** = IMU-live features, **Track F** = free-form + wire, **Track X** = cross-cutting. Strictly sequential WP1 → WP11; each WP builds only on committed predecessors and leaves the suite green.
+
+---
+
+### WP1 — Conversation-scoped sessions: provider persistence, re-arm, sticky fail-through (Track P)
+
+**Goal**: `VoiceBackendCommandProvider` gains an opt-in *conversation* session policy: the backend session outlives individual `start()`/`stop()` windows (turns are per-window; the session is per-conversation), a matched command re-arms rather than one-shots, and fail-through becomes sticky per conversation. Default construction stays byte-identical to M1.
+
+**Files**
+- Modify `Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift`:
+  - `init` gains `sessionPolicy: SessionPolicy = .perWindow` where `SessionPolicy` is `{ case perWindow; case conversation(idleClose: TimeInterval) }` (portable, `Sendable`, in the same file). `.perWindow` is the existing code path, untouched.
+  - `.conversation`: `start()` opens the session once and `beginUserTurn`; `stop()` ends the active turn (only if audio/turn state warrants — see empty-turn guard below) but leaves the session open and arms an idle-close task (injectable `monotonicNow` + task, generation-counted like `windowGeneration`); a match delivers the command, ends the turn, keeps the session; the next `start()` begins a fresh turn on the open session. `sessionFailed` closes and clears state so the next `start()` reopens (fail-open). Add `shutdown()` for host teardown (called where `rawVoice.stop()` sits today in the serve `defer`, `AppleTapQRuntimeService.swift:411-420` — actual call lands with WP6's composition edits; here it only exists and is tested).
+  - New provider surface for later WPs (inert until used): `endActiveTurn()` (public; commits the current turn without tearing the window down — transcripts for the committed audio still route to the armed handler), `cancelActiveResponse()` (calls `backend.cancelResponse()` only when a response is in flight and the *inner* pipe supports barge-in — take a `supportsBargeIn: Bool` hint at init rather than reading composed capabilities; see FailThrough intersection wrinkle in findings), and a single-observer `onTranscriptFinal: ((String, _ matched: Bool) -> Void)?` (needed by WP8; fire after match evaluation).
+- Modify `Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift`: **empty-turn guard** — track appended byte count per turn; `endUserTurn()` with zero appended audio ends the local turn state but sends neither `commit` nor `response.create` (server rejects empty commits; a silent teardown turn must not create spurious responses). Scripted test asserts no frames for an empty turn.
+- Modify `Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift`: `init` gains `stickiness: Stickiness = .retryEachOpen` with `.stickyAfterFailure` — once the primary has failed (open-failure or mid-session), subsequent `open`s go straight to the fallback with zero primary traffic; add `func resetStickiness()` so a host can re-probe on a new conversation. Default preserves M1 behavior exactly.
+
+**Dependencies**: none.
+
+**Acceptance criteria**
+- All existing `VoiceBackendCommandProviderTests` and `FailThroughVoiceBackendTests` pass unmodified (default-path proof).
+- Conversation mode (with `ScriptedVoiceBackend`): one `open` across N `start/stop` cycles; exactly one `beginUserTurn` per `start`; a match delivers once, ends the turn, session stays open; second `start()` yields turn #2 on the same session with a fresh cumulative-transcript slate; idle timer (virtual clock) closes the session after `idleClose` with no window open, and a `start()` after idle-close reopens; `stop()` during the async `open` handshake still closes exactly once (generation test, mirroring the existing `openWindow` guard at `:78-83`); `sessionFailed` mid-conversation → next `start()` reopens; `shutdown()` idempotent.
+- `endActiveTurn()`: commits exactly once; a transcript arriving after the commit still matches and resolves; calling it with no active turn is a recorded no-op (never a protocol violation surfaced to the window).
+- Sticky fail-through: after primary death, the next `open` touches only the fallback (call-sequence assert); `resetStickiness()` restores primary-first; both-fail still surfaces the wrapper's own `sessionFailed`.
+- OpenAI empty-turn guard: scripted server sees no `commit`/`response.create` for an audio-less turn; a normal turn is unchanged.
+
+**Test plan**: extend `Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift`, `Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift`, `OpenAIRealtimeVoiceBackendTests.swift`. No new fakes needed; add an idle-clock seam.
+
+**Risks / judgment calls**
+- "Conversation" is defined operationally as *provider session lifetime with idle-close* (recommended default `idleClose: 60`). Ratify the number.
+- Re-arm changes when `endUserTurn` fires relative to `SpeechGatedVoice` churn; keep the ordering property "turn never spans a TTS-busy interval" as an explicit test.
+- Whether `.conversation` should also be adopted for the openai flag path immediately (WP3/WP6 composition) — recommended yes; it is opt-in already.
+
+---
+
+### WP2 — Response-audio playback contract, provider routing, combined activity signal (Track P, portable)
+
+**Goal**: a portable seam for backend `.audio` playback, the provider routing into it, and the activity plumbing that keeps the self-hearing guard airtight when sound comes from something other than `AVSpeechSynthesizer`.
+
+**Files**
+- Create `Sources/TapQContracts/VoiceResponseAudio.swift` — `@MainActor public protocol VoiceResponseAudioPlaying: AnyObject`: `func enqueue(_ chunk: VoiceAudioChunk)`, `func finishStream()`, `func stopAndFlush()`, `var isPlaying: Bool { get }`, single-observer `var onPlayingChange: (@MainActor (Bool) -> Void)?` (documented exactly like `SpeechActivitySignaling`, `Inputs.swift:180-187`). Doc invariant: `isPlaying` must become true synchronously on the first `enqueue` — the mic gate must close *before* the first sample can sound.
+- Create `Sources/TapQInteractionBaseline/CombinedSpeechActivity.swift` — `public final class CombinedSpeechActivity: SpeechActivitySignaling`: merges the TTS engine's signal and a `VoiceResponseAudioPlaying`'s signal (claims both inner single-observer slots with the house `assert`; exposes one outer slot; `isSpeaking = tts.isSpeaking || playback.isPlaying`). `SpeechGatedVoice` then wraps this with zero changes to itself.
+- Modify `Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift`: `init` gains `responseAudio: (any VoiceResponseAudioPlaying)? = nil`. `.audio` → `enqueue` when a player is present (else the existing `audio.ignored` diagnostic, byte-identical); `.responseCompleted` → `finishStream()`; teardown/`sessionFailed`/`cancelActiveResponse()` → `stopAndFlush()`. Gate on the *event stream* (an `.audio` event is proof the active pipe produces audio), not on composed capabilities (see FailThrough intersection finding).
+
+**Dependencies**: WP1.
+
+**Acceptance criteria**
+- With a `FakePlayback` (new fake in `TapQInteractionBaselineTests`): chunks arrive in order; `finishStream` after `responseCompleted`; `stopAndFlush` on window teardown, on `sessionFailed`, and on `cancelActiveResponse`; without a player, behavior and diagnostics byte-identical to M1 (existing test untouched).
+- `CombinedSpeechActivityTests`: truth table over (tts busy, playback busy); exactly one transition per outer change (no duplicate edges); ownership asserts fire on double-claim; composition test `SpeechGatedVoice(over: CombinedSpeechActivity)` proves the mic is held closed while *playback* is busy and reopens on drain — the M2 self-hearing guarantee.
+- Portable: both new files import only Foundation + TapQContracts.
+
+**Risks / judgment calls**: none major; the `isPlaying`-synchronous-on-enqueue invariant is the one subtle correctness point and is called out in the contract doc and tests.
+
+---
+
+### WP3 — Microphone pump for pipe backends (Track P, macOS)
+
+**Goal**: close the M1 gap — a macOS `VoiceBackend` wrapper that owns the microphone for a pipe backend: opens the mic on `beginUserTurn`, converts buffers to the pipe's wire format, and streams them through `sendAudio`; closes the mic on `endUserTurn`. Wired into the `openai-realtime` composition so that flag path actually hears the wearer.
+
+**Files**
+- Create `Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift` — `@MainActor public final class MicrophonePumpVoiceBackend: VoiceBackend` wrapping `inner: any VoiceBackend` + `format: VoiceAudioFormat` (default `.pcm16Mono24k`):
+  - `capabilities`/`open`/`close`/`requestResponse`/`cancelResponse` forward; `beginUserTurn` forwards then opens a fresh `VoiceAudioSourceController` window (`AVAudioEngineVoiceAudioSource`, same module — `internal` access is available, mirroring `MicrophoneEnvelopeSource.swift:98-101`); `endUserTurn` closes the mic then forwards (mic shuts before the commit, matching `AppleVoiceBackend.swift:195-207` ordering).
+  - Tap thread → one ordered buffering `AsyncStream` → MainActor consumer → format conversion → `inner.sendAudio` (copy the `MicrophoneEnvelopeSource` crossing pattern verbatim; conversion via `AVAudioConverter` created once per mic window; chunks ≤ 100 ms — the inner adapter re-splits anyway, `OpenAIRealtimeVoiceBackend.swift:433-448`).
+  - Route-change invalidation mid-turn → close mic, forward a synthetic session failure path: call `inner.close()` and emit `sessionFailed(.network(...))` through the pump's own event relay (the pump installs itself between `open`'s `onEvent` and the caller), so `FailThroughVoiceBackend` fails over to Apple exactly as for any network death.
+  - Optional observer `onInputLevel: ((Double) -> Void)?` (per-buffer RMS, computed in the tap where the samples are already hot) — inert hook for a possible acoustic-silence endpoint fallback (open question 7); costs a few lines now, avoids reopening the realtime-thread code later.
+- Modify `Executables/tapq/AppleTapQRuntimeService.swift` (minimal diff at `:135-151`): wrap the factory's realtime primary — composition becomes `FailThrough(primary: MicrophonePump(OpenAI…), fallback: AppleVoiceBackend)`. Achieve this via a new optional `makeRealtimePrimaryDecorator` closure parameter on `VoiceBackendFactory.select` (portable factory stays AVFoundation-free; the executable passes the pump constructor), mirroring the existing `makeAppleBackend` closure pattern (`Sources/TapQVoiceBackends/VoiceBackendProvider.swift:81-95`).
+
+**Dependencies**: WP1 (empty-turn guard makes silent windows safe), WP2 (nothing structural, hotspot ordering only).
+
+**Acceptance criteria**
+- `Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift` with a fake `VoiceAudioSource` and `ScriptedVoiceBackend` inner: mic opens only inside a user turn and never in `open` (the "never always-on" invariant, `AppleVoiceBackend.swift:20-22`); buffers reach `inner.sendAudio` in order and in the declared format; conversion math validated against synthetic `AVAudioPCMBuffer`s (48 kHz float stereo → 24 kHz int16 mono; sample-count and value spot checks); `endUserTurn` stops the mic before forwarding; route change mid-turn → inner closed + `sessionFailed` surfaced once; stale-generation audio after teardown dropped; stop idempotent. No test opens real audio hardware.
+- Factory test (`VoiceBackendFactoryTests`): decorator applied to the primary only; `apple` provider untouched.
+- Full-suite green; default serve path untouched (no flag ⇒ no pump constructed).
+
+**Risks / judgment calls**
+- This WP changes the observable behavior of the existing `--voice-backend openai-realtime` flag (it starts actually transmitting audio). Recommended: yes, without a new flag — the flag is opt-in and M1's silence was an omission, not a contract. **Needs ratification** (open question 1/2).
+- `AVAudioConverter` behavior across route sample-rate changes: recreate the converter if the incoming buffer format differs from the last (assert-free, tested).
+
+---
+
+### WP4 — Backend audio playback engine (Track P, macOS)
+
+**Goal**: the macOS implementation of `VoiceResponseAudioPlaying`: cloud voice output actually heard, exception-safe, fail-open.
+
+**Files**
+- Modify `Sources/TapQAudioCaptureBridge/include/TapQAudioCaptureBridge.h` + `TapQAudioCaptureBridge.m`: add `TapQAudioPlaybackEngine` (owns one `AVAudioEngine` + `AVAudioPlayerNode`) and exception-boundary functions `TapQAudioPlaybackEngineStart(engine, sampleRate, channels, error)`, `TapQAudioPlaybackEngineSchedule(engine, buffer, completion)`, `TapQAudioPlaybackEngineStop(engine, error)` — same NSException→NSError conversion contract as the capture functions (header comment parity).
+- Create `Sources/TapQAppleAdapters/BackendAudioPlayback.swift` — `@MainActor public final class BackendAudioPlayback: VoiceResponseAudioPlaying`:
+  - `enqueue`: converts `VoiceAudioChunk` (PCM16 mono, chunk's declared rate) into an `AVAudioPCMBuffer` (int16 format; the engine's mixer resamples), lazily starts the engine on the first chunk of a response, schedules with a completion that decrements an outstanding-buffer count; `isPlaying` true from first enqueue until (outstanding == 0 && stream finished); engine stopped when drained (no idle audio unit).
+  - `stopAndFlush`: stop node, drop queue, `isPlaying` → false, single transition.
+  - Any start/schedule failure or `AVAudioEngineConfigurationChange`: drop audio for the rest of the response, emit `playback.unavailable` diagnostic, transition `isPlaying` → false — **fail open**: transcripts and the window are unaffected (the provider keeps consuming events; `CombinedSpeechActivity` just never sees busy).
+  - Test seam: `init(scheduler: AudioPlaybackScheduling)` where the internal protocol wraps the three bridge functions; production init uses the live bridge (thin, untested live layer — `SpeechEngine`/`AVAudioEngineVoiceAudioSource` precedent).
+- (No composition change yet; WP6 wires the player + combined activity into serve.)
+
+**Dependencies**: WP2 (protocol).
+
+**Acceptance criteria**
+- `Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift` with a fake scheduler: PCM16→`AVAudioPCMBuffer` conversion correctness (values, frame counts, mono); `isPlaying` rises synchronously on first `enqueue`; drains only after `finishStream` + last completion; interleaved responses rejected/serialized deterministically; `stopAndFlush` cancels outstanding schedules and fires exactly one falling edge; scheduler failure → fail-open path with diagnostic, subsequent responses attempt a fresh engine; stale completions after flush ignored (generation counter).
+- Bridge compiles with no new warnings; no test emits audible audio (fake scheduler only).
+
+**Risks / judgment calls**: completion-handler threading from `AVAudioPlayerNode` (arrives on an internal queue) — hop via the same ordered pattern as elsewhere and generation-guard; keep every AVFAudio call inside the ObjC boundary.
+
+---
+
+### WP5 — Live wearer-speech signal producer (Track I)
+
+**Goal**: `HeadphoneMotionSource → WearerSpeechAnalyzer/Detector → WearerSpeechSignaling`, live, with multicast for the milestone's two consumers, without perturbing gesture detection.
+
+**Files**
+- Create `Sources/TapQDetectionBaseline/WearerSpeechMonitor.swift` (portable): push-driven state holder over `WearerSpeechDetector` — `ingest(_ sample:)`, `streamInterrupted()` (resets detector, marks stale), `state`, `lastSampleAt`, `func isFresh(now:) -> Bool` (staleness horizon default = `config.maxSampleGapSeconds`), transition callback. Injectable `monotonicNow`. This is where all logic lives; the adapter below stays a shim.
+- Create `Sources/TapQAppleAdapters/WearerSpeechSignalSource.swift`: `@MainActor public final class WearerSpeechSignalSource` — owns a `WearerSpeechMonitor` (profile config injected), implements the internal sample-tap protocol below, and exposes `func makeSignal() -> any WearerSpeechSignaling` returning independent child handles (each with its own single-observer slot; children read shared state) — the multicast the contract doc anticipates (`WearerSpeech.swift:27-31`). `isSignalAvailable` = tap attached ∧ stream fresh ∧ last sample had per-axis data (`HeadMotionSample.hasPerAxisData`, `HeadMotionSample.swift:96`).
+- Modify `Sources/TapQAppleAdapters/HeadGestureDetector.swift`: internal `protocol MotionSampleObserving` `{ ingest(HeadMotionSample); streamInterrupted() }` + `public func setMotionSampleObserver(_:)`; called from `ingest(_:)` (after `:349`'s recovery handling, before pipeline dispatch), and `streamInterrupted()` from `teardown()`/`resetSession()`/`confirmMotionLoss` (`:309-338, 500-517`). No observer ⇒ zero behavior change (guarded single optional call).
+
+**Dependencies**: none structurally (ordered here to keep `HeadGestureDetector` edits clear of Track P).
+
+**Acceptance criteria**
+- `Tests/TapQDetectionBaselineTests/WearerSpeechMonitorTests.swift`: synthetic speech stream → transitions mirror `WearerSpeechDetector` tests; staleness flips `isFresh` after the horizon (virtual clock); `streamInterrupted` resets to quiet and stale; magnitude-only stream reports unavailable-for-attribution per policy.
+- `Tests/TapQAppleAdaptersTests`: `HeadGestureDetectorTests` extension — observer receives exactly the samples the pipeline ingests, `streamInterrupted` on stop/teardown/motion-loss, **all existing gesture/tap/tilt tests pass unmodified with no observer attached**; `WearerSpeechSignalSourceTests` — two children get independent callbacks for one transition, ownership assert per child slot, availability matrix (no tap / stale / magnitude-only / fresh).
+- ~4:1 test density on the monitor (it is the safety-relevant logic).
+
+**Risks / judgment calls**: per-window stream means the monitor sees hard gaps between windows — the built-in gap reset (`WearerSpeechDetector.ingestDetailed`, `WearerSpeechAnalyzer.swift:278-287`) handles it, but the first ~`windowSeconds` of each window is warm-up during which the signal reports quiet; attribution's backward-looking window (`WearerGatedVoice.defaultAttributionWindow` 2 s) absorbs this for the gate; note it for WP7's endpointing (never endpoint during warm-up: require a `startedSpeaking` before honoring a `stoppedSpeaking`).
+
+---
+
+### WP6 — Live wearer gate: `--wearer-gate` flag + serve composition (Track I)
+
+**Goal**: `WearerGatedVoice` live behind an explicit opt-in flag, fail-open, with the wearer-speech calibration profile finally consumed at runtime.
+
+**Files**
+- Modify `Sources/TapQCLI/CLICommand.swift`: `ServeOptions.wearerGateEnabled = false` via `--wearer-gate`; usage/help text (state: default off, needs AirPods motion, uses `wearer-speech-calibration.json` when present, provisional thresholds otherwise, always fail-open).
+- Modify `Sources/TapQCLI/RuntimeService.swift`: `TapQRuntimeConfiguration.wearerGateEnabled` (default false); `TapQRuntimeEndpoint.wearerSpeechStatus: String?` (nil when off; e.g. `"gate"`; WP7 extends to `"gate+turn-control"`).
+- Modify `Sources/TapQCLI/TapQCLIApplication.swift`: plumb option → configuration; print `Wearer speech: …` in the ready block (next to `voiceBackendStatus`, `:210-211`).
+- Modify `Executables/tapq/AppleTapQRuntimeService.swift`: when enabled — load the wearer-speech profile if present (store already constructed, `:35-41`; default config otherwise, mirroring gesture/tap), build `WearerSpeechSignalSource`, attach via `gestures.setMotionSampleObserver`, and compose `SpeechGatedVoice(wrapping: WearerGatedVoice(wrapping: rawVoice, signal: source.makeSignal(), diagnosticSink:), activity: …)` per the documented stacking order. Works for **both** `.apple` (VoiceListener) and `.openaiRealtime` raw voices. Keep the executable diff to composition-only `if` — anything with logic goes into tested portable/adapter code.
+
+**Dependencies**: WP5.
+
+**Acceptance criteria**
+- `CLICommandParserTests`: flag parsing, help text; `TapQCLIApplicationTests`: configuration passthrough via `FakeRuntimeService`, status line rendering, and — flag omitted — serve output byte-identical to M1.
+- A `CalibrationProfileTests`-adjacent test proving a malformed wearer-speech profile fails serve the same way malformed gesture/tap profiles do today (or is skipped-if-absent — match the existing `loadGestureIfPresent` semantics exactly).
+- Existing `WearerGatedVoiceTests` composition tests remain the behavioral proof; add one InteractionBaseline test stacking `SpeechGatedVoice(WearerGated(inner))` with a *stale* fake signal proving verbatim pass-through (the fail-open regression sentinel).
+
+**Risks / judgment calls**: none new — the gate's delivery policy was ratified in M1 (WP5). Call out in help text that with provisional thresholds the gate may pass bystander speech (attribution window is generous by design) until the capture study lands.
+
+---
+
+### WP7 — IMU turn control: endpointing + barge-in behind `--imu-turn-control` (Track I)
+
+**Goal**: wearer speech-end commits the user turn (endpointing) with command-match/timeout untouched as fallback; wearer speech-onset during TTS/backend playback stops the audio (barge-in) and lets the normal gate machinery open the mic. Default off.
+
+**Files**
+- Create `Sources/TapQInteractionBaseline/WearerTurnCoordinator.swift` (portable): consumes one `WearerSpeechSignaling` child + closures `{ endpoint: () -> Void, interruptPlayback: () -> Void, isResponsePlaying: () -> Bool, isUserTurnActive: () -> Bool }` + injectable clock:
+  - Endpointing: only after observing a `startedSpeaking` within the current turn (warm-up guard, WP5 note), a `stoppedSpeaking` transition starts an endpoint-delay timer (config `endpointDelaySeconds`, default 0.4, on top of the detector's 0.6 s hangover); if the wearer resumes, cancel; on expiry call `endpoint()` exactly once per turn. Signal unavailable/stale at any point ⇒ do nothing (match/timeout fallback — fail open).
+  - Barge-in: `startedSpeaking` while `isResponsePlaying()` ⇒ `interruptPlayback()` once per response.
+- Modify `Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift`: expose the tiny read hooks the coordinator needs (`isUserTurnActiveForCoordination`, `isResponseInFlight`) — no policy inside the provider.
+- Modify CLI/runtime plumbing (`CLICommand.swift`, `RuntimeService.swift`, `TapQCLIApplication.swift`): `--imu-turn-control` (default off; implies the signal source like `--wearer-gate` does; both flags share one `WearerSpeechSignalSource`); status string becomes `"gate"`, `"turn-control"`, or `"gate+turn-control"`.
+- Modify `Executables/tapq/AppleTapQRuntimeService.swift`: compose the coordinator when enabled — `endpoint = provider.endActiveTurn`, `interruptPlayback = { playback?.stopAndFlush(); provider.cancelActiveResponse(); speech.stopAll() }`. Only meaningful on the backend-provider path; on the `.apple`/`VoiceListener` path the coordinator composes with `interruptPlayback = { speech.stopAll() }` and no endpoint (VoiceListener has no turn API) — barge-in-only there.
+
+**Dependencies**: WP1 (`endActiveTurn`/`cancelActiveResponse`), WP2/WP4 (playback flush target), WP5 (signal), WP6 (flag plumbing + shared source).
+
+**Acceptance criteria**
+- `Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift` (fake signal, virtual clock, recording closures): endpoint fires once after delay; resume-within-delay cancels; no endpoint without a prior onset in-turn; no endpoint when signal unavailable; barge-in fires once per playing response and never when idle; no calls after `stop()`; a wedged signal never blocks anything (the coordinator only ever *adds* calls, never gates the existing paths — assert by composing with the full provider + `ScriptedVoiceBackend`: match-on-transcript and window timeout behave identically with the coordinator attached and the signal dead).
+- End-to-end-shaped test: scripted pipe backend + fake playback + coordinator — wearer onset during response audio ⇒ flush + `response.cancel` frame (via `ScriptedVoiceBackend` call record) ⇒ next turn's transcript resolves the window; wearer speech-end ⇒ commit ⇒ post-commit `transcriptFinal` ⇒ command matched (the OpenAI-shaped flow from the findings).
+- `speech.stopAll()` on barge-in is tested at the coordinator seam (closure recorded), documented as deliberately blunt.
+
+**Risks / judgment calls**
+- `speech.stopAll()` also drops queued notifications from other sessions — recommended accept (barge-in means "stop talking, I'm answering"); ratify.
+- Endpoint-delay default (0.4 s) is provisional like every IMU threshold; keep it in `WearerSpeechConfig`? Recommended: no — it is interaction policy, not detection; a constant on the coordinator with an init override is enough until the study.
+- False endpoints (jaw motion that is not speech) commit a turn early on the OpenAI path; consequence is an unmatched transcript and a re-armed turn (WP1), i.e., degraded-not-broken. State in docs.
+
+---
+
+### WP8 — Free-form answers: interaction layer (Track F)
+
+**Goal**: a spoken free-text answer can resolve a selection (AskUserQuestion / `request_user_input` / multi-option stop question), with read-back confirmation, entirely in the portable layer. Off by default; enabled by `--voice-freeform`.
+
+**Files**
+- Modify `Sources/TapQContracts/Inputs.swift`: add `VoiceCommand.freeform(String)` and `InputIntent.freeform(String)` (+ `Equatable` arms, `intent` mapping). Compiler-forced switch updates: `InteractionController.resolve` (`.freeform` → keep listening in approval flow for this milestone), `SelectionController.resolve` (below). `VoiceListener`/`VoiceCommandMatcher` never produce it ⇒ default path untouched.
+- Modify `Sources/TapQContracts/SelectionResult.swift`: `public let freeText: String?` (defaulted init parameter; `noSelection` unchanged). A result with `freeText != nil` and empty `choices` is a *resolution*, not a timeout.
+- Modify `Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift`: `freeformEnabled: Bool = false` init parameter — when true, a **final** transcript that matches no command is delivered once per turn as `.freeform(trimmed)` (final transcripts arrive on Apple via recognizer settling, on OpenAI after an endpoint commit — which is why this WP follows WP7).
+- Modify `Sources/TapQInteractionBaseline/SelectionController.swift`: on `.freeform(text)` — speak read-back `"You said: '<text>'. Nod to send, shake to discard."`, listen; allow/select ⇒ `SelectionResult(choices: [], freeText: text)`; deny ⇒ discard, re-listen; timeout ⇒ defer as today. Condense text via `SpokenText` for the read-back only (the full text rides the result).
+- Modify `Sources/TapQContextBaseline/StopQuestionCoordinator.swift`: multi-option branch — a `freeText` result produces `Self.reply(question:answer:)` with the free text (wording: "they answered: '<text>'"), records the answer for repeat-suppression exactly like a label answer.
+- CLI plumbing: `--voice-freeform` in `CLICommand.swift`/`RuntimeService.swift`/`TapQCLIApplication.swift`; composition passes `freeformEnabled` into the provider on the backend path only (`AppleTapQRuntimeService.swift`); flag rejected (startup error) when the composed voice path cannot produce transcripts (i.e., `.apple` provider) — silent no-op would hide the misconfiguration (question-classifier precedent).
+
+**Dependencies**: WP1 (transcript surfacing/re-arm), WP7 (endpointing makes free-form reachable on the OpenAI path).
+
+**Acceptance criteria**
+- Provider tests: unmatched final ⇒ exactly one `.freeform` per turn (only when enabled); matched final ⇒ command, never freeform; partials never freeform; empty/whitespace transcript never freeform.
+- `SelectionControllerTests`: full read-back cycle (confirm ⇒ result carries text, empty choices, `timedOut == false`; discard ⇒ re-listen; navigation still works after a discard); existing selection tests unmodified.
+- `StopQuestionCoordinatorTests`: free-text reply formatting + repeat suppression.
+- Parser/application tests for the flag incl. the `.apple`-provider rejection message; flag off ⇒ all paths byte-identical.
+
+**Risks / judgment calls**
+- Widening the closed `VoiceCommand`/`InputIntent` enums is the one contract-shape change of the milestone — recommended over a parallel channel because every switch is compiler-audited; **ratify** (open question 4).
+- Read-back-confirm is a deliberate safety tax; ratify (recommended: yes — a stray sentence becoming an agent instruction is worse than one extra nod).
+- Yes/no stop questions and tool approvals stay binary this milestone (a free-form answer to an *approval* is an authorization surface change; out of scope).
+
+---
+
+### WP9 — Wire protocol: `free_text` selection reply + both agent shims (Track F)
+
+**Goal**: the free-form answer flows to Claude Code and Codex.
+
+**Files**
+- Modify `Sources/TapQWireProtocol/WireMessages.swift`: `BrokerResponse.selection(indices:labels:freeText:)` — encode `free_text` only when non-nil; decode via `decodeIfPresent`. Version: bump `WireProtocol.version` to 4; broker accepts {4, 3} (change `validate`'s check to an accepted-set — request shapes are identical in v3/v4, so accepting 3 is sound and keeps every installed shim working); extend `outboundVersion(for:approvalSource:)` so a v4 shim speaks 3 to a v3 broker (mirroring the v2 bridge at `:34-44`). Old shim + new broker: works, simply never sees `free_text` semantics it wouldn't read anyway. New shim + old broker: works, no free-text offered.
+- Modify `Sources/TapQBrokerRuntime/BrokerServer.swift` (`:138-157`): a result with `freeText` and no choices is success ⇒ `selection(indices: [], labels: [], freeText:)`; `timedOut` mapping unchanged.
+- Modify `Sources/TapQClaudeAdapter/HookShim.swift` (`handleAskUserQuestion`, `:388-397`): when `selected_labels` empty but `free_text` present ⇒ deny reason `"User answered via TapQ hands-free interface. They answered in their own words: '<text>' for question: '<question>'. Please proceed accordingly without re-asking."`.
+- Modify `Sources/TapQCodexAdapter/CodexHookShim.swift` (`handleRequestUserInput`, `:214-245`): accept the free-text reply shape ⇒ `answers[questionID] = [text]` response JSON (bypassing the option-label equality check for the free-text arm only; all other validation retained).
+
+**Dependencies**: WP8.
+
+**Acceptance criteria**
+- `TapQWireProtocolTests`: encode/decode round-trip with and without `free_text` (absent field ⇒ byte-identical to v3 bytes); version acceptance matrix {nil,1,2,3,4}; `outboundVersion` matrix incl. the v2 rules unchanged.
+- `TapQBrokerRuntimeTests`: free-text selection response; label selection and timeout responses byte-identical to before.
+- `TapQClaudeAdapterTests`/`TapQCodexAdapterTests`: free-text reply handling; label replies and every fail-open branch unchanged; a reply carrying *both* labels and free_text prefers labels (defensive, tested).
+- Old-shim-versus-new-broker compatibility asserted at the `validate` level (v3 request accepted).
+
+**Risks / judgment calls**
+- Whether Codex's `request_user_input` actually accepts non-option answer strings is **unverifiable from this repo** — the response JSON is a TapQ-fabricated model-visible claim, so the model will see the text either way, but native-UI expectations may differ; smoke item gates it (open question 6).
+- Accept-{3,4} vs strict-exact at the broker: recommended accept-both (nothing in the request changed); if the orchestrator prefers the M1-style strict bump, the only cost is installed shims failing open until `tapq` hooks are reinstalled — decide (open question 5).
+
+---
+
+### WP10 — Linux CI coverage + portability hardening (Track X)
+
+**Goal**: the portable graph provably builds and tests on Linux with the M2 code, and the guardrails actually cover the voice targets.
+
+**Files**
+- Modify `scripts/check-public-boundary.sh:134-143`: add `Sources/TapQVoiceBackends` to the `portable=(…)` list (and `Sources/TapQBrokerRuntime`/`TapQPOSIXBridgeClient` if the grep confirms they're intentionally excluded — investigate, don't assume).
+- Modify `.github/workflows/ci.yml`: add `workflow_dispatch:` and `push: branches: ["main", "worktree-**"]` (keep pinned action SHAs and existing job structure) so milestone branches get macOS+Linux runs on push.
+- Fix anything the audit finds: grep portable targets for Darwin-only APIs outside `#if canImport` guards, `FoundationNetworking` correctness, `Data`/`String` corelibs pitfalls in new M2 files (`WearerTurnCoordinator`, `CombinedSpeechActivity`, `VoiceResponseAudio`, provider changes, wire changes — all must be Linux-clean).
+- Optional: `scripts/linux-check.sh` that runs the build+test inside `docker run --rm -v "$PWD":/src -w /src swift:6.0` when docker is present, exiting with a clear "docker unavailable, run in CI" message otherwise.
+
+**Dependencies**: all previous (it audits their output).
+
+**Acceptance criteria**
+- `scripts/check-public-boundary.sh` green with the expanded list on macOS.
+- If docker is available in the implementer's environment: `swift build && swift test` green in the `swift:6.0` container; if not, a dry audit checklist recorded in the commit message and the CI trigger in place so the next push proves it.
+- Workflow YAML validates (`actionlint` if available, else careful review); no change to the macOS job's steps.
+
+**Risks / judgment calls**: pushing this branch to run CI is outside the implementer's authority (no-push rule from M1 header stands) — the trigger change is preparation; the actual Linux run happens when the orchestrator pushes. Flagged in open questions (8).
+
+---
+
+### WP11 — Docs, changelog, full verification, M2 smoke checklist (Track X, final)
+
+**Goal**: whole-milestone verification and the human handoff artifact.
+
+**Work**
+- `swift build` (debug + release), full `swift test`, `scripts/check-public-boundary.sh`, `scripts/package-runtime-app.sh debug` on macOS.
+- `docs/CLI.md`: serve flags `--wearer-gate`, `--imu-turn-control`, `--voice-freeform`; rewrite the "Voice backend" section (mic pump, playback, conversation sessions + idle-close, sticky fail-through, the OpenAI no-transcript-before-commit behavior and why `--imu-turn-control` is effectively required for voice resolution on that path); Claude/Codex integration sections gain the free-text answer story; wire-protocol/version note (v4, v3 accepted, old-shim behavior).
+- `CHANGELOG.md` Unreleased entries (match the M1 entry style — behavior-first prose, fail-open guarantees named).
+- README design-principles touch only if the half-duplex/echo statement belongs there (check; likely not).
+- Cross-package consistency pass: flag spellings, diagnostic category names (`WearerGate`, `WearerTurn`, `Playback`, `MicPump` — settle one naming scheme), no portable target importing AVFoundation (grep gate), help text matches parser tests.
+- Write `docs/MILESTONE2_SMOKE_CHECKLIST.md` (human + hardware; agents must not attempt), covering at minimum:
+  1. `serve --voice-backend openai-realtime` (with key): speak an answer, **hear the cloud voice**, approval resolves by voice on the *primary* path (the thing M1 could not do).
+  2. `--imu-turn-control`: stop talking ⇒ commit within ~1 s (endpoint), window resolves without waiting for timeout; speak during the agent's audio ⇒ playback stops (barge-in), answer heard on the next turn.
+  3. `--wearer-gate`: a bystander (or a phone speaker) issuing "yes" during a window is rejected; the wearer's own "yes" passes; pulling AirPods motion mid-window degrades to pass-through (fail-open).
+  4. `--voice-freeform` + AskUserQuestion from Claude Code: answer off-list, hear the read-back, nod, verify Claude receives the free text; same via Codex `request_user_input` — **record whether Codex accepts it** (WP9 risk).
+  5. Wi-Fi kill mid-conversation: fail-through to Apple, sticky (no per-window handshake stalls), voice still works; mic never stuck open.
+  6. Old shim (build from `0fc7474`) against new broker: fails open loudly to the on-screen prompt; reinstalling hooks fixes it.
+  7. Regression: flagless `tapq serve` — no new status lines, all M1 behaviors identical; `--voice-backend openai-realtime` *without* the new flags still resolves windows by gesture/tap/timeout.
+
+**Dependencies**: all packages.
+
+---
+
+## 3. Open questions for the orchestrator
+
+1. **Missing scope item — microphone pump (WP3).** The ratified list omits it, but without it scope items 1/4/5 are unreachable and `--voice-backend openai-realtime` transmits no audio (finding above; M1 smoke item 6 could not have passed by voice on the primary). Recommend: ratify WP3 as in-scope.
+2. **Playback + pump ride the existing `openai-realtime` flag, no new flag.** Recommended (the flag is opt-in; M1's silence was an implementation gap, not a contract) — the alternative is a `--voice-playback` sub-flag nobody would ever want off.
+3. **Conversation definition + policies.** Recommend: conversation = provider session lifetime with `idleClose` 60 s; sticky fail-through for the session lifetime, primary re-probed on the next conversation open (`resetStickiness` on idle-close reopen). Numbers need ratification.
+4. **Free-form plumbing = widening `VoiceCommand`/`InputIntent` with `.freeform(String)`**, plus mandatory read-back-confirm, scoped to selections and multi-option stop questions only (approvals and yes/no stop questions stay binary). Recommended as stated; the enum widening is the one contract-shape change.
+5. **Wire version: bump to 4 with the broker accepting {3, 4}** (requests are shape-identical; only a response field was added). Alternative A: no bump at all (technically sufficient — additive optional response field, tolerant decoders both sides). Alternative B: strict exact-4 (M1-style), breaking installed shims until reinstall. Recommend the middle path; the scope's "wire-protocol bump" wording suggests A would under-deliver, B over-breaks.
+6. **Codex free-text**: whether `request_user_input` tolerates non-option answers is unverifiable offline; implement (WP9) and gate on smoke item 4, with pass-through as the documented fallback if Codex re-asks.
+7. **Endpointing fallback without IMU on the OpenAI path**: since transcripts only exist post-commit there, `openai-realtime` without `--imu-turn-control` resolves windows only by gesture/tap/timeout. Recommend documenting that honestly rather than adding an acoustic RMS-silence endpointer this milestone; the `onInputLevel` hook in WP3 keeps that door open as a fast follow (it would still be TapQ-side arbitration, so it does not violate the backend-VAD invariant).
+8. **CI trigger**: WP10 adds `worktree-**` push triggers + `workflow_dispatch`, but the actual Linux proof requires a push, which implementers are barred from. Orchestrator should push (or dispatch) after WP10 lands.
+9. **Barge-in uses `speech.stopAll()`**, which also drops queued cross-session notifications. Recommend accepting the bluntness; a priority-selective stop is a `SpeechEngine` surgery this milestone doesn't need.
+10. **Scope-framing corrections to acknowledge**: contract lives in `TapQContracts` (no `TapQVoiceCore`); Linux CI workflow already exists (gap is triggers + the boundary-script's portable list omitting `TapQVoiceBackends`); stop-question free text needs no wire change (runtime producer only); and `FailThroughVoiceBackend`'s capability *intersection* means composed capabilities can't be used to gate playback/barge-in — WP2/WP7 gate on the event stream and an explicit hint instead.
+
+---
+
+## Genuinely human/hardware-bound (no agent work planned)
+
+Everything in the WP11 smoke checklist; all live OpenAI sessions; the capture study that will replace every provisional threshold (`WearerSpeechConfig` defaults, attribution window, endpoint delay) — all of which remain data changes by construction.

--- a/docs/MILESTONE2_VOICE_LOOP_PLAN.md
+++ b/docs/MILESTONE2_VOICE_LOOP_PLAN.md
@@ -23,6 +23,17 @@ Answers to the open questions in §3; implementers treat these as settled.
 
 **Commit convention for implementers**: one commit per work package, message `milestone2 WPn: <short name>`, each leaving `swift build`, `swift test`, and `scripts/check-public-boundary.sh` green. Execution is strictly sequential (WP1 → … → WP11); all implementers share this worktree and its `.build`. `CHANGELOG.md` and `docs/CLI.md` are touched **only in WP11** to avoid rebase churn.
 
+### Checkpoint A carry-forward (orchestrator, 2026-08-06)
+
+The Checkpoint A review cycle (WP1-4 plus two fix rounds) settled the following; later WPs must honor them:
+
+- **WP6 — conversation adoption seam.** Decision 3's "openai-realtime composition adopts `.conversation` immediately" lands in WP6 (WP3 deferred it — ratified). The provider exposes no idle-close/reopen notification yet, so WP6 must add that seam (e.g. a single-observer `onConversationReopened`) and call `FailThroughVoiceBackend.resetStickiness()` from it, per decision 3 — plus wire `shutdown()` into the serve teardown, the `supportsBargeIn` hint, and `responseAudio` when composing.
+- **WP6 — suppress the match-resolved response.** In conversation mode a command match ends the turn via `endWindowKeepSession -> backend.endUserTurn()`, which on the OpenAI path sends `commit + response.create`: a spurious cloud response per voice-resolved window, dropped between windows and cancelled/deferred at the next `start()`. Add a commit-without-response path on the provider for match-resolved windows and cover it with a scripted test.
+- **WP7 — session-scoped response tracking.** `_responseInFlight` is session-scoped (set on `.audio` before the handler guard, cleared on `responseCompleted`/`sessionFailed`, and cleared together with `pendingUserTurn` on idle-close/fresh open). The coordinator's `isResponseInFlight` read hook therefore observes responses spanning window boundaries; do not regress the stale-flag clears.
+- **WP11 — smoke item.** The `AVAudioPlayerNode` int16-interleaved connect/schedule/completion path was empirically verified on one Mac only; the smoke checklist must confirm playback across output devices and OS versions.
+- **Known cosmetics** (non-blocking; fix only if already touching the file): `MicrophonePumpVoiceBackend.openMicrophone`'s `.alreadyRunning` branch leaves a fresh continuation/controller unconsumed (unreachable in practice); after a mic-start failure `turnActive` stays true until the next `endUserTurn`/`close`.
+
+
 ## Design invariants (restated; non-negotiable)
 
 - **Half-duplex with fast interruption.** The backend is a dumb speech pipe. Only TapQ calls `beginUserTurn`/`endUserTurn`; backend VAD must never end a turn (`Sources/TapQContracts/VoiceBackend.swift:150-165` states this as contract; `VoiceTurnStateMachine` enforces it mechanically).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -68,9 +68,22 @@ exposed by each platform and manufacturer.
   run on. See [TAPQ1_STAGE2.md](TAPQ1_STAGE2.md).
 - [ ] **Personalization and accessibility** — configurable gesture mappings, per-device
   profiles, one-sided controls, and voice-only or haptic-only modes.
+- [ ] **Wearer voice attribution** — decide from head motion whether the person wearing
+  the earbuds is the one talking, so a nearby voice cannot answer an agent's question.
+  The analyzer, its calibration profile, interval-level replay scoring, and the fail-open
+  `WearerGatedVoice` composition wrapper have landed; the wrapper is not yet in the live
+  runtime and its thresholds are provisional, both pending the human capture study.
+- [x] **Pluggable voice backends** — a duplex-capable `VoiceBackend` contract under which
+  turn arbitration stays on TapQ's side and a backend is only ever a speech pipe, with
+  Apple's on-device recognizer as the default and an OpenAI Realtime adapter in
+  manual-turn mode selected by `--voice-backend`. Any remote backend is always composed
+  with the on-device stack beneath it, so an outage costs latency rather than the voice
+  channel.
 - [x] **Local replay and evaluation tools** — `tapq replay` streams user-authorized
   motion captures through the detection backends offline with per-gesture accuracy
-  reporting; broader adapter simulation remains open under the device-adapter SDK.
+  reporting, plus frame-level precision and recall for wearer speech against labeled
+  spans or a co-recorded microphone envelope; broader adapter simulation remains open
+  under the device-adapter SDK.
 - [x] **Pluggable local intelligence** — the TapQ-1 encoder backend: a window-scorer
   protocol with a Core ML adapter, shadow/primary serve modes, a training pipeline in
   `ml/`, and the deterministic heuristics preserved as the always-available offline

--- a/docs/TAPQ1_STAGE2.md
+++ b/docs/TAPQ1_STAGE2.md
@@ -54,7 +54,7 @@ The Track A surface is complete as a mechanism.
 | Hard deadline | `ReasonerDeadline.swift` | A wall-clock bound that holds whether or not the backend cooperates — a task group does not bound anything, and the file says why (`:12-28`) |
 | Caller half | `ReasonerEscalation.swift` | Outer bound = timeout + 0.25 s (`:70`), the confidence filter, the escalation-only merge, voice degradation |
 | Evaluation | `bench/README.md`, `bench/reasoner-scenarios-v1.ndjson`, `docs/CLI.md` §Reasoner bench | Labeled cases (170 at time of writing; the corpus is append-only and grows), grading rules written out, `tapq bench reasoner` implementing them as written |
-| Shadow review | `<broker-dir>/reasoner-log.jsonl` (`docs/CLI.md:81-98`) | One line per reasoner-observed approval: tier, code, confidence or abstention, latency, implied confirmation, what the user then did |
+| Shadow review | `<broker-dir>/reasoner-log.jsonl` (`docs/CLI.md:83-102`) | One line per reasoner-observed approval: tier, code, confidence or abstention, latency, implied confirmation, what the user then did |
 
 ### What is measured
 
@@ -82,7 +82,7 @@ On the maintainer's Mac, `SystemLanguageModel.default.availability` reports
 `reason: model_unavailable` and returns `nil` before doing any work, and
 `tapq bench reasoner --reasoner apple` fails rather than printing a report — by design,
 because "a run of abstentions would print as a report and read as a result"
-(`docs/CLI.md:274-276`).
+(`docs/CLI.md:376-378`).
 
 The consequence is worth stating plainly: **not one number in this repository about
 stage-2 quality is a measurement.** The tier definitions, the grading rules, the
@@ -211,8 +211,8 @@ Rules:
   weights over the network, and this one gates approvals.
 * **Validation at startup**, not at first request: the path exists, is readable, is a
   directory holding the expected config/tokenizer/weight files. On failure `serve`
-  degrades to no reasoner and reports it (matching `--encoder-model`, `docs/CLI.md:76`),
-  while `bench` fails (matching `docs/CLI.md:274-276`).
+  degrades to no reasoner and reports it (matching `--encoder-model`, `docs/CLI.md:77`),
+  while `bench` fails (matching `docs/CLI.md:376-378`).
 * **The bench report must carry model identity.** A stage-2 score without the weights
   that produced it is not comparable to anything. Record the model's own identifier from
   its config plus a digest over the weight files, in both the text and `--json` reports.
@@ -248,7 +248,7 @@ loading a gigabyte.
   backend inherits the hazard and must inherit the discipline.
 * **Sequential only.** `tapq bench reasoner` already runs scenarios sequentially because
   concurrency would thrash the prompt cache and turn reported latency into queueing delay
-  (`docs/CLI.md:269-272`). The same applies live.
+  (`docs/CLI.md:371-374`). The same applies live.
 
 ### Deadline fit
 
@@ -407,7 +407,7 @@ This is the largest gap in Track B and the least glamorous.
 
 Half of it already exists in a different file. `reasoner-log.jsonl` records tier,
 rationale code, confidence or abstention, latency, the implied confirmation, and what
-the user then decided (`docs/CLI.md:81-90`). What is missing is the motion side and the
+the user then decided (`docs/CLI.md:83-92`). What is missing is the motion side and the
 key that joins them.
 
 Proposed `agent-context-v1.ndjson`, written under a new opt-in flag (off by default), one
@@ -439,12 +439,12 @@ Notes that carry weight:
   corpus's schema (`bench/README.md`). Inventing a second request encoding would
   guarantee they diverge.
 * **The clock pair is the crux.** Motion timestamps are CoreMotion hardware timestamps
-  (`docs/CLI.md:188`) and approvals arrive on wall clock. One `{wall, motion}` pair *per
+  (`docs/CLI.md:216`) and approvals arrive on wall clock. One `{wall, motion}` pair *per
   record*, sampled at a known instant — not one per session, which does not survive drift
   over a long run.
 * **Privacy is not a footnote here.** `summary` for a `Bash` request is the front of the
   command line and can carry a connection string or a token passed as an early argument
-  (`docs/CLI.md:92-98`). A paired corpus is strictly local by default, and any shareable
+  (`docs/CLI.md:94-102`). A paired corpus is strictly local by default, and any shareable
   variant needs the context fields redacted or hashed before it leaves the machine.
   `scripts/check-public-boundary.sh` already refuses `*.jsonl` in tracked content, which
   is the right default and should stay.

--- a/scripts/check-public-boundary.sh
+++ b/scripts/check-public-boundary.sh
@@ -139,6 +139,7 @@ portable=(
     Sources/TapQWireProtocol
     Sources/TapQClaudeAdapter
     Sources/TapQCodexAdapter
+    Sources/TapQVoiceBackends
     Sources/TapQCLI
 )
 

--- a/scripts/linux-check.sh
+++ b/scripts/linux-check.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the portable+POSIX build and test suite inside a Swift 6.0 Linux container.
+# Mirrors the linux CI job in .github/workflows/ci.yml.
+#
+# Requires Docker. When Docker is unavailable the script exits with a clear
+# message — push to a worktree-** branch and let GitHub Actions run the Linux
+# job instead.
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is not available on this machine." >&2
+    echo "Push to a worktree-** branch (or main) and CI will run the Linux job." >&2
+    exit 127
+fi
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "Starting swift:6.0 container for Linux build+test..."
+docker run --rm \
+    -v "$repo_root":/src \
+    -w /src \
+    swift:6.0 \
+    bash -c '
+        set -euo pipefail
+        echo "=== Toolchain ==="
+        swift --version
+        echo ""
+        echo "=== Installing ripgrep ==="
+        apt-get update -qq && apt-get install -y -qq ripgrep >/dev/null 2>&1
+        echo ""
+        echo "=== Release version check ==="
+        scripts/check-release-version.sh
+        echo ""
+        echo "=== Public and portability boundary check ==="
+        scripts/check-public-boundary.sh
+        echo ""
+        echo "=== Build (release) ==="
+        swift build -c release
+        echo ""
+        echo "=== Test ==="
+        TAPQ_CODEX_HOOK_EXECUTABLE="$(swift build -c release --show-bin-path)/tapq-codex-hook" swift test
+    '


### PR DESCRIPTION
## What this is

Milestone 2 of the AirPods-augmented voice plan: turns the milestone-1 pieces into a live voice loop on `--voice-backend openai-realtime`. **Stacks on milestone 1** (wearer-speech IMU detection + VoiceBackend contract), which never had its own PR — this PR carries both.

## What's new

- **Conversation-scoped backend sessions** — 60 s idle-close, sticky fail-through with primary re-probe on reopen
- **Microphone pump** — the openai-realtime path now actually transmits audio (milestone-1 gap: nothing ever called `sendAudio`)
- **Backend audio playback** — the cloud voice is audible; mic and speaker are never simultaneously live
- **`--wearer-gate`** — live IMU wearer attribution (jaw-vibration signal), fail-open
- **`--imu-turn-control`** — IMU endpointing + barge-in over agent speech (barge-in-only on the apple path)
- **`--voice-freeform`** — spoken free-text answers to selections and multi-option stop questions, with read-back confirmation; tool approvals stay strictly binary
- **Wire protocol v4** — `free_text` on selection replies; broker accepts v3 and v4, installed shims keep working
- **Linux CI** on worktree branches + boundary-script coverage for the voice targets

## Defaults unchanged

Flagless `tapq serve` is byte-identical to v0.4.0-beta.1 behavior. Every IMU feature ships default-off behind explicit flags with provisional thresholds until the capture study lands.

## Verification

- 1,445 tests (from 1,169), 0 failures; build + `scripts/check-public-boundary.sh` green at every commit
- Two adversarial checkpoint reviews caught 12 composed-path defects the per-WP suites missed (incl. response audio self-cancelling and the OpenAI cancel-ack session kill) — all fixed and re-verified
- Human smoke checklist pending: `docs/MILESTONE2_SMOKE_CHECKLIST.md` (7 items, needs hardware + an OpenAI key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)