### PR TITLE
Fix three launch-review runtime defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,30 @@ All notable changes to TapQ will be recorded in this file. The project uses
   building a throwaway `CMHeadphoneMotionManager`, so availability can be consulted per
   response window without a second manager competing for the headphones.
 
+### Fixed
+
+- Permission modes are read as the modes agents actually send. Both the auto-allow gate
+  in the broker and the stop-question opt-out in the Claude hook tested for the substring
+  "auto", which matches none of `default`, `acceptEdits`, `plan`, `dontAsk`, or
+  `bypassPermissions` — so both were dead code. The new `AgentPermissionMode` contract
+  reads them exactly: `dontAsk` and `bypassPermissions` auto-allow under the strict policy
+  and skip stop questions; `acceptEdits` auto-allows the edit tools only (`Write`, `Edit`,
+  `MultiEdit`, `NotebookEdit`) and still asks its stop questions, because accepting edits
+  is not accepting commands; `default` and `plan` get no automatic behavior, as does any
+  mode TapQ does not recognize.
+- The broker's accept loop survives a transient socket error. Any errno other than `EINTR`
+  ended the loop for good, leaving `tapq serve` running and apparently healthy while every
+  hook call stalled to its timeout. A recoverable state — an aborted connection, an
+  exhausted descriptor table, a momentary buffer shortage — now records an
+  `accept.retry` diagnostic, backs off from 10 ms to a 200 ms ceiling, and keeps
+  accepting; a dead listener records `accept.stopped` and ends the loop as before.
+- A second `tapq serve` no longer takes the socket from the first. Startup unlinked the
+  socket path unconditionally, which left the running broker bound to a name no hook could
+  reach. Startup now probe-connects an existing path: a live broker fails the second
+  instance with "Another TapQ broker is already listening on …", while a socket a crashed
+  run left behind is unlinked and rebound. Shutdown removes only a path the instance
+  itself bound, and the discovery record is protected the same way.
+
 ## [0.5.0-beta.2] - 2026-08-08
 
 *(Replaces 0.5.0-beta.1, which was never released: its tag was cut against a commit

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -535,7 +535,8 @@ import Darwin
         )
 
         let token = BrokerRuntimeDiscovery.generateToken()
-        let transport = UnixSocketTransport(path: discovery.socketPath)
+        let transport = UnixSocketTransport(path: discovery.socketPath,
+                                            diagnosticSink: diagnostics)
         let server = BrokerServer(
             transport: transport,
             token: token,

--- a/Sources/TapQBrokerRuntime/BrokerRuntimeDiscovery.swift
+++ b/Sources/TapQBrokerRuntime/BrokerRuntimeDiscovery.swift
@@ -76,7 +76,15 @@ public struct BrokerRuntimeDiscovery: Sendable {
         )
     }
 
+    /// Clears this runtime's discovery record and socket file, including the pair a
+    /// crashed run left behind.
+    ///
+    /// A socket another broker is still listening on is left alone, record and all: it
+    /// belongs to whoever is answering on it, and removing either half would strand every
+    /// hook against a broker that still looks healthy. A second `tapq serve` therefore
+    /// clears nothing here and fails at bind time with `SocketError.addressInUse`.
     public func remove() {
+        guard !UnixSocketTransport.isSocketListening(at: socketPath) else { return }
         try? FileManager.default.removeItem(at: discoveryURL)
         try? FileManager.default.removeItem(at: socketURL)
     }

--- a/Sources/TapQBrokerRuntime/BrokerServer.swift
+++ b/Sources/TapQBrokerRuntime/BrokerServer.swift
@@ -75,10 +75,12 @@ import TapQWireProtocol
                 ])
                 return BrokerResponse.error("approval_source").encoded()
             }
-            if approvalSource == .preToolUse, Self.isAutoMode(message.permissionMode) {
+            if approvalSource == .preToolUse,
+               Self.isAutoMode(message.permissionMode, toolName: message.toolName) {
                 diagnostics.record("approval.auto_pass", fields: [
                     "tool": message.toolName,
                     "source": approvalSource.rawValue,
+                    "mode": message.permissionMode ?? "",
                 ])
                 return BrokerResponse.decision(.allow, reason: nil).encoded()
             }
@@ -181,8 +183,12 @@ import TapQWireProtocol
         }
     }
 
