### PR TITLE
Add end-to-end detection-path test suite (simulated IMU to decision)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ## [Unreleased]
 
+### Added
+
+- An end-to-end detection-path test suite. Generated 25 Hz IMU traces (and transcript
+  strings for voice) run through the real, fully composed stack — pipeline, analyzers,
+  arbiters, controllers, voice grammar, wearer gate, turn coordinator, and broker — and the
+  tests assert on what comes out the far end: a decision, a selection, or response bytes on
+  the wire. It covers the core approval and selection loops, the false-positive rejections
+  (ambient motion, rotation-contaminated taps, swipe staying off by default), and the
+  wearer-attribution and turn-control paths. It is a regression net for wiring, config and
+  decision logic only: every trace is shaped by construction, so the capture study remains
+  the accuracy gate for every IMU default.
+
 ## [0.5.0-beta.2] - 2026-08-08
 
 *(Replaces 0.5.0-beta.1, which was never released: its tag was cut against a commit

--- a/Package.swift
+++ b/Package.swift
@@ -182,6 +182,21 @@ var targets: [Target] = [
         dependencies: ["TapQCLI", "TapQDetectionBaseline", "TapQWireProtocol"],
         swiftSettings: swiftSettings
     ),
+    // End-to-end detection paths: simulated IMU traces through the real composed stack.
+    // Portable on purpose — the whole path under test (detection, arbitration, decision,
+    // wire) is portable, so a wiring regression must fail on Linux too.
+    .testTarget(
+        name: "TapQDetectionE2ETests",
+        dependencies: [
+            "TapQBrokerRuntime",
+            "TapQCLI",
+            "TapQContracts",
+            "TapQDetectionBaseline",
+            "TapQInteractionBaseline",
+            "TapQWireProtocol",
+        ],
+        swiftSettings: swiftSettings
+    ),
 ]
 
 // Apple acquisition and synthesis frameworks are intentionally absent from Linux's

--- a/Sources/TapQInteractionBaseline/InputArbiter.swift
+++ b/Sources/TapQInteractionBaseline/InputArbiter.swift
@@ -10,14 +10,21 @@ import TapQContracts
     private var continuation: CheckedContinuation<ResolvedInput?, Never>?
     private var timeoutTask: Task<Void, Never>?
     private let diagnostics: TapQDiagnosticEmitter
+    private let timeoutSleep: @MainActor (TimeInterval) async -> Void
 
+    /// - Parameter timeoutSleep: Injectable sleep for testing (virtual clock). The default
+    ///   is the real timer, so runtime behavior is unchanged.
     public init(gestures: HeadGestureProviding?, voice: VoiceCommandProviding?,
                 taps: TapCommandProviding? = nil,
-                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
+                timeoutSleep: @escaping @MainActor (TimeInterval) async -> Void = {
+                    try? await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000))
+                }) {
         self.gestures = gestures
         self.voice = voice
         self.taps = taps
         self.diagnostics = TapQDiagnosticEmitter(category: "InputArbiter", sink: diagnosticSink)
+        self.timeoutSleep = timeoutSleep
     }
 
     public func listen(timeout: TimeInterval) async -> InputIntent? {
@@ -68,8 +75,9 @@ import TapQContracts
             self?.finish(.init(intent: command.intent, channel: .voice))
         }
         if timeout > 0 {
+            let sleep = timeoutSleep
             timeoutTask = Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                await sleep(timeout)
                 if !Task.isCancelled { self?.finish(nil) }
             }
         }

--- a/Sources/TapQInteractionBaseline/SelectionArbiter.swift
+++ b/Sources/TapQInteractionBaseline/SelectionArbiter.swift
@@ -13,17 +13,24 @@ import TapQContracts
     private var continuation: CheckedContinuation<InputIntent?, Never>?
     private var timeoutTask: Task<Void, Never>?
     private let diagnostics: TapQDiagnosticEmitter
+    private let timeoutSleep: @MainActor (TimeInterval) async -> Void
 
+    /// - Parameter timeoutSleep: Injectable sleep for testing (virtual clock). The default
+    ///   is the real timer, so runtime behavior is unchanged.
     public init(voice: VoiceCommandProviding?, tilts: TiltCommandProviding?,
                 swipes: VolumeSwipeProviding?, taps: TapCommandProviding?,
                 gestures: HeadGestureProviding? = nil,
-                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
+                timeoutSleep: @escaping @MainActor (TimeInterval) async -> Void = {
+                    try? await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000))
+                }) {
         self.voice = voice
         self.tilts = tilts
         self.swipes = swipes
         self.taps = taps
         self.gestures = gestures
         self.diagnostics = TapQDiagnosticEmitter(category: "SelectionArbiter", sink: diagnosticSink)
+        self.timeoutSleep = timeoutSleep
     }
 
     public func listen(timeout: TimeInterval) async -> InputIntent? {
@@ -77,8 +84,9 @@ import TapQContracts
             self?.finish(command.intent)
         }
         if timeout > 0 {
+            let sleep = timeoutSleep
             timeoutTask = Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                await sleep(timeout)
                 if !Task.isCancelled { self?.finish(nil) }
             }
         }

