### PR TITLE
Degrade to a plain voice agent when no AirPods are connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Added
 
+- A one-time spoken startup notice when no AirPods are connected: "No AirPods detected.
+  Running voice only." — or "Prompts will use the screen." when voice is unavailable too.
+  It is polled on the detector's own bounded availability cadence, so headphones that are
+  merely slow to appear never draw a spurious notice, and unlike the mid-window disconnect
+  announcement it is a status line and respects `--no-announcements`.
+- `MotionGatedSwipes`, a gating decorator beside `SpeechGatedVoice` and `WearerGatedVoice`
+  that attaches the volume-swipe channel only while a motion device is present.
+  `VolumeSwipeDetector` reads the default output device's volume, so without AirPods it was
+  reading the built-in speaker and turning volume-key presses into selection navigation.
+  Eligibility is re-read per window, which is also the recovery path: AirPods connected
+  mid-session restore swipes on the next prompt.
+- An availability-aware selection hint. `SelectionController` takes a `controlsHint`
+  provider, consulted when a hint is actually spoken, so a voice-only window teaches
+  `SelectionController.voiceOnlyControlsHint` — "Say next, previous, or select." — rather
+  than naming volume swipes and nods that cannot resolve the question. The default provider
+  keeps the existing wording, and reading it per prompt means "repeat" after AirPods
+  connect re-teaches the full controls.
+- The ready banner's motion line now says what a session without AirPods is rather than
+  what it lacks: `unavailable (voice-only; gestures return when AirPods connect)`.
 - An end-to-end detection-path test suite. Generated 25 Hz IMU traces (and transcript
   strings for voice) run through the real, fully composed stack — pipeline, analyzers,
   arbiters, controllers, voice grammar, wearer gate, turn coordinator, and broker — and the
@@ -16,6 +35,28 @@ All notable changes to TapQ will be recorded in this file. The project uses
   wearer-attribution and turn-control paths. It is a regression net for wiring, config and
   decision logic only: every trace is shaped by construction, so the capture study remains
   the accuracy gate for every IMU default.
+
+### Changed
+
+- Serving with no AirPods connected degrades to a plain voice agent instead of announcing
+  a disconnection that never happened. Every response window used to end its bounded motion
+  retry by speaking "AirPods motion disconnected. Deferring to the screen.", cancelling
+  both arbiters — which took the live voice window down with the dead gesture one — and
+  then speaking "Deferring to the screen." a second time from the cancel path. Such a
+  window now continues silently on voice and resolves by voice or by its ordinary timeout.
+  Voice I/O already followed the system default route, so prompts speak on the Mac's
+  speaker and answer through its microphone with no audio change.
+- The mid-window disconnect announcement is trimmed to "AirPods motion disconnected." The
+  cancel path it triggers already ends in "Deferring to the screen."; the contract is
+  otherwise unchanged, including that this one announcement still ignores
+  `--no-announcements` because an inaudible state change mid-interaction strands the user.
+- `HeadGestureDetector.onMotionLost` carries a `MotionLossReason` — `.neverStreamed`,
+  `.lostWhileStreaming`, or `.silentStream` — which is what the host branches on, and the
+  `motion.lost` diagnostic gains the matching `reason` field. A pre-1.0 source break for
+  anything outside this repository that assigns the callback. `isMotionCurrentlyAvailable`
+  is the accompanying instance probe: it asks the detector's own source rather than
+  building a throwaway `CMHeadphoneMotionManager`, so availability can be consulted per
+  response window without a second manager competing for the headphones.
 
 ## [0.5.0-beta.2] - 2026-08-08
 

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -343,9 +343,21 @@ import Darwin
         )
         let interactionGate = InteractionGate()
 
-        gestures.onMotionLost = { _ in
+        // A disconnect is only worth interrupting the user about when there was something
+        // to disconnect. `.neverStreamed` means no AirPods were connected when this window
+        // opened, which every window in a no-AirPods session reports once its bounded
+        // availability retry expires: announcing it would say "disconnected" about hardware
+        // the user never put in, and cancelling would take the live voice window down with
+        // it. So the window stays open and resolves by voice or by its ordinary timeout.
+        //
+        // The remaining reasons are a real mid-window outage. That announcement deliberately
+        // ignores `--no-announcements`: an inaudible state change mid-interaction strands
+        // the user. It stops at the state change, because the cancel below already ends in
+        // `deferToScreen()`, which speaks "Deferring to the screen." itself.
+        gestures.onMotionLost = { reason in
+            guard reason != .neverStreamed else { return }
             speech.speak(
-                "AirPods motion disconnected. Deferring to the screen.",
+                "AirPods motion disconnected.",
                 priority: .notification,
                 onFinish: nil
             )

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -320,7 +320,15 @@ import Darwin
             diagnosticSink: diagnostics
         )
 
-        let volumeSwipe = VolumeSwipeDetector(diagnosticSink: diagnostics)
+        // The detector reads the *default output device's* volume, which without AirPods is
+        // the built-in speaker — every volume-key press during a selection window would
+        // navigate. The gate is re-consulted per window, so connecting AirPods mid-session
+        // brings swipes back on the next prompt.
+        let volumeSwipe = MotionGatedSwipes(
+            wrapping: VolumeSwipeDetector(diagnosticSink: diagnostics),
+            isEligible: { gestures.isMotionCurrentlyAvailable },
+            diagnosticSink: diagnostics
+        )
         let selectionArbiter = SelectionArbiter(
             voice: voice,
             // Tilt navigation is the roll-axis double tilt: roll is orthogonal to nod

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -365,6 +365,32 @@ import Darwin
             selectionArbiter.cancel()
         }
 
+        // Said once, or never. With no AirPods connected nothing else in the session will
+        // mention it — that is the point of the branch above — so without this the user
+        // hears prompts on the Mac speaker and is left to infer why nodding does nothing.
+        //
+        // Polled on the detector's own availability cadence (6 × 250 ms is the same
+        // bounded retry `waitForMotionAvailability` runs) so headphones that are merely
+        // slow to appear never draw a spurious notice. Unlike the mid-window disconnect
+        // announcement, which has to be audible or the user is stranded mid-interaction,
+        // this is a status line and respects `--no-announcements`.
+        let startupNotice: Task<Void, Never>? = configuration.announcementsEnabled
+            ? Task { @MainActor in
+                for _ in 0..<6 {
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                    guard !Task.isCancelled else { return }
+                    guard !gestures.isMotionCurrentlyAvailable else { return }
+                }
+                speech.speak(
+                    voiceAuthorized
+                        ? "No AirPods detected. Running voice only."
+                        : "No AirPods detected. Prompts will use the screen.",
+                    priority: .notification,
+                    onFinish: nil
+                )
+            }
+            : nil
+
         let discovery = BrokerRuntimeDiscovery(
             supportDirectory: configuration.brokerDirectory
         )
@@ -561,7 +587,9 @@ import Darwin
             discoveryPath: discovery.discoveryURL.path,
             gestureProfileLoaded: gestureProfile != nil,
             tapProfileLoaded: tapProfile != nil,
-            motionAvailable: HeadGestureDetector.isAvailable,
+            // The composed detector's own probe, not the static one: identical answer
+            // without a second `CMHeadphoneMotionManager` competing for the headphones.
+            motionAvailable: gestures.isMotionCurrentlyAvailable,
             voiceAvailable: voiceAuthorized,
             voiceBackendStatus: configuration.voiceBackend.statusDescription,
             encoderStatus: encoderStatus,
@@ -571,6 +599,7 @@ import Darwin
 
         defer {
             finishShutdownWait()
+            startupNotice?.cancel()
             turnCoordinator?.stop()
             // Prevent ARC from releasing the wearer-speech source at the
             // waitForShutdown suspension. HeadGestureDetector and every ChildSignal hold

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -382,32 +382,6 @@ import Darwin
             selectionArbiter.cancel()
         }
 
-        // Said once, or never. With no AirPods connected nothing else in the session will
-        // mention it — that is the point of the branch above — so without this the user
-        // hears prompts on the Mac speaker and is left to infer why nodding does nothing.
-        //
-        // Polled on the detector's own availability cadence (6 × 250 ms is the same
-        // bounded retry `waitForMotionAvailability` runs) so headphones that are merely
-        // slow to appear never draw a spurious notice. Unlike the mid-window disconnect
-        // announcement, which has to be audible or the user is stranded mid-interaction,
-        // this is a status line and respects `--no-announcements`.
-        let startupNotice: Task<Void, Never>? = configuration.announcementsEnabled
-            ? Task { @MainActor in
-                for _ in 0..<6 {
-                    try? await Task.sleep(nanoseconds: 250_000_000)
-                    guard !Task.isCancelled else { return }
-                    guard !gestures.isMotionCurrentlyAvailable else { return }
-                }
-                speech.speak(
-                    voiceAuthorized
-                        ? "No AirPods detected. Running voice only."
-                        : "No AirPods detected. Prompts will use the screen.",
-                    priority: .notification,
-                    onFinish: nil
-                )
-            }
-            : nil
-
         let discovery = BrokerRuntimeDiscovery(
             supportDirectory: configuration.brokerDirectory
         )
@@ -598,6 +572,37 @@ import Darwin
             discovery.remove()
             throw error
         }