-    static func isAutoMode(_ mode: String?) -> Bool {
-        mode?.lowercased().contains("auto") == true
+    /// Strict policy routes every matched tool call through TapQ, so the broker is where
+    /// a mode the agent would never have prompted for gets its silent allow. The mode
+    /// alone is not enough: `acceptEdits` skips the prompt for file edits only, and Bash
+    /// under it still deserves a hands-free confirmation.
+    static func isAutoMode(_ mode: String?, toolName: String) -> Bool {
+        AgentPermissionMode(mode)?.autoAllows(toolName: toolName) == true
     }
 
     private func resolveStopQuestion(_ question: StopQuestion) async -> String? {

--- a/Sources/TapQBrokerRuntime/UnixSocketTransport.swift
+++ b/Sources/TapQBrokerRuntime/UnixSocketTransport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TapQContracts
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -13,20 +14,48 @@ import Glibc
 /// prevent another agent session from reaching the broker; interaction serialization is a
 /// higher-level runtime responsibility.
 public final class UnixSocketTransport: BrokerTransport, @unchecked Sendable {
+    /// The `accept(2)` call itself, injectable so tests can drive the loop's error
+    /// handling without provoking real kernel errnos. It mirrors the syscall: a connected
+    /// descriptor, or -1 with `errno` set.
+    typealias AcceptCall = @Sendable (Int32) -> Int32
+
     private let path: String
     private let maxRequestBytes: Int
     private let stateLock = NSLock()
+    private let acceptConnection: AcceptCall
+    private let diagnostics: TapQDiagnosticEmitter
     private var listenFD: Int32 = -1
     private var running = false
+    /// The path this instance bound, so `stop()` removes its own socket and never one a
+    /// second broker has since taken over.
+    private var boundPath: String?
     private var handler: (@Sendable (Data) async -> Data)?
     private let connectionQueue = DispatchQueue(
         label: "ai.tapq.broker.connection",
         attributes: .concurrent
     )
 
-    public init(path: String, maxRequestBytes: Int = 1 << 20) {
+    public convenience init(
+        path: String,
+        maxRequestBytes: Int = 1 << 20,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.init(path: path, maxRequestBytes: maxRequestBytes,
+                  diagnosticSink: diagnosticSink,
+                  acceptConnection: { accept($0, nil, nil) })
+    }
+
+    init(
+        path: String,
+        maxRequestBytes: Int = 1 << 20,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
+        acceptConnection: @escaping AcceptCall
+    ) {
         self.path = path
         self.maxRequestBytes = maxRequestBytes
+        self.acceptConnection = acceptConnection
+        self.diagnostics = TapQDiagnosticEmitter(category: "BrokerTransport",
+                                                 sink: diagnosticSink)
     }
 
     deinit { stop() }
@@ -36,7 +65,7 @@ public final class UnixSocketTransport: BrokerTransport, @unchecked Sendable {
         defer { stateLock.unlock() }
         guard listenFD < 0 else { throw SocketError.alreadyStarted }
 
-        unlink(path)
+        try Self.clearStaleSocket(at: path)
         let descriptor = socket(AF_UNIX, Self.streamSocketType, 0)
         guard descriptor >= 0 else { throw SocketError.errno("socket", errno) }
 
@@ -80,6 +109,7 @@ public final class UnixSocketTransport: BrokerTransport, @unchecked Sendable {
 
         self.handler = handler
         listenFD = descriptor
+        boundPath = path
         running = true
         Thread.detachNewThread { [weak self] in
             self?.acceptLoop(descriptor: descriptor)
@@ -91,25 +121,123 @@ public final class UnixSocketTransport: BrokerTransport, @unchecked Sendable {
         running = false
         let descriptor = listenFD
         listenFD = -1
+        let ownedPath = boundPath
+        boundPath = nil
         handler = nil
         stateLock.unlock()
 
         if descriptor >= 0 { close(descriptor) }
-        unlink(path)
+        if let ownedPath { unlink(ownedPath) }
+    }
+
+    /// A crashed broker leaves its socket file behind, so a stale path must be
+    /// reclaimable — but a path with a broker still listening on it belongs to that
+    /// broker. Unlinking it would leave the first `tapq serve` bound to a name no hook
+    /// can reach: every hook call would then stall to its timeout against a broker that
+    /// still looks healthy. Probe first, and refuse to start rather than take the path.
+    private static func clearStaleSocket(at path: String) throws {
+        guard FileManager.default.fileExists(atPath: path) else { return }
+        guard !isSocketListening(at: path) else { throw SocketError.addressInUse(path) }
+        guard unlink(path) == 0 || errno == ENOENT else {
+            throw SocketError.errno("unlink", errno)
+        }
+    }
+
+    /// Connects and immediately closes, sending no application data — the broker treats
+    /// an EOF-only connection as a no-op. Anything that is not an accepting listener
+    /// (a refused connection, a leftover regular file, a socket nobody owns) reads as
+    /// not listening.
+    static func isSocketListening(at path: String, timeoutMilliseconds: Int32 = 100) -> Bool {
+        let descriptor = socket(AF_UNIX, streamSocketType, 0)
+        guard descriptor >= 0 else { return false }
+        defer { close(descriptor) }
+
+        let flags = fcntl(descriptor, F_GETFL, 0)
+        guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0 else {
+            return false
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard path.utf8.count < capacity else { return false }
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                    _ = strncpy($0, source, capacity - 1)
+                }
+            }
+        }
+
+        let result = withUnsafePointer(to: &address) { rawAddress in
+            rawAddress.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.stride))
+            }
+        }
+        if result == 0 { return true }
+        guard errno == EINPROGRESS else { return false }
+
+        var poller = pollfd(fd: descriptor, events: Int16(POLLOUT), revents: 0)
+        guard poll(&poller, 1, max(0, timeoutMilliseconds)) > 0 else { return false }
+
+        var socketError: Int32 = 0
+        var socketErrorSize = socklen_t(MemoryLayout<Int32>.size)
+        guard getsockopt(descriptor, SOL_SOCKET, SO_ERROR,
+                         &socketError, &socketErrorSize) == 0 else { return false }
+        return socketError == 0
     }
 
     private func acceptLoop(descriptor: Int32) {
+        var backoff = Self.acceptBackoffFloor
         while isRunning {
-            let connection = accept(descriptor, nil, nil)
+            let connection = acceptConnection(descriptor)
             if connection < 0 {
-                if isRunning, errno == EINTR { continue }
-                break
+                let code = errno
+                // A closed listener during stop() is the ordinary shutdown path, not a
+                // failure worth reporting.
+                guard isRunning else { break }
+                if code == EINTR { continue }
+                guard Self.isTransientAcceptErrno(code) else {
+                    // Descriptor-level errors mean this listener is gone for good; the
+                    // loop has nothing left to accept on.
+                    diagnostics.record("accept.stopped", level: .error,
+                                       fields: ["errno": "\(code)"])
+                    break
+                }
+                // A per-connection abort or an exhausted descriptor table is momentary:
+                // giving up here would leave the broker listening but answering nothing,
+                // so back off (bounded) and keep accepting.
+                diagnostics.record("accept.retry", level: .warning, fields: [
+                    "errno": "\(code)",
+                    "backoff_ms": "\(Int(backoff * 1000))",
+                ])
+                Thread.sleep(forTimeInterval: backoff)
+                backoff = min(backoff * 2, Self.acceptBackoffCeiling)
+                continue
             }
+            backoff = Self.acceptBackoffFloor
             connectionQueue.async { [weak self] in
                 self?.handleConnection(connection)
             }
         }
     }
+
+    /// Transient accept failures: the connection died before it was accepted, or the
+    /// process/system is briefly out of descriptors or buffers. None of them says
+    /// anything about the listening socket, which stays valid.
+    private static let transientAcceptErrnos: Set<Int32> = [
+        ECONNABORTED, EMFILE, ENFILE, ENOBUFS, ENOMEM, EAGAIN, EWOULDBLOCK, EPROTO,
+        ECONNRESET, ETIMEDOUT,
+    ]
+
+    static func isTransientAcceptErrno(_ code: Int32) -> Bool {
+        transientAcceptErrnos.contains(code)
+    }
+
+    /// Backoff starts short enough to be invisible to a healthy broker and is capped so a
+    /// persistent transient condition never turns into an unbounded stall.
+    private static let acceptBackoffFloor: TimeInterval = 0.01
+    private static let acceptBackoffCeiling: TimeInterval = 0.2
 
     private func handleConnection(_ descriptor: Int32) {
         defer { close(descriptor) }
@@ -202,6 +330,7 @@ public final class UnixSocketTransport: BrokerTransport, @unchecked Sendable {
 
     public enum SocketError: Error, LocalizedError, Equatable {
         case alreadyStarted
+        case addressInUse(String)
         case pathTooLong(String)
         case errno(String, Int32)
 
@@ -209,6 +338,9 @@ public final class UnixSocketTransport: BrokerTransport, @unchecked Sendable {
             switch self {
             case .alreadyStarted:
                 return "The broker socket is already running."
+            case .addressInUse(let path):
+                return "Another TapQ broker is already listening on \(path). "
+                    + "Stop it before starting a second one."
             case .pathTooLong(let path):
                 return "The broker socket path is too long: \(path)"
             case .errno(let operation, let code):

--- a/Sources/TapQClaudeAdapter/HookShim.swift
+++ b/Sources/TapQClaudeAdapter/HookShim.swift
@@ -10,8 +10,8 @@ import TapQWireProtocol
 /// Two PreToolUse failure modes are distinguished, matching Claude Code's own fallback:
 ///   - Broker unreachable (`tapq serve` stopped/crashed/never started) or an unintelligible reply:
 ///     pass through silently (no stdout, exit 0) so Claude Code uses its own permission
-///     flow. Emitting "ask" here would force a prompt on every tool call even in
-///     auto-accept mode.
+///     flow. Emitting "ask" here would force a prompt on every tool call even in a mode
+///     the user set to stop being asked (acceptEdits, dontAsk, bypassPermissions).
 ///   - Broker REACHED but it returned no allow/deny (the hands-free window timed out):
 ///     resolve to "ask" so the normal on-screen prompt appears.
 ///
@@ -239,10 +239,12 @@ public struct HookShim {
         diagnostics: TapQDiagnosticEmitter,
         send: (_ message: [String: JSONValue], _ timeout: TimeInterval) throws -> Data
     ) -> StopInterception {
-        // Auto mode mirrors the AskUserQuestion decision: the user opted out of
-        // hands-free interruptions, so stop questions defer to the screen too.
-        let mode = data["permission_mode"]?.stringValue ?? ""
-        guard !mode.lowercased().contains("auto") else { return .pass }
+        // A mode that stops Claude asking at all — dontAsk, bypassPermissions — is the
+        // user opting out of hands-free interruptions, so stop questions defer to the
+        // screen too. acceptEdits is not that opt-out: it silences file edits, not
+        // questions, so those still reach the user hands-free.
+        let mode = AgentPermissionMode(data["permission_mode"]?.stringValue)
+        guard mode?.skipsStopQuestions != true else { return .pass }
 
         guard let transcriptPath = data["transcript_path"]?.stringValue,
               let text = TranscriptReader.lastAssistantText(transcriptPath: transcriptPath),

--- a/Sources/TapQContracts/AgentPermissionMode.swift
+++ b/Sources/TapQContracts/AgentPermissionMode.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// The permission mode an agent reports on its hook payloads.
+///
+/// Claude Code sends exactly one of these five strings, and the Codex hook contract
+/// mirrors them. Any other value — an unrecognized mode, or an agent such as Cursor or
+/// OpenCode that sends none at all — parses to nil and earns no automatic behavior, so a
+/// mode TapQ has never seen is treated as the cautious `default`.
+///
+/// Matching is exact: these are protocol tokens, not prose, and a near-miss spelling is a
+/// contract change worth noticing rather than guessing at.
+public enum AgentPermissionMode: String, Sendable, Equatable, CaseIterable {
+    /// Ask before every matched tool call.
+    case `default`
+    /// Accept file edits without asking; everything else still prompts.
+    case acceptEdits
+    /// Plan first, execute nothing.
+    case plan
+    /// Stop asking for this session.
+    case dontAsk
+    /// Stop asking, permission checks included.
+    case bypassPermissions
+
+    /// The tools `acceptEdits` answers on the user's behalf. Bash is deliberately absent:
+    /// accepting edits is not accepting commands.
+    public static let editTools: Set<String> = ["Write", "Edit", "MultiEdit", "NotebookEdit"]
+
+    /// Parses an unnormalized mode string, including the nil an adapter sends when its
+    /// agent reports no mode.
+    public init?(_ raw: String?) {
+        guard let raw, let mode = AgentPermissionMode(rawValue: raw) else { return nil }
+        self = mode
+    }
+
+    /// True when the agent would not have asked about this tool anyway, so TapQ has
+    /// nothing to confirm hands-free.
+    public func autoAllows(toolName: String) -> Bool {
+        switch self {
+        case .dontAsk, .bypassPermissions:
+            return true
+        case .acceptEdits:
+            return Self.editTools.contains(toolName)
+        case .default, .plan:
+            return false
+        }
+    }
+
+    /// True when the user has opted out of being asked at all, which makes a spoken
+    /// stop question an interruption they did not want. `acceptEdits` is not such an
+    /// opt-out: it silences file edits, not questions.
+    public var skipsStopQuestions: Bool {
+        switch self {
+        case .dontAsk, .bypassPermissions:
+            return true
+        case .default, .acceptEdits, .plan:
+            return false
+        }
+    }
+}

--- a/Sources/TapQContracts/ApprovalRequest.swift
+++ b/Sources/TapQContracts/ApprovalRequest.swift
@@ -39,7 +39,8 @@ public struct ApprovalRequest: Sendable, Equatable, Identifiable {
     public let toolInput: [String: JSONValue]?
     /// The agent's working directory when it asked.
     public let cwd: String?
-    /// The agent's permission mode string, unnormalized (for example "default", "auto").
+    /// The agent's permission mode string, unnormalized (for example "default",
+    /// "acceptEdits"); `AgentPermissionMode` interprets it.
     public let permissionMode: String?
     /// Which agent hook event produced this approval.
     public let approvalSource: ApprovalSource?

--- a/Tests/TapQBrokerRuntimeTests/BrokerRoundTripTests.swift
+++ b/Tests/TapQBrokerRuntimeTests/BrokerRoundTripTests.swift
@@ -197,14 +197,18 @@ final class BrokerRoundTripTests: XCTestCase {
         try server.start()
 
         let response = try await send(
-            #"{"type":"approval.request","token":"tok","protocol_version":3,"session_id":"s","tool_name":"Bash","tool_input":{},"permission_mode":"auto","request_id":"r1"}"#
+            #"{"type":"approval.request","token":"tok","protocol_version":3,"session_id":"s","tool_name":"Bash","tool_input":{},"permission_mode":"bypassPermissions","request_id":"r1"}"#
         )
 
         XCTAssertEqual(response, .error("approval_source"))
         XCTAssertNil(received.request)
     }
 
-    func testExplicitPreToolUseApprovalInAutoModePassesWithoutCallingHandler() async throws {
+    /// The strict-policy auto-allow gate, across every permission mode Claude Code
+    /// actually sends. A mode that would not have prompted for this tool is allowed
+    /// without spending the user's attention; everything else reaches the hands-free
+    /// handler. `acceptEdits` splits on the tool: it accepts file edits, not commands.
+    func testPreToolUseAutoAllowsOnlyWhereTheAgentWouldNotHavePrompted() async throws {
         defer { transport.stop() }
         let received = ApprovalBox()
         let server = BrokerServer(
@@ -215,15 +219,42 @@ final class BrokerRoundTripTests: XCTestCase {
         )
         try server.start()
 
-        let response = try await send(
-            #"{"type":"approval.request","token":"tok","protocol_version":3,"session_id":"s","tool_name":"Bash","tool_input":{},"permission_mode":"auto","approval_source":"pre_tool_use","request_id":"r1"}"#
-        )
+        let matrix: [(mode: String, tool: String, autoAllowed: Bool)] = [
+            ("default", "Bash", false),
+            ("default", "Edit", false),
+            ("plan", "Bash", false),
+            ("plan", "Edit", false),
+            ("acceptEdits", "Bash", false),
+            ("acceptEdits", "Write", true),
+            ("acceptEdits", "Edit", true),
+            ("acceptEdits", "MultiEdit", true),
+            ("acceptEdits", "NotebookEdit", true),
+            ("dontAsk", "Bash", true),
+            ("dontAsk", "Edit", true),
+            ("bypassPermissions", "Bash", true),
+            ("bypassPermissions", "Edit", true),
+            ("aModeClaudeHasNeverSent", "Bash", false),
+            ("aModeClaudeHasNeverSent", "Edit", false),
+        ]
 
-        XCTAssertEqual(response, .decision(.allow, reason: nil))
-        XCTAssertNil(received.request)
+        for row in matrix {
+            received.request = nil
+            let label = "\(row.mode)/\(row.tool)"
+            let response = try await send(
+                #"{"type":"approval.request","token":"tok","protocol_version":3,"session_id":"s","tool_name":"\#(row.tool)","tool_input":{},"permission_mode":"\#(row.mode)","approval_source":"pre_tool_use","request_id":"r1"}"#
+            )
+            if row.autoAllowed {
+                XCTAssertEqual(response, .decision(.allow, reason: nil), label)
+                XCTAssertNil(received.request, "\(label) must never reach the handler")
+            } else {
+                XCTAssertEqual(response, .decision(.deny, reason: "Denied via TapQ"), label)
+                XCTAssertEqual(received.request?.toolName, row.tool,
+                               "\(label) must be confirmed hands-free")
+            }
+        }
     }
 
-    func testPermissionRequestApprovalInAutoModeAlwaysCallsHandler() async throws {
+    func testPreToolUseApprovalWithoutAPermissionModeAlwaysCallsHandler() async throws {
         defer { transport.stop() }
         let received = ApprovalBox()
         let server = BrokerServer(
@@ -235,7 +266,26 @@ final class BrokerRoundTripTests: XCTestCase {
         try server.start()
 
         let response = try await send(
-            #"{"type":"approval.request","token":"tok","protocol_version":3,"session_id":"s","tool_name":"Bash","tool_input":{},"permission_mode":"auto","approval_source":"permission_request","request_id":"r1"}"#
+            #"{"type":"approval.request","token":"tok","protocol_version":3,"session_id":"s","tool_name":"Edit","tool_input":{},"approval_source":"pre_tool_use","request_id":"r1"}"#
+        )
+
+        XCTAssertEqual(response, .decision(.deny, reason: "Denied via TapQ"))
+        XCTAssertEqual(received.request?.toolName, "Edit")
+    }
+
+    func testPermissionRequestApprovalAlwaysCallsHandlerEvenInBypassPermissions() async throws {
+        defer { transport.stop() }
+        let received = ApprovalBox()
+        let server = BrokerServer(
+            transport: transport,
+            token: "tok",
+            onApproval: { received.request = $0; return .deny },
+            onNotification: { _ in }
+        )
+        try server.start()
+
+        let response = try await send(
+            #"{"type":"approval.request","token":"tok","protocol_version":3,"session_id":"s","tool_name":"Bash","tool_input":{},"permission_mode":"bypassPermissions","approval_source":"permission_request","request_id":"r1"}"#
         )
 
         XCTAssertEqual(response, .decision(.deny, reason: "Denied via TapQ"))
@@ -292,7 +342,7 @@ final class BrokerRoundTripTests: XCTestCase {
         try server.start()
 
         let response = try await send(
-            #"{"type":"approval.request","token":"tok","protocol_version":2,"session_id":"s","tool_name":"Bash","tool_input":{},"permission_mode":"auto","approval_source":"permission_request","request_id":"r1"}"#
+            #"{"type":"approval.request","token":"tok","protocol_version":2,"session_id":"s","tool_name":"Bash","tool_input":{},"permission_mode":"bypassPermissions","approval_source":"permission_request","request_id":"r1"}"#
         )
 
         XCTAssertEqual(response, .error("protocol_version"))

--- a/Tests/TapQBrokerRuntimeTests/UnixSocketTransportTests.swift
+++ b/Tests/TapQBrokerRuntimeTests/UnixSocketTransportTests.swift
@@ -1,0 +1,265 @@
+import XCTest
+@testable import TapQBrokerRuntime
+import TapQContracts
+import TapQPOSIXBridgeClient
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// The transport's survival properties: a momentary accept failure must not silently end
+/// the broker's listening life, and a second broker must never take the socket path away
+/// from the one already answering on it.
+final class UnixSocketTransportTests: XCTestCase {
+    private var socketPath = ""
+
+    override func setUp() {
+        super.setUp()
+        // Short by necessity: `sun_path` is barely 100 bytes, and the sandbox temporary
+        // directory alone overruns it.
+        socketPath = "/tmp/tapq-transport-\(UUID().uuidString).sock"
+    }
+
+    override func tearDown() {
+        unlink(socketPath)
+        super.tearDown()
+    }
+
+    // MARK: - Accept loop
+
+    func testTransientAcceptFailureBacksOffAndKeepsServing() throws {
+        let sink = RecordingSink()
+        let failures = CountingBox(remaining: 3)
+        let transport = UnixSocketTransport(
+            path: socketPath,
+            diagnosticSink: sink,
+            acceptConnection: { descriptor in
+                if failures.consume() {
+                    errno = ECONNABORTED
+                    return -1
+                }
+                return accept(descriptor, nil, nil)
+            }
+        )
+        defer { transport.stop() }
+        try transport.start { _ in Data("served".utf8) }
+
+        let response = try request("ping")
+
+        XCTAssertEqual(String(decoding: response, as: UTF8.self), "served",
+                       "the broker must still answer after a transient accept failure")
+        let retries = sink.events.filter { $0.name == "accept.retry" }
+        XCTAssertEqual(retries.count, 3)
+        XCTAssertEqual(retries.first?.category, "BrokerTransport")
+        XCTAssertEqual(retries.first?.level, .warning)
+        XCTAssertEqual(retries.first?.fields["errno"], "\(ECONNABORTED)")
+        XCTAssertEqual(retries.map { $0.fields["backoff_ms"] }, ["10", "20", "40"],
+                       "backoff grows but stays bounded")
+        XCTAssertTrue(sink.events.allSatisfy { $0.name != "accept.stopped" })
+    }
+
+    func testTransientErrnoClassificationCoversTheKnownRecoverableStates() {
+        for code in [ECONNABORTED, EMFILE, ENFILE, ENOBUFS, ENOMEM, EAGAIN, EWOULDBLOCK] {
+            XCTAssertTrue(UnixSocketTransport.isTransientAcceptErrno(code), "\(code)")
+        }
+        for code in [EBADF, EINVAL, ENOTSOCK, EOPNOTSUPP] {
+            XCTAssertFalse(UnixSocketTransport.isTransientAcceptErrno(code), "\(code)")
+        }
+    }
+
+    func testFatalAcceptFailureStopsTheLoopOnce() throws {
+        let sink = RecordingSink()
+        let attempts = CountingBox(remaining: 0)
+        let transport = UnixSocketTransport(
+            path: socketPath,
+            diagnosticSink: sink,
+            acceptConnection: { _ in
+                attempts.increment()
+                errno = EBADF
+                return -1
+            }
+        )
+        defer { transport.stop() }
+        try transport.start { _ in Data("served".utf8) }
+
+        XCTAssertTrue(waitUntil { sink.events.contains { $0.name == "accept.stopped" } },
+                      "a dead listener must be reported, not looped on")
+        let settled = attempts.count
+        Thread.sleep(forTimeInterval: 0.05)
+        XCTAssertEqual(attempts.count, settled, "the loop must not spin on a dead listener")
+        let stopped = try XCTUnwrap(sink.events.first { $0.name == "accept.stopped" })
+        XCTAssertEqual(stopped.level, .error)
+        XCTAssertEqual(stopped.fields["errno"], "\(EBADF)")
+    }
+
+    // MARK: - Socket ownership
+
+    func testStartRefusesAPathAnotherBrokerIsListeningOnAndLeavesItIntact() throws {
+        let survivor = UnixSocketTransport(path: socketPath)
+        defer { survivor.stop() }
+        try survivor.start { _ in Data("survivor".utf8) }
+
+        let intruder = UnixSocketTransport(path: socketPath)
+        XCTAssertThrowsError(try intruder.start { _ in Data("intruder".utf8) }) { error in
+            XCTAssertEqual(error as? UnixSocketTransport.SocketError,
+                           .addressInUse(socketPath))
+        }
+        // The failed instance bound nothing, so its teardown owns nothing to remove.
+        intruder.stop()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socketPath))
+        let response = try request("ping")
+        XCTAssertEqual(String(decoding: response, as: UTF8.self), "survivor",
+                       "the first broker must keep the socket it is answering on")
+    }
+
+    func testStartReclaimsTheSocketACrashedBrokerLeftBehind() throws {
+        try bindWithoutListening(at: socketPath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socketPath))
+
+        let transport = UnixSocketTransport(path: socketPath)
+        defer { transport.stop() }
+        try transport.start { _ in Data("rebound".utf8) }
+
+        let response = try request("ping")
+        XCTAssertEqual(String(decoding: response, as: UTF8.self), "rebound")
+    }
+
+    func testStopRemovesOnlyTheSocketThisInstanceBound() throws {
+        let survivor = UnixSocketTransport(path: socketPath)
+        defer { survivor.stop() }
+        try survivor.start { _ in Data("survivor".utf8) }
+
+        let neverStarted = UnixSocketTransport(path: socketPath)
+        neverStarted.stop()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socketPath),
+                      "a transport that bound nothing must unlink nothing")
+        XCTAssertEqual(String(decoding: try request("ping"), as: UTF8.self), "survivor")
+
+        survivor.stop()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: socketPath),
+                       "the instance that bound the path still cleans it up")
+    }
+
+    func testDiscoveryRemoveLeavesALiveBrokersRecordsAlone() throws {
+        let directory = URL(fileURLWithPath: "/tmp/tapq-discovery-\(UUID().uuidString)",
+                            isDirectory: true)
+        let discovery = BrokerRuntimeDiscovery(supportDirectory: directory)
+        try discovery.prepareDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+
+        let survivor = UnixSocketTransport(path: discovery.socketPath)
+        defer { survivor.stop() }
+        try survivor.start { _ in Data("survivor".utf8) }
+        try discovery.publish(token: "tok")
+
+        // What a second `tapq serve` does before it starts its own broker.
+        discovery.remove()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: discovery.discoveryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: discovery.socketPath))
+
+        survivor.stop()
+        discovery.remove()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: discovery.discoveryURL.path))
+    }
+
+    // MARK: - Helpers
+
+    private func request(_ line: String, timeout: TimeInterval = 2) throws -> Data {
+        try UnixSocketClient.request(Data(line.utf8), socketPath: socketPath, timeout: timeout)
+    }
+
+    /// A crashed broker's leftover: the socket file exists but nothing listens on it, so
+    /// connecting is refused.
+    private func bindWithoutListening(at path: String) throws {
+        #if canImport(Darwin)
+        let streamType = SOCK_STREAM
+        #else
+        let streamType = Int32(SOCK_STREAM.rawValue)
+        #endif
+        let descriptor = socket(AF_UNIX, streamType, 0)
+        try XCTSkipIf(descriptor < 0, "could not create a stale socket fixture")
+        defer { close(descriptor) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        path.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                destination.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                    _ = strncpy($0, source, capacity - 1)
+                }
+            }
+        }
+        let bound = withUnsafePointer(to: &address) { rawAddress in
+            rawAddress.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                #if canImport(Darwin)
+                Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.stride))
+                #else
+                Glibc.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.stride))
+                #endif
+            }
+        }
+        XCTAssertEqual(bound, 0, "stale socket fixture failed to bind (errno \(errno))")
+    }
+
+    private func waitUntil(attempts: Int = 300, condition: () -> Bool) -> Bool {
+        for _ in 0..<attempts {
+            if condition() { return true }
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+        return condition()
+    }
+
+    private final class CountingBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var remaining: Int
+        private var calls = 0
+
+        init(remaining: Int) {
+            self.remaining = remaining
+        }
+
+        /// Reports whether this call should fail, spending one of the seeded failures.
+        func consume() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            calls += 1
+            guard remaining > 0 else { return false }
+            remaining -= 1
+            return true
+        }
+
+        func increment() {
+            lock.lock()
+            calls += 1
+            lock.unlock()
+        }
+
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return calls
+        }
+    }
+
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+}