--- a/Tests/TapQDetectionE2ETests/ApprovalPathE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/ApprovalPathE2ETests.swift
@@ -1,0 +1,93 @@
+import XCTest
+import TapQBrokerRuntime
+import TapQContracts
+import TapQWireProtocol
+@testable import TapQInteractionBaseline
+
+/// Tier 1: the core approval loop, IMU samples in, decision out.
+@MainActor
+final class ApprovalPathE2ETests: XCTestCase {
+    private func request() -> ApprovalRequest {
+        ApprovalRequest(id: "r1", sessionID: "s1", toolName: "Bash",
+                        summary: "run the test suite", detail: "swift test")
+    }
+
+    /// Bytes to bytes: an agent's approval request arrives on the wire, a nod arrives on
+    /// the IMU, and the allow leaves on the wire. Everything between — broker, controller,
+    /// arbiter, pipeline — is the shipping implementation.
+    func testNodApprovesWireToWire() async throws {
+        let harness = DetectionPathHarness()
+        let transport = InMemoryBrokerTransport()
+        let server = BrokerServer(
+            transport: transport,
+            token: "tok",
+            onApproval: { [harness] in await harness.interaction.resolve($0) },
+            onNotification: { _ in }
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let exchange = Task { try await transport.deliver(Data(Self.approvalRequestJSON.utf8)) }
+        let opened = await harness.waitForWindow(1)
+        XCTAssertTrue(opened, "the approval opened no input window")
+        harness.feed(TraceGenerators.doubleNod())
+
+        let responseData = try await exchange.value
+        let response = try JSONDecoder().decode(BrokerResponse.self, from: responseData)
+        XCTAssertEqual(response, .decision(.allow, reason: nil))
+        XCTAssertTrue(harness.speech.spoken.contains { $0.text.contains("run the test suite") },
+                      "the request must have been spoken before the window opened")
+    }
+
+    func testShakeDenies() async {
+        let harness = DetectionPathHarness()
+        let decision = Task { await harness.interaction.resolve(self.request()) }
+        let opened = await harness.waitForWindow(1)
+        XCTAssertTrue(opened)
+
+        harness.feed(TraceGenerators.doubleShake())
+
+        let outcome = await decision.value
+        XCTAssertEqual(outcome, .deny)
+    }
+
+    /// `gestureAndVoice` demands two independent channels. A nod arms it, a second nod
+    /// does not complete it, and only a spoken "yes" — matched by the real grammar — does.
+    func testGestureAndVoiceNeedsBothChannels() async {
+        let harness = DetectionPathHarness()
+        let decision = Task {
+            await harness.interaction.resolve(
+                self.request(), requiredConfirmation: .gestureAndVoice)
+        }
+
+        let firstWindow = await harness.waitForWindow(1)
+        XCTAssertTrue(firstWindow)
+        harness.feed(TraceGenerators.doubleNod())
+
+        let secondWindow = await harness.waitForWindow(2)
+        XCTAssertTrue(secondWindow, "a nod alone must arm the requirement, not resolve it")
+        XCTAssertTrue(harness.speech.said("Risky action. Say yes to confirm."),
+                      "the cue must name the missing half")
+        harness.feed(TraceGenerators.doubleNod())
+
+        let thirdWindow = await harness.waitForWindow(3)
+        XCTAssertTrue(thirdWindow,
+                      "a second head movement is one channel twice, not two channels")
+        harness.hear("yes")
+
+        let outcome = await decision.value
+        XCTAssertEqual(outcome, .allow)
+        XCTAssertEqual(harness.inputs.openedWindows, 3,
+                       "the spoken half completed the requirement without a further window")
+    }
+
+    /// Wire protocol v4, `pre_tool_use` outside auto mode, so the broker delegates to the
+    /// approval closure rather than auto-passing.
+    private static let approvalRequestJSON = """
+        {"type":"approval.request","token":"tok","protocol_version":4,\
+        "agent":{"id":"claude-code","display_name":"Claude Code"},\
+        "session_id":"s1","tool_name":"Bash","tool_input":{"command":"swift test"},\
+        "summary":"run the test suite","detail":"swift test",\
+        "approval_source":"pre_tool_use","request_id":"r1"}
+        """
+}

--- a/Tests/TapQDetectionE2ETests/ApprovalPathE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/ApprovalPathE2ETests.swift
@@ -33,6 +33,7 @@ final class ApprovalPathE2ETests: XCTestCase {
         harness.feed(TraceGenerators.doubleNod())
 
         let responseData = try await exchange.value
+        harness.assertWatchdogDidNotFire()
         let response = try JSONDecoder().decode(BrokerResponse.self, from: responseData)
         XCTAssertEqual(response, .decision(.allow, reason: nil))
         XCTAssertTrue(harness.speech.spoken.contains { $0.text.contains("run the test suite") },
@@ -48,6 +49,7 @@ final class ApprovalPathE2ETests: XCTestCase {
         harness.feed(TraceGenerators.doubleShake())
 
         let outcome = await decision.value
+        harness.assertWatchdogDidNotFire()
         XCTAssertEqual(outcome, .deny)
     }
 
@@ -76,6 +78,7 @@ final class ApprovalPathE2ETests: XCTestCase {
         harness.hear("yes")
 
         let outcome = await decision.value
+        harness.assertWatchdogDidNotFire()
         XCTAssertEqual(outcome, .allow)
         XCTAssertEqual(harness.inputs.openedWindows, 3,
                        "the spoken half completed the requirement without a further window")

--- a/Tests/TapQDetectionE2ETests/CaptureTraceCompatibilityTests.swift
+++ b/Tests/TapQDetectionE2ETests/CaptureTraceCompatibilityTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import TapQContracts
+import TapQDetectionBaseline
+@testable import TapQCLI
+
+/// Tier 1: generated traces are also `tapq replay` input.
+///
+/// No trace is checked in, so the guarantee that keeps them useful outside this suite is
+/// that they survive the capture file format. If this fails, a trace can still be fed to
+/// the pipeline in-process but can no longer be written out and replayed by hand.
+@MainActor
+final class CaptureTraceCompatibilityTests: XCTestCase {
+    func testGeneratedTraceSurvivesCaptureJSONLAndReplaysIdentically() async throws {
+        let trace = TraceGenerators.doubleNod()
+        let jsonl = trace
+            .map { MotionSampleFormatter.line(for: $0, format: .jsonl) }
+            .joined(separator: "\n")
+
+        let replayed = try MotionCaptureReader.samples(fromText: jsonl, format: .jsonl)
+
+        XCTAssertEqual(replayed, trace, "capture JSONL must round-trip every sample field")
+        XCTAssertEqual(Self.detections(in: trace), [.nod])
+        XCTAssertEqual(Self.detections(in: replayed), Self.detections(in: trace),
+                       "the replayed trace must reach the same detection as the live one")
+    }
+
+    private static func detections(in samples: [HeadMotionSample]) -> [HeadGesture] {
+        var pipeline = MotionGesturePipeline()
+        return samples.compactMap { pipeline.ingest($0).gesture }
+    }
+}

--- a/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
+++ b/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
@@ -1,0 +1,285 @@
+import Foundation
+import TapQBrokerRuntime
+import TapQContracts
+import TapQDetectionBaseline
+@testable import TapQInteractionBaseline
+
+/// The real, fully composed detection-to-decision stack, driven by synthetic IMU traces.
+///
+/// Composition is deliberately the production one: a real `MotionGesturePipeline` feeds a
+/// forwarding-only adapter, which feeds a real `InputArbiter`/`SelectionArbiter`, which
+/// feeds a real `InteractionController`/`SelectionController`. Only the edges are
+/// substituted — the motion stream (generated traces), the microphone (transcript strings
+/// through the real `VoiceCommandMatcher`), the speech engine, and the two clocks.
+///
+/// What that buys: a change that breaks the wiring between any two of those layers, or a
+/// config default that drifts far enough to stop detecting a plainly-shaped gesture, fails
+/// here. What it does not buy: any claim about real-world accuracy. See `TraceGenerators`.
+@MainActor
+final class DetectionPathHarness {
+    /// How long the stream stays still between fed traces. Longer than every pair window
+    /// and debounce in the pipeline (max 1.6 s), so consecutive traces cannot pair with
+    /// each other and each one starts from a rested detector.
+    static let idleGap: TimeInterval = 2.0
+
+    let clock = VirtualClock()
+    let speech = RecordingSpeech()
+    let diagnostics = RecordingSink()
+    let timeouts = ManualTimeout()
+    let inputs: PipelineInputAdapter
+    let voice = TranscriptVoiceChannel()
+    let inputArbiter: InputArbiter
+    let selectionArbiter: SelectionArbiter
+    let interaction: InteractionController
+    let selection: SelectionController
+
+    /// The stream clock: where the next fed sample lands.
+    private var cursor = TraceGenerators.epoch
+
+    init(pipeline: MotionGesturePipeline = MotionGesturePipeline()) {
+        let inputs = PipelineInputAdapter(pipeline: pipeline)
+        self.inputs = inputs
+        let timeouts = self.timeouts
+        let sleep: @MainActor (TimeInterval) async -> Void = { await timeouts.sleep($0) }
+        inputArbiter = InputArbiter(
+            gestures: inputs, voice: voice, taps: inputs,
+            diagnosticSink: diagnostics, timeoutSleep: sleep
+        )
+        selectionArbiter = SelectionArbiter(
+            voice: voice, tilts: inputs, swipes: inputs, taps: inputs, gestures: inputs,
+            diagnosticSink: diagnostics, timeoutSleep: sleep
+        )
+        interaction = InteractionController(
+            speech: speech, arbiter: inputArbiter, diagnosticSink: diagnostics
+        )
+        selection = SelectionController(
+            speech: speech, arbiter: selectionArbiter, diagnosticSink: diagnostics
+        )
+        let clock = self.clock
+        interaction.now = { clock.now }
+        selection.now = { clock.now }
+    }
+
+    /// Streams one trace into the pipeline at the current stream position, then keeps the
+    /// stream running through `idleGap` seconds of stillness.
+    func feed(_ trace: [HeadMotionSample]) {
+        let rebased = TraceGenerators.shift(trace, to: cursor)
+        for sample in rebased { inputs.ingest(sample) }
+        cursor = (rebased.last?.timestamp ?? cursor) + TraceGenerators.sampleInterval
+        for sample in TraceGenerators.quiet(startingAt: cursor, duration: Self.idleGap) {
+            inputs.ingest(sample)
+        }
+        cursor += Self.idleGap
+    }
+
+    /// Delivers a recognizer transcript to the open window. The grammar under test is the
+    /// real `VoiceCommandMatcher`, so an unmatched transcript is silently dropped exactly
+    /// as it would be on device.
+    func hear(_ transcript: String) {
+        voice.hear(transcript)
+    }
+
+    /// Waits until the arbiter has opened its `index`-th input window (1-based), which is
+    /// the point at which a fed trace can reach the decision layer. Polling rather than an
+    /// expectation: the window opens on a later main-actor turn, and the house rule is no
+    /// `XCTestExpectation` for actor hops.
+    @discardableResult
+    func waitForWindow(_ index: Int, attempts: Int = 2_000) async -> Bool {
+        for _ in 0..<attempts {
+            if inputs.openedWindows >= index { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return inputs.openedWindows >= index
+    }
+}
+
+/// Test stand-in for `ContinuousClock`: time moves only when a test says so.
+@MainActor
+final class VirtualClock {
+    private(set) var now: ContinuousClock.Instant = .now
+    func advance(by seconds: TimeInterval) { now = now.advanced(by: .seconds(seconds)) }
+}
+
+/// The `InputArbiter`/`SelectionArbiter` timeout seam under test control: the window's
+/// requested duration is recorded, and the sleep ends either when a test expires the
+/// window or when the arbiter cancels the timer because an input resolved it first.
+@MainActor
+final class ManualTimeout {
+    private(set) var requested: [TimeInterval] = []
+    private var expired = false
+
+    func sleep(_ seconds: TimeInterval) async {
+        requested.append(seconds)
+        while !Task.isCancelled {
+            if expired {
+                expired = false
+                return
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+
+    /// Fires the timeout path for the window currently waiting.
+    func expire() { expired = true }
+}
+
+/// Forwards `MotionGesturePipeline` detections to the arbiters, and nothing else.
+///
+/// This is the one piece the production stack builds differently (there, CoreMotion feeds
+/// the pipeline inside `HeadGestureDetector`). It must stay a pass-through: no filtering,
+/// no debounce, no interpretation — every one of those decisions belongs to the pipeline
+/// or the arbiter, which is what this suite exists to exercise.
+@MainActor
+final class PipelineInputAdapter: HeadGestureProviding, TapCommandProviding,
+                                  TiltCommandProviding, VolumeSwipeProviding {
+    var pipeline: MotionGesturePipeline
+
+    private var onGesture: (@MainActor (HeadGesture) -> Void)?
+    private var onTap: (@MainActor (TapCommand) -> Void)?
+    private var onTilt: (@MainActor (TiltCommand) -> Void)?
+    private var onSwipe: (@MainActor (VolumeSwipeCommand) -> Void)?
+    private var isOpen = false
+
+    /// How many input windows have been opened on this adapter. An arbiter opens several
+    /// channels per window, so this counts the window, not the channel.
+    private(set) var openedWindows = 0
+
+    init(pipeline: MotionGesturePipeline) {
+        self.pipeline = pipeline
+    }
+
+    func start(onGesture: @escaping @MainActor (HeadGesture) -> Void) {
+        openWindow()
+        self.onGesture = onGesture
+    }
+
+    func start(onTap: @escaping @MainActor (TapCommand) -> Void) {
+        openWindow()
+        self.onTap = onTap
+    }
+
+    func start(onTilt: @escaping @MainActor (TiltCommand) -> Void) {
+        openWindow()
+        self.onTilt = onTilt
+    }
+
+    func start(onSwipe: @escaping @MainActor (VolumeSwipeCommand) -> Void) {
+        openWindow()
+        self.onSwipe = onSwipe
+    }
+
+    func stop() {
+        isOpen = false
+        onGesture = nil
+        onTap = nil
+        onTilt = nil
+        onSwipe = nil
+    }
+
+    /// Ingests one sample and hands every resulting detection straight to whichever
+    /// channels the arbiter opened. Samples keep flowing while no window is open — the
+    /// detectors are stateful and a real IMU does not stop between prompts.
+    func ingest(_ sample: HeadMotionSample) {
+        let result = pipeline.ingest(sample)
+        if let gesture = result.gesture { onGesture?(gesture) }
+        if let tap = result.tap { onTap?(tap) }
+        if let tilt = result.tilt { onTilt?(tilt) }
+        if let swipe = result.swipe {
+            onSwipe?(swipe == .swipeUp ? .swipeUp : .swipeDown)
+        }
+    }
+
+    private func openWindow() {
+        guard !isOpen else { return }
+        isOpen = true
+        openedWindows += 1
+    }
+}
+
+/// The voice channel as transcripts: speech-to-text is the platform's job, so the tested
+/// surface starts at the grammar. Commands reach the arbiter only through the real
+/// `VoiceCommandMatcher`, never as pre-built `VoiceCommand` values.
+@MainActor
+final class TranscriptVoiceChannel: VoiceCommandProviding {
+    private var onCommand: (@MainActor (VoiceCommand) -> Void)?
+
+    func start(onCommand: @escaping @MainActor (VoiceCommand) -> Void) {
+        self.onCommand = onCommand
+    }
+
+    func stop() {
+        onCommand = nil
+    }
+
+    func hear(_ transcript: String) {
+        guard let command = VoiceCommandMatcher.match(transcript) else { return }
+        onCommand?(command)
+    }
+}
+
+@MainActor
+final class RecordingSpeech: SpeechPresenting {
+    private(set) var spoken: [(text: String, priority: SpeechPriority)] = []
+
+    func speak(_ text: String, priority: SpeechPriority, onFinish: (() -> Void)?) {
+        spoken.append((text, priority))
+        onFinish?()
+    }
+
+    func stopAll() {}
+
+    func said(_ text: String) -> Bool {
+        spoken.contains { $0.text == text }
+    }
+}
+
+final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [TapQDiagnosticEvent] = []
+
+    func record(_ event: TapQDiagnosticEvent) {
+        lock.lock()
+        storage.append(event)
+        lock.unlock()
+    }
+
+    var events: [TapQDiagnosticEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
+/// A `BrokerTransport` that hands request bytes to the broker in-process and returns the
+/// response bytes, so a wire-level test needs no socket, no filesystem, and no thread.
+final class InMemoryBrokerTransport: BrokerTransport, @unchecked Sendable {
+    enum Failure: Error, Equatable {
+        case notStarted
+    }
+
+    private let lock = NSLock()
+    private var handler: (@Sendable (Data) async -> Data)?
+
+    func start(handler: @escaping @Sendable (Data) async -> Data) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        self.handler = handler
+    }
+
+    func stop() {
+        lock.lock()
+        defer { lock.unlock() }
+        handler = nil
+    }
+
+    func deliver(_ request: Data) async throws -> Data {
+        guard let handler = currentHandler() else { throw Failure.notStarted }
+        return await handler(request)
+    }
+
+    private func currentHandler() -> (@Sendable (Data) async -> Data)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return handler
+    }
+}

--- a/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
+++ b/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
@@ -20,6 +20,7 @@
 // for wiring, config, and logic, and are worthless as evidence that a threshold is correct.
 
 import Foundation
+import XCTest
 import TapQBrokerRuntime
 import TapQContracts
 import TapQDetectionBaseline
@@ -129,6 +130,21 @@ final class DetectionPathHarness {
         }
         return inputs.openedWindows >= index
     }
+
+    /// Fails if any window ended on `ManualTimeout`'s watchdog. Call it after awaiting a
+    /// decision a fed trace was supposed to produce: the outcome assertion already goes red
+    /// when detection fails, but this one says why — nothing the trace produced ever reached
+    /// the arbiter, so the window ran out instead of being answered.
+    func assertWatchdogDidNotFire(file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertFalse(
+            timeouts.watchdogTripped,
+            """
+            a window ran the full \(ManualTimeout.watchdogSeconds)s watchdog: no detection \
+            reached the arbiter
+            """,
+            file: file, line: line
+        )
+    }
 }
 
 /// Test stand-in for `ContinuousClock`: time moves only when a test says so.
@@ -143,14 +159,33 @@ final class VirtualClock {
 /// window or when the arbiter cancels the timer because an input resolved it first.
 @MainActor
 final class ManualTimeout {
+    /// The bound on a window nobody ever closes. Without it, a trace that stops being
+    /// detected — a drifted threshold, an unwired channel — leaves the arbiter waiting on a
+    /// timer that only a test can fire, and the awaiting test blocks until CI kills the job
+    /// instead of going red. This ends the window in bounded real time so the outcome
+    /// assertions get to run and fail.
+    ///
+    /// A passing run never reaches it: detections resolve the window synchronously inside
+    /// `feed(_:)`, which cancels the timer. It can only fire once detection has failed, so
+    /// it costs green-path determinism nothing and can be generous.
+    static let watchdogSeconds: TimeInterval = 20
+
     private(set) var requested: [TimeInterval] = []
+    /// Whether any window in this harness ended on the watchdog rather than on a detection
+    /// or an `expire()`. Assert on it to name the cause; see `assertWatchdogDidNotFire`.
+    private(set) var watchdogTripped = false
     private var expired = false
 
     func sleep(_ seconds: TimeInterval) async {
         requested.append(seconds)
+        let deadline = ContinuousClock.now.advanced(by: .seconds(Self.watchdogSeconds))
         while !Task.isCancelled {
             if expired {
                 expired = false
+                return
+            }
+            if ContinuousClock.now >= deadline {
+                watchdogTripped = true
                 return
             }
             try? await Task.sleep(nanoseconds: 1_000_000)

--- a/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
+++ b/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
@@ -36,7 +36,13 @@ final class DetectionPathHarness {
     /// The stream clock: where the next fed sample lands.
     private var cursor = TraceGenerators.epoch
 
-    init(pipeline: MotionGesturePipeline = MotionGesturePipeline()) {
+    /// - Parameter configure: Applied to the pipeline the harness builds, for tests that
+    ///   need a non-default detector config. The pipeline is constructed here rather than
+    ///   accepted whole so it always reports into `diagnostics`, which is where analyzer
+    ///   rejection reasons are asserted.
+    init(configure: (inout MotionGesturePipeline) -> Void = { _ in }) {
+        var pipeline = MotionGesturePipeline(diagnosticSink: diagnostics)
+        configure(&pipeline)
         let inputs = PipelineInputAdapter(pipeline: pipeline)
         self.inputs = inputs
         let timeouts = self.timeouts

--- a/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
+++ b/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
@@ -1,3 +1,24 @@
+// The end-to-end detection-path suite.
+//
+// Every test in this target feeds generated IMU sample streams (and, for voice, transcript
+// strings) into the real detection-to-decision stack and asserts on what comes out the far
+// end: a `Decision`, a `SelectionResult`, or broker response bytes. Nothing between the
+// sample and the answer is faked — the pipeline, analyzers, arbiters, controllers, voice
+// grammar, wearer gate, and broker are all the shipping implementations. Only the edges are
+// substituted: the motion source, the recognizer, the speech output, and the clocks.
+//
+// What the suite guarantees: the layers stay wired together, the shipped configs stay
+// capable of detecting a plainly-shaped gesture, the default-off flags stay off, and the
+// decision logic (first-wins arbitration, confirmation channels, timeout outcomes,
+// attribution, turn control) keeps behaving as specified. Any change that breaks one of
+// those fails here rather than on someone's head.
+//
+// What it does not guarantee: real-world accuracy. Every trace is shaped by construction,
+// generated well clear of the thresholds it needs to cross or stay under, so the suite says
+// nothing about how a real nod on real hardware compares to a real threshold. The capture
+// study remains the accuracy gate for every IMU default; these tests are a regression net
+// for wiring, config, and logic, and are worthless as evidence that a threshold is correct.
+
 import Foundation
 import TapQBrokerRuntime
 import TapQContracts
@@ -28,6 +49,9 @@ final class DetectionPathHarness {
     let timeouts = ManualTimeout()
     let inputs: PipelineInputAdapter
     let voice = TranscriptVoiceChannel()
+    /// What the arbiters actually listen to: the transcript channel itself by default, or
+    /// whatever decorator a test wrapped around it (M2's wearer gate).
+    let gatedVoice: VoiceCommandProviding
     let inputArbiter: InputArbiter
     let selectionArbiter: SelectionArbiter
     let interaction: InteractionController
@@ -36,23 +60,31 @@ final class DetectionPathHarness {
     /// The stream clock: where the next fed sample lands.
     private var cursor = TraceGenerators.epoch
 
-    /// - Parameter configure: Applied to the pipeline the harness builds, for tests that
-    ///   need a non-default detector config. The pipeline is constructed here rather than
-    ///   accepted whole so it always reports into `diagnostics`, which is where analyzer
-    ///   rejection reasons are asserted.
-    init(configure: (inout MotionGesturePipeline) -> Void = { _ in }) {
+    /// - Parameters:
+    ///   - configure: Applied to the pipeline the harness builds, for tests that need a
+    ///     non-default detector config. The pipeline is constructed here rather than
+    ///     accepted whole so it always reports into `diagnostics`, which is where analyzer
+    ///     rejection reasons are asserted.
+    ///   - voiceGate: Wraps the transcript channel before the arbiters see it, for tests of
+    ///     the M2 decorators. It receives the harness's sink so a decorator's own verdicts
+    ///     land in the same event stream as the arbiter's. The default adds nothing.
+    init(configure: (inout MotionGesturePipeline) -> Void = { _ in },
+         voiceGate: @MainActor (TranscriptVoiceChannel, RecordingSink) -> VoiceCommandProviding
+             = { channel, _ in channel }) {
         var pipeline = MotionGesturePipeline(diagnosticSink: diagnostics)
         configure(&pipeline)
         let inputs = PipelineInputAdapter(pipeline: pipeline)
         self.inputs = inputs
+        let gatedVoice = voiceGate(voice, diagnostics)
+        self.gatedVoice = gatedVoice
         let timeouts = self.timeouts
         let sleep: @MainActor (TimeInterval) async -> Void = { await timeouts.sleep($0) }
         inputArbiter = InputArbiter(
-            gestures: inputs, voice: voice, taps: inputs,
+            gestures: inputs, voice: gatedVoice, taps: inputs,
             diagnosticSink: diagnostics, timeoutSleep: sleep
         )
         selectionArbiter = SelectionArbiter(
-            voice: voice, tilts: inputs, swipes: inputs, taps: inputs, gestures: inputs,
+            voice: gatedVoice, tilts: inputs, swipes: inputs, taps: inputs, gestures: inputs,
             diagnosticSink: diagnostics, timeoutSleep: sleep
         )
         interaction = InteractionController(
@@ -220,6 +252,37 @@ final class TranscriptVoiceChannel: VoiceCommandProviding {
     func hear(_ transcript: String) {
         guard let command = VoiceCommandMatcher.match(transcript) else { return }
         onCommand?(command)
+    }
+}
+
+/// A real `WearerSpeechMonitor` presented as the `WearerSpeechSignaling` contract.
+///
+/// The shipping presenter, `WearerSpeechSignalSource`, lives in the Apple-only adapter
+/// layer and is out of reach of a portable test target, so this restates its two rules —
+/// speaking is the monitor's state, availability is fresh-and-per-axis — and forwards the
+/// monitor's transitions. Every answer it gives is the real detector's; nothing here
+/// decides anything about speech.
+@MainActor
+final class MonitorSpeechSignal: WearerSpeechSignaling {
+    let monitor: WearerSpeechMonitor
+
+    var isWearerSpeaking: Bool { monitor.state == .speaking }
+
+    /// Mirrors `WearerSpeechSignalSource.isSignalAvailable` minus its `isAttached` flag,
+    /// which is an attachment bookkeeping bit the source's owner sets; here the monitor is
+    /// attached by construction.
+    var isSignalAvailable: Bool {
+        monitor.isFresh() && monitor.lastSampleHadPerAxisData
+    }
+
+    var onWearerSpeakingChange: (@MainActor (Bool) -> Void)?
+
+    init(monitor: WearerSpeechMonitor) {
+        self.monitor = monitor
+        monitor.onTransition = { [weak self] _ in
+            guard let self else { return }
+            self.onWearerSpeakingChange?(self.monitor.state == .speaking)
+        }
     }
 }
 

--- a/Tests/TapQDetectionE2ETests/FalsePositiveE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/FalsePositiveE2ETests.swift
@@ -43,6 +43,7 @@ final class FalsePositiveE2ETests: XCTestCase {
         XCTAssertTrue(cleanWindow)
         clean.feed(TraceGenerators.doubleTap())
         let cleanOutcome = await approved.value
+        clean.assertWatchdogDidNotFire()
         XCTAssertEqual(cleanOutcome, .allow, "the trace must be a real double-tap")
 
         let harness = DetectionPathHarness()
@@ -104,6 +105,7 @@ final class FalsePositiveE2ETests: XCTestCase {
         enabled.feed(TraceGenerators.doubleNod())
 
         let selection = await result.value
+        enabled.assertWatchdogDidNotFire()
         XCTAssertEqual(
             enabled.diagnostics.events.filter { $0.name == "input.swipe" }
                 .map { $0.fields["swipe"] },

--- a/Tests/TapQDetectionE2ETests/FalsePositiveE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/FalsePositiveE2ETests.swift
@@ -1,0 +1,144 @@
+import XCTest
+import TapQContracts
+import TapQDetectionBaseline
+@testable import TapQInteractionBaseline
+
+/// Tier 2: motion that must never become a decision.
+///
+/// Each case pairs the negative with its positive control, because a rejection test that
+/// no longer generates the thing it is rejecting passes for the wrong reason.
+@MainActor
+final class FalsePositiveE2ETests: XCTestCase {
+    /// Six seconds of walking and looking around, fed into an open approval window. The
+    /// user never answered, so the only correct ending is the one an unanswered request
+    /// already has: the window times out and the request goes back to the screen.
+    func testAmbientNoiseNeverApproves() async {
+        let harness = DetectionPathHarness()
+        let decision = Task { await harness.interaction.resolve(Self.request) }
+        let window = await harness.waitForWindow(1)
+        XCTAssertTrue(window)
+
+        harness.feed(TraceGenerators.ambientNoise())
+
+        XCTAssertFalse(harness.diagnostics.events.contains { Self.inputEvents.contains($0.name) },
+                       "ambient motion reached the arbiter as an input")
+
+        harness.timeouts.expire()
+        let outcome = await decision.value
+        XCTAssertEqual(outcome, .ask, "an unanswered approval defers; it never allows")
+        XCTAssertTrue(harness.speech.said("Deferring to the screen."))
+        XCTAssertEqual(harness.inputs.openedWindows, 1,
+                       "the noise neither answered the window nor caused a re-listen")
+        XCTAssertEqual(harness.timeouts.requested, [240],
+                       "the decision came from the window timeout, not from an input")
+    }
+
+    /// A double-tap whose spikes land while the head is turning is not a double-tap: the
+    /// same acceleration a finger makes is also what a shake's turnaround makes, and the
+    /// rotation gate is the only thing telling them apart. Cleared first, then contaminated.
+    func testRotationContaminatedTapIsRejected() async throws {
+        let clean = DetectionPathHarness()
+        let approved = Task { await clean.interaction.resolve(Self.request) }
+        let cleanWindow = await clean.waitForWindow(1)
+        XCTAssertTrue(cleanWindow)
+        clean.feed(TraceGenerators.doubleTap())
+        let cleanOutcome = await approved.value
+        XCTAssertEqual(cleanOutcome, .allow, "the trace must be a real double-tap")
+
+        let harness = DetectionPathHarness()
+        let decision = Task { await harness.interaction.resolve(Self.request) }
+        let window = await harness.waitForWindow(1)
+        XCTAssertTrue(window)
+
+        harness.feed(TraceGenerators.doubleTap(rotation: Self.contaminatedRotation))
+
+        let rejected = try XCTUnwrap(
+            harness.diagnostics.events.first { $0.name == "tap.candidate_rejected" },
+            "the analyzer logged no verdict on the spike at all"
+        )
+        XCTAssertEqual(rejected.fields["reason"], "rotation_not_quiet")
+        XCTAssertEqual(rejected.fields["peak_g"], "0.7000",
+                       "the spike must clear tap amplitude, so rotation is the sole defect")
+        XCTAssertEqual(rejected.fields["max_rotation_rad_s"], "0.9000")
+        XCTAssertFalse(harness.diagnostics.events.contains { $0.name == "input.tap" },
+                       "a rejected tap must not reach the arbiter")
+
+        harness.timeouts.expire()
+        let outcome = await decision.value
+        XCTAssertEqual(outcome, .ask)
+        XCTAssertEqual(harness.inputs.openedWindows, 1)
+    }
+
+    /// The motion-swipe channel is experimental and ships off. One trace, two harnesses:
+    /// with the flagless default it is inert, and with the flag set the same samples
+    /// navigate — so the default-off guarantee is not just an undetectable trace.
+    func testSwipeStaysInertUntilTheFlagIsSet() async {
+        let drag = TraceGenerators.swipe(.swipeDown)
+
+        let flagless = DetectionPathHarness()
+        let ignored = Task { await flagless.selection.resolve(Self.selectionRequest) }
+        let flaglessWindow = await flagless.waitForWindow(1)
+        XCTAssertTrue(flaglessWindow)
+        flagless.feed(drag)
+        XCTAssertFalse(flagless.diagnostics.events.contains { $0.name == "input.swipe" },
+                       "the default pipeline emitted a swipe")
+
+        flagless.timeouts.expire()
+        let ignoredResult = await ignored.value
+        XCTAssertTrue(ignoredResult.timedOut)
+        XCTAssertTrue(ignoredResult.choices.isEmpty)
+        XCTAssertEqual(flagless.inputs.openedWindows, 1, "no navigation, so no re-listen")
+
+        let enabled = DetectionPathHarness { $0.swipeDetectionEnabled = true }
+        let result = Task { await enabled.selection.resolve(Self.selectionRequest) }
+        let firstWindow = await enabled.waitForWindow(1)
+        XCTAssertTrue(firstWindow)
+        enabled.feed(drag)
+
+        let secondWindow = await enabled.waitForWindow(2)
+        XCTAssertTrue(secondWindow, "the drag must advance and re-listen")
+        enabled.feed(TraceGenerators.swipe(.swipeUp))
+
+        let thirdWindow = await enabled.waitForWindow(3)
+        XCTAssertTrue(thirdWindow)
+        enabled.feed(TraceGenerators.doubleNod())
+
+        let selection = await result.value
+        XCTAssertEqual(
+            enabled.diagnostics.events.filter { $0.name == "input.swipe" }
+                .map { $0.fields["swipe"] },
+            ["swipeDown", "swipeUp"]
+        )
+        XCTAssertEqual(
+            enabled.diagnostics.events.filter { $0.name == "selection.navigated" }
+                .map { $0.fields["intent"] },
+            ["next", "previous", "select"]
+        )
+        XCTAssertEqual(selection.choices.map(\.index), [0],
+                       "one option forward and one back lands where it started")
+    }
+
+    /// 1.5x `TapConfig.rotationQuiet` (0.6 rad/s): the head is plainly turning, not still.
+    private static let contaminatedRotation = 0.9
+
+    /// Every arbiter event that means "an input won the window". None may appear in a
+    /// window that only saw noise.
+    private static let inputEvents: Set<String> = [
+        "input.gesture", "input.tap", "input.tilt", "input.swipe", "input.voice",
+    ]
+
+    private static let request = ApprovalRequest(
+        id: "r1", sessionID: "s1", toolName: "Bash",
+        summary: "run the test suite", detail: "swift test"
+    )
+
+    private static let selectionRequest = SelectionRequest(
+        id: "r1", sessionID: "s1", question: "Which format?",
+        options: [
+            .init(label: "PDF", description: ""),
+            .init(label: "PNG", description: ""),
+            .init(label: "SVG", description: ""),
+        ],
+        multiSelect: false
+    )
+}

--- a/Tests/TapQDetectionE2ETests/SelectionPathE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/SelectionPathE2ETests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import TapQContracts
+@testable import TapQInteractionBaseline
+
+/// Tier 1: navigating a multi-option question with the head alone.
+@MainActor
+final class SelectionPathE2ETests: XCTestCase {
+    /// Two lateral tilts walk the cursor forward one option each, and a nod confirms
+    /// wherever it landed. Three sequential windows on one `SelectionController.resolve`,
+    /// all of them answered by motion.
+    func testTiltTiltNodSelectsTheThirdOption() async {
+        let harness = DetectionPathHarness()
+        let result = Task { await harness.selection.resolve(Self.request) }
+
+        let firstWindow = await harness.waitForWindow(1)
+        XCTAssertTrue(firstWindow)
+        harness.feed(TraceGenerators.doubleTilt(.tiltRight))
+
+        let secondWindow = await harness.waitForWindow(2)
+        XCTAssertTrue(secondWindow, "the first tilt must advance and re-listen")
+        harness.feed(TraceGenerators.doubleTilt(.tiltRight))
+
+        let thirdWindow = await harness.waitForWindow(3)
+        XCTAssertTrue(thirdWindow)
+        harness.feed(TraceGenerators.doubleNod())
+
+        let selection = await result.value
+        XCTAssertFalse(selection.timedOut)
+        XCTAssertEqual(selection.choices.map(\.index), [2])
+        XCTAssertEqual(selection.choices.map(\.label), ["SVG"])
+        XCTAssertEqual(harness.inputs.openedWindows, 3,
+                       "each tilt consumed exactly one window")
+    }
+
+    private static let request = SelectionRequest(
+        id: "r1", sessionID: "s1", question: "Which format?",
+        options: [
+            .init(label: "PDF", description: ""),
+            .init(label: "PNG", description: ""),
+            .init(label: "SVG", description: ""),
+        ],
+        multiSelect: false
+    )
+}

--- a/Tests/TapQDetectionE2ETests/SelectionPathE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/SelectionPathE2ETests.swift
@@ -25,6 +25,7 @@ final class SelectionPathE2ETests: XCTestCase {
         harness.feed(TraceGenerators.doubleNod())
 
         let selection = await result.value
+        harness.assertWatchdogDidNotFire()
         XCTAssertFalse(selection.timedOut)
         XCTAssertEqual(selection.choices.map(\.index), [2])
         XCTAssertEqual(selection.choices.map(\.label), ["SVG"])

--- a/Tests/TapQDetectionE2ETests/TraceGenerators.swift
+++ b/Tests/TapQDetectionE2ETests/TraceGenerators.swift
@@ -1,0 +1,212 @@
+import Foundation
+import TapQContracts
+import TapQDetectionBaseline
+
+/// Deterministic synthetic AirPods motion traces at the 25 Hz headphone sample rate.
+///
+/// Every waveform is a closed-form function of the sample index and a caller-supplied
+/// start time: no `Date.now`, no randomness, so a failure always reproduces. Timestamps
+/// are absolute and begin at `epoch` unless the caller says otherwise.
+///
+/// Amplitudes default to well above the threshold each channel measures — see the
+/// per-generator notes — because a suite that generates at the margin reports config
+/// drift and scheduler noise with the same red X.
+///
+/// Each generator drives only the axis its channel reads and leaves the others at rest,
+/// so a nod trace cannot accidentally satisfy the tap or tilt analyzer. These traces are
+/// shaped by construction and prove wiring, not real-world accuracy — the capture study
+/// remains the accuracy gate for every IMU default.
+enum TraceGenerators {
+    /// Headphone motion arrives at ~25 Hz.
+    static let sampleInterval: TimeInterval = 0.04
+    /// Fixed, arbitrary, non-zero start time: nothing downstream may assume a zero origin.
+    static let epoch: TimeInterval = 1_000
+
+    /// Gravity for an upright, worn earbud. Present on every sample so traces carry
+    /// per-axis data (`hasPerAxisData`) exactly as the CoreMotion adapter produces it.
+    static let uprightGravity = MotionVector(x: 0, y: 0, z: -1)
+
+    // MARK: - Head gestures (nod / shake)
+
+    /// One nod excursion: a pitch zigzag of `amplitude` radians peak-to-peak.
+    ///
+    /// `amplitude` is directly comparable to `HeadGestureConfig.amplitudeThreshold`
+    /// (0.30 rad), which the analyzer also measures peak-to-peak. The default is 2x it.
+    /// A single excursion never emits — the pipeline pairs two into a nod.
+    static func nod(startingAt start: TimeInterval = epoch,
+                    amplitude: Double = 0.60,
+                    duration: TimeInterval = 0.24) -> [HeadMotionSample] {
+        oscillation(on: .pitch, startingAt: start, amplitude: amplitude, duration: duration)
+    }
+
+    /// One shake excursion: the same zigzag on yaw. See `nod(startingAt:amplitude:duration:)`.
+    static func shake(startingAt start: TimeInterval = epoch,
+                      amplitude: Double = 0.60,
+                      duration: TimeInterval = 0.24) -> [HeadMotionSample] {
+        oscillation(on: .yaw, startingAt: start, amplitude: amplitude, duration: duration)
+    }
+
+    /// The paired trace the pipeline turns into exactly one `.nod`.
+    ///
+    /// `separation` is the interval between the two excursion starts, and because both
+    /// excursions are detected on their own final sample it is also the pair gap the
+    /// pipeline measures. It must sit inside
+    /// [`minDoubleNodGap`, `doubleNodWindowSeconds`] = [0.3 s, 1.5 s].
+    static func doubleNod(startingAt start: TimeInterval = epoch,
+                          amplitude: Double = 0.60,
+                          separation: TimeInterval = 0.8) -> [HeadMotionSample] {
+        nod(startingAt: start, amplitude: amplitude)
+            + nod(startingAt: start + separation, amplitude: amplitude)
+    }
+
+    /// The paired trace the pipeline turns into exactly one `.shake`. `separation` must
+    /// sit inside [`minDoubleShakeGap`, `doubleShakeWindowSeconds`] = [0.3 s, 1.5 s].
+    static func doubleShake(startingAt start: TimeInterval = epoch,
+                            amplitude: Double = 0.60,
+                            separation: TimeInterval = 0.8) -> [HeadMotionSample] {
+        shake(startingAt: start, amplitude: amplitude)
+            + shake(startingAt: start + separation, amplitude: amplitude)
+    }
+
+    // MARK: - Lateral tilt
+
+    /// One lateral (roll-axis) tilt excursion: out to `amplitude` radians and back to
+    /// neutral, which is the shape `TiltAnalyzer` requires — it fires only once the head
+    /// has returned. `amplitude` is peak deviation, comparable to
+    /// `TiltConfig.amplitudeThreshold` (0.18 rad); the default is ~1.7x it.
+    /// A single excursion never emits — the pipeline pairs two same-direction tilts.
+    static func tilt(_ direction: TiltCommand,
+                     startingAt start: TimeInterval = epoch,
+                     amplitude: Double = 0.30,
+                     duration: TimeInterval = 0.96) -> [HeadMotionSample] {
+        let count = sampleCount(for: duration, minimum: 10)
+        let sign = direction == .tiltRight ? 1.0 : -1.0
+        return (0..<count).map { index in
+            let phase = Double(index) / Double(count - 1)
+            return sample(at: start + Double(index) * sampleInterval,
+                          roll: sign * amplitude * sin(phase * .pi))
+        }
+    }
+
+    /// The paired trace the pipeline turns into exactly one tilt command. `separation`
+    /// is the interval between excursion starts and, since both excursions are detected
+    /// at the same offset within themselves, also the pair gap: it must sit inside
+    /// [`minDoubleTiltGap`, `doubleTiltWindowSeconds`] = [0.25 s, 1.6 s].
+    static func doubleTilt(_ direction: TiltCommand,
+                           startingAt start: TimeInterval = epoch,
+                           amplitude: Double = 0.30,
+                           separation: TimeInterval = 1.28) -> [HeadMotionSample] {
+        tilt(direction, startingAt: start, amplitude: amplitude)
+            + tilt(direction, startingAt: start + separation, amplitude: amplitude)
+    }
+
+    // MARK: - Tap
+
+    /// One tap: a single-sample acceleration spike bracketed by rest, with the head still.
+    ///
+    /// `amplitude` is peak `|userAcceleration|` in g, comparable to
+    /// `TapConfig.amplitudeThreshold` (0.45 g); the default is ~1.6x it. `rotation` is the
+    /// concurrent `|rotationRate|` in rad/s and stays far below `TapConfig.rotationQuiet`
+    /// (0.6) unless a caller is deliberately contaminating the spike.
+    /// A single tap never emits — the pipeline pairs two into a double-tap.
+    static func tap(startingAt start: TimeInterval = epoch,
+                    amplitude: Double = 0.70,
+                    rotation: Double = 0.05) -> [HeadMotionSample] {
+        [0.0, amplitude, 0.0, 0.0].enumerated().map { index, level in
+            sample(at: start + Double(index) * sampleInterval,
+                   userAcceleration: MotionVector(x: 0, y: 0, z: level),
+                   rotationRate: MotionVector(x: rotation, y: 0, z: 0))
+        }
+    }
+
+    /// The paired trace the pipeline turns into exactly one `.tap`. `separation` is the
+    /// interval between spike starts and also the pair gap, so it must sit inside
+    /// [`minDoubleTapGap`, `doubleTapWindowSeconds`] = [0.1 s, 0.5 s].
+    static func doubleTap(startingAt start: TimeInterval = epoch,
+                          amplitude: Double = 0.70,
+                          rotation: Double = 0.05,
+                          separation: TimeInterval = 0.36) -> [HeadMotionSample] {
+        tap(startingAt: start, amplitude: amplitude, rotation: rotation)
+            + tap(startingAt: start + separation, amplitude: amplitude, rotation: rotation)
+    }
+
+    // MARK: - Rest
+
+    /// A still, worn earbud: gravity only. Used to keep the stream continuous between
+    /// gestures so pair windows and debounce expire the way they do on hardware.
+    static func quiet(startingAt start: TimeInterval,
+                      duration: TimeInterval) -> [HeadMotionSample] {
+        let count = max(0, Int((duration / sampleInterval).rounded()))
+        return (0..<count).map { sample(at: start + Double($0) * sampleInterval) }
+    }
+
+    // MARK: - Timeline
+
+    /// Rebases a trace so its first sample lands on `start`, preserving every interval.
+    /// Detection reads only differences, so a rebased trace detects identically.
+    static func shift(_ trace: [HeadMotionSample],
+                      to start: TimeInterval) -> [HeadMotionSample] {
+        guard let first = trace.first else { return [] }
+        let offset = start - first.timestamp
+        return trace.map { $0.restamped(to: $0.timestamp + offset) }
+    }
+
+    // MARK: - Private
+
+    private enum Axis { case pitch, yaw }
+
+    /// The zigzag both head gestures share: rest, alternating peaks, rest. Four direction
+    /// reversals at the default six samples, comfortably past `minReversals` (2), and a
+    /// peak-to-peak swing of exactly `amplitude` on the driven axis with the other axis
+    /// flat, which is what makes the analyzer's dominance test unambiguous.
+    private static func oscillation(on axis: Axis,
+                                    startingAt start: TimeInterval,
+                                    amplitude: Double,
+                                    duration: TimeInterval) -> [HeadMotionSample] {
+        let count = sampleCount(for: duration, minimum: 6)
+        let peak = amplitude / 2
+        return (0..<count).map { index in
+            let value: Double
+            if index == 0 || index == count - 1 {
+                value = 0
+            } else {
+                value = index.isMultiple(of: 2) ? -peak : peak
+            }
+            return sample(at: start + Double(index) * sampleInterval,
+                          pitch: axis == .pitch ? value : 0,
+                          yaw: axis == .yaw ? value : 0)
+        }
+    }
+
+    /// Durations are quantized to the 25 Hz grid; `minimum` is the analyzer's `minSamples`
+    /// for the channel, below which no waveform can be detected at all.
+    private static func sampleCount(for duration: TimeInterval, minimum: Int) -> Int {
+        max(minimum, Int((duration / sampleInterval).rounded()))
+    }
+
+    private static func sample(at time: TimeInterval,
+                               pitch: Double = 0, yaw: Double = 0, roll: Double = 0,
+                               userAcceleration: MotionVector = .zero,
+                               rotationRate: MotionVector = .zero) -> HeadMotionSample {
+        HeadMotionSample(timestamp: time, pitch: pitch, yaw: yaw, roll: roll,
+                         userAcceleration: userAcceleration,
+                         rotationRate: rotationRate,
+                         gravity: uprightGravity)
+    }
+}
+
+extension HeadMotionSample {
+    /// The same sample on a new clock. Magnitude-only samples stay magnitude-only: the
+    /// per-axis initializer derives magnitudes from vectors and would zero them.
+    func restamped(to timestamp: TimeInterval) -> HeadMotionSample {
+        guard hasPerAxisData else {
+            return HeadMotionSample(timestamp: timestamp, pitch: pitch, yaw: yaw,
+                                    accelerationMagnitude: accelerationMagnitude,
+                                    rotationMagnitude: rotationMagnitude)
+        }
+        return HeadMotionSample(timestamp: timestamp, pitch: pitch, yaw: yaw, roll: roll,
+                                userAcceleration: userAcceleration,
+                                rotationRate: rotationRate,
+                                gravity: gravity)
+    }
+}

--- a/Tests/TapQDetectionE2ETests/TraceGenerators.swift
+++ b/Tests/TapQDetectionE2ETests/TraceGenerators.swift
@@ -208,6 +208,41 @@ enum TraceGenerators {
         }
     }
 
+    // MARK: - Wearer speech (jerk envelope)
+
+    /// The wearer talking: jaw- and skull-borne vibration as a sustained jerk envelope.
+    ///
+    /// `WearerSpeechDetector` differences consecutive acceleration samples, so the shape
+    /// that matters is the sample-to-sample *change*, not the level. Alternating ±`jerk`/2
+    /// makes every difference exactly `jerk`, which is therefore directly comparable to
+    /// `WearerSpeechConfig.envelopeEnterThreshold` (0.020 g); the default is 2x it.
+    /// `rotation` stays far under `rotationQuiet` (0.8 rad/s) — the gate that separates
+    /// speech from a nod. Samples carry per-axis data because attribution requires it.
+    ///
+    /// The default duration clears the detector's onset cost (a `windowSeconds` fill plus
+    /// `minimumSpeakingSeconds`, ~0.9 s) with room to spare.
+    static func speechEnvelope(startingAt start: TimeInterval = epoch,
+                               duration: TimeInterval = 1.5,
+                               jerk: Double = 0.040,
+                               rotation: Double = 0.02) -> [HeadMotionSample] {
+        let count = max(0, Int((duration / sampleInterval).rounded()))
+        return (0..<count).map { index in
+            let sign = index.isMultiple(of: 2) ? 1.0 : -1.0
+            return sample(at: start + Double(index) * sampleInterval,
+                          userAcceleration: MotionVector(x: sign * jerk / 2, y: 0, z: 0),
+                          rotationRate: MotionVector(x: 0, y: rotation, z: 0))
+        }
+    }
+
+    /// A worn but silent earbud: the same stream shape with an envelope at 0.33x
+    /// `envelopeExitThreshold` (0.012 g), so no window can read it as speech even while the
+    /// detector is already speaking. Still per-axis and still arriving, which is what keeps
+    /// the signal *available* — this is a quiet wearer, not a dead sensor.
+    static func restingJitter(startingAt start: TimeInterval = epoch,
+                              duration: TimeInterval) -> [HeadMotionSample] {
+        speechEnvelope(startingAt: start, duration: duration, jerk: 0.004)
+    }
+
     // MARK: - Rest
 
     /// A still, worn earbud: gravity only. Used to keep the stream continuous between

--- a/Tests/TapQDetectionE2ETests/TraceGenerators.swift
+++ b/Tests/TapQDetectionE2ETests/TraceGenerators.swift
@@ -130,6 +130,84 @@ enum TraceGenerators {
             + tap(startingAt: start + separation, amplitude: amplitude, rotation: rotation)
     }
 
+    // MARK: - Swipe
+
+    /// One finger drag along the bud: a gentle acceleration plateau with the head still,
+    /// bracketed by rest — the shape `SwipeAnalyzer` reads and `TapAnalyzer` does not.
+    ///
+    /// `amplitude` is the plateau's `|userAcceleration|` in g. The default sits ~1.7x
+    /// `SwipeConfig.elevatedLevel` (0.12) and below `TapConfig`'s elevated level (0.225),
+    /// so the drag is unambiguously a drag and never even starts a tap candidate.
+    /// `plateauSamples` must land inside
+    /// [`minElevatedSamples`, `maxElevatedSamples`] = [4, 14]; the rest samples on either
+    /// side fill the 0.8 s judging window and give the analyzer the quiet tail it needs.
+    ///
+    /// Direction follows the analyzer's convention: acceleration against gravity is
+    /// `.swipeUp`. With the earbud upright (`uprightGravity`), that is +z.
+    static func swipe(_ direction: MotionSwipeCommand,
+                      startingAt start: TimeInterval = epoch,
+                      amplitude: Double = 0.20,
+                      plateauSamples: Int = 8) -> [HeadMotionSample] {
+        let sign = direction == .swipeUp ? 1.0 : -1.0
+        let levels = [Double](repeating: 0, count: 4)
+            + [Double](repeating: sign * amplitude, count: plateauSamples)
+            + [Double](repeating: 0, count: 6)
+        return levels.enumerated().map { index, level in
+            sample(at: start + Double(index) * sampleInterval,
+                   userAcceleration: MotionVector(x: 0, y: 0, z: level))
+        }
+    }
+
+    // MARK: - Ambient noise
+
+    /// A worn earbud on a walking, looking-around user: nothing deliberate, everything
+    /// moving. Walking-cadence bob on pitch with matching footfall acceleration, a slow
+    /// head turn on yaw, and the lateral lean that rides along on roll.
+    ///
+    /// Every channel is bounded at `fraction` of the threshold that channel's analyzer
+    /// measures, computed from the shipping configs so the bound tracks the defaults
+    /// rather than a copied number. Peaks are halved where the analyzer measures
+    /// peak-to-peak or deviation-from-baseline, so no sliding window can see more than
+    /// `fraction` of a threshold no matter where it lands. `fraction` must stay at or
+    /// below 0.5 (D6): this trace exists to prove that plausible non-input stays
+    /// non-input, which says nothing if it is generated at the margin.
+    static func ambientNoise(startingAt start: TimeInterval = epoch,
+                             duration: TimeInterval = 6.0,
+                             fraction: Double = 0.4) -> [HeadMotionSample] {
+        let gesture = HeadGestureConfig()
+        let tap = TapConfig()
+        let tilt = TiltConfig()
+        let pitchPeak = fraction * gesture.amplitudeThreshold / 2
+        let yawPeak = fraction * gesture.amplitudeThreshold / 2
+        let rollPeak = fraction * tilt.amplitudeThreshold / 2
+        let accelerationPeak = fraction * tap.amplitudeThreshold
+        let rotationPeak = fraction * tap.rotationQuiet
+
+        let count = max(0, Int((duration / sampleInterval).rounded()))
+        return (0..<count).map { index in
+            let seconds = Double(index) * sampleInterval
+            // ~1.9 Hz strides and a ~9 s look-around, deliberately incommensurate so the
+            // two motions never settle into a repeating combined shape.
+            let stride = 2 * .pi * 1.9 * seconds
+            let turn = 2 * .pi * 0.11 * seconds
+            // Two footfalls per stride, and the head is never perfectly still between
+            // them, so |accel| touches zero only at the crossings.
+            let footfall = accelerationPeak * abs(sin(stride))
+            return sample(
+                at: start + seconds,
+                pitch: pitchPeak * sin(stride),
+                yaw: yawPeak * sin(turn),
+                roll: rollPeak * sin(turn + .pi / 3),
+                userAcceleration: MotionVector(x: 0, y: 0, z: footfall),
+                // Split across two axes with weights whose quadrature sum is under 1, so
+                // the magnitude stays inside `rotationPeak` at every phase.
+                rotationRate: MotionVector(x: 0.3 * rotationPeak * sin(stride),
+                                           y: 0.7 * rotationPeak * cos(turn),
+                                           z: 0)
+            )
+        }
+    }
+
     // MARK: - Rest
 
     /// A still, worn earbud: gravity only. Used to keep the stream continuous between

--- a/Tests/TapQDetectionE2ETests/WearerPathE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/WearerPathE2ETests.swift
@@ -40,6 +40,7 @@ final class WearerPathE2ETests: XCTestCase {
         harness.hear("yes")
 
         let allowed = await approved.value
+        harness.assertWatchdogDidNotFire()
         XCTAssertEqual(allowed, .allow)
 
         // (b) Nobody in the room is wearing the earbuds. The same transcript arrives with
@@ -75,6 +76,7 @@ final class WearerPathE2ETests: XCTestCase {
         harness.hear("yes")
 
         let passedThrough = await failedOpen.value
+        harness.assertWatchdogDidNotFire()
         XCTAssertEqual(passedThrough, .allow, "a dead signal must fail open, not deny")
         XCTAssertTrue(harness.diagnostics.events.contains {
             $0.name == "command.passed_signal_unavailable"

--- a/Tests/TapQDetectionE2ETests/WearerPathE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/WearerPathE2ETests.swift
@@ -1,0 +1,179 @@
+import XCTest
+import TapQContracts
+import TapQDetectionBaseline
+@testable import TapQInteractionBaseline
+
+/// Tier 3: the M2 wearer paths, where the IMU answers questions the microphone cannot —
+/// who said that, and is the wearer still talking.
+///
+/// Both tests drive a real `WearerSpeechMonitor` with a synthetic jerk envelope, so the
+/// speaking/quiet answers, the hangover, and the staleness horizon are all the shipping
+/// detector's own. The stream's timestamps and the monotonic clock the consumers read are
+/// the same clock, which is what makes "inside the attribution window" mean what it says.
+@MainActor
+final class WearerPathE2ETests: XCTestCase {
+    /// One approval prompt answered three times over, by the same word from three different
+    /// worlds: the wearer said it, somebody else said it, and nobody can tell.
+    func testOnlyTheWearersYesApproves() async throws {
+        let clock = StreamClock()
+        let monitor = WearerSpeechMonitor(monotonicNow: { clock.now })
+        let signal = MonitorSpeechSignal(monitor: monitor)
+        let harness = DetectionPathHarness(voiceGate: { channel, sink in
+            WearerGatedVoice(wrapping: channel, signal: signal,
+                             monotonicNow: { clock.now }, diagnosticSink: sink)
+        })
+        var cursor = TraceGenerators.epoch
+
+        // (a) The wearer speaks, stops, and the recognizer's match lands a few hundred
+        // milliseconds later — the ordinary case, and the reason the window looks backwards.
+        let approved = Task { await harness.interaction.resolve(Self.request) }
+        let firstWindow = await harness.waitForWindow(1)
+        XCTAssertTrue(firstWindow)
+
+        cursor = stream(TraceGenerators.speechEnvelope(startingAt: cursor),
+                        into: monitor, clock: clock)
+        XCTAssertEqual(monitor.state, .speaking, "the envelope must read as wearer speech")
+        cursor = stream(TraceGenerators.restingJitter(startingAt: cursor, duration: 1.0),
+                        into: monitor, clock: clock)
+        XCTAssertEqual(monitor.state, .quiet, "the utterance must be over when the match lands")
+        XCTAssertTrue(signal.isSignalAvailable, "a quiet wearer is not an absent signal")
+        harness.hear("yes")
+
+        let allowed = await approved.value
+        XCTAssertEqual(allowed, .allow)
+
+        // (b) Nobody in the room is wearing the earbuds. The same transcript arrives with
+        // the wearer's last speech well outside the attribution window.
+        let deferred = Task { await harness.interaction.resolve(Self.request) }
+        let secondWindow = await harness.waitForWindow(2)
+        XCTAssertTrue(secondWindow)
+
+        cursor = stream(TraceGenerators.restingJitter(startingAt: cursor, duration: 3.0),
+                        into: monitor, clock: clock)
+        harness.hear("yes")
+
+        XCTAssertEqual(harness.diagnostics.events.filter { $0.name == "input.voice" }.count, 1,
+                       "a bystander's yes reached the arbiter")
+        let rejection = try XCTUnwrap(
+            harness.diagnostics.events.last { $0.name == "command.rejected_nonwearer" },
+            "the gate dropped the command without saying why"
+        )
+        XCTAssertEqual(rejection.fields["attribution_window_seconds"], "2.000")
+
+        harness.timeouts.expire()
+        let outcome = await deferred.value
+        XCTAssertEqual(outcome, .ask, "an unattributed approval defers; it never allows")
+
+        // (c) The stream stops — AirPods asleep, motion updates gone. Attribution may only
+        // ever remove commands it is sure about, so an absent signal answers as it always did.
+        let failedOpen = Task { await harness.interaction.resolve(Self.request) }
+        let thirdWindow = await harness.waitForWindow(3)
+        XCTAssertTrue(thirdWindow)
+
+        clock.now += monitor.stalenessHorizon + Self.beyondStaleness
+        XCTAssertFalse(signal.isSignalAvailable, "the stalled stream must read as unavailable")
+        harness.hear("yes")
+
+        let passedThrough = await failedOpen.value
+        XCTAssertEqual(passedThrough, .allow, "a dead signal must fail open, not deny")
+        XCTAssertTrue(harness.diagnostics.events.contains {
+            $0.name == "command.passed_signal_unavailable"
+        })
+        XCTAssertEqual(harness.inputs.openedWindows, 3, "one window per phase, no re-listens")
+    }
+
+    /// The agent is mid-sentence and the wearer starts talking over it: the response is cut
+    /// off on the spot, and when the wearer stops, the turn commits a delay later.
+    func testSpeechOnsetInterruptsPlaybackAndSilenceEndpointsTheTurn() async {
+        let clock = StreamClock()
+        let monitor = WearerSpeechMonitor(monotonicNow: { clock.now })
+        let signal = MonitorSpeechSignal(monitor: monitor)
+        let turn = TurnRecorder()
+        let coordinator = WearerTurnCoordinator(
+            signal: signal,
+            endpoint: { turn.endpoint() },
+            interruptPlayback: { turn.interrupt() },
+            isResponsePlaying: { turn.isResponsePlaying },
+            isUserTurnActive: { true },
+            delaySleep: { await turn.sleep($0) }
+        )
+        coordinator.start()
+        turn.beginResponse()
+        var cursor = TraceGenerators.epoch
+
+        cursor = stream(TraceGenerators.speechEnvelope(startingAt: cursor),
+                        into: monitor, clock: clock)
+
+        XCTAssertEqual(monitor.state, .speaking)
+        XCTAssertEqual(turn.interruptions, 1, "speech onset over a response must barge in")
+        XCTAssertFalse(turn.isResponsePlaying)
+        XCTAssertEqual(turn.endpoints, 0, "barge-in is not an endpoint")
+
+        cursor = stream(TraceGenerators.restingJitter(startingAt: cursor, duration: 1.0),
+                        into: monitor, clock: clock)
+        await settle()
+
+        XCTAssertEqual(monitor.state, .quiet)
+        XCTAssertEqual(turn.requestedDelays, [WearerTurnCoordinator.defaultEndpointDelay],
+                       "the commit must wait exactly the configured endpoint delay")
+        XCTAssertEqual(WearerTurnCoordinator.defaultEndpointDelay, 0.4)
+        XCTAssertEqual(turn.endpoints, 1, "the silence must commit the turn exactly once")
+        XCTAssertEqual(turn.interruptions, 1, "the response was already cut off")
+    }
+
+    // MARK: - Stream plumbing
+
+    /// Feeds a trace to the monitor with the monotonic clock pinned to each sample's own
+    /// timestamp, so freshness and the attribution window are measured in stream time
+    /// rather than in wall-clock time this test does not control. Returns where the next
+    /// contiguous trace starts — a gap wider than `maxSampleGapSeconds` would reset the
+    /// detector instead of continuing the stream.
+    @discardableResult
+    private func stream(_ trace: [HeadMotionSample],
+                        into monitor: WearerSpeechMonitor,
+                        clock: StreamClock) -> TimeInterval {
+        for sample in trace {
+            clock.now = sample.timestamp
+            monitor.ingest(sample)
+        }
+        return (trace.last?.timestamp ?? clock.now) + TraceGenerators.sampleInterval
+    }
+
+    /// Yields the main actor enough for the coordinator's endpoint-delay task to run.
+    private func settle() async {
+        for _ in 0..<4 { await Task.yield() }
+    }
+
+    /// The monotonic clock the monitor and the wearer gate both read. Not `VirtualClock`:
+    /// these consumers take a `TimeInterval` seam, not a `ContinuousClock.Instant` one.
+    private final class StreamClock {
+        var now: TimeInterval = TraceGenerators.epoch
+    }
+
+    /// The runtime side of turn control. `interrupt` flushes the audio exactly as the live
+    /// closure does, so the endpoint half of the test runs against a response already cut
+    /// off, and `sleep` records what the coordinator asked to wait instead of waiting.
+    @MainActor
+    private final class TurnRecorder {
+        private(set) var isResponsePlaying = false
+        private(set) var interruptions = 0
+        private(set) var endpoints = 0
+        private(set) var requestedDelays: [TimeInterval] = []
+
+        func beginResponse() { isResponsePlaying = true }
+        func interrupt() {
+            interruptions += 1
+            isResponsePlaying = false
+        }
+        func endpoint() { endpoints += 1 }
+        func sleep(_ seconds: TimeInterval) async { requestedDelays.append(seconds) }
+    }
+
+    /// Comfortably past the horizon: the stream has stopped, not merely jittered.
+    private static let beyondStaleness: TimeInterval = 0.1
+
+    private static let request = ApprovalRequest(
+        id: "r1", sessionID: "s1", toolName: "Bash",
+        summary: "run the test suite", detail: "swift test"
+    )
+}

--- a/docs/E2E_DETECTION_TEST_PLAN.md
+++ b/docs/E2E_DETECTION_TEST_PLAN.md
@@ -1,0 +1,192 @@
+# End-to-end detection-path test plan
+
+Status: ratified by the orchestrator, 2026-08-09. This document is the authoritative
+spec for the `e2e-detection-paths` branch. Implementation agents follow it exactly;
+deviations require an explicit note in the commit message explaining why.
+
+## Goal
+
+An automated suite that feeds simulated AirPods IMU sample streams (and transcript
+strings for voice) through the **real, fully composed detection-to-decision
+pipeline** and asserts on the resulting `Decision` / `SelectionResult` / wire
+response. Today, unit tests stop at detector outputs, `tapq replay` stops at
+`MotionDetectionResult`, and broker tests start above detection with faked inputs —
+no automated test exercises the whole critical path. This suite closes that gap.
+
+Deliberately small: ~10–12 new tests total. Quality and realism of composition over
+quantity.
+
+## Non-goals
+
+- **Not** a real-world accuracy validation. Synthetic traces are shaped by
+  construction; the capture study remains the accuracy gate for all IMU defaults.
+- No live audio, network, or hardware in tests (house rule).
+- No changes to runtime behavior except the one seam in D5. Flagless defaults must
+  remain byte-identical.
+
+## What exists (verified by exploration; line numbers approximate — re-verify on read)
+
+- Sample type: `Sources/TapQDetectionBaseline/HeadMotionSample.swift` (`MotionVector`,
+  per-axis + magnitude fields, `hasPerAxisData`).
+- Detectors (all portable, synchronous, timestamp-driven — no clock injection
+  needed): `MotionGesturePipeline` (`ingest(_:)` → nod/shake via `GestureAnalyzer`,
+  tap via `TapAnalyzer`, roll-tilt via `TiltAnalyzer`, swipe via `SwipeAnalyzer`,
+  swipe default **off**). Configs with thresholds: `HeadGestureConfig` (amplitude
+  0.30 rad), `TapConfig` (amplitude 0.45 g, rotationQuiet 0.6 rad/s),
+  `TiltConfig` (amplitude 0.18 rad), `SwipeConfig`.
+- Voice: `VoiceCommandMatcher` (transcript `String` → `VoiceCommand?`; negation
+  words make `.yes` unreachable).
+- Decision layer: `InputArbiter` (nod→`.allow`, shake→`.deny`, first-wins),
+  `SelectionArbiter` (nod→`.select`, tilt→`.next`/`.previous`), `InteractionController`
+  (`resolve(_:deadline:requiredConfirmation:)`, clock seam `var now`),
+  `SelectionController` (same seam), `RequiredConfirmation.gestureAndVoice` +
+  `ResolvedInput` channel provenance, `BrokerServer` (`handle(_ data:)` → response
+  bytes; transport is the tiny `BrokerTransport` protocol).
+- M2 components (on main): `WearerSpeechDetector`/`WearerSpeechMonitor`
+  (synthetic jerk-envelope streams; injectable `monotonicNow`), `WearerGatedVoice`
+  (fail-open when signal unavailable, `defaultAttributionWindow` 2.0 s),
+  `WearerTurnCoordinator` (injectable `delaySleep`, endpoint delay 0.4 s).
+- Existing waveform precedent: `feedNod`/`feedShake`/`feedTap` in
+  `Tests/TapQDetectionBaselineTests/MotionGesturePipelineTests.swift`, `feedTilt` in
+  `MotionPipelineTiltTests.swift`, `StreamBuilder` in `WearerSpeechMonitorTests.swift`.
+- Trace format + replay: `Sources/TapQCLI/MotionCapture.swift`
+  (`MotionSampleFormatter`, JSONL `CaptureRecord`) and
+  `Sources/TapQCLI/CaptureReplay.swift` (`MotionCaptureReader`, `ReplayEvaluator`,
+  `ReplayBackendRunner` — all internal to `TapQCLI`).
+- Test clock precedent: `VirtualClock` in
+  `Tests/TapQInteractionBaselineTests/InteractionDeadlineTests.swift`.
+- Known gap: `InputArbiter` timeout uses raw `Task.sleep` with no seam
+  (`Sources/TapQInteractionBaseline/InputArbiter.swift`, ~line 71).
+
+## Ratified decisions
+
+- **D1 — Location.** New test target `TapQDetectionE2ETests` in the portable test
+  graph (must build and run on Linux). Depends on `TapQDetectionBaseline`,
+  `TapQInteractionBaseline`, `TapQBrokerRuntime`, `TapQContracts`, and
+  `@testable import TapQCLI` (for `MotionCaptureReader`/`MotionSampleFormatter` in
+  the compatibility test only). If wiring a dedicated target fights
+  `scripts/check-public-boundary.sh` or the Package graph disproportionately, fall
+  back to placing the suite inside `Tests/TapQCLITests/` under an `E2E` subfolder —
+  and say so in the commit message. Do NOT widen any `internal` type to `public`
+  for this suite.
+- **D2 — Traces are generated in code, not checked in.** A shared
+  `TraceGenerators` helper (test-support source in the new target) produces
+  deterministic 25 Hz timestamped `[HeadMotionSample]` waveforms parameterized by
+  amplitude/duration/axis. No fixture files. One **compatibility test** serializes
+  a generated nod trace through `MotionSampleFormatter` JSONL, reads it back with
+  `MotionCaptureReader`, asserts sample fidelity, and runs the samples through the
+  pipeline to the same detection — proving every generated trace is also
+  `tapq replay`-runnable. No `Date.now`/randomness in generators; fully
+  deterministic timestamps starting at a fixed epoch.
+- **D3 — Composition.** The harness composes the REAL portable stack:
+  `MotionGesturePipeline` → a small `PipelineInputAdapter` test shim that conforms
+  to the input-providing protocols (`HeadGestureProviding`, `TapCommandProviding`,
+  `TiltCommandProviding`, swipe equivalent) by forwarding pipeline callbacks →
+  real `InputArbiter`/`SelectionArbiter` → real
+  `InteractionController`/`SelectionController` with `VirtualClock` on the `now`
+  seam. The shim forwards; it must not filter, debounce, or interpret. Voice enters
+  as transcript strings through the real `VoiceCommandMatcher` (wrapped in a
+  minimal `VoiceCommandProviding` shim), never as pre-built `VoiceCommand` values,
+  so the matcher's grammar is inside the tested path.
+- **D4 — At least one wire-to-wire test.** Tier 1 case 1 must go bytes-in →
+  bytes-out through a real `BrokerServer` with an in-memory fake transport
+  (approval request JSON in, response JSON out, wire protocol v4), with the broker's
+  approval closure wired to the real controller+arbiter+pipeline harness. Remaining
+  cases may stop at `InteractionController.resolve` / `SelectionController.resolve`
+  to stay focused.
+- **D5 — InputArbiter timeout seam.** Add an injectable async sleep seam to
+  `InputArbiter` (and `SelectionArbiter` if it shares the raw `Task.sleep`
+  pattern), following the existing house pattern (`delaySleep`/`idleSleep` in the
+  M2 components): default remains `Task.sleep`, runtime behavior unchanged, tests
+  inject an instant or controllable sleep. Smallest possible diff.
+- **D6 — Margins, not knife edges.** Positive traces at ≥1.5× the relevant
+  detection threshold; negative traces ≤0.5× or built to trip a specific analyzer
+  rejection reason. Never generate at the margin — the suite must catch gross
+  config drift without flakiness.
+- **D7 — House test idioms.** Class-level `@MainActor` + `async` test methods
+  (Linux-safe; sync `@MainActor` tests do not compile on Linux). Polling via the
+  existing `waitUntil`-style helper where needed. `RecordingSink` on
+  `TapQDiagnosticSink` for pipeline-internal assertions where useful. No
+  `XCTestExpectation` for actor hops.
+- **D8 — Docs and changelog.** One `### Added` line under `[Unreleased]` in
+  `CHANGELOG.md`. A README-style header comment at the top of the harness file
+  explaining what the suite guarantees (wiring/config/logic regressions) and what
+  it does not (real-world accuracy — capture study). No other doc changes.
+
+## Test cases
+
+### Tier 1 — core approval loop (WP1)
+
+1. **Nod approves, wire-to-wire.** Broker approval request bytes → harness → nod
+   trace ingested → response bytes carry allow. (D4 path.)
+2. **Shake denies.** Approval prompt via controller → shake trace → `.deny`.
+3. **Selection: tilt, tilt, nod.** Selection prompt with ≥3 options → tilt-right
+   trace → `.next`; tilt-right → `.next`; nod → `.select` of the expected index.
+   Sequential prompts through `SelectionController`.
+4. **gestureAndVoice confirmation.** Approval with
+   `RequiredConfirmation.gestureAndVoice`: nod alone must NOT resolve; nod + spoken
+   "yes" (transcript through the real matcher) resolves `.allow`. Verify the
+   channel-provenance rules exactly as `InteractionConfirmationTests` models them.
+5. **Compatibility test** (also WP1): generated trace → JSONL → `MotionCaptureReader`
+   → pipeline → same detection as the in-memory run (D2).
+
+### Tier 2 — false-positive rejection (WP2)
+
+6. **Ambient noise never approves.** A sustained mixed-motion noise trace
+   (walking-cadence low-amplitude oscillation + slow head turns, all ≤0.5×
+   thresholds) fed during an approval window → no input resolves; the controller
+   takes its timeout path (verify actual timeout semantics in
+   `InteractionController` — assert the exact outcome, and that it is not
+   `.allow`).
+7. **Rotation-contaminated tap rejected.** A tap-amplitude accel spike with
+   concurrent rotation above `rotationQuiet` → `TapAnalyzer` rejects; no tap intent
+   reaches the arbiter (assert via diagnostics sink rejection reason + no
+   resolution).
+8. **Flagless default: swipe stays off.** A clean swipe trace with default pipeline
+   config produces no selection movement; the same trace with
+   `swipeDetectionEnabled = true` produces `.next`/`.previous` — proving both the
+   default-off guarantee and that the trace is a real swipe.
+
+### Tier 3 — M2 wearer/voice paths (WP3)
+
+9. **Wearer-gate trio** (one test, three phases, real `WearerGatedVoice` +
+   `WearerSpeechMonitor` fed synthetic jerk envelopes):
+   (a) "yes" transcript with wearer-speech IMU envelope inside the attribution
+   window → accepted; (b) "yes" with quiet IMU (bystander) → rejected; (c) IMU
+   signal unavailable/stale → fail-open accepted.
+10. **Turn control: barge-in + endpoint.** Real `WearerTurnCoordinator` driven by a
+    real `WearerSpeechMonitor` ingesting a synthetic envelope: speech onset during
+    response playback fires `interruptPlayback`; speech end fires `endpoint()`
+    after the 0.4 s delay (inject `delaySleep`; assert delay was requested with the
+    configured duration).
+
+## Work packages (sequential; commit after each)
+
+- **WP1 — Seam, generators, harness, Tier 1.**
+  1. D5 seam in `InputArbiter` (+`SelectionArbiter` if applicable) with existing
+     unit tests still green.
+  2. New target `TapQDetectionE2ETests` (D1) with `TraceGenerators` (D2) and the
+     composition harness (D3).
+  3. Tests 1–5.
+  Acceptance: new tests green; full `swift build` green; existing suite untouched
+  and green in the affected targets; boundary script green.
+- **WP2 — Tier 2.** Tests 6–8, reusing generators (extend with noise + swipe
+  waveforms). Acceptance: same bar.
+- **WP3 — Tier 3 + polish.** Tests 9–10; CHANGELOG line + harness header comment
+  (D8); run the FULL test suite and report the total count. Acceptance: full suite
+  green.
+
+## Execution rules (binding on all agents)
+
+- Work ONLY in `/Users/finale/tapq-open/.claude/worktrees/e2e-detection-paths`.
+  Use absolute paths and `git -C` for every git command; never rely on the shell
+  cwd persisting.
+- Never pipe build/test output through `tail`/`head` in a way that masks exit
+  codes: redirect to a file under the scratchpad and echo `$?` separately, then
+  read the file.
+- Do not push. Do not touch `VERSION`, `Info.plist`, version constants, or
+  `docs/CLI.md`'s version JSON. CHANGELOG: only the one `[Unreleased]` line in WP3.
+- Match surrounding code style; comments only for constraints code can't express.
+- Commit messages: imperative, concise subject; body explains any deviation from
+  this plan; end with the Co-Authored-By line for Claude.
+- Verify line numbers by reading files; this plan's references may be stale.


### PR DESCRIPTION
Automated E2E coverage for the critical detection paths: deterministic simulated AirPods IMU traces (and transcript strings for voice) driven through the real, fully composed pipeline — `MotionGesturePipeline` → arbiters → controllers → `BrokerServer` — asserting on the resulting decision, selection, or wire response.

## What's here

- **New portable test target `TapQDetectionE2ETests`** (10 tests, runs in the Linux graph): shared deterministic 25 Hz trace generators, a forwarding-only harness composing the real stack, and a `VirtualClock`/injectable-timeout setup so nothing sleeps for real.
- **Tier 1 — core approval loop**: nod approves wire-to-wire through a real `BrokerServer` (protocol v4 bytes in/out); shake denies; tilt-tilt-nod selects the third option; `gestureAndVoice` requires both channels (voice goes through the real `VoiceCommandMatcher`).
- **Tier 2 — false-positive rejection**: sustained ambient noise never approves (controller defers to screen); a rotation-contaminated tap is rejected with the analyzer's named reason; swipe stays inert under flagless defaults and works only when explicitly enabled.
- **Tier 3 — M2 wearer/voice paths**: only the wearer's "yes" approves (attributed / bystander-rejected / fail-open when the signal is stale — all three phases against the real `WearerGatedVoice` + `WearerSpeechMonitor`); speech onset barge-in + 0.4 s endpoint via the real `WearerTurnCoordinator`.
- **Replay compatibility**: generated traces round-trip through the capture JSONL format (`MotionSampleFormatter` → `MotionCaptureReader`) and detect identically, so every waveform is also `tapq replay`-runnable.
- **One production change**: an injectable timeout-sleep seam in `InputArbiter`/`SelectionArbiter`; the default is byte-identical to the old inline `Task.sleep`.
- A 20 s watchdog bounds every decision wait, so a missed detection fails with a named assertion instead of hanging the suite.

## What this does and doesn't guarantee

Catches wiring, config-drift, and decision-logic regressions across the whole sample-to-decision path (mutation-checked: breaking a detection threshold or unwiring an input channel turns tests red). It is **not** a real-world accuracy claim — synthetic traces are shaped by construction; the capture study remains the accuracy gate, and its recorded traces can later drop into this same harness as golden fixtures.

Plan with ratified decisions: `docs/E2E_DETECTION_TEST_PLAN.md`. Suite: 1,455 → 1,465 tests, all green locally (macOS); Linux CI is the final portability gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)