+
+        // Said once, or never. With no AirPods connected nothing else in the session will
+        // mention it — that is the point of the `.neverStreamed` branch above — so without
+        // this the user hears prompts on the Mac speaker and is left to infer why nodding
+        // does nothing.
+        //
+        // Polled on the detector's own availability cadence (6 × 250 ms is the same bounded
+        // retry `waitForMotionAvailability` runs) so headphones that are merely slow to
+        // appear never draw a spurious notice. Unlike the mid-window disconnect
+        // announcement, which has to be audible or the user is stranded mid-interaction,
+        // this is a status line and respects `--no-announcements`.
+        //
+        // Started here, past every throwing step and immediately before the `defer` that
+        // cancels it, so an aborted startup can never leave a notice to speak over the
+        // failure. It does not block: `onReady` runs on the next line.
+        let startupNotice: Task<Void, Never>? = configuration.announcementsEnabled
+            ? Task { @MainActor in
+                for _ in 0..<6 {
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                    guard !Task.isCancelled else { return }
+                    guard !gestures.isMotionCurrentlyAvailable else { return }
+                }
+                speech.speak(
+                    voiceAuthorized
+                        ? "No AirPods detected. Running voice only."
+                        : "No AirPods detected. Prompts will use the screen.",
+                    priority: .notification,
+                    onFinish: nil
+                )
+            }
+            : nil
 
         onReady(.init(
             socketPath: discovery.socketPath,

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -347,6 +347,15 @@ import Darwin
             speech: speech,
             arbiter: selectionArbiter,
             timeout: configuration.interactionTimeout,
+            // Teach only controls that can actually resolve the question. Without a motion
+            // device, volume swipes are gated off and nods never arrive, so naming them
+            // would send the user through gestures that cannot work. Read per prompt, so
+            // an explicit "repeat" after AirPods connect re-teaches the full controls.
+            controlsHint: {
+                gestures.isMotionCurrentlyAvailable
+                    ? SelectionController.controlsHint
+                    : SelectionController.voiceOnlyControlsHint
+            },
             diagnosticSink: diagnostics
         )
         let interactionGate = InteractionGate()

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -343,7 +343,7 @@ import Darwin
         )
         let interactionGate = InteractionGate()
 