--- a/Tests/TapQClaudeAdapterTests/HookShimTests.swift
+++ b/Tests/TapQClaudeAdapterTests/HookShimTests.swift
@@ -215,7 +215,7 @@ final class HookShimTests: XCTestCase {
     }
 
     func testPermissionRequestSendsNativeApprovalSourceAndMetadata() throws {
-        let input = stdin(#"{"hook_event_name":"PermissionRequest","session_id":"s9","tool_name":"Bash","tool_input":{"command":"curl example.com"},"permission_mode":"auto","cwd":"/tmp"}"#)
+        let input = stdin(#"{"hook_event_name":"PermissionRequest","session_id":"s9","tool_name":"Bash","tool_input":{"command":"curl example.com"},"permission_mode":"acceptEdits","cwd":"/tmp"}"#)
         var captured: [String: JSONValue]?
         var capturedTimeout: TimeInterval?
         _ = HookShim.handle(stdinData: input) { message, timeout in
@@ -228,7 +228,7 @@ final class HookShimTests: XCTestCase {
         XCTAssertEqual(captured?["session_id"]?.stringValue, "s9")
         XCTAssertEqual(captured?["tool_name"]?.stringValue, "Bash")
         XCTAssertEqual(captured?["tool_input"]?["command"]?.stringValue, "curl example.com")
-        XCTAssertEqual(captured?["permission_mode"]?.stringValue, "auto")
+        XCTAssertEqual(captured?["permission_mode"]?.stringValue, "acceptEdits")
         XCTAssertEqual(captured?["approval_source"]?.stringValue, "permission_request")
         XCTAssertEqual(captured?["cwd"]?.stringValue, "/tmp")
         XCTAssertFalse(captured?["request_id"]?.stringValue?.isEmpty ?? true)
@@ -556,15 +556,33 @@ final class HookShimTests: XCTestCase {
         XCTAssertEqual(sentTypes, ["notification.event"], "no ? means no stop.question round-trip")
     }
 
-    func testStopInAutoModePassesThrough() throws {
+    /// The stop-question opt-out, across every permission mode Claude Code actually
+    /// sends. Only the modes where the user stopped being asked at all skip the question;
+    /// `acceptEdits` silences file edits, not questions, so it still gets one.
+    func testStopQuestionOptOutAcrossEveryRealPermissionMode() throws {
         let path = try transcript("Which approach? 1) A 2) B")
-        var sentTypes: [String] = []
-        let result = HookShim.handle(stdinData: stopInput(path, mode: "autoAccept")) { message, _ in
-            sentTypes.append(message["type"]?.stringValue ?? "")
-            return Data(#"{"ok":true}"#.utf8)
+        let matrix: [(mode: String, asksTheUser: Bool)] = [
+            ("default", true),
+            ("plan", true),
+            ("acceptEdits", true),
+            ("dontAsk", false),
+            ("bypassPermissions", false),
+            ("aModeClaudeHasNeverSent", true),
+        ]
+
+        for row in matrix {
+            var sentTypes: [String] = []
+            let result = HookShim.handle(stdinData: stopInput(path, mode: row.mode)) { message, _ in
+                sentTypes.append(message["type"]?.stringValue ?? "")
+                return Data(#"{"action":"pass"}"#.utf8)
+            }
+            XCTAssertNil(result.stdout, row.mode)
+            XCTAssertEqual(
+                sentTypes,
+                row.asksTheUser ? ["stop.question", "notification.event"] : ["notification.event"],
+                row.mode
+            )
         }
-        XCTAssertNil(result.stdout)
-        XCTAssertEqual(sentTypes, ["notification.event"])
     }
 
     func testStopWithMissingTranscriptPassesThrough() {

--- a/Tests/TapQContractsTests/AgentPermissionModeTests.swift
+++ b/Tests/TapQContractsTests/AgentPermissionModeTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import TapQContracts
+
+final class AgentPermissionModeTests: XCTestCase {
+    func testParsesOnlyTheModesAgentsActuallySend() {
+        XCTAssertEqual(AgentPermissionMode("default"), .default)
+        XCTAssertEqual(AgentPermissionMode("acceptEdits"), .acceptEdits)
+        XCTAssertEqual(AgentPermissionMode("plan"), .plan)
+        XCTAssertEqual(AgentPermissionMode("dontAsk"), .dontAsk)
+        XCTAssertEqual(AgentPermissionMode("bypassPermissions"), .bypassPermissions)
+        XCTAssertEqual(AgentPermissionMode.allCases.count, 5)
+
+        XCTAssertNil(AgentPermissionMode(nil), "an agent that reports no mode gets no automatic behavior")
+        XCTAssertNil(AgentPermissionMode(""))
+        XCTAssertNil(AgentPermissionMode("auto"), "\"auto\" is not a mode any agent sends")
+        XCTAssertNil(AgentPermissionMode("autoAccept"))
+        XCTAssertNil(AgentPermissionMode("acceptedits"), "modes are protocol tokens, matched exactly")
+    }
+
+    func testAutoAllowCoversEveryModeAndSplitsAcceptEditsByTool() {
+        for tool in ["Bash", "Write", "Edit", "MultiEdit", "NotebookEdit", "WebFetch"] {
+            XCTAssertFalse(AgentPermissionMode.default.autoAllows(toolName: tool), tool)
+            XCTAssertFalse(AgentPermissionMode.plan.autoAllows(toolName: tool), tool)
+            XCTAssertTrue(AgentPermissionMode.dontAsk.autoAllows(toolName: tool), tool)
+            XCTAssertTrue(AgentPermissionMode.bypassPermissions.autoAllows(toolName: tool), tool)
+        }
+
+        for tool in ["Write", "Edit", "MultiEdit", "NotebookEdit"] {
+            XCTAssertTrue(AgentPermissionMode.acceptEdits.autoAllows(toolName: tool), tool)
+        }
+        for tool in ["Bash", "WebFetch", "AskUserQuestion", "edit"] {
+            XCTAssertFalse(AgentPermissionMode.acceptEdits.autoAllows(toolName: tool),
+                           "accepting edits is not accepting \(tool)")
+        }
+    }
+
+    func testOnlyStopAskingModesOptOutOfStopQuestions() {
+        XCTAssertTrue(AgentPermissionMode.dontAsk.skipsStopQuestions)
+        XCTAssertTrue(AgentPermissionMode.bypassPermissions.skipsStopQuestions)
+        XCTAssertFalse(AgentPermissionMode.default.skipsStopQuestions)
+        XCTAssertFalse(AgentPermissionMode.plan.skipsStopQuestions)
+        XCTAssertFalse(AgentPermissionMode.acceptEdits.skipsStopQuestions,
+                       "acceptEdits silences file edits, not questions")
+    }
+}


### PR DESCRIPTION
## Problem

Three confirmed defects from the 2026-07-24 post-launch review:

1. The auto-mode gate matched `contains("auto")`, which no real Claude Code permission mode ever satisfies — strict-policy auto-allow and stop-question opt-out were dead code, pinned by tests using fictional modes.
2. `UnixSocketTransport`'s accept loop exited permanently on any non-EINTR errno: the broker looked healthy while every hook call stalled to its 255 s timeout.
3. `start()`/`stop()` unlinked the socket path unconditionally, so a second `tapq serve` silently killed the surviving instance.

## Change

- **Real permission-mode matrix**: `bypassPermissions` and `dontAsk` auto-allow under the strict policy and opt out of stop questions; `acceptEdits` auto-allows only the edit-family tools (Write, Edit, MultiEdit, NotebookEdit) and does not opt out; `default` and `plan` get no auto behavior. The fictional-mode tests are replaced by a full matrix at both call sites.
- **Accept-loop recovery**: transient errnos (ECONNABORTED, EMFILE, ENFILE, ENOBUFS, EAGAIN) log a diagnostic, back off briefly, and continue; genuinely fatal states still exit. An injection seam covers both paths with tests, and the runtime now passes its diagnostic sink into the production transport so `accept.retry`/`accept.stopped` are visible.
- **Live-socket protection**: on start, an existing socket is probe-connected — a live listener fails startup with a clear error instead of being unlinked; only stale sockets are cleaned up, and `stop()` unlinks only a path this instance bound.

## Testing

- `swift test`: **1,594 tests, 0 failures** (baseline 1,583). `scripts/check-public-boundary.sh` green.
- Independently reviewed with mutation checks (restoring `contains("auto")` turns the new matrix red at both sites; recovery test exercises the real accept loop via the seam).
- Known limit: the runtime-side sink wiring lives in the executable target, which no test target imports — review-protected only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)