-        gestures.onMotionLost = {
+        gestures.onMotionLost = { _ in
             speech.speak(
                 "AirPods motion disconnected. Deferring to the screen.",
                 priority: .notification,

--- a/Executables/tapq/TapQMain.swift
+++ b/Executables/tapq/TapQMain.swift
@@ -110,7 +110,7 @@ private final class AppleHeadphoneMotionCapture: TapQMotionCapturing {
         onSample: @escaping @MainActor (HeadMotionSample) -> Void
     ) async throws {
         health = MotionCaptureHealth()
-        detector.onMotionLost = { [weak self] in self?.health.recordLoss() }
+        detector.onMotionLost = { [weak self] _ in self?.health.recordLoss() }
         guard detector.startCapture(onSample: { [weak self] sample in
             self?.health.recordSample()
             onSample(sample)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ tested on AirPods Pro), and Claude Code with hook support or a local Codex CLI
 (`0.142.5` or newer). Keep the AirPods connected,
 in-ear, and selected as the audio output.
 
+Without AirPods, `tapq serve` still runs. TapQ says so once and degrades to a plain
+voice agent on whatever the system's default input and output are — prompts spoken on
+the Mac's speaker, answered by voice — with gestures, taps, tilts, and volume swipes
+inert. Connect AirPods mid-session and the next prompt has them back.
+
 ```bash
 git clone https://github.com/spaceamoeba-t/tapq.git
 cd tapq

--- a/Sources/TapQAppleAdapters/HeadGestureDetector.swift
+++ b/Sources/TapQAppleAdapters/HeadGestureDetector.swift
@@ -11,6 +11,24 @@ import TapQDetectionBaseline
     func streamInterrupted()
 }
 
+/// Why a motion channel ended. The host branches on it: a window that never had motion
+/// at all is a different situation from one whose stream died under the user's ear, and
+/// only the latter is worth interrupting them about.
+///
+/// Raw values are the `reason` field of the `motion.lost` diagnostic event.
+public enum MotionLossReason: String, Sendable, Equatable {
+    /// No device was ever subscribed to in this session — the bounded availability retry
+    /// expired, or the connection vanished between the poll and the actual start. This is
+    /// the no-AirPods-at-all case: nothing was lost, because nothing was ever there.
+    case neverStreamed = "never_streamed"
+    /// A stream that was delivering samples stopped delivering them and did not recover
+    /// within the interruption grace period.
+    case lostWhileStreaming = "lost_while_streaming"
+    /// CoreMotion accepted the subscription but the callback never produced a sample,
+    /// through the bounded startup restart as well. The device is present and mute.
+    case silentStream = "silent_stream"
+}
+
 /// Adapts the Apple headphone motion source to the portable `MotionGesturePipeline`.
 /// One subscription feeds gestures, taps, and tilts so competing CoreMotion managers
 /// never contend for the same headphones.
@@ -51,9 +69,11 @@ import TapQDetectionBaseline
     /// Experimental motion-swipe events; delivered only while swipe detection is enabled.
     public var onMotionSwipe: (@MainActor (MotionSwipeCommand) -> Void)?
 
-    /// Fired once per contiguous motion outage. A later valid sample rearms the callback
-    /// so a genuinely new outage is reported as well.
-    public var onMotionLost: (@MainActor () -> Void)?
+    /// Fired once per contiguous motion outage, carrying why the channel ended. A later
+    /// valid sample rearms the callback so a genuinely new outage is reported as well.
+    /// Hosts are expected to branch on the reason rather than treat every outage as a
+    /// disconnect: see `MotionLossReason`.
+    public var onMotionLost: (@MainActor (MotionLossReason) -> Void)?
 
     /// A secondary consumer of the raw motion sample stream (e.g. wearer-speech
     /// detection). Receives samples after recovery handling, before pipeline dispatch.
@@ -163,6 +183,15 @@ import TapQDetectionBaseline
         #endif
     }
 
+    /// Whether this detector's own source can deliver headphone motion right now.
+    ///
+    /// Unlike the static `isAvailable`, which builds a throwaway `CMHeadphoneMotionManager`
+    /// to answer, this asks the source the detector is actually subscribed to — so an
+    /// injected test source answers for itself, and no second manager ever contends for the
+    /// same headphones. Cheap enough to consult per response window, which is what makes
+    /// AirPods connected mid-session take effect on the next prompt.
+    public var isMotionCurrentlyAvailable: Bool { source.isDeviceMotionAvailable }
+
     public func start(onGesture: @escaping @MainActor (HeadGesture) -> Void) {
         self.onGesture = onGesture
         startDetecting()
@@ -184,8 +213,10 @@ import TapQDetectionBaseline
         onGesture = handler
     }
 
-    func handleMotionLoss(error: Error? = nil) {
-        confirmMotionLoss(errorDescription: error.map { String(describing: $0) })
+    func handleMotionLoss(reason: MotionLossReason = .lostWhileStreaming,
+                          error: Error? = nil) {
+        confirmMotionLoss(reason: reason,
+                          errorDescription: error.map { String(describing: $0) })
     }
 
     /// A single CoreMotion disconnect/nil callback is not final. AirPods can briefly
@@ -208,7 +239,7 @@ import TapQDetectionBaseline
             try? await Task.sleep(nanoseconds: self.motionLossGraceNanoseconds)
             guard !Task.isCancelled, self.running else { return }
             self.motionInterruptionTask = nil
-            self.confirmMotionLoss(errorDescription: description)
+            self.confirmMotionLoss(reason: .lostWhileStreaming, errorDescription: description)
         }
     }
 
@@ -245,6 +276,7 @@ import TapQDetectionBaseline
         // not leave the interaction running without either a subscription or a poller.
         guard source.isDeviceMotionAvailable else {
             confirmMotionLoss(
+                reason: .neverStreamed,
                 errorDescription: "headphone motion became unavailable before startup"
             )
             return
@@ -434,6 +466,7 @@ import TapQDetectionBaseline
                 self.awaitingFirstSampleEpoch = nil
                 self.firstSampleStartedAt = nil
                 self.confirmMotionLoss(
+                    reason: .silentStream,
                     errorDescription: "headphone motion stream started but produced no samples"
                 )
                 return
@@ -468,6 +501,7 @@ import TapQDetectionBaseline
             guard self.source.isDeviceMotionAvailable else {
                 self.firstSampleWatchdogTask = nil
                 self.confirmMotionLoss(
+                    reason: .silentStream,
                     errorDescription: "headphone motion unavailable during startup retry"
                 )
                 return
@@ -518,11 +552,14 @@ import TapQDetectionBaseline
                 }
             }
             self.availabilityTask = nil
-            self.confirmMotionLoss(errorDescription: "headphone motion unavailable")
+            self.confirmMotionLoss(
+                reason: .neverStreamed,
+                errorDescription: "headphone motion unavailable"
+            )
         }
     }
 
-    private func confirmMotionLoss(errorDescription: String?) {
+    private func confirmMotionLoss(reason: MotionLossReason, errorDescription: String?) {
         availabilityTask?.cancel()
         availabilityTask = nil
         motionInterruptionTask?.cancel()
@@ -534,12 +571,10 @@ import TapQDetectionBaseline
         guard running, !motionLossSignaled else { return }
         motionLossSignaled = true
         motionSampleObserver?.streamInterrupted()
-        diagnostics.record(
-            "motion.lost",
-            level: .error,
-            fields: errorDescription.map { ["error": $0] } ?? [:]
-        )
-        onMotionLost?()
+        var fields = ["reason": reason.rawValue]
+        if let errorDescription { fields["error"] = errorDescription }
+        diagnostics.record("motion.lost", level: .error, fields: fields)
+        onMotionLost?(reason)
     }
 
     // Adapter test seams. Algorithm tests live under TapQDetectionBaselineTests.

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -219,7 +219,13 @@ public struct TapQCLIIO {
             io.writeOutput("Discovery: \(endpoint.discoveryPath)\n")
             io.writeOutput("Gesture profile: \(endpoint.gestureProfileLoaded ? "loaded" : "default")\n")
             io.writeOutput("Tap profile: \(endpoint.tapProfileLoaded ? "loaded" : "default")\n")
-            io.writeOutput("AirPods motion: \(endpoint.motionAvailable ? "available" : "unavailable")\n")
+            // "unavailable" on its own reads like a failed start. It is not one: serving
+            // continues, voice answers every prompt, and the gesture channels come back
+            // without a restart — so the line says what the session is, not what it lacks.
+            let motionStatus = endpoint.motionAvailable
+                ? "available"
+                : "unavailable (voice-only; gestures return when AirPods connect)"
+            io.writeOutput("AirPods motion: \(motionStatus)\n")
             io.writeOutput("Voice input: \(endpoint.voiceAvailable ? "available" : "unavailable")\n")
             if let voiceBackendStatus = endpoint.voiceBackendStatus {
                 io.writeOutput("Voice backend: \(voiceBackendStatus)\n")

--- a/Sources/TapQInteractionBaseline/MotionGatedSwipes.swift
+++ b/Sources/TapQInteractionBaseline/MotionGatedSwipes.swift
@@ -1,0 +1,54 @@
+import Foundation
+import TapQContracts
+
+/// Wraps the volume-swipe channel so it is only ever attached while the motion device it
+/// belongs to is actually present.
+///
+/// Stem swipes are read from the *default output device's* volume, which on a Mac with no
+/// AirPods connected is the built-in speaker. Left ungated, every volume-key press during
+/// a selection window would be read as next/previous — the user changes the volume and the
+/// selection moves. Eligibility is the fix, and it is a function rather than a flag because
+/// `SelectionArbiter.begin/finish` start and stop swipes once per window: AirPods connected
+/// mid-session make the very next window eligible, with nothing to recompose.
+///
+/// Fail-closed on purpose, and the only decorator here that is: `SpeechGatedVoice` and
+/// `WearerGatedVoice` fail open because a wedged signal must never remove a way to answer,
+/// while a swipe channel that survives its device does not remove an answer — it invents
+/// one the user did not give.
+@MainActor public final class MotionGatedSwipes: VolumeSwipeProviding {
+    private let inner: VolumeSwipeProviding
+    private let isEligible: @MainActor () -> Bool
+    private let diagnostics: TapQDiagnosticEmitter
+    /// `stop()` must not reach an inner provider that was never started: the concrete
+    /// detector installs and removes a CoreAudio property listener, and unbalanced
+    /// teardown is exactly the kind of thing that only shows up on someone else's Mac.
+    private var innerStarted = false
+
+    /// `isEligible` is consulted on every `start`, so it must answer for the moment it is
+    /// called rather than for composition time.
+    public init(wrapping inner: VolumeSwipeProviding,
+                isEligible: @escaping @MainActor () -> Bool,
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
+        self.inner = inner
+        self.isEligible = isEligible
+        self.diagnostics = TapQDiagnosticEmitter(category: "SwipeGate", sink: diagnosticSink)
+    }
+
+    public func start(onSwipe: @escaping @MainActor (VolumeSwipeCommand) -> Void) {
+        guard isEligible() else {
+            diagnostics.record(
+                "swipes.suppressed",
+                fields: ["reason": "motion_unavailable"]
+            )
+            return
+        }
+        innerStarted = true
+        inner.start(onSwipe: onSwipe)
+    }
+
+    public func stop() {
+        guard innerStarted else { return }
+        innerStarted = false
+        inner.stop()
+    }
+}

--- a/Sources/TapQInteractionBaseline/SelectionController.swift
+++ b/Sources/TapQInteractionBaseline/SelectionController.swift
@@ -26,13 +26,25 @@ import TapQContracts
     /// The controls are taught once per runtime session. The controller outlives every
     /// individual request, so this survives across questions by design.
     private var hasAnnouncedControls = false
+    /// Which controls to teach, asked for at the moment a hint is spoken rather than at
+    /// composition time: the channels available to a window are a per-window fact, and a
+    /// device that appears mid-session must change what the next prompt teaches.
+    private let controlsHint: @MainActor () -> String
 
+    /// `controlsHint` is consulted on the session's first prompt and on every explicit
+    /// repeat, and must answer for the window it is called in. The default teaches the
+    /// full motion controls, which is the composition every host had before the provider
+    /// existed.
     public init(speech: SpeechPresenting, arbiter: SelectionArbitrating,
                 timeout: TimeInterval = 240,
+                controlsHint: @escaping @MainActor () -> String = {
+                    SelectionController.controlsHint
+                },
                 diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
         self.speech = speech
         self.arbiter = arbiter
         self.timeout = timeout
+        self.controlsHint = controlsHint
         self.diagnostics = TapQDiagnosticEmitter(category: "Selection", sink: diagnosticSink)
     }
 
@@ -171,7 +183,14 @@ import TapQContracts
     /// How to navigate and confirm. The controls never change between selections, so
     /// repeating them on every question is 37 characters the user must sit through before
     /// reaching the option they are actually choosing between.
-    static let controlsHint = "Volume, then nod twice or double-tap."
+    public static let controlsHint = "Volume, then nod twice or double-tap."
+
+    /// The same teaching for a session with no motion device: every word is in
+    /// `VoiceCommandMatcher`'s grammar, so the hint only names controls that will work.
+    /// Teaching volume and nods to a user whose earbuds are in a case is worse than
+    /// teaching nothing — it is the runtime telling them to do something that cannot
+    /// resolve the question.
+    public static let voiceOnlyControlsHint = "Say next, previous, or select."
 
     private func promptText(
         _ request: SelectionRequest,
@@ -190,7 +209,7 @@ import TapQContracts
             maxCharacters: 48
         )
         let prompt = "\(SpokenText.sentence(question)) \(cursor + 1) of \(request.options.count): \(SpokenText.sentence(label))"
-        return includeControls ? "\(prompt) \(Self.controlsHint)" : prompt
+        return includeControls ? "\(prompt) \(controlsHint())" : prompt
     }
 
     private func optionText(_ request: SelectionRequest, cursor: Int) -> String {

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -42,6 +42,34 @@ scripts/run-runtime-app.sh capture --duration 5 --output -
 If capture produces no records, the problem is device acquisition or permission,
 not the gesture classifier.
 
+## No AirPods are connected at all
+
+This is a supported configuration, not a failure. TapQ degrades to a plain voice
+agent and says so once.
+
+Expected behavior:
+
+- The ready banner reads `AirPods motion: unavailable (voice-only; gestures return
+  when AirPods connect)`.
+- About a second and a half after startup, TapQ speaks one notice — "No AirPods
+  detected. Running voice only." — and then stays quiet about it. `--no-announcements`
+  suppresses the notice; prompts still speak.
+- Every response window runs its bounded motion retry, finds nothing, and continues
+  on voice. There is no per-prompt disconnect announcement: "AirPods motion
+  disconnected." is reserved for a device that was present when the window opened.
+- Gesture, tap, and tilt channels deliver nothing. Volume swipes are switched off
+  rather than left attached to the built-in speaker, so volume keys change the volume
+  instead of moving the selection.
+- The first selection prompt teaches the controls that can answer it: "Say next,
+  previous, or select."
+- Connect AirPods mid-session and the next prompt has gestures and swipes back — no
+  restart, no reconfiguration. Say `repeat` on a selection to hear the full controls.
+
+The fallback voice is **not wearer-attributed.** Attribution is a claim about the
+in-ear IMU, and with no IMU there is nothing to attribute with, so `--wearer-gate` and
+`--imu-turn-control` fail open: every command the microphone hears passes, and turn
+control is inert. Both flags are safe to leave on and do nothing.
+
 ## Tap calibration is too weak
 
 Keep your head still and give the outside body of an earbud several quick,

--- a/Tests/TapQAppleAdaptersTests/HeadGestureDetectorTests.swift
+++ b/Tests/TapQAppleAdaptersTests/HeadGestureDetectorTests.swift
@@ -388,11 +388,17 @@ final class HeadGestureDetectorTests: XCTestCase {
         var samples: [HeadMotionSample] = []
         var lost = 0
         detector.onMotionLost = { _ in lost += 1 }
+        // Deliver recovery from inside the second subscription. Waiting for the test task
+        // to resume before emitting would race that task against the new 10 ms watchdog.
+        source.onStart = { [weak source] attempt in
+            guard attempt == 2 else { return }
+            source?.emit(expected)
+        }
         XCTAssertTrue(detector.startCapture { samples.append($0) })
 
         let didRestart = await waitUntil { source.startCount == 2 }
         XCTAssertTrue(didRestart)
-        source.emit(expected)
+        // Exceed the watchdog deadline to prove the synchronous recovery cancelled it.
         try? await Task.sleep(nanoseconds: 20_000_000)
 
         XCTAssertEqual(samples, [expected])

--- a/Tests/TapQAppleAdaptersTests/HeadGestureDetectorTests.swift
+++ b/Tests/TapQAppleAdaptersTests/HeadGestureDetectorTests.swift
@@ -122,7 +122,7 @@ final class HeadGestureDetectorTests: XCTestCase {
     func testMotionLossFiresCallbackOncePerSession() {
         let detector = HeadGestureDetector()
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         detector.beginListeningForTesting()
         detector.handleMotionLoss()
         detector.handleMotionLoss() // nil samples keep arriving after a disconnect
@@ -132,7 +132,7 @@ final class HeadGestureDetectorTests: XCTestCase {
     func testMotionLossIgnoredWhenNotListening() {
         let detector = HeadGestureDetector()
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         detector.handleMotionLoss()
         XCTAssertEqual(lost, 0, "no window open — nothing to rescue")
     }
@@ -140,7 +140,7 @@ final class HeadGestureDetectorTests: XCTestCase {
     func testMotionLossSignalsAgainOnNextSession() {
         let detector = HeadGestureDetector()
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         detector.beginListeningForTesting()
         detector.handleMotionLoss()
         detector.stop()
@@ -226,7 +226,7 @@ final class HeadGestureDetectorTests: XCTestCase {
             diagnosticSink: sink
         )
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         source.onStart = { [weak source] attempt in
             guard attempt == 2 else { return }
             source?.emit(pitch: 0.1, yaw: 0.1, at: 1)
@@ -259,17 +259,45 @@ final class HeadGestureDetectorTests: XCTestCase {
             firstSampleTimeout: 0.01,
             startupRestartBackoff: 0.005
         )
-        var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        var losses: [MotionLossReason] = []
+        detector.onMotionLost = { losses.append($0) }
         detector.start { (_: HeadGesture) in }
 
-        let didFailThrough = await waitUntil { lost == 1 }
+        let didFailThrough = await waitUntil { losses.count == 1 }
         XCTAssertTrue(didFailThrough)
         try? await Task.sleep(nanoseconds: 20_000_000)
 
         XCTAssertEqual(source.startCount, 2, "startup recovery is bounded to one restart")
         XCTAssertEqual(source.stopCount, 1)
-        XCTAssertEqual(lost, 1)
+        XCTAssertEqual(losses, [.silentStream],
+                       "a device that accepted the subscription and stayed mute is present, not absent")
+        detector.stop()
+    }
+
+    func testSilentStartupRestartFindsDeviceGoneSignalsSilentStream() async {
+        let source = FakeMotionSource()
+        // The headphones go away while the mute subscription is open, so the restart's
+        // post-backoff availability check finds nothing to resubscribe to. Flipping the
+        // flag from `onStart` rather than scripting `availabilitySequence` keeps the test
+        // independent of how many times the detector happens to probe availability —
+        // `isDeviceMotionAvailable` consumes a scripted entry per read, including the one
+        // the start-timeout diagnostic makes.
+        source.onStart = { [weak source] _ in source?.available = false }
+        let detector = HeadGestureDetector(
+            source: source,
+            firstSampleTimeout: 0.01,
+            startupRestartBackoff: 0.005
+        )
+        var losses: [MotionLossReason] = []
+        detector.onMotionLost = { losses.append($0) }
+        detector.start { (_: HeadGesture) in }
+
+        let didFailThrough = await waitUntil { losses.count == 1 }
+
+        XCTAssertTrue(didFailThrough)
+        XCTAssertEqual(source.startCount, 1, "the restart gave up before resubscribing")
+        XCTAssertEqual(losses, [.silentStream],
+                       "the window opened on a device that was there, so this is a loss, not an absence")
         detector.stop()
     }
 
@@ -281,7 +309,7 @@ final class HeadGestureDetectorTests: XCTestCase {
             startupRestartBackoff: 0.005
         )
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         detector.start { (_: HeadGesture) in }
         source.emit(pitch: 0.1, yaw: 0.1, at: 1)
 
@@ -306,7 +334,7 @@ final class HeadGestureDetectorTests: XCTestCase {
             startupRestartBackoff: 0.005
         )
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         // Deliver recovery from inside the second subscription. Waiting for the test task
         // to resume before emitting would race that task against the new 10 ms watchdog.
         source.onStart = { [weak source] attempt in
@@ -359,7 +387,7 @@ final class HeadGestureDetectorTests: XCTestCase {
         )
         var samples: [HeadMotionSample] = []
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         XCTAssertTrue(detector.startCapture { samples.append($0) })
 
         let didRestart = await waitUntil { source.startCount == 2 }
@@ -414,7 +442,7 @@ final class HeadGestureDetectorTests: XCTestCase {
             firstSampleTimeout: 0.1
         )
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
 
         XCTAssertTrue(detector.startCapture { (_: HeadMotionSample) in })
         detector.stopCapture()
@@ -432,14 +460,14 @@ final class HeadGestureDetectorTests: XCTestCase {
         let source = FakeMotionSource()
         let detector = HeadGestureDetector(source: source, motionLossGrace: 0.01)
         defer { detector.stop() }
-        var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        var losses: [MotionLossReason] = []
+        detector.onMotionLost = { losses.append($0) }
         detector.start { (_: HeadGesture) in }
         source.fail()
         source.fail()   // nil samples keep arriving after a disconnect
-        let didLoseMotion = await waitUntil { lost == 1 }
+        let didLoseMotion = await waitUntil { losses.count == 1 }
         XCTAssertTrue(didLoseMotion)
-        XCTAssertEqual(lost, 1)
+        XCTAssertEqual(losses, [.lostWhileStreaming])
     }
 
     func testValidSampleInsideGraceSuppressesFalseMotionLoss() async {
@@ -447,7 +475,7 @@ final class HeadGestureDetectorTests: XCTestCase {
         let detector = HeadGestureDetector(source: source, motionLossGrace: 0.02)
         defer { detector.stop() }
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         detector.start { (_: HeadGesture) in }
 
         source.fail()
@@ -461,21 +489,22 @@ final class HeadGestureDetectorTests: XCTestCase {
         let source = FakeMotionSource()
         let detector = HeadGestureDetector(source: source, motionLossGrace: 0.01)
         defer { detector.stopCapture() }
-        var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        var losses: [MotionLossReason] = []
+        detector.onMotionLost = { losses.append($0) }
         XCTAssertTrue(detector.startCapture { (_: HeadMotionSample) in })
 
         source.fail()
         source.fail()
-        let didLoseMotion = await waitUntil { lost == 1 }
+        let didLoseMotion = await waitUntil { losses.count == 1 }
         XCTAssertTrue(didLoseMotion)
-        XCTAssertEqual(lost, 1, "one outage is signaled only once")
+        XCTAssertEqual(losses, [.lostWhileStreaming], "one outage is signaled only once")
 
         source.emit(pitch: 0.1, yaw: 0.1, at: 1)
         source.fail()
-        let didLoseMotionAgain = await waitUntil { lost == 2 }
+        let didLoseMotionAgain = await waitUntil { losses.count == 2 }
         XCTAssertTrue(didLoseMotionAgain)
-        XCTAssertEqual(lost, 2, "a valid sample proves recovery and rearms loss signaling")
+        XCTAssertEqual(losses, [.lostWhileStreaming, .lostWhileStreaming],
+                       "a valid sample proves recovery and rearms loss signaling")
     }
 
     func testUnavailableStartWaitsBrieflyAndRecovers() async {
@@ -492,7 +521,7 @@ final class HeadGestureDetectorTests: XCTestCase {
             availabilityRetry: 0.01
         )
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         detector.start { (_: HeadGesture) in }
 
         // Safe as a fixed wait: it only lets retry ticks accumulate, and overrunning it
@@ -517,15 +546,16 @@ final class HeadGestureDetectorTests: XCTestCase {
             availabilityRetry: 0.005
         )
         defer { detector.stop() }
-        var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        var losses: [MotionLossReason] = []
+        detector.onMotionLost = { losses.append($0) }
         detector.start { (_: HeadGesture) in }
 
-        let didFailThrough = await waitUntil { lost == 1 }
+        let didFailThrough = await waitUntil { losses.count == 1 }
 
         XCTAssertTrue(didFailThrough, "an unavailable channel must fail through after its bounded grace")
         XCTAssertEqual(source.startCount, 0)
-        XCTAssertEqual(lost, 1, "an unavailable channel must not leave the prompt silently waiting")
+        XCTAssertEqual(losses, [.neverStreamed],
+                       "no device was ever there, so the host must not be told one disconnected")
     }
 
     func testAvailabilityDropBetweenPollAndActualStartFailsImmediately() async {
@@ -539,15 +569,15 @@ final class HeadGestureDetectorTests: XCTestCase {
             motionLossGrace: 0.1,
             availabilityRetry: 0.005
         )
-        var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        var losses: [MotionLossReason] = []
+        detector.onMotionLost = { losses.append($0) }
         detector.start { (_: HeadGesture) in }
 
-        let didFailThrough = await waitUntil { lost == 1 }
+        let didFailThrough = await waitUntil { losses.count == 1 }
 
         XCTAssertTrue(didFailThrough)
         XCTAssertEqual(source.startCount, 0)
-        XCTAssertEqual(lost, 1)
+        XCTAssertEqual(losses, [.neverStreamed], "nothing was ever subscribed to")
         detector.stop()
     }
 
@@ -622,7 +652,7 @@ final class HeadGestureDetectorTests: XCTestCase {
 
     func testStopPreservesMotionLostWiring() {
         let detector = HeadGestureDetector()
-        detector.onMotionLost = {}
+        detector.onMotionLost = { _ in }
         detector.beginListeningForTesting()
         detector.stop()
         XCTAssertNotNil(detector.onMotionLost, "app-level wiring must survive window close")
@@ -644,7 +674,7 @@ final class HeadGestureDetectorTests: XCTestCase {
     func testStopCaptureEndsCaptureSession() {
         let detector = HeadGestureDetector()
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         detector.beginCaptureForTesting()
         detector.stopCapture()
         detector.handleMotionLoss()
@@ -656,7 +686,7 @@ final class HeadGestureDetectorTests: XCTestCase {
         // the window's callbacks without tearing down the live capture session.
         let (detector, emitted) = makeDetector()
         var lost = 0
-        detector.onMotionLost = { lost += 1 }
+        detector.onMotionLost = { _ in lost += 1 }
         detector.beginCaptureForTesting()
         detector.stop()
         feedNod(detector, at: 0.0)

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -29,6 +29,8 @@ final class TapQCLIApplicationTests: XCTestCase {
     private final class FakeRuntime: TapQRuntimeServing {
         private(set) var configurations: [TapQRuntimeConfiguration] = []
         private(set) var receivedReasonerLoader = false
+        /// What the host's own availability probe would have answered at ready time.
+        var motionAvailable = true
 
         static func wearerSpeechStatus(
             configuration: TapQRuntimeConfiguration
@@ -56,7 +58,7 @@ final class TapQCLIApplicationTests: XCTestCase {
                 discoveryPath: "/tmp/broker.json",
                 gestureProfileLoaded: true,
                 tapProfileLoaded: true,
-                motionAvailable: true,
+                motionAvailable: motionAvailable,
                 voiceAvailable: false,
                 // The live host derives the line the same way: from the provider it was
                 // handed, with the default reporting nothing.
@@ -406,6 +408,24 @@ final class TapQCLIApplicationTests: XCTestCase {
         XCTAssertEqual(configuration.questionClassifier, .anthropic)
         XCTAssertTrue(buffer.output.contains("TapQ runtime is ready"))
         XCTAssertTrue(buffer.output.contains("AirPods motion: available"))
+    }
+
+    @MainActor
+    func testServeReportsVoiceOnlyWhenMotionIsUnavailable() async {
+        let buffer = Buffer()
+        let runtime = FakeRuntime()
+        runtime.motionAvailable = false
+        let app = application(io: buffer.io, runtime: runtime)
+
+        let status = await app.run(arguments: ["serve"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(
+            buffer.output.contains(
+                "AirPods motion: unavailable (voice-only; gestures return when AirPods connect)"
+            ),
+            "the banner must say serving continues, not just that motion is missing"
+        )
     }
 
     @MainActor

--- a/Tests/TapQInteractionBaselineTests/MotionGatedSwipesTests.swift
+++ b/Tests/TapQInteractionBaselineTests/MotionGatedSwipesTests.swift
@@ -34,7 +34,7 @@ final class MotionGatedSwipesTests: XCTestCase {
         func fire(_ command: VolumeSwipeCommand) { onSwipe?(command) }
     }
 
-    func testEligibleStartDelegatesAndForwardsSwipes() {
+    func testEligibleStartDelegatesAndForwardsSwipes() async {
         let inner = FakeSwipes()
         let gated = MotionGatedSwipes(wrapping: inner, isEligible: { true })
         var received: [VolumeSwipeCommand] = []
@@ -44,7 +44,7 @@ final class MotionGatedSwipesTests: XCTestCase {
         XCTAssertEqual(received, [.swipeDown])
     }
 
-    func testIneligibleStartLeavesInnerUntouched() {
+    func testIneligibleStartLeavesInnerUntouched() async {
         let sink = RecordingSink()
         let inner = FakeSwipes()
         let gated = MotionGatedSwipes(
@@ -58,7 +58,7 @@ final class MotionGatedSwipesTests: XCTestCase {
         XCTAssertEqual(suppressed?.fields["reason"], "motion_unavailable")
     }
 
-    func testIneligibleStopIsNotForwarded() {
+    func testIneligibleStopIsNotForwarded() async {
         let inner = FakeSwipes()
         let gated = MotionGatedSwipes(wrapping: inner, isEligible: { false })
         gated.start { _ in }
@@ -66,7 +66,7 @@ final class MotionGatedSwipesTests: XCTestCase {
         XCTAssertEqual(inner.stops, 0, "teardown must stay balanced with startup")
     }
 
-    func testEligibleStopIsForwardedOnce() {
+    func testEligibleStopIsForwardedOnce() async {
         let inner = FakeSwipes()
         let gated = MotionGatedSwipes(wrapping: inner, isEligible: { true })
         gated.start { _ in }
@@ -75,7 +75,7 @@ final class MotionGatedSwipesTests: XCTestCase {
         XCTAssertEqual(inner.stops, 1)
     }
 
-    func testEligibilityIsReEvaluatedOnEveryWindow() {
+    func testEligibilityIsReEvaluatedOnEveryWindow() async {
         // The upgrade path: AirPods connected mid-session. `SelectionArbiter` starts and
         // stops swipes per window, so the next window is the one that recovers them.
         let inner = FakeSwipes()
@@ -93,7 +93,7 @@ final class MotionGatedSwipesTests: XCTestCase {
         XCTAssertEqual(inner.stops, 1)
     }
 
-    func testEligibilityLossBetweenWindowsDisablesSwipesAgain() {
+    func testEligibilityLossBetweenWindowsDisablesSwipesAgain() async {
         let inner = FakeSwipes()
         var eligible = true
         let gated = MotionGatedSwipes(wrapping: inner, isEligible: { eligible })

--- a/Tests/TapQInteractionBaselineTests/MotionGatedSwipesTests.swift
+++ b/Tests/TapQInteractionBaselineTests/MotionGatedSwipesTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+@MainActor
+final class MotionGatedSwipesTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    @MainActor
+    final class FakeSwipes: VolumeSwipeProviding {
+        var onSwipe: (@MainActor (VolumeSwipeCommand) -> Void)?
+        private(set) var starts = 0
+        private(set) var stops = 0
+        func start(onSwipe: @escaping @MainActor (VolumeSwipeCommand) -> Void) {
+            starts += 1
+            self.onSwipe = onSwipe
+        }
+        func stop() { stops += 1 }
+        func fire(_ command: VolumeSwipeCommand) { onSwipe?(command) }
+    }
+
+    func testEligibleStartDelegatesAndForwardsSwipes() {
+        let inner = FakeSwipes()
+        let gated = MotionGatedSwipes(wrapping: inner, isEligible: { true })
+        var received: [VolumeSwipeCommand] = []
+        gated.start { received.append($0) }
+        XCTAssertEqual(inner.starts, 1)
+        inner.fire(.swipeDown)
+        XCTAssertEqual(received, [.swipeDown])
+    }
+
+    func testIneligibleStartLeavesInnerUntouched() {
+        let sink = RecordingSink()
+        let inner = FakeSwipes()
+        let gated = MotionGatedSwipes(
+            wrapping: inner, isEligible: { false }, diagnosticSink: sink)
+        var received: [VolumeSwipeCommand] = []
+        gated.start { received.append($0) }
+        XCTAssertEqual(inner.starts, 0, "no listener may attach to the built-in speaker")
+        inner.fire(.swipeDown)
+        XCTAssertEqual(received, [], "a volume key press is not a navigation command")
+        let suppressed = sink.events.first { $0.name == "swipes.suppressed" }
+        XCTAssertEqual(suppressed?.fields["reason"], "motion_unavailable")
+    }
+
+    func testIneligibleStopIsNotForwarded() {
+        let inner = FakeSwipes()
+        let gated = MotionGatedSwipes(wrapping: inner, isEligible: { false })
+        gated.start { _ in }
+        gated.stop()
+        XCTAssertEqual(inner.stops, 0, "teardown must stay balanced with startup")
+    }
+
+    func testEligibleStopIsForwardedOnce() {
+        let inner = FakeSwipes()
+        let gated = MotionGatedSwipes(wrapping: inner, isEligible: { true })
+        gated.start { _ in }
+        gated.stop()
+        gated.stop()
+        XCTAssertEqual(inner.stops, 1)
+    }
+
+    func testEligibilityIsReEvaluatedOnEveryWindow() {
+        // The upgrade path: AirPods connected mid-session. `SelectionArbiter` starts and
+        // stops swipes per window, so the next window is the one that recovers them.
+        let inner = FakeSwipes()
+        var eligible = false
+        let gated = MotionGatedSwipes(wrapping: inner, isEligible: { eligible })
+
+        gated.start { _ in }
+        gated.stop()
+        XCTAssertEqual(inner.starts, 0)
+
+        eligible = true
+        gated.start { _ in }
+        XCTAssertEqual(inner.starts, 1, "a device that appeared between windows re-enables swipes")
+        gated.stop()
+        XCTAssertEqual(inner.stops, 1)
+    }
+
+    func testEligibilityLossBetweenWindowsDisablesSwipesAgain() {
+        let inner = FakeSwipes()
+        var eligible = true
+        let gated = MotionGatedSwipes(wrapping: inner, isEligible: { eligible })
+
+        gated.start { _ in }
+        gated.stop()
+        eligible = false
+        gated.start { _ in }
+
+        XCTAssertEqual(inner.starts, 1, "the second window found no device and stayed off")
+        XCTAssertEqual(inner.stops, 1)
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/SelectionControllerTests.swift
+++ b/Tests/TapQInteractionBaselineTests/SelectionControllerTests.swift
@@ -197,6 +197,43 @@ final class SelectionControllerTests: XCTestCase {
                        "only the opening prompt may carry the hint")
     }
 
+    func testVoiceOnlyHintIsSpokenWhenTheProviderSaysSo() async {
+        let speech = FakeSpeech()
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.select]),
+            controlsHint: { SelectionController.voiceOnlyControlsHint }
+        )
+        _ = await controller.resolve(request())
+        XCTAssertEqual(speech.spoken[0], "Which color? 1 of 3: Option 1. Say next, previous, or select.",
+                       "with no motion device the hint must name only channels that can answer")
+    }
+
+    func testControlsHintProviderIsConsultedPerPrompt() async {
+        // The upgrade path: AirPods connected mid-session. The provider is read when a hint
+        // is actually spoken, so the repeat re-teaches the controls that now exist.
+        let speech = FakeSpeech()
+        var motionAvailable = false
+        let controller = SelectionController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.select, .repeatRequest, .select]),
+            controlsHint: {
+                motionAvailable
+                    ? SelectionController.controlsHint
+                    : SelectionController.voiceOnlyControlsHint
+            }
+        )
+        _ = await controller.resolve(request())
+        motionAvailable = true
+        _ = await controller.resolve(request())
+
+        XCTAssertEqual(speech.spoken[0],
+                       "Which color? 1 of 3: Option 1. \(SelectionController.voiceOnlyControlsHint)")
+        XCTAssertEqual(speech.spoken[2],
+                       "Which color? 1 of 3: Option 1. \(SelectionController.controlsHint)",
+                       "a device that appeared between questions changes what repeat teaches")
+    }
+
     func testDoubleTapConfirmsSelection() async {
         // .allow is what double-tap maps to; in selection context it means "confirm current"
         let controller = SelectionController(speech: FakeSpeech(), arbiter: ScriptedArbiter([.next, .allow]))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -294,6 +294,21 @@ period, resumes on a corresponding reconnect, and announces disconnection only
 when samples do not recover. When a new prompt opens without motion, the runtime
 retries for a bounded period.
 
+A device that was never connected is not a disconnection. The bounded retry still
+runs at every window, but when it finds nothing the window continues voice-only and
+says nothing: the disconnect announcement is reserved for a device that was present
+when the window opened. TapQ speaks one notice at startup instead, and the motion
+channels re-arm by themselves at the first window after AirPods connect. The
+`motion.lost` diagnostic carries a `reason` field — `never_streamed`,
+`lost_while_streaming`, or `silent_stream` — which is what the runtime branches on.
+
+Without motion, a request the stage-2 reasoner escalates to `gesture_and_voice`
+cannot be collected: the gesture half never arrives, so the window times out to the
+on-screen prompt, which is the fail-open path every unanswered window takes. This
+only applies to `--reasoner-mode primary`, which is opt-in. A `double_gesture`
+requirement stays collectable without motion — a second spoken "yes" counts as the
+repeat allow.
+
 Warnings and errors are printed by default. `TAPQ_DEBUG=1` adds broker, speech,
 gesture, tap, selection, voice backend, playback, microphone pump, wearer gate, and
 lifecycle events. Tap diagnostics include peak and threshold acceleration, rotation


### PR DESCRIPTION
## Problem

Serving with no AirPods connected at all routed every response window into the disconnect path: the bounded motion retry expired, the runtime spoke "AirPods motion disconnected. Deferring to the screen.", cancelled both arbiters — taking the live voice window down with the dead gesture one — and then spoke "Deferring to the screen." a second time from the cancel path. A no-AirPods Mac got a bogus disconnect announcement on every prompt and could never answer by voice, even though voice I/O already follows the system default route.

## Change

A device that was never connected is not a disconnection.

- `HeadGestureDetector.onMotionLost` now carries a `MotionLossReason` (`never_streamed`, `lost_while_streaming`, `silent_stream`; also the new `reason` field on the `motion.lost` diagnostic). The host branches on it: `.neverStreamed` windows continue silently on voice and resolve by voice or ordinary timeout; the remaining reasons keep the announce-and-cancel contract, with the utterance trimmed to "AirPods motion disconnected." since the cancel path already speaks the deferral notice. Pre-1.0 source break for external assigners of the callback.
- One spoken startup notice — "No AirPods detected. Running voice only." — debounced on the detector's own availability cadence so slow-to-appear headphones never draw it, and gated by `--no-announcements`. Idle disconnects stay silent.
- New `MotionGatedSwipes` decorator: without AirPods the volume-swipe listener attached to the built-in speaker and read volume-key presses as next/previous. Swipes now attach only while a motion device is present, re-checked per window.
- `SelectionController` takes a `controlsHint` provider: voice-only windows teach "Say next, previous, or select." instead of volume swipes and nods that cannot resolve the question.
- Ready banner: `AirPods motion: unavailable (voice-only; gestures return when AirPods connect)`.
- Docs: README Quick start, a new TROUBLESHOOTING section (including that fallback voice is not wearer-attributed; `--wearer-gate`/`--imu-turn-control` fail open and are inert), the never-connected contract in docs/CLI.md, CHANGELOG.

Connecting AirPods mid-session restores gestures and swipes on the next prompt — the existing per-window bounded retry is the upgrade path, which is why this is per-window behavior rather than a startup mode switch. No new CLI flags.

## Testing

- `swift build -c release`, `scripts/check-public-boundary.sh`, and the CI test invocation: 1475 tests, 0 failures. New/updated coverage: reason mapping across all five terminal loss sites (including the silent-restart-finds-device-gone path), `MotionGatedSwipes` (6 tests incl. per-window re-evaluation both directions), hint provider consulted per prompt, banner wording.
- Host closures (loss policy, startup notice) live in the executable target and are not unit-testable; the manual no-AirPods checklist (spoken notices, mid-session connect/disconnect, volume keys on speaker) still needs a hardware pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)