### PR TITLE
Fall back to backend-native turn detection without an IMU turn signal; migrate the realtime adapter to the GA API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,24 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Changed
 
+- The `openai-realtime` voice path no longer needs AirPods to be usable. Its only endpoint
+  was the IMU one behind `--imu-turn-control`, and on that pipe a transcript does not exist
+  until the audio is committed — so a wearer without AirPods spoke into a buffer nothing
+  committed until the window timed out, silently. When TapQ has no live wearer turn signal,
+  the session is now switched to the backend's own end-of-speech detection
+  (`turn_detection: server_vad`, `create_response: false`, `interrupt_response: false`) so
+  a transcript arrives and the window resolves through the ordinary match path. The mode is
+  chosen at each window open from the live motion state, so AirPods connecting or
+  disconnecting mid-run switches it back without a restart, and an IMU-armed run behaves
+  exactly as it did before. Declared as a backend capability rather than an OpenAI special
+  case. See the [CLI reference](docs/CLI.md#turn-detection).
+- **What the backend still may not do.** A native commit ends an *utterance*, not TapQ's
+  turn and never a window: the microphone stays open, and only a matched transcript, a
+  gesture, a tap, or the timeout resolves anything. The service is configured never to
+  create a response and never to interrupt playback, and a commit it makes with the mode
+  off is still a protocol violation that ends the session. The honest cost is that in the
+  degraded mode the remote endpoint decides where the wearer's sentences end — from audio
+  it was already being sent, and only while a window is open.
 - An endpointed voice turn that matched no command no longer asks the backend for a reply.
   Committing the turn used to hand the whole utterance to the realtime model and let it
   answer, which was the one path where TapQ spoke a sentence nothing in TapQ wrote. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,7 +298,20 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Fixed
 
-- Paired-but-disconnected AirPods no longer draw a per-window disconnect announcement.
+- `--voice-backend openai-realtime` works again. OpenAI retired the Realtime Beta API on
+  2026-08-27 and every session open began failing with "The Realtime Beta API is no longer
+  supported", silently degrading every run to the Apple backend. The adapter now speaks the
+  GA protocol: the `OpenAI-Beta: realtime=v1` header is gone (it, not the URL, is what
+  routed the connection to the retired API), the session object carries `type: "realtime"`
+  and `output_modalities`, audio settings moved under `audio.input` / `audio.output`, an
+  encoding is an object (`{"type":"audio/pcm","rate":24000}`) rather than the string
+  `"pcm16"`, and turn detection moved under `audio.input.turn_detection`, where *off* is a
+  literal `null` rather than `{"type":"none"}`. The wire audio format is unchanged — 24 kHz
+  is the only rate GA accepts for PCM — so the microphone pump and playback are untouched.
+  Both turn-detection modes, the manual commit path, and the handshake-ack criterion behave
+  exactly as before; `response.output_audio.delta` and `response.done` are now the only
+  spellings accepted for response audio and completion, the Beta names having no API left
+  to arrive from.
   macOS answers `isDeviceMotionAvailable == true` for AirPods sitting in their closed
   case, so the no-AirPods degrade path — window continues voice-only, says nothing —
   was unreachable in the most common no-AirPods state: every window ran the sampleless

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -251,6 +251,20 @@ import Darwin
             }
         }
 
+        // -- Wearer turn signal liveness --
+        // The one question the realtime path asks at each window open: is TapQ's own
+        // endpointer working right now? A `nil` signal — no `--imu-turn-control` — answers
+        // no forever, because without the flag no coordinator is listening and nothing on
+        // TapQ's side would ever commit the turn. With the flag, the answer starts yes and
+        // is retracted by a confirmed motion loss below, which is what catches AirPods that
+        // are paired but sitting in their case. Its own child signal, not the coordinator's:
+        // each child owns one `onWearerSpeakingChange` slot.
+        let turnSignalLiveness = WearerTurnSignalLiveness(
+            signal: configuration.imuTurnControlEnabled
+                ? wearerSpeechSource?.makeSignal()
+                : nil
+        )
+
         // -- Voice composition --
         // `apple` is the shipped path and stays literally the shipped path: the same
         // `VoiceListener` instance, wrapped by the same `SpeechGatedVoice`, with nothing
@@ -299,6 +313,7 @@ import Darwin
                 supportsBargeIn: true,
                 responseAudio: player,
                 freeformEnabled: configuration.voiceFreeformEnabled,
+                isWearerTurnSignalLive: { [turnSignalLiveness] in turnSignalLiveness.isLive },
                 diagnosticSink: diagnostics
             )
             // Wire the conversation-reopened seam so sticky fail-through resets on a new
@@ -621,7 +636,16 @@ import Darwin
         // `NotificationPolicy` never suppresses a motion loss outright, for the reason
         // above — a wearer who hears nothing waits for a prompt that is not coming — so the
         // wearer is still told, in the channel quiet mode leaves open.
-        gestures.onMotionLost = { reason in
+        let turnDetectionProvider = backendProvider
+        gestures.onMotionLost = { [weak turnDetectionProvider] reason in
+            // Every reason means the same thing to the turn signal: there is no IMU
+            // endpointer any more. On the realtime path the provider is re-asked
+            // immediately rather than at the next window, because the window this fired
+            // inside is the one a wearer with no AirPods is waiting on — see
+            // `refreshTurnDetectionMode`. Recorded first, so the refresh reads the retracted
+            // value. Both calls are inert on the Apple path.
+            turnSignalLiveness.noteMotionUnavailable()
+            turnDetectionProvider?.refreshTurnDetectionMode()
             guard reason != .neverStreamed else {
                 voiceOnlyNotice()
                 return
@@ -1103,6 +1127,20 @@ import Darwin
             }
             : nil
 
+        // Which endpointer the run is starting with, appended to the backend line rather
+        // than given one of its own: it is a property of the pipe, and an operator reading
+        // "openai-realtime" needs to know in the same breath whether the far end is deciding
+        // where their sentences stop. Later windows may switch it — that is what the
+        // `turn_detection.*` diagnostics are for — but a run that *starts* degraded should
+        // say so on the line the operator is already reading.
+        let voiceBackendStatus: String? = configuration.voiceBackend.statusDescription.map {
+            base in
+            guard backendProvider != nil else { return base }
+            return turnSignalLiveness.isLive
+                ? base + ", turns ended by TapQ (IMU endpointing)"
+                : base + ", turns ended by the backend's own VAD (no IMU turn signal)"
+        }
+
         onReady(.init(
             socketPath: discovery.socketPath,
             discoveryPath: discovery.discoveryURL.path,
@@ -1112,7 +1150,7 @@ import Darwin
             // without a second `CMHeadphoneMotionManager` competing for the headphones.
             motionAvailable: gestures.isMotionCurrentlyAvailable,
             voiceAvailable: voiceAuthorized,
-            voiceBackendStatus: configuration.voiceBackend.statusDescription,
+            voiceBackendStatus: voiceBackendStatus,
             encoderStatus: encoderStatus,
             reasonerStatus: reasonerStatus,
             wearerSpeechStatus: wearerSpeechStatus,

--- a/Sources/TapQAppleAdapters/AppleVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/AppleVoiceBackend.swift
@@ -247,6 +247,22 @@ import AVFoundation
         }
     }
 
+    /// A documented no-op: `capabilities.supportsNativeTurnDetection` is false, so TapQ
+    /// never asks for it and the only caller that can reach this is
+    /// `FailThroughVoiceBackend` replaying a mode onto the fallback after the cloud pipe
+    /// died mid-degrade.
+    ///
+    /// There is nothing here to switch. `SFSpeechRecognizer` already marks a result final
+    /// from its own silence heuristic, and this backend already forwards that as
+    /// `transcriptFinal` — a window on the Apple stack never needed a commit to get a
+    /// transcript, which is why the degraded mode has nothing to add and losing it costs
+    /// nothing. The turn stays exactly as open as TapQ left it, per the invariant at the top
+    /// of this file.
+    public func setNativeTurnDetection(_ enabled: Bool) {
+        guard enabled else { return }
+        diagnostics.record("native_turn.not_applicable")
+    }
+
     #if canImport(Speech) && canImport(AVFoundation)
     private func handleRecognition(transcript: String?, isFinal: Bool,
                                    error: (any Error)?, generation: UInt64) {

--- a/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
@@ -159,6 +159,18 @@ import AVFoundation
         inner.cancelResponse()
     }
 
+    /// Forwarded verbatim: the mode is the inner pipe's business, and the pump has no
+    /// opinion about who decides where a sentence ended.
+    ///
+    /// What matters here is what the pump does *not* do in response to the inner backend's
+    /// native commits. A commit ends an utterance, not the turn, so the microphone stays
+    /// open — the wearer may not be finished, and a pump that closed the mic on the first
+    /// VAD commit would make every second sentence in a window inaudible. The mic still
+    /// closes exactly where it always did: in `endUserTurn`, and nowhere else.
+    public func setNativeTurnDetection(_ enabled: Bool) {
+        inner.setNativeTurnDetection(enabled)
+    }
+
     // MARK: - Event relay
 
     private func relayEvent(_ event: VoiceBackendEvent, sessionGeneration sessGen: UInt64) {

--- a/Sources/TapQContracts/VoiceBackend.swift
+++ b/Sources/TapQContracts/VoiceBackend.swift
@@ -74,12 +74,23 @@ public struct VoiceBackendCapabilities: Sendable, Equatable {
     public let producesAudio: Bool
     /// The transport can carry input and output audio simultaneously.
     public let duplex: Bool
+    /// The backend can run end-of-speech detection of its own over the audio TapQ feeds
+    /// it, and commit that audio for transcription when it decides the speaker stopped.
+    ///
+    /// Declaring it does **not** turn it on. It is off on every fresh session and stays off
+    /// until TapQ calls `setNativeTurnDetection(true)`, which TapQ does only in the one
+    /// situation the carve-out on this protocol describes: no wearer turn signal exists, so
+    /// nothing on TapQ's side can tell when the utterance ended. When false,
+    /// `setNativeTurnDetection(true)` is a request the backend cannot honour and TapQ must
+    /// never make — the caller checks this flag first.
+    public let supportsNativeTurnDetection: Bool
 
     public init(supportsBargeIn: Bool = false, producesAudio: Bool = false,
-                duplex: Bool = false) {
+                duplex: Bool = false, supportsNativeTurnDetection: Bool = false) {
         self.supportsBargeIn = supportsBargeIn
         self.producesAudio = producesAudio
         self.duplex = duplex
+        self.supportsNativeTurnDetection = supportsNativeTurnDetection
     }
 
     /// The shape of a recognition-only backend: transcripts in, nothing spoken back, one
@@ -120,10 +131,11 @@ public enum VoiceBackendFailure: Error, LocalizedError, Equatable, Sendable {
 
 /// Everything a backend is allowed to tell TapQ.
 ///
-/// Note what is absent: there is no "user started speaking", "user stopped speaking", or
-/// "turn ended" event. Those are decisions, and decisions live on TapQ's side of this
-/// boundary. A backend that believes it detected end-of-speech has nothing in this enum
-/// to say so with, which is the point.
+/// Note what is still absent: there is no "user started speaking", no "user stopped
+/// speaking", and above all no "window resolved". Those are decisions, and decisions live
+/// on TapQ's side of this boundary. The single report a backend may make about the shape of
+/// a turn is `userAudioCommittedByBackend`, and it exists only because TapQ explicitly
+/// asked the backend to do the endpointing — see the carve-out on `VoiceBackend`.
 public enum VoiceBackendEvent: Sendable, Equatable {
     /// Best-guess transcript so far. Cumulative for the current turn, matching the
     /// semantics `VoiceListener` already relies on: matchers see the whole utterance
@@ -137,6 +149,18 @@ public enum VoiceBackendEvent: Sendable, Equatable {
     /// backend that is the end of recognition; for a speaking backend it is the end of
     /// its response audio.
     case responseCompleted
+    /// The backend's own end-of-speech detection decided the speaker stopped and committed
+    /// the audio buffered so far for transcription. Emitted **only** while TapQ has turned
+    /// native turn detection on with `setNativeTurnDetection(true)`; a backend that sends
+    /// it otherwise has broken the contract and the adapter fails the session.
+    ///
+    /// What it does *not* mean: the user turn is over. TapQ's turn is still open, `sendAudio`
+    /// is still accepted, and the microphone stays live — the wearer may keep talking, and a
+    /// second segment will be committed the same way. All this event reports is that a
+    /// transcript for the audio so far is on its way, which is what lets the window resolve
+    /// through the ordinary match-on-transcript path instead of waiting out its timeout.
+    /// It never carries a response with it: `create_response` stays off.
+    case userAudioCommittedByBackend
     /// The session is over and no further events will arrive. The caller must treat the
     /// backend as closed and, if it still needs voice, open a new one.
     case sessionFailed(VoiceBackendFailure)
@@ -155,6 +179,29 @@ public enum VoiceBackendEvent: Sendable, Equatable {
 ///    before anything else). This is not a preference: TapQ's windows are arbitrated
 ///    against head gestures, taps, and timeouts, and a backend that ends turns behind
 ///    TapQ's back resolves approvals the interaction controller never authorized.
+///
+///    **The carve-out, and exactly how far it goes.** The rule above assumes TapQ *has* a
+///    turn signal. It has one only from the in-ear IMU: `WearerTurnCoordinator` watches
+///    bone-conducted speech and commits the turn when the wearer stops. With no AirPods
+///    streaming — or without `--imu-turn-control` — nothing on TapQ's side knows the
+///    utterance ended, and against a backend that only produces transcripts on commit the
+///    wearer's answer sits unheard in a buffer until the window times out. A voice channel
+///    that is silently unusable is worse than one that admits a remote endpoint decided
+///    where the sentence stopped. So when, and only when, TapQ has no wearer turn signal,
+///    it may call `setNativeTurnDetection(true)` on a backend that declares
+///    `supportsNativeTurnDetection`, and that backend's own VAD may then end the *user
+///    turn* — meaning: commit buffered audio for transcription, and report it as
+///    `userAudioCommittedByBackend`.
+///
+///    Everything else about non-negotiable 1 survives intact, and each clause is load-bearing:
+///    the backend still must never create a response of its own (`create_response: false`);
+///    it still must never resolve anything — match-on-transcript, gestures, taps, and the
+///    window timeout remain the only ways a window ends, and every one of them runs on
+///    TapQ's side of this boundary; and it is still TapQ that decides the mode, per window,
+///    from the liveness of its own signal, so an IMU-armed run behaves exactly as it did
+///    before this carve-out existed. What the wearer trades for a usable voice channel is
+///    narrow and worth naming: the remote endpoint learns where their sentences end. It
+///    learns that only from audio it was already being sent, only while a window is open.
 /// 2. **Wearer attribution lives on TapQ's side.** The microphone hears the whole room;
 ///    only the in-ear IMU knows whose jaw moved. No backend is ever asked, or trusted,
 ///    to say who spoke — see `WearerSpeechSignaling` and `WearerGatedVoice`.
@@ -219,4 +266,24 @@ public enum VoiceBackendEvent: Sendable, Equatable {
     /// Abandons an in-flight response (barge-in). Only meaningful when
     /// `capabilities.supportsBargeIn` is true.
     func cancelResponse()
+
+    /// Switches the backend's own end-of-speech detection on or off for this session.
+    ///
+    /// This is the carve-out on non-negotiable 1, expressed as one call. `true` asks the
+    /// backend to commit buffered audio for transcription when its VAD hears the speaker
+    /// stop, and to report each such commit as `userAudioCommittedByBackend`; it never
+    /// authorizes creating a response, ending TapQ's window, or resolving anything.
+    /// `false` — the state every fresh session starts in — puts commits back under
+    /// `endUserTurn(expectingResponse:)` alone, and a commit the backend makes anyway is a
+    /// protocol violation that kills the session.
+    ///
+    /// Every backend implements this rather than inheriting a default no-op: a protocol
+    /// extension would let a backend that cannot do it look, from the call site, exactly
+    /// like one that can, which is the failure mode the whole capability exists to prevent.
+    /// A backend whose `capabilities.supportsNativeTurnDetection` is false implements it as
+    /// a documented no-op, and TapQ checks the flag before ever asking.
+    ///
+    /// Callable before `open` (the mode is applied to the session when it is established)
+    /// and on a live session (the mode changes from the next segment on). Idempotent.
+    func setNativeTurnDetection(_ enabled: Bool)
 }

--- a/Sources/TapQContracts/VoiceBackendSession.swift
+++ b/Sources/TapQContracts/VoiceBackendSession.swift
@@ -26,6 +26,12 @@ public enum VoiceTurnViolation: Error, LocalizedError, Equatable, Sendable {
     /// `cancelResponse` against a backend whose `capabilities.supportsBargeIn` is false.
     /// Rejected rather than ignored so a caller can never believe barge-in worked.
     case bargeInUnsupported
+    /// The backend committed the input buffer of its own accord while TapQ owned turn
+    /// arbitration — native turn detection was off, so nothing authorized it. The exact
+    /// hole non-negotiable 1 exists to close, and the reason a commit is checked here
+    /// rather than trusted: an unauthorized commit produces a transcript, and a transcript
+    /// can resolve an approval window.
+    case unsolicitedBackendCommit
 
     public var errorDescription: String? {
         switch self {
@@ -45,6 +51,8 @@ public enum VoiceTurnViolation: Error, LocalizedError, Equatable, Sendable {
             return "No response is in flight."
         case .bargeInUnsupported:
             return "This voice backend does not support barge-in."
+        case .unsolicitedBackendCommit:
+            return "The voice backend committed the input buffer while TapQ owned turn arbitration."
         }
     }
 }
@@ -87,6 +95,16 @@ public struct VoiceTurnStateMachine: Equatable, Sendable {
 
     public private(set) var state: State
     public let capabilities: VoiceBackendCapabilities
+
+    /// Whether TapQ has handed end-of-speech detection to the backend for this session —
+    /// the carve-out documented on `VoiceBackend`. Off for every fresh session, and reset
+    /// by `close()`/`sessionFailed()` so a reconnect never inherits it: the adapter re-asks
+    /// for the mode it wants once the new session is established.
+    ///
+    /// It exists here, in the legality checker, because it is the one thing that decides
+    /// whether a commit the backend made on its own is a legal report or the session-ending
+    /// contract violation it is by default.
+    public private(set) var nativeTurnDetectionEnabled = false
 
     public init(capabilities: VoiceBackendCapabilities = .transcriptOnly) {
         self.capabilities = capabilities
@@ -163,14 +181,53 @@ public struct VoiceTurnStateMachine: Equatable, Sendable {
         }
     }
 
+    /// Records that TapQ has switched the backend's own end-of-speech detection on or off.
+    ///
+    /// Deliberately not a transition and deliberately not guarded by state: the mode is a
+    /// property of the session, not of the turn, and an adapter must be able to set it
+    /// before `open` as readily as between windows.
+    public mutating func setNativeTurnDetection(_ enabled: Bool) {
+        nativeTurnDetectionEnabled = enabled
+    }
+
+    /// The backend's own VAD committed the buffered input audio.
+    ///
+    /// Legal only while `nativeTurnDetectionEnabled` — that is the whole point of tracking
+    /// the mode. With it off, this is `unsolicitedBackendCommit`: a backend ending turns
+    /// behind TapQ's back, which the adapters turn into a dead session rather than a
+    /// silently resolved approval window.
+    ///
+    /// Note what this does *not* do when it is legal: it does not leave `.userTurn`. A
+    /// native commit ends an *utterance*, not TapQ's turn. The window is still open, the
+    /// microphone is still live, `sendAudio` is still legal, and the wearer may say a second
+    /// sentence that gets committed exactly the same way. Moving to `.committed` here would
+    /// make the very next microphone buffer an illegal `sendAudio` and kill the session
+    /// under a wearer who did nothing but keep talking.
+    ///
+    /// - Returns: `true` when this commit ended an utterance inside an open user turn — the
+    ///   case worth reporting upward. `false` for a commit that arrives outside one (between
+    ///   windows, or while a response is playing): tolerated in native mode because the
+    ///   backend's VAD runs on the audio stream rather than on TapQ's window boundaries, and
+    ///   there is nothing to report about a segment nobody is listening for.
+    @discardableResult
+    public mutating func backendCommittedUserTurn() throws -> Bool {
+        guard state != .idle else { throw VoiceTurnViolation.notOpen }
+        guard nativeTurnDetectionEnabled else {
+            throw VoiceTurnViolation.unsolicitedBackendCommit
+        }
+        return state == .userTurn
+    }
+
     /// The backend reported `VoiceBackendEvent.sessionFailed`. Always legal, from any
     /// state: failures arrive whenever they arrive.
     public mutating func sessionFailed() {
         state = .idle
+        nativeTurnDetectionEnabled = false
     }
 
     /// Teardown. Always legal and idempotent, from any state.
     public mutating func close() {
         state = .idle
+        nativeTurnDetectionEnabled = false
     }
 }

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -50,6 +50,10 @@ public enum SessionPolicy: Sendable, Equatable {
     private let responseAudio: (any VoiceResponseAudioPlaying)?
     private let freeformEnabled: Bool
     private let idleSleep: @MainActor (TimeInterval) async -> Void
+    /// Reports whether TapQ's own wearer turn signal is live. `nil` — the default, and every
+    /// composition that predates the degrade path — means "assume it is", which keeps turn
+    /// arbitration on TapQ's side exactly as it has always been.
+    private let isWearerTurnSignalLive: (@MainActor () -> Bool)?
 
     private var handler: (@MainActor (VoiceCommand) -> Void)?
     private var sessionOpen = false
@@ -97,6 +101,7 @@ public enum SessionPolicy: Sendable, Equatable {
                 supportsBargeIn: Bool = false,
                 responseAudio: (any VoiceResponseAudioPlaying)? = nil,
                 freeformEnabled: Bool = false,
+                isWearerTurnSignalLive: (@MainActor () -> Bool)? = nil,
                 monotonicNow: @escaping @MainActor () -> TimeInterval = {
                     ProcessInfo.processInfo.systemUptime
                 },
@@ -110,6 +115,7 @@ public enum SessionPolicy: Sendable, Equatable {
         self.supportsBargeIn = supportsBargeIn
         self.responseAudio = responseAudio
         self.freeformEnabled = freeformEnabled
+        self.isWearerTurnSignalLive = isWearerTurnSignalLive
         self.monotonicNow = monotonicNow
         self.idleSleep = idleSleep
         self.diagnostics = TapQDiagnosticEmitter(category: "VoiceBackend", sink: diagnosticSink)
@@ -133,6 +139,10 @@ public enum SessionPolicy: Sendable, Equatable {
         handler = onCommand
         // Cancel any pending idle-close: a window is opening.
         idleGeneration &+= 1
+        // Decided here, before any turn exists, because a window is the unit the answer can
+        // change on: AirPods connect and disconnect mid-run, and the turn that is about to
+        // open has to be ended by whichever of the two endpointers is actually working now.
+        applyTurnDetectionMode()
 
         switch sessionPolicy {
         case .perWindow:
@@ -250,6 +260,61 @@ public enum SessionPolicy: Sendable, Equatable {
         isShutDown = true
         idleGeneration &+= 1
         teardown()
+    }
+
+    // MARK: - Turn detection mode
+
+    /// Which endpointer is in force, or `nil` before the question has been asked of this
+    /// session. Reset to `nil` whenever the session goes away, so a fresh backend is always
+    /// told explicitly rather than assumed to have inherited the last one's mode.
+    private var nativeTurnDetectionOn: Bool?
+
+    /// Chooses, for the window that is about to open, whether TapQ ends the wearer's turn or
+    /// the backend's own end-of-speech detection does.
+    ///
+    /// The rule is one line — TapQ keeps turns while it has a wearer turn signal, and hands
+    /// them over when it does not — and it is worth being explicit about why it is asked
+    /// per window rather than settled once at startup. AirPods connect and disconnect while
+    /// a run is going. A run that resolved the question at composition time would either
+    /// leave a wearer with no AirPods talking into a buffer nobody commits until the window
+    /// times out (the bug this exists to fix), or leave a wearer who has just put their
+    /// AirPods in with a remote endpoint deciding where their sentences end for the rest of
+    /// the day (the privacy cost this exists to keep narrow). Asking every time costs a
+    /// boolean read and one frame on the sessions where the answer actually changed.
+    ///
+    /// Fail direction: an unknown answer counts as "signal live", so the fallback is TapQ
+    /// keeping turn arbitration. That is the conservative direction — the failure it
+    /// produces is a window that resolves late, not one that resolves without authorization.
+    private func applyTurnDetectionMode() {
+        guard backend.capabilities.supportsNativeTurnDetection else {
+            // Nothing to decide: the Apple stack's recognizer finalizes transcripts from its
+            // own silence heuristic, so a window there never depended on a commit. Recorded
+            // once per session so the log says which of the two shapes this run is in.
+            if nativeTurnDetectionOn == nil {
+                nativeTurnDetectionOn = false
+                diagnostics.record("turn_detection.manual", fields: ["reason": "unsupported"])
+            }
+            return
+        }
+        let native = !(isWearerTurnSignalLive?() ?? true)
+        guard nativeTurnDetectionOn != native else { return }
+        nativeTurnDetectionOn = native
+        backend.setNativeTurnDetection(native)
+        diagnostics.record(native ? "turn_detection.native" : "turn_detection.manual",
+                           fields: ["reason": native ? "no_wearer_turn_signal"
+                                                     : "wearer_turn_signal_live"])
+    }
+
+    /// Re-asks the question outside a window open.
+    ///
+    /// One caller: the host's motion-loss handler. Without it, a run started with
+    /// `--imu-turn-control` and no AirPods would spend its *first* window in manual mode —
+    /// the flag says AirPods are expected, and the detector only discovers the availability
+    /// lie a bounded moment into that window. That is the one window a wearer with no
+    /// AirPods most needs to work. The switch lands on the live session, so the turn already
+    /// open is endpointed by the backend from that moment on.
+    public func refreshTurnDetectionMode() {
+        applyTurnDetectionMode()
     }
 
     // MARK: - Turn coordination hooks (for WP7)
@@ -463,6 +528,20 @@ public enum SessionPolicy: Sendable, Equatable {
             } else {
                 diagnostics.record("audio.ignored")
             }
+        case .userAudioCommittedByBackend:
+            // The degraded endpoint firing: the backend's VAD heard the wearer stop and
+            // committed the audio, so a transcript is on its way and the window can resolve
+            // through the ordinary match path instead of waiting out its timeout.
+            //
+            // Nothing else is done here, and that is deliberate. The turn is *not* closed —
+            // the wearer may still be talking, the microphone is still theirs, and a second
+            // sentence is committed the same way. No response was created (the mode is sent
+            // with `create_response: false`), so none of the response tracking moves. And the
+            // window is not resolved: only a matched transcript, a gesture, a tap, or the
+            // timeout may do that, which is the half of turn arbitration that never left
+            // TapQ's side. What the event buys is the transcript; what it must never buy is
+            // a decision.
+            diagnostics.record("turn.committed_by_backend")
         case .responseCompleted:
             _responseInFlight = false
             _responsePendingFromTurn = false
@@ -549,6 +628,9 @@ public enum SessionPolicy: Sendable, Equatable {
         _responseSuppressed = false
         pendingUserTurn = false
         windowPaused = false
+        // The mode belonged to the session that is going away. The next one is told
+        // explicitly rather than assumed to have inherited it.
+        nativeTurnDetectionOn = nil
         responseAudio?.stopAndFlush()
         if turnActive {
             turnActive = false
@@ -635,6 +717,7 @@ public enum SessionPolicy: Sendable, Equatable {
         _responsePendingFromTurn = false
         _responseSuppressed = false
         pendingUserTurn = false
+        nativeTurnDetectionOn = nil
         sessionGeneration &+= 1
         backend.close()
     }

--- a/Sources/TapQInteractionBaseline/WearerTurnSignalLiveness.swift
+++ b/Sources/TapQInteractionBaseline/WearerTurnSignalLiveness.swift
@@ -1,0 +1,80 @@
+import Foundation
+import TapQContracts
+
+/// Whether TapQ's own wearer turn signal — the in-ear IMU endpointing path — is something
+/// this run can actually end turns with.
+///
+/// One question, asked at each window open, whose answer decides whether TapQ keeps turn
+/// arbitration or hands end-of-speech detection to the backend (the carve-out documented on
+/// `VoiceBackend`). It is deliberately not the same question `WearerSpeechSignaling`
+/// answers, and the difference is the reason this type exists at all:
+///
+/// - `isSignalAvailable` describes **now**: is a fresh, per-axis motion sample in hand this
+///   instant. Between windows the motion stream is stopped — every arbiter `finish()` stops
+///   the detector — so it reads false during exactly the moment the decision has to be
+///   made, on a run whose AirPods are working perfectly.
+/// - `isLive` describes **this run**: is there reason to believe an IMU endpoint will fire
+///   when the wearer stops talking. That is a claim about hardware, not about the last 200
+///   milliseconds of it.
+///
+/// So the default is optimism, and it is retracted only by evidence. A run with
+/// `--imu-turn-control` starts live: the flag says AirPods are expected, and starting
+/// degraded would change the behavior of the working path — the case the carve-out is
+/// explicitly not for. A confirmed motion loss retracts it, which is what catches the
+/// availability lie macOS tells about AirPods that are paired but sitting in their case:
+/// `isDeviceMotionAvailable` answers true, no sample ever arrives, and the detector reports
+/// `neverStreamed` a bounded moment into the first window. From then on the run is degraded.
+/// A sample arriving later — the wearer put the AirPods in mid-run — restores it, and the
+/// next window switches back.
+///
+/// A run without the flag has no signal at all and is never live: there is no coordinator
+/// listening, so nothing would ever commit the turn.
+///
+/// Nothing here polls, schedules, or holds a timer. It reads the signal when asked and
+/// listens for the transitions it already broadcasts, so a run that never consults it pays
+/// nothing for it.
+@MainActor public final class WearerTurnSignalLiveness {
+    private let signal: (any WearerSpeechSignaling)?
+
+    /// Set when the motion channel has been *confirmed* absent — not merely quiet. Retracts
+    /// the optimism above until a real sample proves the hardware is back.
+    private var motionConfirmedAbsent = false
+
+    /// - Parameter signal: a `WearerSpeechSignaling` child, or `nil` for a run with no IMU
+    ///   turn control at all. A child rather than the source itself: this claims its own
+    ///   `onWearerSpeakingChange`, and the coordinator claims a different child's.
+    public init(signal: (any WearerSpeechSignaling)?) {
+        self.signal = signal
+        signal?.onWearerSpeakingChange = { [weak self] _ in
+            self?.noteSignalObserved()
+        }
+    }
+
+    /// Whether an IMU endpoint can be expected to end the wearer's turns.
+    ///
+    /// Reading it is also how a returning motion stream is noticed: a window that is open
+    /// with samples flowing answers true and clears any earlier loss, so the *next* window
+    /// switches back to manual turns without anything having to watch for a reconnect.
+    public var isLive: Bool {
+        guard let signal else { return false }
+        if signal.isSignalAvailable {
+            motionConfirmedAbsent = false
+            return true
+        }
+        return !motionConfirmedAbsent
+    }
+
+    /// The motion channel is confirmed gone — no sample has ever arrived this run, or a
+    /// stream that was delivering them stopped. Called from the host's `onMotionLost`
+    /// handler, which is the one place that knows the difference between "quiet" and "not
+    /// there".
+    public func noteMotionUnavailable() {
+        guard !motionConfirmedAbsent else { return }
+        motionConfirmedAbsent = true
+    }
+
+    private func noteSignalObserved() {
+        guard signal?.isSignalAvailable == true else { return }
+        motionConfirmedAbsent = false
+    }
+}

--- a/Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/FailThroughVoiceBackend.swift
@@ -32,12 +32,23 @@ public enum FailThroughStickiness: Sendable, Equatable {
 /// wrapper's own `sessionFailed`: there is nothing left to fall through to, and pretending
 /// otherwise would hide a broken voice channel behind an endless reconnect.
 @MainActor public final class FailThroughVoiceBackend: VoiceBackend {
-    /// The conservative intersection of both backends.
+    /// The conservative intersection of both backends — with one deliberate exception.
     ///
     /// Capabilities are static for an instance's lifetime by contract, but which backend is
     /// active is not, so the only honest answer is what *both* can do. Advertising the
     /// primary's barge-in would strand a caller mid-failover holding a capability the
     /// fallback never had.
+    ///
+    /// `supportsNativeTurnDetection` is the union instead, because the asymmetry that makes
+    /// intersection right for the others is absent here. Barge-in, audio, and duplex are
+    /// things a caller *relies* on: it changes its own behavior because the backend can do
+    /// them, and a failover that quietly removes one leaves the caller wrong. Native turn
+    /// detection is something the caller *delegates*, and delegating it to a backend that
+    /// cannot do it costs nothing — the Apple fallback's recognizer already emits final
+    /// transcripts from its own silence heuristic, so a window on the fallback resolves
+    /// exactly as it always has. Intersecting here would mean the composition TapQ actually
+    /// ships — realtime primary, Apple fallback — could never degrade at all, which is the
+    /// whole feature.
     public let capabilities: VoiceBackendCapabilities
 
     private let primary: any VoiceBackend
@@ -57,6 +68,11 @@ public enum FailThroughStickiness: Sendable, Equatable {
     private var generation: UInt64 = 0
     /// When sticky and the primary has failed, subsequent opens skip the primary entirely.
     private var primaryStuck = false
+    /// The turn-detection mode the caller asked for. Held here rather than read back off a
+    /// backend for the same reason `turnActive` is: it is what gets replayed. A session
+    /// established after this was set — a failover, a reconnect, a new conversation — must
+    /// come up in the mode the caller is still expecting, not in the default.
+    private var nativeTurnDetection = false
 
     public init(primary: any VoiceBackend,
                 fallback: any VoiceBackend,
@@ -70,7 +86,9 @@ public enum FailThroughStickiness: Sendable, Equatable {
                 && fallback.capabilities.supportsBargeIn,
             producesAudio: primary.capabilities.producesAudio
                 && fallback.capabilities.producesAudio,
-            duplex: primary.capabilities.duplex && fallback.capabilities.duplex)
+            duplex: primary.capabilities.duplex && fallback.capabilities.duplex,
+            supportsNativeTurnDetection: primary.capabilities.supportsNativeTurnDetection
+                || fallback.capabilities.supportsNativeTurnDetection)
         self.diagnostics = TapQDiagnosticEmitter(category: "VoiceFailThrough", sink: diagnosticSink)
     }
 
@@ -118,6 +136,10 @@ public enum FailThroughStickiness: Sendable, Equatable {
             }
             primaryOpen = true
             active = primary
+            // Replayed onto the fresh session, exactly like the open turn below: a backend
+            // that has just come up is in its default manual mode and does not know what the
+            // caller asked for before it existed.
+            primary.setNativeTurnDetection(nativeTurnDetection)
             diagnostics.record("primary.opened")
             return
         } catch {
@@ -186,6 +208,13 @@ public enum FailThroughStickiness: Sendable, Equatable {
             return
         }
         active.cancelResponse()
+    }
+
+    public func setNativeTurnDetection(_ enabled: Bool) {
+        nativeTurnDetection = enabled
+        // Forwarded even with nothing active: both wrapped backends accept the call before
+        // `open`, and one of them is about to be opened.
+        active?.setNativeTurnDetection(enabled)
     }
 
     // MARK: - Event routing
@@ -257,6 +286,7 @@ public enum FailThroughStickiness: Sendable, Equatable {
         fallbackOpen = true
         failingOver = false
         active = fallback
+        fallback.setNativeTurnDetection(nativeTurnDetection)
         diagnostics.record("fallback.opened")
     }
 

--- a/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
@@ -7,7 +7,7 @@ import TapQContracts
 /// dumb speech pipe `VoiceBackend` describes:
 ///
 /// - The first frame on every connection is a `session.update` carrying
-///   `turn_detection: none`, and the handshake is not considered complete until the
+///   `audio.input.turn_detection: null`, and the handshake is not considered complete until the
 ///   service acknowledges it with `session.updated`. Until that ack lands, the service
 ///   would be running its own voice-activity detection on settings TapQ never chose, and a
 ///   server-side commit would resolve an approval window TapQ never authorized.
@@ -125,7 +125,7 @@ import TapQContracts
         // The one setting the adapter refuses to take on faith: whatever a caller passes,
         // this session runs without server-side turn detection.
         var manualTurns = configuration
-        manualTurns.turnDetection = .disabled
+        manualTurns.turnDetection = nil
         self.configuration = manualTurns
         self.timeout = timeout
         self.monotonicNow = monotonicNow
@@ -353,10 +353,10 @@ import TapQContracts
         // kill the session TapQ had just degraded on purpose.
         turns.setNativeTurnDetection(nativeTurnDetectionApplied)
         var update = configuration
-        update.turnDetection = nativeTurnDetectionApplied ? .serverVAD : .disabled
+        update.turnDetection = nativeTurnDetectionApplied ? .serverVAD : nil
         enqueue(.sessionUpdate(update), generation: generation)
         diagnostics.record("turn_detection.updated",
-                           fields: ["mode": nativeTurnDetectionApplied ? "server_vad" : "none"])
+                           fields: ["mode": nativeTurnDetectionApplied ? "server_vad" : "null"])
     }
 
     // MARK: - Inbound

--- a/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
@@ -9,11 +9,18 @@ import TapQContracts
 /// - The first frame on every connection is a `session.update` carrying
 ///   `turn_detection: none`, and the handshake is not considered complete until the
 ///   service acknowledges it with `session.updated`. Until that ack lands, the service
-///   would be running its own voice-activity detection, and a server-side commit would
-///   resolve an approval window TapQ never authorized.
+///   would be running its own voice-activity detection on settings TapQ never chose, and a
+///   server-side commit would resolve an approval window TapQ never authorized.
 /// - Audio only ever leaves during an open user turn, the buffer is committed only from
 ///   `endUserTurn()`, and a response is only ever created by TapQ — on commit, or on an
 ///   explicit `requestResponse(text:)`.
+/// - `setNativeTurnDetection(true)` is the one documented exception, and it is a second
+///   `session.update` on an already-established session, never a shortcut through the
+///   handshake above. It moves `turn_detection` to `server_vad` with `create_response:
+///   false` and `interrupt_response: false`, so the service may say where a sentence ended
+///   and may not do anything else. The empty-turn guard, the "a response happens only when
+///   TapQ asks" rule, and the half-duplex policy are all untouched by it. See the carve-out
+///   on `VoiceBackend` for why TapQ ever asks.
 /// - `capabilities` reports what the *transport* can do (barge-in, audio, duplex). TapQ
 ///   still runs half-duplex; that policy is enforced by `VoiceTurnStateMachine`, which
 ///   every inbound call and every server event routes through, so a protocol mistake
@@ -39,7 +46,8 @@ import TapQContracts
 
     public let capabilities = VoiceBackendCapabilities(supportsBargeIn: true,
                                                        producesAudio: true,
-                                                       duplex: true)
+                                                       duplex: true,
+                                                       supportsNativeTurnDetection: true)
 
     private let transport: any RealtimeTransporting
     private let configuration: RealtimeSessionConfiguration
@@ -76,10 +84,29 @@ import TapQContracts
     /// the shape `VoiceCommandMatcher` expects. The service sends deltas.
     private var transcript = ""
 
-    /// Bytes of audio appended in the current turn. An `endUserTurn` with zero appended
+    /// Bytes of audio appended since the last commit. An `endUserTurn` with zero appended
     /// audio sends neither `commit` nor `response.create` — the OpenAI service rejects an
-    /// empty commit, and a silent teardown turn must not create spurious responses.
+    /// empty commit, and a silent teardown turn must not create spurious responses. Reset
+    /// on `beginUserTurn` and on every commit, including the service's own: what it counts
+    /// is what is sitting in the input buffer right now.
     private var turnAudioByteCount = 0
+
+    /// The mode TapQ has asked for, which outlives any one session: a caller sets it once
+    /// per window and a reconnect must come back up in it rather than silently reverting to
+    /// manual. Applied to a session only through `applyTurnDetection`.
+    private var nativeTurnDetectionRequested = false
+    /// The mode this session is actually in. Separate from the request so `applyTurnDetection`
+    /// can be called freely — from `open`, from a caller, from a caller before `open` — and
+    /// send a frame only when something really changed.
+    private var nativeTurnDetectionApplied = false
+    /// Commits this adapter issued that the service has not yet echoed back as
+    /// `input_audio_buffer.committed`.
+    ///
+    /// The service sends that event for TapQ's own commits *and* for the ones its VAD makes,
+    /// with nothing in the payload that distinguishes them. Counting is the distinction:
+    /// an echo that matches an outstanding commit is an ack, and one that does not is the
+    /// service ending an utterance on its own — legal only in native mode, fatal otherwise.
+    private var pendingOwnCommits = 0
 
     /// - Parameters:
     ///   - transport: the frame pipe. Injected so tests drive a scripted server and never a
@@ -147,6 +174,11 @@ import TapQContracts
         let generation = sessionGeneration
         self.onEvent = onEvent
         transcript = ""
+        // A new session starts in manual-turn mode no matter what the last one was doing.
+        // `nativeTurnDetectionRequested` survives, and is re-applied once the handshake
+        // lands — a reconnect must come back up in the mode the caller asked for.
+        nativeTurnDetectionApplied = false
+        pendingOwnCommits = 0
 
         do {
             try await transport.connect()
@@ -173,6 +205,12 @@ import TapQContracts
         // Manual-turn mode before anything else, including before any audio can exist.
         enqueue(.sessionUpdate(configuration), generation: generation)
         try await awaitHandshake(generation: generation)
+        // Only now, on an established session whose settings the service has acknowledged,
+        // is the degraded mode allowed to be asked for. Folding `server_vad` into the
+        // handshake frame would save one round trip and give away the property the handshake
+        // exists for: that there is no instant in a session's life where the service is
+        // running turn detection TapQ did not deliberately turn on.
+        applyTurnDetection(generation: generation)
         diagnostics.record("session.opened", fields: ["model": configuration.model])
     }
 
@@ -234,6 +272,19 @@ import TapQContracts
             return false
         }
         let generation = sessionGeneration
+        // In native mode the service owns commits, and whatever is in the buffer at window
+        // teardown is the tail end of an utterance its VAD has not called finished. TapQ
+        // must not commit it: the fragment is usually shorter than the 100 ms the service
+        // accepts, and a rejected commit arrives as an `error` frame that ends the session.
+        // Dropping it is the right answer anyway — nobody is listening for it any more, and
+        // the buffer outlives this window.
+        guard !nativeTurnDetectionApplied else {
+            turnAudioByteCount = 0
+            enqueue(.clearInputAudio, generation: generation)
+            diagnostics.record("turn.ended_native")
+            return false
+        }
+        pendingOwnCommits += 1
         enqueue(.commitInputAudio, generation: generation)
         // When TapQ does not want a spoken reply (match-resolved, gesture stop,
         // activity pause), commit for transcription only — no response.create.
@@ -278,6 +329,36 @@ import TapQContracts
         enqueue(.cancelResponse, generation: sessionGeneration)
     }
 
+    // MARK: - Turn detection mode
+
+    public func setNativeTurnDetection(_ enabled: Bool) {
+        nativeTurnDetectionRequested = enabled
+        // Before a session exists, or while its handshake is still in flight, the request is
+        // recorded and nothing is sent: `open` applies it the moment the service has
+        // acknowledged the manual-turn configuration, which is the only ordering that keeps
+        // the "no unauthorized VAD, ever" property of the handshake intact.
+        guard turns.isOpen, handshakeGeneration == nil else { return }
+        applyTurnDetection(generation: sessionGeneration)
+    }
+
+    /// Brings the live session into the requested mode, or does nothing if it is already
+    /// there. Idempotent by construction, so every caller can call it unconditionally.
+    private func applyTurnDetection(generation: UInt64) {
+        guard sessionGeneration == generation else { return }
+        guard nativeTurnDetectionApplied != nativeTurnDetectionRequested else { return }
+        nativeTurnDetectionApplied = nativeTurnDetectionRequested
+        // The state machine learns the mode before the frame goes out, not after: the
+        // service can answer a `session.update` with a VAD commit in the same breath, and a
+        // machine that still thought the session was manual would call that a violation and
+        // kill the session TapQ had just degraded on purpose.
+        turns.setNativeTurnDetection(nativeTurnDetectionApplied)
+        var update = configuration
+        update.turnDetection = nativeTurnDetectionApplied ? .serverVAD : .disabled
+        enqueue(.sessionUpdate(update), generation: generation)
+        diagnostics.record("turn_detection.updated",
+                           fields: ["mode": nativeTurnDetectionApplied ? "server_vad" : "none"])
+    }
+
     // MARK: - Inbound
 
     private func startReceiveLoop(generation: UInt64) {
@@ -313,6 +394,17 @@ import TapQContracts
             diagnostics.record("session.created")
         case .sessionUpdated:
             settleHandshake(.success(()), generation: generation)
+        case .speechStarted:
+            // Recorded, never acted on. The service's opinion about where speech began is
+            // not an event TapQ has any use for — it does not open windows, does not
+            // attribute the speaker, and does not arm barge-in — but a "voice did nothing"
+            // report is far easier to read when the log shows whether the service heard
+            // anything at all.
+            diagnostics.record("native_turn.speech_started")
+        case .speechStopped:
+            diagnostics.record("native_turn.speech_stopped")
+        case .inputAudioCommitted:
+            handleInputAudioCommitted(generation: generation)
         case .transcriptDelta(let delta):
             guard !delta.isEmpty else { return }
             transcript += delta
@@ -364,6 +456,46 @@ import TapQContracts
         case .unsupported(let type):
             diagnostics.record("event.ignored", fields: ["type": type])
         }
+    }
+
+    /// Sorts an `input_audio_buffer.committed` into an ack for a commit TapQ sent and a
+    /// commit the service's own VAD made, and lets only the second one reach the caller.
+    private func handleInputAudioCommitted(generation: UInt64) {
+        if pendingOwnCommits > 0 {
+            pendingOwnCommits -= 1
+            diagnostics.record("commit.acked")
+            return
+        }
+        let endedUtterance: Bool
+        do {
+            endedUtterance = try turns.backendCommittedUserTurn()
+        } catch {
+            // Native mode is off and the service committed anyway. This is precisely the
+            // failure non-negotiable 1 names: the transcript that follows such a commit can
+            // match the grammar and resolve an approval window nobody authorized, so the
+            // session dies here rather than one frame later with a decision attached.
+            return failSession(
+                .protocolViolation(
+                    "the realtime peer committed the input buffer while TapQ owned turn arbitration"),
+                generation: generation)
+        }
+        // The buffer the service just took is gone; what follows belongs to the next
+        // utterance. The transcript is reset for the same reason — each VAD segment is a
+        // whole utterance as far as the grammar is concerned, and carrying the previous
+        // sentence's words into the next one would have the matcher answering a question
+        // out of two half-heard ones.
+        turnAudioByteCount = 0
+        transcript = ""
+        guard endedUtterance else {
+            // A segment that closed outside an open user turn: between windows, or while a
+            // response is playing. Tolerated (the service's VAD tracks the audio stream, not
+            // TapQ's windows) and reported to nobody — there is no window it could resolve.
+            diagnostics.record("native_turn.commit_ignored",
+                               fields: ["state": turns.state.rawValue])
+            return
+        }
+        diagnostics.record("native_turn.committed")
+        emit(.userAudioCommittedByBackend)
     }
 
     // MARK: - Outbound pump
@@ -477,6 +609,11 @@ import TapQContracts
         pumpRunning = false
         transcript = ""
         expectCancelAck = false
+        turnAudioByteCount = 0
+        pendingOwnCommits = 0
+        // The applied mode belongs to the session that just died; the requested one belongs
+        // to the caller and is re-applied by the next `open`.
+        nativeTurnDetectionApplied = false
         turns.close()
         transport.close()
         // A continuation that is never resumed is a task leaked forever, so teardown from

--- a/Sources/TapQVoiceBackends/RealtimeMessages.swift
+++ b/Sources/TapQVoiceBackends/RealtimeMessages.swift
@@ -6,12 +6,20 @@ import Foundation
 /// `OpenAILunaQuestionClassifier.defaultModel` / `.defaultEndpoint` / `.defaultTimeout`.
 public enum RealtimeDefaults {
     public static let model = "gpt-realtime"
+    /// The GA endpoint. The Beta API that used to answer here was retired on 2026-08-27,
+    /// and a session that reaches for it now is refused before the first frame.
     public static let endpoint = URL(string: "wss://api.openai.com/v1/realtime")!
+    /// What kind of session this is. GA requires it on every `session.update`; the Beta
+    /// session object had no discriminator at all.
+    public static let sessionType = "realtime"
     /// Whisper-class transcription of the *wearer's* audio. Without this the session
     /// returns only the model's own words, and TapQ's grammar has nothing to match.
     public static let inputTranscriptionModel = "gpt-4o-transcribe"
     /// The only encoding this adapter frames, matching `VoiceAudioFormat.pcm16Mono24k`.
-    public static let audioFormat = "pcm16"
+    public static let audioFormat = RealtimeAudioFormat.pcm24k
+    /// GA takes one output modality, not the Beta pair. `audio` is the one TapQ needs, and
+    /// asking for it does not cost the transcript — an audio response carries its own.
+    public static let outputModalities = ["audio"]
     /// What the session is for, sent once with the first `session.update`.
     ///
     /// TapQ asks this model to do exactly two things: read sentences TapQ wrote, and
@@ -42,20 +50,39 @@ public enum RealtimeMessageError: Error, LocalizedError, Equatable, Sendable {
     }
 }
 
-/// Server-side voice activity detection: off by default, and never given more than one job
-/// when it is on.
+/// How an audio stream is encoded.
 ///
-/// Modelled as a value rather than hardcoded so both settings are visible on the wire and
-/// assertable in a test. `.disabled` is what every session starts with and what an
-/// IMU-armed run stays on. `.serverVAD` is the carve-out documented on `VoiceBackend`: with
-/// no wearer turn signal, the service is allowed to say where the sentence ended, and
-/// nothing else.
+/// Beta named an encoding with a bare string (`"pcm16"`). GA takes an object with a MIME
+/// type and a sample rate, and rejects the string outright, so the shape has to be modelled
+/// even though TapQ only ever sends one value.
+public struct RealtimeAudioFormat: Codable, Equatable, Sendable {
+    public let type: String
+    public let rate: Int?
+
+    public init(type: String, rate: Int? = nil) {
+        self.type = type
+        self.rate = rate
+    }
+
+    /// The one format this adapter frames, matching `VoiceAudioFormat.pcm16Mono24k`. 24 kHz
+    /// is the only rate GA accepts for `audio/pcm`, which is why the mic pump and the
+    /// playback path never had to change across this migration.
+    public static let pcm24k = RealtimeAudioFormat(type: "audio/pcm", rate: 24_000)
+}
+
+/// Server-side voice activity detection, never given more than one job when it is on.
+///
+/// Modelled as a value rather than hardcoded so the setting is visible on the wire and
+/// assertable in a test. Turn detection being *off* is not a value in GA — it is the
+/// absence of one, a literal `null` under `audio.input.turn_detection` — so manual-turn
+/// mode is `nil` here rather than a `.disabled` case. `.serverVAD` is the carve-out
+/// documented on `VoiceBackend`: with no wearer turn signal, the service is allowed to say
+/// where the sentence ended, and nothing else.
 public struct RealtimeTurnDetection: Codable, Equatable, Sendable {
     public let type: String
     /// Whether the service may start a response of its own when its VAD ends a turn.
     /// TapQ sends `false` and only `false`: end-of-speech detection is delegated, speaking
-    /// never is — TapQ authors every sentence its voice says. Omitted from the frame when
-    /// nil, which is how `.disabled` keeps encoding to exactly `{"type":"none"}`.
+    /// never is — TapQ authors every sentence its voice says.
     public let createResponse: Bool?
     /// Whether the service may cut its own playback short when it hears speech. TapQ sends
     /// `false`: barge-in belongs to `WearerTurnCoordinator`, which knows whether the voice
@@ -68,10 +95,6 @@ public struct RealtimeTurnDetection: Codable, Equatable, Sendable {
         self.createResponse = createResponse
         self.interruptResponse = interruptResponse
     }
-
-    /// Manual-turn mode: the server never commits a buffer or starts a response on its
-    /// own. The value every session is established with.
-    public static let disabled = RealtimeTurnDetection(type: "none")
 
     /// Degraded-turn mode: the server's own VAD commits the input buffer at speech-end so a
     /// transcript exists, and does nothing else — no response, no interruption.
@@ -95,58 +118,134 @@ public struct RealtimeInputTranscription: Codable, Equatable, Sendable {
     }
 }
 
-/// The `session` payload of a `session.update`.
-///
-/// Only the fields this slice needs. Everything absent is left at the service default on
-/// purpose: an adapter that pins settings it does not care about turns every upstream
-/// default change into a TapQ behavior change.
-public struct RealtimeSessionConfiguration: Codable, Equatable, Sendable {
-    public var model: String
-    public var modalities: [String]
-    public var inputAudioFormat: String
-    public var outputAudioFormat: String
-    public var inputAudioTranscription: RealtimeInputTranscription?
-    /// `.disabled` on every handshake. The adapter overwrites whatever a caller passes, and
-    /// moves the live session to `.serverVAD` only through `setNativeTurnDetection(true)`.
-    public var turnDetection: RealtimeTurnDetection
-    public var instructions: String?
-    public var voice: String?
+/// Everything GA groups under `session.audio.input` — the wearer's side of the session.
+public struct RealtimeInputAudioConfiguration: Codable, Equatable, Sendable {
+    public var format: RealtimeAudioFormat
+    public var transcription: RealtimeInputTranscription?
+    /// `nil` on every handshake, and `nil` again whenever native detection is turned back
+    /// off. The adapter overwrites whatever a caller passes and moves the live session to
+    /// `.serverVAD` only through `setNativeTurnDetection(true)`.
+    public var turnDetection: RealtimeTurnDetection?
 
-    public init(model: String = RealtimeDefaults.model,
-                modalities: [String] = ["audio", "text"],
-                inputAudioFormat: String = RealtimeDefaults.audioFormat,
-                outputAudioFormat: String = RealtimeDefaults.audioFormat,
-                inputAudioTranscription: RealtimeInputTranscription? = RealtimeInputTranscription(),
-                turnDetection: RealtimeTurnDetection = .disabled,
-                instructions: String? = nil,
-                voice: String? = nil) {
-        self.model = model
-        self.modalities = modalities
-        self.inputAudioFormat = inputAudioFormat
-        self.outputAudioFormat = outputAudioFormat
-        self.inputAudioTranscription = inputAudioTranscription
+    public init(format: RealtimeAudioFormat = RealtimeDefaults.audioFormat,
+                transcription: RealtimeInputTranscription? = RealtimeInputTranscription(),
+                turnDetection: RealtimeTurnDetection? = nil) {
+        self.format = format
+        self.transcription = transcription
         self.turnDetection = turnDetection
-        self.instructions = instructions
-        self.voice = voice
     }
 
     enum CodingKeys: String, CodingKey {
-        case model
-        case modalities
-        case instructions
-        case voice
-        case inputAudioFormat = "input_audio_format"
-        case outputAudioFormat = "output_audio_format"
-        case inputAudioTranscription = "input_audio_transcription"
+        case format
+        case transcription
         case turnDetection = "turn_detection"
+    }
+
+    /// Hand-written for one reason: `turn_detection` must be an explicit `null` when it is
+    /// off, never an absent key. GA's `session.update` is a merge — an omitted field keeps
+    /// whatever the session already had — so the synthesized encoding, which drops nil
+    /// keys, would make the native-back-to-manual transition a no-op and leave the service's
+    /// VAD running against TapQ's own turn arbitration.
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(format, forKey: .format)
+        try container.encodeIfPresent(transcription, forKey: .transcription)
+        if let turnDetection {
+            try container.encode(turnDetection, forKey: .turnDetection)
+        } else {
+            try container.encodeNil(forKey: .turnDetection)
+        }
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        format = try container.decode(RealtimeAudioFormat.self, forKey: .format)
+        transcription = try container.decodeIfPresent(RealtimeInputTranscription.self,
+                                                      forKey: .transcription)
+        turnDetection = try container.decodeIfPresent(RealtimeTurnDetection.self,
+                                                      forKey: .turnDetection)
+    }
+}
+
+/// Everything GA groups under `session.audio.output` — the voice TapQ speaks with.
+public struct RealtimeOutputAudioConfiguration: Codable, Equatable, Sendable {
+    public var format: RealtimeAudioFormat
+    /// Beta carried this at the top of the session object; GA moved it here.
+    public var voice: String?
+
+    public init(format: RealtimeAudioFormat = RealtimeDefaults.audioFormat,
+                voice: String? = nil) {
+        self.format = format
+        self.voice = voice
+    }
+}
+
+/// The `audio` object GA introduced. Beta spelled these four settings as four flat keys.
+public struct RealtimeAudioConfiguration: Codable, Equatable, Sendable {
+    public var input: RealtimeInputAudioConfiguration
+    public var output: RealtimeOutputAudioConfiguration
+
+    public init(input: RealtimeInputAudioConfiguration = RealtimeInputAudioConfiguration(),
+                output: RealtimeOutputAudioConfiguration = RealtimeOutputAudioConfiguration()) {
+        self.input = input
+        self.output = output
+    }
+}
+
+/// The `session` payload of a `session.update`, in GA shape.
+///
+/// Only the fields this slice needs. Everything absent is left at the service default on
+/// purpose: an adapter that pins settings it does not care about turns every upstream
+/// default change into a TapQ behavior change. The one exception is `turn_detection`, which
+/// is pinned precisely because the service default — `server_vad` with `create_response`
+/// on — is the thing TapQ exists to not have.
+public struct RealtimeSessionConfiguration: Codable, Equatable, Sendable {
+    public var type: String
+    public var model: String
+    public var outputModalities: [String]
+    public var audio: RealtimeAudioConfiguration
+    public var instructions: String?
+
+    public init(model: String = RealtimeDefaults.model,
+                type: String = RealtimeDefaults.sessionType,
+                outputModalities: [String] = RealtimeDefaults.outputModalities,
+                audio: RealtimeAudioConfiguration = RealtimeAudioConfiguration(),
+                turnDetection: RealtimeTurnDetection? = nil,
+                instructions: String? = nil,
+                voice: String? = nil) {
+        self.type = type
+        self.model = model
+        self.outputModalities = outputModalities
+        self.audio = audio
+        self.instructions = instructions
+        if turnDetection != nil { self.audio.input.turnDetection = turnDetection }
+        if let voice { self.audio.output.voice = voice }
+    }
+
+    /// Where turn detection lives in GA, reached from where every caller already looked for
+    /// it. The adapter flips this on an otherwise-untouched copy of the configuration, which
+    /// is the whole of what a mode change is on the wire.
+    public var turnDetection: RealtimeTurnDetection? {
+        get { audio.input.turnDetection }
+        set { audio.input.turnDetection = newValue }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case model
+        case audio
+        case instructions
+        case outputModalities = "output_modalities"
     }
 }
 
 /// Everything TapQ ever says to the realtime service.
 ///
-/// Pinned to the OpenAI Realtime protocol as observed 2026-05 (`gpt-realtime` family).
-/// The set is small by design — this is a speech pipe, and every client event beyond
-/// these six would be policy leaking across the `VoiceBackend` boundary.
+/// Pinned to the GA OpenAI Realtime protocol as verified against the live service
+/// 2026-08-27 (`gpt-realtime` family). The client event *names* survived the Beta
+/// retirement unchanged; only the `session.update` payload was reshaped. The set is small
+/// by design — this is a speech pipe, and every client event beyond these six would be
+/// policy leaking across the `VoiceBackend` boundary.
 public enum RealtimeClientEvent: Equatable, Sendable {
     /// Configures the session. Always the first frame on a connection: until it lands, the
     /// service is running its own VAD.
@@ -329,7 +428,10 @@ public enum RealtimeServerEvent: Equatable, Sendable {
             return .transcriptDelta(envelope.delta ?? "")
         case "conversation.item.input_audio_transcription.completed":
             return .transcriptCompleted(envelope.transcript ?? envelope.text ?? "")
-        case "response.output_audio.delta", "response.audio.delta":
+        // GA renamed this from Beta's `response.audio.delta`. The old name is not accepted
+        // here any more: the API that sent it no longer exists, and a dead alias in a
+        // decode switch reads like a live compatibility promise.
+        case "response.output_audio.delta":
             guard let encoded = envelope.delta else {
                 throw RealtimeMessageError.malformedFrame("\(envelope.type) carried no audio")
             }
@@ -338,7 +440,7 @@ public enum RealtimeServerEvent: Equatable, Sendable {
                     "\(envelope.type) carried audio that is not base64")
             }
             return .audioDelta(audio)
-        case "response.done", "response.completed":
+        case "response.done":
             return .responseCompleted
         case "error":
             guard let error = envelope.error else {

--- a/Sources/TapQVoiceBackends/RealtimeMessages.swift
+++ b/Sources/TapQVoiceBackends/RealtimeMessages.swift
@@ -42,22 +42,48 @@ public enum RealtimeMessageError: Error, LocalizedError, Equatable, Sendable {
     }
 }
 
-/// Server-side voice activity detection, which TapQ always turns off.
+/// Server-side voice activity detection: off by default, and never given more than one job
+/// when it is on.
 ///
-/// Modelled as a value rather than hardcoded so the disabling is visible on the wire and
-/// assertable in a test. A backend that ends turns from its own VAD resolves approval
-/// windows TapQ's interaction controller never authorized — see the non-negotiables on
-/// `VoiceBackend`.
+/// Modelled as a value rather than hardcoded so both settings are visible on the wire and
+/// assertable in a test. `.disabled` is what every session starts with and what an
+/// IMU-armed run stays on. `.serverVAD` is the carve-out documented on `VoiceBackend`: with
+/// no wearer turn signal, the service is allowed to say where the sentence ended, and
+/// nothing else.
 public struct RealtimeTurnDetection: Codable, Equatable, Sendable {
     public let type: String
+    /// Whether the service may start a response of its own when its VAD ends a turn.
+    /// TapQ sends `false` and only `false`: end-of-speech detection is delegated, speaking
+    /// never is — TapQ authors every sentence its voice says. Omitted from the frame when
+    /// nil, which is how `.disabled` keeps encoding to exactly `{"type":"none"}`.
+    public let createResponse: Bool?
+    /// Whether the service may cut its own playback short when it hears speech. TapQ sends
+    /// `false`: barge-in belongs to `WearerTurnCoordinator`, which knows whether the voice
+    /// it heard was the wearer's, and a service that truncates on a colleague's cough would
+    /// be resolving a policy question from the wrong side of the boundary.
+    public let interruptResponse: Bool?
 
-    public init(type: String) {
+    public init(type: String, createResponse: Bool? = nil, interruptResponse: Bool? = nil) {
         self.type = type
+        self.createResponse = createResponse
+        self.interruptResponse = interruptResponse
     }
 
     /// Manual-turn mode: the server never commits a buffer or starts a response on its
-    /// own. The only value TapQ ever sends.
+    /// own. The value every session is established with.
     public static let disabled = RealtimeTurnDetection(type: "none")
+
+    /// Degraded-turn mode: the server's own VAD commits the input buffer at speech-end so a
+    /// transcript exists, and does nothing else — no response, no interruption.
+    public static let serverVAD = RealtimeTurnDetection(type: "server_vad",
+                                                        createResponse: false,
+                                                        interruptResponse: false)
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case createResponse = "create_response"
+        case interruptResponse = "interrupt_response"
+    }
 }
 
 /// Transcription settings for the wearer's own audio.
@@ -80,8 +106,8 @@ public struct RealtimeSessionConfiguration: Codable, Equatable, Sendable {
     public var inputAudioFormat: String
     public var outputAudioFormat: String
     public var inputAudioTranscription: RealtimeInputTranscription?
-    /// Always `.disabled` for TapQ. Settable only so a test can prove the adapter refuses
-    /// to ship anything else.
+    /// `.disabled` on every handshake. The adapter overwrites whatever a caller passes, and
+    /// moves the live session to `.serverVAD` only through `setNativeTurnDetection(true)`.
     public var turnDetection: RealtimeTurnDetection
     public var instructions: String?
     public var voice: String?
@@ -120,7 +146,7 @@ public struct RealtimeSessionConfiguration: Codable, Equatable, Sendable {
 ///
 /// Pinned to the OpenAI Realtime protocol as observed 2026-05 (`gpt-realtime` family).
 /// The set is small by design — this is a speech pipe, and every client event beyond
-/// these five would be policy leaking across the `VoiceBackend` boundary.
+/// these six would be policy leaking across the `VoiceBackend` boundary.
 public enum RealtimeClientEvent: Equatable, Sendable {
     /// Configures the session. Always the first frame on a connection: until it lands, the
     /// service is running its own VAD.
@@ -131,6 +157,16 @@ public enum RealtimeClientEvent: Equatable, Sendable {
     /// Commits the input buffer. In manual-turn mode this is the *only* thing that ends a
     /// user turn, and only TapQ sends it.
     case commitInputAudio
+    /// Discards whatever is in the input buffer without transcribing it.
+    ///
+    /// Sent at one moment only: a window ending while the server's own VAD owns commits.
+    /// Whatever the wearer said since the last VAD commit is a fragment nobody is listening
+    /// for any more, and the buffer outlives the window — left there, it would be prepended
+    /// to the next window's utterance and transcribed as part of a sentence spoken minutes
+    /// later. Committing it instead is not an option: the service rejects a commit holding
+    /// less than 100 ms of audio, and a rejected commit is an `error` frame that ends the
+    /// session.
+    case clearInputAudio
     /// Asks the model to respond. `instructions` carries TapQ's own text when the caller
     /// wants something specific spoken.
     case createResponse(instructions: String?)
@@ -153,6 +189,8 @@ public enum RealtimeClientEvent: Equatable, Sendable {
                 data = try encoder.encode(AppendFrame(audio: audio.base64EncodedString()))
             case .commitInputAudio:
                 data = try encoder.encode(CommitFrame())
+            case .clearInputAudio:
+                data = try encoder.encode(ClearFrame())
             case .createResponse(let instructions):
                 let response = instructions.map { ResponseCreateFrame.Response(instructions: $0) }
                 data = try encoder.encode(ResponseCreateFrame(response: response))
@@ -171,6 +209,7 @@ public enum RealtimeClientEvent: Equatable, Sendable {
         case .sessionUpdate: return "session.update"
         case .appendInputAudio: return "input_audio_buffer.append"
         case .commitInputAudio: return "input_audio_buffer.commit"
+        case .clearInputAudio: return "input_audio_buffer.clear"
         case .createResponse: return "response.create"
         case .cancelResponse: return "response.cancel"
         }
@@ -188,6 +227,10 @@ public enum RealtimeClientEvent: Equatable, Sendable {
 
     private struct CommitFrame: Encodable {
         let type = "input_audio_buffer.commit"
+    }
+
+    private struct ClearFrame: Encodable {
+        let type = "input_audio_buffer.clear"
     }
 
     private struct ResponseCreateFrame: Encodable {
@@ -238,6 +281,16 @@ public enum RealtimeServerEvent: Equatable, Sendable {
     /// The configuration TapQ sent has been applied. This — not `session.created` — is the
     /// handshake ack, because before it lands the service is still running its own VAD.
     case sessionUpdated
+    /// The service's own VAD heard speech begin in the input buffer. Diagnostic only, and
+    /// only ever seen while native turn detection is on.
+    case speechStarted
+    /// The service's own VAD heard speech end. Diagnostic only: the commit that follows is
+    /// what actually matters, and acting on this instead would double-count a segment.
+    case speechStopped
+    /// The input buffer was committed and a conversation item created. Sent for TapQ's own
+    /// `input_audio_buffer.commit` *and* for a commit the service's VAD made on its own —
+    /// the adapter tells them apart by counting the commits it issued.
+    case inputAudioCommitted
     /// Incremental transcript of the *wearer's* audio.
     case transcriptDelta(String)
     /// Settled transcript of the wearer's audio for the committed turn.
@@ -266,6 +319,12 @@ public enum RealtimeServerEvent: Equatable, Sendable {
             return .sessionCreated
         case "session.updated":
             return .sessionUpdated
+        case "input_audio_buffer.speech_started":
+            return .speechStarted
+        case "input_audio_buffer.speech_stopped":
+            return .speechStopped
+        case "input_audio_buffer.committed":
+            return .inputAudioCommitted
         case "conversation.item.input_audio_transcription.delta":
             return .transcriptDelta(envelope.delta ?? "")
         case "conversation.item.input_audio_transcription.completed":

--- a/Sources/TapQVoiceBackends/RealtimeTransport.swift
+++ b/Sources/TapQVoiceBackends/RealtimeTransport.swift
@@ -80,12 +80,13 @@ public enum RealtimeTransportFailure: Error, LocalizedError, Equatable, Sendable
     ///   - url: the realtime endpoint, model already in the query string.
     ///   - apiKey: sent as a bearer header and never stored anywhere else, never logged,
     ///     and never included in a failure description.
+    ///
+    /// Authorization is the only header GA needs. `OpenAI-Beta: realtime=v1` used to ride
+    /// along here and is deliberately gone: it is what routed the connection to the Beta
+    /// API, which was retired on 2026-08-27 and now refuses the session outright.
     public init(url: URL, apiKey: String, session: URLSession = .shared) {
         self.url = url
-        self.headers = [
-            "Authorization": "Bearer \(apiKey)",
-            "OpenAI-Beta": "realtime=v1",
-        ]
+        self.headers = ["Authorization": "Bearer \(apiKey)"]
         self.session = session
     }
 

--- a/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
+++ b/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
@@ -138,6 +138,12 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
             calls.append(.cancelResponse)
         }
 
+        private(set) var nativeTurnDetection: [Bool] = []
+
+        func setNativeTurnDetection(_ enabled: Bool) {
+            nativeTurnDetection.append(enabled)
+        }
+
         func emit(_ event: VoiceBackendEvent) {
             handler?(event)
         }
@@ -649,6 +655,8 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
         func sendAudio(_ chunk: VoiceAudioChunk) { calls.append("sendAudio") }
         func requestResponse(text: String) { calls.append("requestResponse") }
         func cancelResponse() { calls.append("cancelResponse") }
+
+        func setNativeTurnDetection(_ enabled: Bool) {}
     }
 
     func testBeginUserTurnInnerFailureDoesNotOpenMicrophone() async throws {

--- a/Tests/TapQContractsTests/VoiceBackendContractTests.swift
+++ b/Tests/TapQContractsTests/VoiceBackendContractTests.swift
@@ -478,12 +478,18 @@ final class VoiceBackendConformanceTests: XCTestCase {
 
         func cancelResponse() { guarded { try machine.cancelResponse() } }
 
+        func setNativeTurnDetection(_ enabled: Bool) {
+            machine.setNativeTurnDetection(enabled)
+        }
+
         /// Test hook: the transport handing an event up, checked for legality the same
         /// way an inbound call is.
         func deliver(_ event: VoiceBackendEvent) {
             switch event {
             case .responseCompleted:
                 guarded { try machine.responseCompleted() }
+            case .userAudioCommittedByBackend:
+                guarded { try machine.backendCommittedUserTurn() }
             case .sessionFailed:
                 machine.sessionFailed()
             case .transcriptPartial, .transcriptFinal, .audio:
@@ -594,6 +600,100 @@ private extension VoiceTurnViolation {
         case .responseAlreadyInFlight: return "responseAlreadyInFlight"
         case .noResponseInFlight: return "noResponseInFlight"
         case .bargeInUnsupported: return "bargeInUnsupported"
+        case .unsolicitedBackendCommit: return "unsolicitedBackendCommit"
         }
+    }
+}
+
+/// The carve-out on `VoiceBackend`, as legality rules.
+///
+/// The whole feature rests on one asymmetry: a commit the backend made on its own is a
+/// legal report when TapQ asked for it and a session-ending violation when it did not. These
+/// tests own that asymmetry, and the second-order property it depends on — that a legal
+/// native commit does **not** end TapQ's turn.
+final class VoiceTurnNativeDetectionTests: XCTestCase {
+
+    private func openTurn(native: Bool) -> VoiceTurnStateMachine {
+        var machine = VoiceTurnStateMachine()
+        try! machine.open()
+        machine.setNativeTurnDetection(native)
+        try! machine.beginUserTurn()
+        return machine
+    }
+
+    func testABackendCommitIsAViolationWhileTapQOwnsTurns() {
+        var machine = openTurn(native: false)
+        XCTAssertThrowsError(try machine.backendCommittedUserTurn()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .unsolicitedBackendCommit)
+        }
+        XCTAssertEqual(machine.state, .userTurn, "a rejected commit changes nothing")
+    }
+
+    /// The load-bearing half: a native commit ends the *utterance*, not the turn.
+    ///
+    /// If it moved the machine to `.committed`, the very next microphone buffer would be an
+    /// illegal `sendAudio` and the session would die under a wearer who did nothing but keep
+    /// talking. So the assertion is on both facts together — the commit is legal, and audio
+    /// after it still is.
+    func testALegalNativeCommitKeepsTheUserTurnOpen() throws {
+        var machine = openTurn(native: true)
+        XCTAssertTrue(try machine.backendCommittedUserTurn())
+        XCTAssertEqual(machine.state, .userTurn)
+        XCTAssertNoThrow(try machine.sendAudio())
+        XCTAssertTrue(try machine.backendCommittedUserTurn(),
+                      "a second utterance in the same turn is committed the same way")
+    }
+
+    /// The service's VAD runs on the audio stream, not on TapQ's window boundaries, so a
+    /// commit can land outside a turn. Tolerated and reported as nothing — there is no
+    /// window it could resolve.
+    func testANativeCommitOutsideAUserTurnIsToleratedAndReportsNothing() throws {
+        var machine = VoiceTurnStateMachine()
+        try machine.open()
+        machine.setNativeTurnDetection(true)
+        XCTAssertFalse(try machine.backendCommittedUserTurn())
+        XCTAssertEqual(machine.state, .open)
+    }
+
+    func testANativeCommitOnAClosedSessionIsNotOpenWhateverTheMode() {
+        var machine = VoiceTurnStateMachine()
+        machine.setNativeTurnDetection(true)
+        XCTAssertThrowsError(try machine.backendCommittedUserTurn()) { error in
+            XCTAssertEqual(error as? VoiceTurnViolation, .notOpen)
+        }
+    }
+
+    /// Teardown forgets the mode, so a reconnected session is manual until its adapter asks
+    /// again. Anything else would let a socket drop silently hand turn arbitration away.
+    func testTeardownResetsTheModeSoAReopenedSessionIsManual() throws {
+        let teardowns: [(inout VoiceTurnStateMachine) -> Void] = [
+            { $0.close() },
+            { $0.sessionFailed() },
+        ]
+        for teardown in teardowns {
+            var machine = VoiceTurnStateMachine()
+            try machine.open()
+            machine.setNativeTurnDetection(true)
+            XCTAssertTrue(machine.nativeTurnDetectionEnabled)
+            teardown(&machine)
+            XCTAssertFalse(machine.nativeTurnDetectionEnabled)
+
+            try machine.open()
+            try machine.beginUserTurn()
+            XCTAssertThrowsError(try machine.backendCommittedUserTurn())
+        }
+    }
+
+    func testTheCapabilityIsOffByDefaultAndIsNotTheSameAsTheMode() throws {
+        XCTAssertFalse(VoiceBackendCapabilities.transcriptOnly.supportsNativeTurnDetection)
+        XCTAssertFalse(VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                duplex: true).supportsNativeTurnDetection)
+        // Declaring the capability does not turn the mode on: a fresh session is manual.
+        var machine = VoiceTurnStateMachine(
+            capabilities: VoiceBackendCapabilities(supportsNativeTurnDetection: true))
+        try machine.open()
+        XCTAssertFalse(machine.nativeTurnDetectionEnabled)
+        try machine.beginUserTurn()
+        XCTAssertThrowsError(try machine.backendCommittedUserTurn())
     }
 }

--- a/Tests/TapQDetectionE2ETests/VoiceHarnessFakes.swift
+++ b/Tests/TapQDetectionE2ETests/VoiceHarnessFakes.swift
@@ -76,13 +76,32 @@ extension TranscriptVoiceChannel: HarnessVoiceChannel {
 /// drift in any of those now fails a test instead of passing one.
 @MainActor
 final class ProviderVoiceChannel: HarnessVoiceChannel {
-    let backend = ScriptedVoiceBackend()
+    let backend: ScriptedVoiceBackend
     let provider: VoiceBackendCommandProvider
+
+    /// A settable box for the liveness answer. A box rather than a stored property because
+    /// the provider's closure is built in `init`, before `self` exists to capture.
+    @MainActor private final class Liveness {
+        var isLive = true
+    }
+
+    private let liveness: Liveness
+
+    /// Whether TapQ's own wearer turn signal is live, as the provider reads it at each
+    /// window open. `true` is the IMU-armed run; flipping it between windows is a pair of
+    /// AirPods going in or coming out mid-run.
+    var isWearerTurnSignalLive: Bool {
+        get { liveness.isLive }
+        set { liveness.isLive = newValue }
+    }
 
     /// - Parameters:
     ///   - freeformEnabled: the `--voice-freeform` switch, read by the provider itself.
     ///   - sessionPolicy: `.perWindow` is M1's shape and the default here for the same
     ///     reason it is the default there — it holds no timers.
+    ///   - backendCapabilities: what the pipe underneath can do. `.transcriptOnly` is the
+    ///     Apple shape; a cloud pipe declares `supportsNativeTurnDetection` and is the only
+    ///     kind the degrade path can reach.
     ///   - idleSleep: conversation mode's idle-close timer. The default never fires within
     ///     a test run, so a `.conversation` harness that does not script one keeps its
     ///     session for the whole test rather than closing it at some wall-clock moment.
@@ -91,9 +110,16 @@ final class ProviderVoiceChannel: HarnessVoiceChannel {
          sessionPolicy: SessionPolicy = .perWindow,
          supportsBargeIn: Bool = false,
          responseAudio: (any VoiceResponseAudioPlaying)? = nil,
+         backendCapabilities: VoiceBackendCapabilities = .transcriptOnly,
          idleSleep: @escaping @MainActor (TimeInterval) async -> Void = { _ in
              try? await Task.sleep(nanoseconds: 3_600_000_000_000)
          }) {
+        let backend = ScriptedVoiceBackend(capabilities: backendCapabilities)
+        self.backend = backend
+        // Read through a box the channel owns, so a test can flip the answer between
+        // windows exactly as a mid-run AirPods connect would.
+        let liveness = Liveness()
+        self.liveness = liveness
         provider = VoiceBackendCommandProvider(
             backend: backend,
             // R3: the grammar stays real and is passed explicitly, exactly as the host
@@ -103,10 +129,17 @@ final class ProviderVoiceChannel: HarnessVoiceChannel {
             supportsBargeIn: supportsBargeIn,
             responseAudio: responseAudio,
             freeformEnabled: freeformEnabled,
+            isWearerTurnSignalLive: { liveness.isLive },
             idleSleep: idleSleep,
             diagnosticSink: diagnosticSink
         )
     }
+
+    /// The realtime shape: a duplex cloud pipe that can do its own end-of-speech detection.
+    /// The only capabilities under which the degrade path can be reached at all.
+    static let realtimeCapabilities = VoiceBackendCapabilities(
+        supportsBargeIn: true, producesAudio: true, duplex: true,
+        supportsNativeTurnDetection: true)
 
     // MARK: VoiceCommandProviding — straight through to the real provider.
 
@@ -125,6 +158,18 @@ final class ProviderVoiceChannel: HarnessVoiceChannel {
     /// scripted transcript can reach the grammar.
     var isReadyForDelivery: Bool {
         backend.isOpen && provider.isWindowOpenForTesting
+    }
+
+    /// The degraded ordering, exactly as the realtime service produces it: the backend's own
+    /// VAD commits the buffered audio, and only then does a transcript for it exist.
+    ///
+    /// There is no partial. Under `turn_detection: server_vad` the conversation item — and
+    /// therefore input transcription — is created by the commit, so nothing about the
+    /// utterance is available before it, which is the whole reason this path needs the
+    /// commit to happen at all.
+    func deliverAfterNativeCommit(_ transcript: String) {
+        backend.emit(.userAudioCommittedByBackend)
+        backend.emit(.transcriptFinal(transcript))
     }
 
     /// Emits the partial, then the final — the ordering every streaming recognizer
@@ -209,6 +254,14 @@ final class ScriptedVoiceBackend: VoiceBackend {
     func requestResponse(text: String) { requestedResponses.append(text) }
 
     func cancelResponse() { cancellations += 1 }
+
+    /// Every turn-detection mode the provider asked for, in order — the whole record of the
+    /// degrade decision as a backend experiences it.
+    private(set) var nativeTurnDetection: [Bool] = []
+
+    func setNativeTurnDetection(_ enabled: Bool) {
+        nativeTurnDetection.append(enabled)
+    }
 
     /// Pushes one event at whoever opened the session. A no-op when nobody has — which is
     /// the honest shape of a closed backend, and the reason `isReadyForDelivery` exists.

--- a/Tests/TapQDetectionE2ETests/VoiceProviderRouteE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/VoiceProviderRouteE2ETests.swift
@@ -283,6 +283,122 @@ final class VoiceProviderRouteE2ETests: XCTestCase {
         XCTAssertEqual(channel.backend.closes, 0, "and one session for both of them")
     }
 
+    // MARK: - Turn detection, degraded and not
+
+    /// The bug this path exists to fix, from the wearer's side.
+    ///
+    /// No AirPods streaming means no IMU endpoint, and on the realtime pipe a transcript
+    /// does not exist until something commits the audio. Before the carve-out, "something"
+    /// was only TapQ, so a wearer without AirPods spoke into a buffer that nobody committed
+    /// until the window timed out — up to four minutes of a voice channel that looked alive
+    /// and was not. Here the backend's own VAD commits, and the very next thing that happens
+    /// is the ordinary match-on-transcript resolution the window has always used.
+    ///
+    /// The order of the assertions is the argument: the mode was chosen before the turn
+    /// opened, the commit resolved nothing by itself, and the transcript resolved the window.
+    func testWithNoWearerTurnSignalTheBackendsOwnVADCarriesTheWindowToAnAnswer() async throws {
+        let harness = DetectionPathHarness(
+            voiceChannel: { sink in
+                ProviderVoiceChannel(diagnosticSink: sink,
+                                     backendCapabilities: ProviderVoiceChannel.realtimeCapabilities)
+            }
+        )
+        let channel = try XCTUnwrap(harness.providerChannel)
+        channel.isWearerTurnSignalLive = false
+
+        let decision = Task { await harness.interaction.resolve(Self.approval) }
+        let opened = await harness.waitForWindow(1)
+        XCTAssertTrue(opened, "the approval opened no input window")
+        XCTAssertEqual(channel.backend.nativeTurnDetection, [true],
+                       "the window degraded before its turn opened")
+        XCTAssertEqual(channel.backend.beganTurns, 1)
+
+        channel.backend.emit(.userAudioCommittedByBackend)
+        XCTAssertTrue(channel.provider.isUserTurnActiveForCoordination,
+                      "a commit ends an utterance, not the wearer's turn")
+        XCTAssertTrue(channel.backend.endedTurns.isEmpty,
+                      "and it is not TapQ ending anything")
+
+        channel.backend.emit(.transcriptFinal("yes"))
+        let outcome = await decision.value
+        harness.assertWatchdogDidNotFire()
+        XCTAssertEqual(outcome, .allow, "the window resolved by transcript, not by timeout")
+        XCTAssertEqual(channel.backend.endedTurns, [false],
+                       "the match ended the turn, and never asked for a spoken reply")
+        XCTAssertEqual(Self.count("turn.committed_by_backend", in: harness), 1)
+        XCTAssertEqual(Self.count("turn_detection.native", in: harness), 1)
+    }
+
+    /// The other half, and the one that has to keep being true: with the IMU signal live,
+    /// nothing about the wire traffic changes.
+    ///
+    /// The wearer nods this one through rather than speaking it, so the only thing the
+    /// backend ever hears about is the mode — and the assertion is that the mode it heard is
+    /// "TapQ still owns turns". A regression that degraded an IMU-armed run would hand a
+    /// remote endpoint the shape of the wearer's speech for no reason at all.
+    func testWithALiveWearerTurnSignalTheRealtimePathIsUntouched() async throws {
+        let harness = DetectionPathHarness(
+            voiceChannel: { sink in
+                ProviderVoiceChannel(diagnosticSink: sink,
+                                     backendCapabilities: ProviderVoiceChannel.realtimeCapabilities)
+            }
+        )
+        let channel = try XCTUnwrap(harness.providerChannel)
+        channel.isWearerTurnSignalLive = true
+
+        let decision = Task { await harness.interaction.resolve(Self.approval) }
+        let opened = await harness.waitForWindow(1)
+        XCTAssertTrue(opened, "the approval opened no input window")
+
+        XCTAssertEqual(channel.backend.nativeTurnDetection, [false])
+        XCTAssertEqual(Self.count("turn_detection.native", in: harness), 0)
+
+        harness.hear("yes")
+        let outcome = await decision.value
+        harness.assertWatchdogDidNotFire()
+        XCTAssertEqual(outcome, .allow)
+        XCTAssertEqual(channel.backend.endedTurns, [false],
+                       "one window, one turn, ended by TapQ exactly as before")
+    }
+
+    /// AirPods connect between two requests. The second window switches back on its own —
+    /// nothing above the provider is told, and nothing is spoken about it.
+    func testTheModeSwitchesBetweenWindowsWhenTheSignalComesBack() async throws {
+        let harness = DetectionPathHarness(
+            voiceChannel: { sink in
+                ProviderVoiceChannel(diagnosticSink: sink,
+                                     sessionPolicy: .conversation(idleClose: 3_600),
+                                     backendCapabilities: ProviderVoiceChannel.realtimeCapabilities)
+            }
+        )
+        let channel = try XCTUnwrap(harness.providerChannel)
+        channel.isWearerTurnSignalLive = false
+
+        let first = Task { await harness.interaction.resolve(Self.approval) }
+        let firstOpened = await harness.waitForWindow(1)
+        XCTAssertTrue(firstOpened, "the first approval opened no window")
+        XCTAssertEqual(channel.backend.nativeTurnDetection, [true])
+        channel.deliverAfterNativeCommit("yes")
+        let firstOutcome = await first.value
+        XCTAssertEqual(firstOutcome, .allow)
+
+        // The wearer puts their AirPods in.
+        channel.isWearerTurnSignalLive = true
+
+        let second = Task { await harness.interaction.resolve(Self.approval) }
+        let secondOpened = await harness.waitForWindow(2)
+        XCTAssertTrue(secondOpened, "the second approval opened no window")
+        XCTAssertEqual(channel.backend.nativeTurnDetection, [true, false],
+                       "the next window is TapQ's again, on the same conversation session")
+
+        harness.hear("no")
+        let secondOutcome = await second.value
+        XCTAssertEqual(secondOutcome, .deny)
+        harness.assertWatchdogDidNotFire()
+        XCTAssertEqual(channel.backend.closes, 0,
+                       "the mode changed on the live session; nothing reconnected")
+    }
+
     // MARK: - Helpers
 
     /// Drives one approval from wire bytes to wire bytes with the provider in the path, and

--- a/Tests/TapQInteractionBaselineTests/BackendPreferredSpeechTests.swift
+++ b/Tests/TapQInteractionBaselineTests/BackendPreferredSpeechTests.swift
@@ -218,6 +218,8 @@ final class BackendPreferredSpeechTests: XCTestCase {
         func sendAudio(_ chunk: VoiceAudioChunk) {}
         func requestResponse(text: String) { spoken.append(text) }
         func cancelResponse() {}
+
+        func setNativeTurnDetection(_ enabled: Bool) {}
     }
 
     func testComposedWithTheProviderSpeaksNotificationsThroughTheBackend() async {

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -111,6 +111,18 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             calls.append(.cancelResponse)
         }
 
+        /// Every turn-detection mode the provider asked for, in order. Kept out of `Call`
+        /// deliberately: this file asserts on exact call sequences everywhere, and a mode
+        /// switch appearing inside one would make sixty tests argue about a decision only a
+        /// handful of them are actually testing.
+        private(set) var nativeTurnDetection: [Bool] = []
+
+        func setNativeTurnDetection(_ enabled: Bool) {
+            XCTAssertTrue(capabilities.supportsNativeTurnDetection,
+                          "a backend that cannot do native turn detection was asked to")
+            nativeTurnDetection.append(enabled)
+        }
+
         /// Delivers an event to the newest window, or to an older one when a test needs to
         /// prove stale callbacks are dropped.
         func emit(_ event: VoiceBackendEvent, toHandler index: Int? = nil) {
@@ -1483,6 +1495,8 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             isResponding = false
         }
 
+        func setNativeTurnDetection(_ enabled: Bool) {}
+
         func emit(_ event: VoiceBackendEvent) {
             if case .responseCompleted = event { isResponding = false }
             handler?(event)
@@ -2273,6 +2287,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         func sendAudio(_ chunk: VoiceAudioChunk) { calls.append(.sendAudio(chunk.data.count)) }
         func requestResponse(text: String) { calls.append(.requestResponse(text)) }
         func cancelResponse() { calls.append(.cancelResponse) }
+        func setNativeTurnDetection(_ enabled: Bool) {}
 
         func emit(_ event: VoiceBackendEvent) { handler?(event) }
     }
@@ -2673,5 +2688,176 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
         var isWearerSpeaking = false
         var isSignalAvailable = false
         var onWearerSpeakingChange: (@MainActor (Bool) -> Void)?
+    }
+
+    // MARK: - Turn detection mode
+
+    /// The realtime shape: the only capabilities under which the question is asked at all.
+    private static let realtimeCapabilities = VoiceBackendCapabilities(
+        supportsBargeIn: true, producesAudio: true, duplex: true,
+        supportsNativeTurnDetection: true)
+
+    /// A settable answer to "is TapQ's own turn signal live", so a test can put the AirPods
+    /// in and take them out between windows.
+    @MainActor
+    private final class LivenessBox {
+        var isLive: Bool
+        init(_ isLive: Bool) { self.isLive = isLive }
+    }
+
+    private func makeConversationProvider(
+        backend: ScriptedVoiceBackend,
+        liveness: LivenessBox,
+        sink: RecordingSink = RecordingSink()
+    ) -> VoiceBackendCommandProvider {
+        VoiceBackendCommandProvider(
+            backend: backend,
+            match: Self.match,
+            sessionPolicy: .conversation(idleClose: 3_600),
+            supportsBargeIn: true,
+            isWearerTurnSignalLive: { liveness.isLive },
+            idleSleep: { _ in try? await Task.sleep(nanoseconds: 3_600_000_000_000) },
+            diagnosticSink: sink
+        )
+    }
+
+    /// No wearer turn signal: the window opens with the backend's own VAD doing the
+    /// endpointing, and the log says why.
+    func testAWindowWithNoWearerTurnSignalDegradesToNativeTurnDetection() async {
+        let backend = ScriptedVoiceBackend(capabilities: Self.realtimeCapabilities)
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend,
+                                                liveness: LivenessBox(false), sink: sink)
+
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertEqual(backend.nativeTurnDetection, [true])
+        XCTAssertEqual(sink.events.first { $0.name == "turn_detection.native" }?
+            .fields["reason"], "no_wearer_turn_signal")
+    }
+
+    /// The IMU-armed run, unchanged. This is the assertion that the carve-out stayed a
+    /// carve-out: a wearer with working AirPods must reach the same wire traffic they always
+    /// did, and the remote endpoint must not be told where their sentences end.
+    func testAWindowWithALiveWearerTurnSignalKeepsTurnArbitrationOnTapQsSide() async {
+        let backend = ScriptedVoiceBackend(capabilities: Self.realtimeCapabilities)
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend,
+                                                liveness: LivenessBox(true), sink: sink)
+
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertEqual(backend.nativeTurnDetection, [false])
+        XCTAssertEqual(sink.events.first { $0.name == "turn_detection.manual" }?
+            .fields["reason"], "wearer_turn_signal_live")
+        XCTAssertTrue(sink.names.filter { $0 == "turn_detection.native" }.isEmpty)
+    }
+
+    /// AirPods go in and come out mid-run, and each window is endpointed by whichever of the
+    /// two endpointers is actually working. Only the windows where the answer *changed* send
+    /// anything: the provider asks every time, the backend hears about it only when it
+    /// matters.
+    func testTheModeFollowsTheSignalFromOneWindowToTheNext() async {
+        let backend = ScriptedVoiceBackend(capabilities: Self.realtimeCapabilities)
+        let liveness = LivenessBox(false)
+        let provider = makeConversationProvider(backend: backend, liveness: liveness)
+
+        provider.start { _ in }
+        await settle()
+        XCTAssertEqual(backend.nativeTurnDetection, [true])
+
+        // The wearer puts their AirPods in: the next window is TapQ's again.
+        provider.stop()
+        liveness.isLive = true
+        provider.start { _ in }
+        await settle()
+        XCTAssertEqual(backend.nativeTurnDetection, [true, false])
+
+        // A window with no change sends nothing.
+        provider.stop()
+        provider.start { _ in }
+        await settle()
+        XCTAssertEqual(backend.nativeTurnDetection, [true, false])
+
+        // And out again.
+        provider.stop()
+        liveness.isLive = false
+        provider.start { _ in }
+        await settle()
+        XCTAssertEqual(backend.nativeTurnDetection, [true, false, true])
+    }
+
+    /// The motion-loss path: the *first* window of a run started with `--imu-turn-control`
+    /// and no AirPods. The flag says AirPods are expected, so the window opens in manual
+    /// mode; the detector discovers the availability lie a moment later and the host
+    /// re-asks, on the live session, inside the window a wearer is waiting on.
+    func testRefreshSwitchesTheLiveWindowWhenMotionIsConfirmedGone() async {
+        let backend = ScriptedVoiceBackend(capabilities: Self.realtimeCapabilities)
+        let liveness = LivenessBox(true)
+        let provider = makeConversationProvider(backend: backend, liveness: liveness)
+
+        provider.start { _ in }
+        await settle()
+        XCTAssertEqual(backend.nativeTurnDetection, [false])
+
+        liveness.isLive = false
+        provider.refreshTurnDetectionMode()
+        XCTAssertEqual(backend.nativeTurnDetection, [false, true],
+                       "the window already open is degraded in place")
+    }
+
+    /// A backend that cannot do it is never asked, whatever the signal says.
+    func testABackendWithoutTheCapabilityIsNeverAsked() async {
+        let backend = ScriptedVoiceBackend()
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend,
+                                                liveness: LivenessBox(false), sink: sink)
+
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertEqual(backend.nativeTurnDetection, [])
+        XCTAssertEqual(sink.events.first { $0.name == "turn_detection.manual" }?
+            .fields["reason"], "unsupported")
+    }
+
+    /// The default composition — no liveness source at all — keeps turn arbitration, which
+    /// is what makes this change inert for every caller that has not opted in.
+    func testWithNoLivenessSourceTheProviderNeverDegrades() async {
+        let backend = ScriptedVoiceBackend(capabilities: Self.realtimeCapabilities)
+        let provider = VoiceBackendCommandProvider(backend: backend, match: Self.match)
+
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertEqual(backend.nativeTurnDetection, [false])
+    }
+
+    /// The degraded endpoint firing, end to end at this layer: the commit arrives, the turn
+    /// stays open, and the transcript that follows resolves the window.
+    func testANativeCommitLeavesTheTurnOpenAndItsTranscriptResolvesTheWindow() async {
+        let backend = ScriptedVoiceBackend(capabilities: Self.realtimeCapabilities)
+        let sink = RecordingSink()
+        let provider = makeConversationProvider(backend: backend,
+                                                liveness: LivenessBox(false), sink: sink)
+        var received: [VoiceCommand] = []
+
+        provider.start { received.append($0) }
+        await settle()
+        XCTAssertTrue(backend.isTurnActive)
+
+        backend.emit(.userAudioCommittedByBackend)
+        XCTAssertTrue(provider.isUserTurnActiveForCoordination,
+                      "the wearer may still be talking; the turn is not TapQ's to close here")
+        XCTAssertTrue(backend.isTurnActive)
+        XCTAssertEqual(received, [], "a commit is not a decision")
+        XCTAssertTrue(sink.names.contains("turn.committed_by_backend"))
+
+        backend.emit(.transcriptFinal("yes"))
+        XCTAssertEqual(received, [.yes], "the post-commit transcript resolves the window")
+        XCTAssertEqual(backend.endUserTurnExpectations, [false],
+                       "and the window's own turn end never asks for a spoken reply")
     }
 }

--- a/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerTurnCoordinatorTests.swift
@@ -742,6 +742,10 @@ final class WearerTurnCoordinatorTests: XCTestCase {
             calls.append(.cancelResponse)
         }
 
+        /// The coordinator never touches the mode; this fake records nothing so the call
+        /// sequences the endpointing tests assert on stay exactly what they were.
+        func setNativeTurnDetection(_ enabled: Bool) {}
+
         func emit(_ event: VoiceBackendEvent, toHandler index: Int? = nil) {
             guard !handlers.isEmpty else { return }
             handlers[index ?? handlers.count - 1](event)

--- a/Tests/TapQInteractionBaselineTests/WearerTurnSignalLivenessTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerTurnSignalLivenessTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+/// The one question the realtime degrade path asks, and the reason it is not the same
+/// question `WearerSpeechSignaling.isSignalAvailable` answers.
+///
+/// Availability describes the last few hundred milliseconds. Between windows the motion
+/// stream is stopped, so it reads false on a run whose AirPods are working perfectly — at
+/// exactly the moment the decision has to be made. These tests pin the difference: the
+/// default is optimism about the *run*, and only real evidence retracts it.
+@MainActor
+final class WearerTurnSignalLivenessTests: XCTestCase {
+
+    private final class FakeSignal: WearerSpeechSignaling {
+        var isWearerSpeaking = false
+        var isSignalAvailable: Bool
+        var onWearerSpeakingChange: (@MainActor (Bool) -> Void)?
+
+        init(isSignalAvailable: Bool = false) {
+            self.isSignalAvailable = isSignalAvailable
+        }
+
+        /// A quiet↔speaking edge, as the source broadcasts it.
+        func transition(to speaking: Bool) {
+            isWearerSpeaking = speaking
+            onWearerSpeakingChange?(speaking)
+        }
+    }
+
+    /// No `--imu-turn-control`: there is no coordinator listening, so nothing on TapQ's side
+    /// would ever commit the turn and the answer is no, permanently.
+    func testARunWithoutTheFlagIsNeverLive() {
+        XCTAssertFalse(WearerTurnSignalLiveness(signal: nil).isLive)
+    }
+
+    /// A flagged run starts live even though no sample has arrived yet. The alternative —
+    /// starting degraded and upgrading once samples flow — would put the *first* window of
+    /// every working AirPods run on the remote endpoint's VAD, which is a behavior change to
+    /// the path the carve-out is explicitly not for.
+    func testAFlaggedRunStartsLiveBeforeAnySampleArrives() {
+        let signal = FakeSignal(isSignalAvailable: false)
+        XCTAssertTrue(WearerTurnSignalLiveness(signal: signal).isLive)
+    }
+
+    /// The availability lie: macOS reports AirPods that are paired but sitting in their case
+    /// as available, and the only thing that ever discovers it is a stream that never
+    /// produces a sample. That discovery arrives here as `noteMotionUnavailable`.
+    func testAConfirmedMotionLossRetractsTheOptimism() {
+        let liveness = WearerTurnSignalLiveness(signal: FakeSignal())
+        liveness.noteMotionUnavailable()
+        XCTAssertFalse(liveness.isLive)
+    }
+
+    /// Staleness is not absence. Between two windows the last sample ages out and
+    /// `isSignalAvailable` goes false; that must not degrade the next window, or a working
+    /// pair of AirPods would hand endpointing away every time the wearer paused.
+    func testAStaleSignalDoesNotCountAsALoss() {
+        let signal = FakeSignal(isSignalAvailable: true)
+        let liveness = WearerTurnSignalLiveness(signal: signal)
+        XCTAssertTrue(liveness.isLive)
+
+        signal.isSignalAvailable = false
+        XCTAssertTrue(liveness.isLive, "the stream stopped with the window, not with the hardware")
+    }
+
+    /// The wearer puts their AirPods in mid-run. Samples reach the source during the window,
+    /// and the next window is TapQ's again — without anything having to watch for a
+    /// reconnect.
+    func testAReturningSampleRestoresTheSignal() {
+        let signal = FakeSignal(isSignalAvailable: false)
+        let liveness = WearerTurnSignalLiveness(signal: signal)
+        liveness.noteMotionUnavailable()
+        XCTAssertFalse(liveness.isLive)
+
+        signal.isSignalAvailable = true
+        XCTAssertTrue(liveness.isLive)
+    }
+
+    /// The same recovery through the other door: a transition observed while the signal is
+    /// available clears the loss, so a query landing between windows — when availability has
+    /// already aged out again — still answers yes.
+    func testATransitionOnALiveSignalRearmsTheRun() {
+        let signal = FakeSignal(isSignalAvailable: false)
+        let liveness = WearerTurnSignalLiveness(signal: signal)
+        liveness.noteMotionUnavailable()
+
+        signal.isSignalAvailable = true
+        signal.transition(to: true)
+        signal.isSignalAvailable = false
+
+        XCTAssertTrue(liveness.isLive)
+    }
+
+    /// A transition on a signal that cannot be trusted proves nothing and must not re-arm.
+    func testATransitionOnAnUnavailableSignalDoesNotRearm() {
+        let signal = FakeSignal(isSignalAvailable: false)
+        let liveness = WearerTurnSignalLiveness(signal: signal)
+        liveness.noteMotionUnavailable()
+
+        signal.transition(to: true)
+
+        XCTAssertFalse(liveness.isLive)
+    }
+
+    func testRepeatedLossReportsAreIdempotent() {
+        let liveness = WearerTurnSignalLiveness(signal: FakeSignal())
+        liveness.noteMotionUnavailable()
+        liveness.noteMotionUnavailable()
+        XCTAssertFalse(liveness.isLive)
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/WearerTurnSignalLivenessTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WearerTurnSignalLivenessTests.swift
@@ -30,7 +30,7 @@ final class WearerTurnSignalLivenessTests: XCTestCase {
 
     /// No `--imu-turn-control`: there is no coordinator listening, so nothing on TapQ's side
     /// would ever commit the turn and the answer is no, permanently.
-    func testARunWithoutTheFlagIsNeverLive() {
+    func testARunWithoutTheFlagIsNeverLive() async {
         XCTAssertFalse(WearerTurnSignalLiveness(signal: nil).isLive)
     }
 
@@ -38,7 +38,7 @@ final class WearerTurnSignalLivenessTests: XCTestCase {
     /// starting degraded and upgrading once samples flow — would put the *first* window of
     /// every working AirPods run on the remote endpoint's VAD, which is a behavior change to
     /// the path the carve-out is explicitly not for.
-    func testAFlaggedRunStartsLiveBeforeAnySampleArrives() {
+    func testAFlaggedRunStartsLiveBeforeAnySampleArrives() async {
         let signal = FakeSignal(isSignalAvailable: false)
         XCTAssertTrue(WearerTurnSignalLiveness(signal: signal).isLive)
     }
@@ -46,7 +46,7 @@ final class WearerTurnSignalLivenessTests: XCTestCase {
     /// The availability lie: macOS reports AirPods that are paired but sitting in their case
     /// as available, and the only thing that ever discovers it is a stream that never
     /// produces a sample. That discovery arrives here as `noteMotionUnavailable`.
-    func testAConfirmedMotionLossRetractsTheOptimism() {
+    func testAConfirmedMotionLossRetractsTheOptimism() async {
         let liveness = WearerTurnSignalLiveness(signal: FakeSignal())
         liveness.noteMotionUnavailable()
         XCTAssertFalse(liveness.isLive)
@@ -55,7 +55,7 @@ final class WearerTurnSignalLivenessTests: XCTestCase {
     /// Staleness is not absence. Between two windows the last sample ages out and
     /// `isSignalAvailable` goes false; that must not degrade the next window, or a working
     /// pair of AirPods would hand endpointing away every time the wearer paused.
-    func testAStaleSignalDoesNotCountAsALoss() {
+    func testAStaleSignalDoesNotCountAsALoss() async {
         let signal = FakeSignal(isSignalAvailable: true)
         let liveness = WearerTurnSignalLiveness(signal: signal)
         XCTAssertTrue(liveness.isLive)
@@ -67,7 +67,7 @@ final class WearerTurnSignalLivenessTests: XCTestCase {
     /// The wearer puts their AirPods in mid-run. Samples reach the source during the window,
     /// and the next window is TapQ's again — without anything having to watch for a
     /// reconnect.
-    func testAReturningSampleRestoresTheSignal() {
+    func testAReturningSampleRestoresTheSignal() async {
         let signal = FakeSignal(isSignalAvailable: false)
         let liveness = WearerTurnSignalLiveness(signal: signal)
         liveness.noteMotionUnavailable()
@@ -80,7 +80,7 @@ final class WearerTurnSignalLivenessTests: XCTestCase {
     /// The same recovery through the other door: a transition observed while the signal is
     /// available clears the loss, so a query landing between windows — when availability has
     /// already aged out again — still answers yes.
-    func testATransitionOnALiveSignalRearmsTheRun() {
+    func testATransitionOnALiveSignalRearmsTheRun() async {
         let signal = FakeSignal(isSignalAvailable: false)
         let liveness = WearerTurnSignalLiveness(signal: signal)
         liveness.noteMotionUnavailable()
@@ -93,7 +93,7 @@ final class WearerTurnSignalLivenessTests: XCTestCase {
     }
 
     /// A transition on a signal that cannot be trusted proves nothing and must not re-arm.
-    func testATransitionOnAnUnavailableSignalDoesNotRearm() {
+    func testATransitionOnAnUnavailableSignalDoesNotRearm() async {
         let signal = FakeSignal(isSignalAvailable: false)
         let liveness = WearerTurnSignalLiveness(signal: signal)
         liveness.noteMotionUnavailable()
@@ -103,7 +103,7 @@ final class WearerTurnSignalLivenessTests: XCTestCase {
         XCTAssertFalse(liveness.isLive)
     }
 
-    func testRepeatedLossReportsAreIdempotent() {
+    func testRepeatedLossReportsAreIdempotent() async {
         let liveness = WearerTurnSignalLiveness(signal: FakeSignal())
         liveness.noteMotionUnavailable()
         liveness.noteMotionUnavailable()

--- a/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
@@ -93,6 +93,45 @@ final class FailThroughVoiceBackendTests: XCTestCase {
         XCTAssertEqual(both.capabilities, duplex)
     }
 
+    /// The one capability the wrapper reports as a union, and the reason it has to.
+    ///
+    /// Barge-in, audio, and duplex are things a caller *relies* on, so removing one at
+    /// failover would leave the caller wrong — hence the intersection. Native turn detection
+    /// is something the caller *delegates*, and delegating it to a backend that cannot do it
+    /// costs nothing: the Apple fallback's recognizer finalizes transcripts on its own and a
+    /// window there never needed a commit. Intersecting would make the composition TapQ
+    /// actually ships — realtime primary over an Apple fallback — unable to degrade at all.
+    func testNativeTurnDetectionIsTheUnionRatherThanTheIntersection() {
+        let realtime = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                duplex: true,
+                                                supportsNativeTurnDetection: true)
+        let wrapper = FailThroughVoiceBackend(
+            primary: ScriptedVoiceBackend(name: "primary", capabilities: realtime),
+            fallback: ScriptedVoiceBackend(name: "fallback"))
+
+        XCTAssertTrue(wrapper.capabilities.supportsNativeTurnDetection)
+        XCTAssertFalse(wrapper.capabilities.supportsBargeIn,
+                       "the other three are still the intersection")
+    }
+
+    /// The mode is replayed onto every session the wrapper establishes — the open one, and
+    /// whichever one comes up after a failure. A reconnect that silently reverted to manual
+    /// would strand a wearer with no AirPods talking into a buffer again.
+    func testTheRequestedModeIsReplayedOntoEveryBackendItOpens() async throws {
+        let (primary, fallback, wrapper) = makeBackends()
+        wrapper.setNativeTurnDetection(true)
+
+        try await wrapper.open { _ in }
+        XCTAssertEqual(primary.nativeTurnDetection, [true],
+                       "a mode asked for before any session exists is replayed onto the first one")
+
+        primary.emit(.sessionFailed(.network("socket dropped")))
+        await settle()
+
+        XCTAssertEqual(fallback.nativeTurnDetection, [true],
+                       "the fallback comes up in the mode the caller is still expecting")
+    }
+
     // MARK: - Open-time failover
 
     func testPrimaryOpenFailureFallsThroughTransparently() async throws {

--- a/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/FailThroughVoiceBackendTests.swift
@@ -101,7 +101,7 @@ final class FailThroughVoiceBackendTests: XCTestCase {
     /// costs nothing: the Apple fallback's recognizer finalizes transcripts on its own and a
     /// window there never needed a commit. Intersecting would make the composition TapQ
     /// actually ships — realtime primary over an Apple fallback — unable to degrade at all.
-    func testNativeTurnDetectionIsTheUnionRatherThanTheIntersection() {
+    func testNativeTurnDetectionIsTheUnionRatherThanTheIntersection() async {
         let realtime = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
                                                 duplex: true,
                                                 supportsNativeTurnDetection: true)

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -895,4 +895,227 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         XCTAssertTrue(server.sentTypes.contains("response.create"))
         XCTAssertEqual(events.failures, [], "the empty turn must not corrupt later turns")
     }
+
+    // MARK: - Degraded turn detection
+
+    private func turnDetection(_ server: ScriptedRealtimeServer,
+                               ofUpdate index: Int) -> [String: Any]? {
+        let updates = server.sent.filter { $0["type"] as? String == "session.update" }
+        guard index < updates.count else { return nil }
+        return (updates[index]["session"] as? [String: Any])?["turn_detection"] as? [String: Any]
+    }
+
+    /// The degraded mode is a *second* `session.update`, never a different handshake.
+    ///
+    /// `ScriptedRealtimeServer` fails the test if the first frame on a connection carries
+    /// anything but `turn_detection: none`, and that is deliberate: there must be no instant
+    /// in a session's life during which the service is running turn detection TapQ has not
+    /// deliberately switched on. A caller asking before `open` gets it after the ack, not
+    /// folded into it.
+    func testNativeTurnDetectionIsAppliedAfterTheManualHandshake() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+
+        backend.setNativeTurnDetection(true)
+        try await backend.open { events.append($0) }
+        await settle()
+
+        XCTAssertEqual(turnDetection(server, ofUpdate: 0)?["type"] as? String, "none")
+        XCTAssertEqual(turnDetection(server, ofUpdate: 1)?["type"] as? String, "server_vad")
+        XCTAssertEqual(turnDetection(server, ofUpdate: 1)?["create_response"] as? Bool, false)
+        XCTAssertEqual(events.failures, [])
+    }
+
+    /// The switch is idempotent and only ever sends a frame when something really changed —
+    /// the provider calls it at every window open, and most windows do not change the answer.
+    func testRepeatingTheSameModeSendsNothing() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await backend.open { events.append($0) }
+        await settle()
+        let baseline = server.sentTypes.filter { $0 == "session.update" }.count
+
+        backend.setNativeTurnDetection(false)
+        backend.setNativeTurnDetection(false)
+        await settle()
+        XCTAssertEqual(server.sentTypes.filter { $0 == "session.update" }.count, baseline,
+                       "already-manual is already-manual")
+
+        backend.setNativeTurnDetection(true)
+        backend.setNativeTurnDetection(true)
+        await settle()
+        XCTAssertEqual(server.sentTypes.filter { $0 == "session.update" }.count, baseline + 1)
+
+        backend.setNativeTurnDetection(false)
+        await settle()
+        XCTAssertEqual(turnDetection(server, ofUpdate: baseline)?["type"] as? String, "server_vad")
+        XCTAssertEqual(turnDetection(server, ofUpdate: baseline + 1)?["type"] as? String, "none",
+                       "and the way back is the same frame it always was")
+    }
+
+    /// The whole degraded flow as the service produces it, and the property the whole design
+    /// turns on: the commit ends an utterance, not TapQ's turn.
+    func testAServerVADCommitReportsTheUtteranceAndLeavesTheTurnOpen() async throws {
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await openTurn(backend, collecting: events)
+
+        backend.sendAudio(pcm16(2_400))
+        await settle()
+        server.push(#"{"type":"input_audio_buffer.speech_started"}"#)
+        server.push(#"{"type":"input_audio_buffer.speech_stopped"}"#)
+        server.push(#"{"type":"input_audio_buffer.committed","item_id":"item_1"}"#)
+        await settle()
+
+        XCTAssertEqual(events.events, [.userAudioCommittedByBackend])
+        XCTAssertEqual(backend.turnStateForTesting, .userTurn,
+                       "a native commit must never end TapQ's turn")
+        XCTAssertFalse(server.sentTypes.contains("input_audio_buffer.commit"),
+                       "TapQ does not commit when the service is doing it")
+        XCTAssertFalse(server.sentTypes.contains("response.create"),
+                       "and the service was told never to answer")
+
+        // The turn is genuinely still usable: the wearer kept talking.
+        backend.sendAudio(pcm16(2_400))
+        server.push(#"{"type":"input_audio_buffer.committed","item_id":"item_2"}"#)
+        server.push(RealtimeFrame.transcriptCompleted("yes"))
+        await settle()
+
+        XCTAssertEqual(events.failures, [], "audio after a native commit is still legal")
+        XCTAssertEqual(events.events.last, .transcriptFinal("yes"))
+        XCTAssertTrue(sink.names.contains("native_turn.speech_started"))
+        XCTAssertTrue(sink.names.contains("native_turn.committed"))
+    }
+
+    /// Each committed segment is a whole utterance to the grammar above, so the transcript
+    /// starts over rather than accreting two half-heard sentences into one.
+    func testEachServerVADSegmentTranscribesOnItsOwn() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await openTurn(backend, collecting: events)
+        backend.sendAudio(pcm16(2_400))
+        await settle()
+
+        server.push(#"{"type":"input_audio_buffer.committed","item_id":"item_1"}"#)
+        server.push(RealtimeFrame.transcriptDelta("show me the "))
+        server.push(RealtimeFrame.transcriptDelta("details"))
+        await settle()
+        XCTAssertEqual(events.events.last, .transcriptPartial("show me the details"))
+
+        server.push(#"{"type":"input_audio_buffer.committed","item_id":"item_2"}"#)
+        server.push(RealtimeFrame.transcriptDelta("yes"))
+        await settle()
+        XCTAssertEqual(events.events.last, .transcriptPartial("yes"),
+                       "the second segment is its own utterance")
+    }
+
+    /// The other half of the asymmetry: with the mode off, the same frame kills the session.
+    func testAnUnsolicitedServerCommitFailsTheSession() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+        backend.sendAudio(pcm16(2_400))
+        await settle()
+
+        server.push(#"{"type":"input_audio_buffer.committed","item_id":"item_1"}"#)
+        await settle()
+
+        guard case .protocolViolation(let detail) = try XCTUnwrap(events.failures.first) else {
+            return XCTFail("expected a protocol violation, got \(events.failures)")
+        }
+        XCTAssertTrue(detail.contains("committed the input buffer"), detail)
+        XCTAssertEqual(backend.turnStateForTesting, .idle)
+    }
+
+    /// TapQ's own commit comes back as the same event type. Mistaking the echo for a
+    /// server-initiated commit would fail every manual-mode turn in the field.
+    func testTheEchoOfTapQsOwnCommitIsNotMistakenForTheServices() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        try await openTurn(backend, collecting: events)
+
+        backend.sendAudio(pcm16(2_400))
+        backend.endUserTurn(expectingResponse: false)
+        await settle()
+        server.push(#"{"type":"input_audio_buffer.committed","item_id":"item_1"}"#)
+        await settle()
+
+        XCTAssertEqual(events.events, [], "an ack is not an event")
+        XCTAssertEqual(events.failures, [])
+        XCTAssertEqual(backend.turnStateForTesting, .committed)
+    }
+
+    /// Window teardown in the degraded mode discards the residue rather than committing it.
+    ///
+    /// Both halves matter. The service rejects a commit holding less than 100 ms, and a
+    /// rejected commit is an `error` frame that ends the session; and the input buffer
+    /// outlives the window, so a fragment left in it would be transcribed as the opening of
+    /// a sentence spoken in some later window.
+    func testANativeTurnEndClearsTheBufferInsteadOfCommittingIt() async throws {
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let backend = makeBackend(server, sink: sink)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await openTurn(backend, collecting: events)
+
+        backend.sendAudio(pcm16(240))
+        XCTAssertFalse(backend.endUserTurn(expectingResponse: true),
+                       "a native turn end never creates a response")
+        await settle()
+
+        XCTAssertTrue(server.sentTypes.contains("input_audio_buffer.clear"))
+        XCTAssertFalse(server.sentTypes.contains("input_audio_buffer.commit"))
+        XCTAssertFalse(server.sentTypes.contains("response.create"))
+        XCTAssertTrue(sink.names.contains("turn.ended_native"))
+        XCTAssertEqual(events.failures, [])
+    }
+
+    /// A turn that carried no audio still skips the clear: the empty-turn guard runs first,
+    /// and a frame about an empty buffer is a frame nobody needs.
+    func testAnEmptyNativeTurnSendsNothingAtAll() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await openTurn(backend, collecting: events)
+
+        backend.endUserTurn(expectingResponse: false)
+        await settle()
+
+        XCTAssertFalse(server.sentTypes.contains("input_audio_buffer.clear"))
+        XCTAssertFalse(server.sentTypes.contains("input_audio_buffer.commit"))
+    }
+
+    /// A reconnect comes back up in the mode the caller is still expecting. Anything else
+    /// would let a socket drop silently hand turn arbitration back to a wearer who has no
+    /// AirPods to arbitrate with.
+    func testTheRequestedModeSurvivesAReconnect() async throws {
+        let server = ScriptedRealtimeServer()
+        let backend = makeBackend(server)
+        backend.setNativeTurnDetection(true)
+        try await backend.open { _ in }
+        await settle()
+        backend.close()
+
+        let reopened = EventLog()
+        try await backend.open { reopened.append($0) }
+        await settle()
+
+        let updates = server.sent.filter { $0["type"] as? String == "session.update" }
+        XCTAssertEqual(updates.count, 4, "two sessions, two frames each")
+        XCTAssertEqual(turnDetection(server, ofUpdate: 2)?["type"] as? String, "none",
+                       "the reconnect handshakes manual, like every other handshake")
+        XCTAssertEqual(turnDetection(server, ofUpdate: 3)?["type"] as? String, "server_vad",
+                       "and is then put back into the mode the caller asked for")
+    }
 }

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -85,8 +85,8 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         try await backend.open { _ in }
 
         XCTAssertEqual(server.sentTypes, ["session.update"])
-        let detection = server.sessionConfiguration?["turn_detection"] as? [String: Any]
-        XCTAssertEqual(detection?["type"] as? String, "none")
+        let input = ScriptedRealtimeServer.inputAudio(of: server.sessionConfiguration)
+        XCTAssertTrue(input?["turn_detection"] is NSNull)
         XCTAssertTrue(sink.names.contains("session.opened"))
     }
 
@@ -100,9 +100,9 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
 
         try await backend.open { _ in }
 
-        let detection = server.sessionConfiguration?["turn_detection"] as? [String: Any]
-        XCTAssertEqual(detection?["type"] as? String, "none",
-                       "the adapter refuses to run a session the service can end itself")
+        let input = ScriptedRealtimeServer.inputAudio(of: server.sessionConfiguration)
+        XCTAssertTrue(input?["turn_detection"] is NSNull,
+                      "the adapter refuses to run a session the service can end itself")
     }
 
     func testSessionCreatedAloneDoesNotCompleteTheHandshake() async {
@@ -898,11 +898,26 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
 
     // MARK: - Degraded turn detection
 
-    private func turnDetection(_ server: ScriptedRealtimeServer,
-                               ofUpdate index: Int) -> [String: Any]? {
+    /// The raw `audio.input.turn_detection` value of one `session.update` — an object when
+    /// native detection is on, and `NSNull` when it is off. Deliberately not collapsed to
+    /// `nil`: "off" and "absent" are different frames to GA, and only one of them disables
+    /// anything.
+    private func turnDetectionValue(_ server: ScriptedRealtimeServer,
+                                    ofUpdate index: Int) -> Any? {
         let updates = server.sent.filter { $0["type"] as? String == "session.update" }
         guard index < updates.count else { return nil }
-        return (updates[index]["session"] as? [String: Any])?["turn_detection"] as? [String: Any]
+        return ScriptedRealtimeServer.inputAudio(of: updates[index]["session"] as? [String: Any])?
+            .first { $0.key == "turn_detection" }?.value
+    }
+
+    private func turnDetection(_ server: ScriptedRealtimeServer,
+                               ofUpdate index: Int) -> [String: Any]? {
+        turnDetectionValue(server, ofUpdate: index) as? [String: Any]
+    }
+
+    private func turnDetectionIsOff(_ server: ScriptedRealtimeServer,
+                                    ofUpdate index: Int) -> Bool {
+        turnDetectionValue(server, ofUpdate: index) is NSNull
     }
 
     /// The degraded mode is a *second* `session.update`, never a different handshake.
@@ -921,7 +936,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         try await backend.open { events.append($0) }
         await settle()
 
-        XCTAssertEqual(turnDetection(server, ofUpdate: 0)?["type"] as? String, "none")
+        XCTAssertTrue(turnDetectionIsOff(server, ofUpdate: 0))
         XCTAssertEqual(turnDetection(server, ofUpdate: 1)?["type"] as? String, "server_vad")
         XCTAssertEqual(turnDetection(server, ofUpdate: 1)?["create_response"] as? Bool, false)
         XCTAssertEqual(events.failures, [])
@@ -951,8 +966,8 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         backend.setNativeTurnDetection(false)
         await settle()
         XCTAssertEqual(turnDetection(server, ofUpdate: baseline)?["type"] as? String, "server_vad")
-        XCTAssertEqual(turnDetection(server, ofUpdate: baseline + 1)?["type"] as? String, "none",
-                       "and the way back is the same frame it always was")
+        XCTAssertTrue(turnDetectionIsOff(server, ofUpdate: baseline + 1),
+                      "and the way back is an explicit null, which is how GA disables it")
     }
 
     /// The whole degraded flow as the service produces it, and the property the whole design
@@ -1113,8 +1128,8 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
 
         let updates = server.sent.filter { $0["type"] as? String == "session.update" }
         XCTAssertEqual(updates.count, 4, "two sessions, two frames each")
-        XCTAssertEqual(turnDetection(server, ofUpdate: 2)?["type"] as? String, "none",
-                       "the reconnect handshakes manual, like every other handshake")
+        XCTAssertTrue(turnDetectionIsOff(server, ofUpdate: 2),
+                      "the reconnect handshakes manual, like every other handshake")
         XCTAssertEqual(turnDetection(server, ofUpdate: 3)?["type"] as? String, "server_vad",
                        "and is then put back into the mode the caller asked for")
     }

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -658,7 +658,8 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let backend = makeBackend(ScriptedRealtimeServer())
         XCTAssertEqual(backend.capabilities,
                        VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
-                                                duplex: true))
+                                                duplex: true,
+                                                supportsNativeTurnDetection: true))
     }
 
     // MARK: - Failure paths

--- a/Tests/TapQVoiceBackendsTests/RealtimeMessagesTests.swift
+++ b/Tests/TapQVoiceBackendsTests/RealtimeMessagesTests.swift
@@ -77,11 +77,55 @@ final class RealtimeMessagesTests: XCTestCase {
         XCTAssertEqual(response["instructions"] as? String, "say yes")
     }
 
+    /// The degraded direction of the switch, field by field.
+    ///
+    /// Every one of these three is load-bearing and none of them is obvious from the type
+    /// name: `server_vad` is what makes a transcript exist at all without an IMU endpoint;
+    /// `create_response: false` is the line between "the service may say where the sentence
+    /// ended" and "the service may answer it", which is the whole limit of the carve-out;
+    /// and `interrupt_response: false` keeps barge-in with `WearerTurnCoordinator`, which is
+    /// the only component that knows whether the voice it heard belonged to the wearer.
+    func testSessionUpdateCanHandEndOfSpeechDetectionToTheService() throws {
+        let configuration = RealtimeSessionConfiguration(turnDetection: .serverVAD)
+        let json = try object(try RealtimeClientEvent.sessionUpdate(configuration).encodedFrame())
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        let detection = try XCTUnwrap(session["turn_detection"] as? [String: Any])
+
+        XCTAssertEqual(detection["type"] as? String, "server_vad")
+        XCTAssertEqual(detection["create_response"] as? Bool, false,
+                       "the service may end a turn; it may never author a sentence")
+        XCTAssertEqual(detection["interrupt_response"] as? Bool, false,
+                       "barge-in stays with the IMU, which knows who spoke")
+    }
+
+    /// The manual direction, byte for byte what it always was.
+    ///
+    /// The new fields are optional so that switching back is not a different frame from the
+    /// one every session has always handshaked with — a `create_response: null` riding along
+    /// would be a wire change nobody asked for.
+    func testTheManualFrameIsUnchangedByTheNewFields() throws {
+        let json = try object(
+            try RealtimeClientEvent.sessionUpdate(
+                RealtimeSessionConfiguration(turnDetection: .disabled)).encodedFrame())
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        let detection = try XCTUnwrap(session["turn_detection"] as? [String: Any])
+
+        XCTAssertEqual(detection["type"] as? String, "none")
+        XCTAssertEqual(detection.count, 1,
+                       "manual mode carries nothing but its type: \(detection)")
+    }
+
+    func testClearIsABareFrame() throws {
+        XCTAssertEqual(try object(try RealtimeClientEvent.clearInputAudio.encodedFrame())["type"]
+                        as? String, "input_audio_buffer.clear")
+    }
+
     func testWireTypesMatchTheEncodedFrames() throws {
         let events: [RealtimeClientEvent] = [
             .sessionUpdate(RealtimeSessionConfiguration()),
             .appendInputAudio(Data([1, 2])),
             .commitInputAudio,
+            .clearInputAudio,
             .createResponse(instructions: nil),
             .cancelResponse,
         ]
@@ -197,5 +241,22 @@ final class RealtimeMessagesTests: XCTestCase {
 
     func testErrorEventWithoutAnErrorBodyIsMalformed() {
         XCTAssertThrowsError(try RealtimeServerEvent.decode(#"{"type":"error"}"#))
+    }
+
+    /// The server-VAD flow, decoded. Modelled rather than left to `.unsupported` because the
+    /// commit is the event the degraded path turns on, and the two speech events around it
+    /// are what make a silent run diagnosable from the log alone.
+    func testDecodesTheServerVADFlow() throws {
+        XCTAssertEqual(
+            try RealtimeServerEvent.decode(#"{"type":"input_audio_buffer.speech_started"}"#),
+            .speechStarted)
+        XCTAssertEqual(
+            try RealtimeServerEvent.decode(#"{"type":"input_audio_buffer.speech_stopped"}"#),
+            .speechStopped)
+        XCTAssertEqual(
+            try RealtimeServerEvent.decode(
+                #"{"type":"input_audio_buffer.committed","item_id":"item_1"}"#),
+            .inputAudioCommitted,
+            "the payload's item id is the service's bookkeeping, not TapQ's")
     }
 }

--- a/Tests/TapQVoiceBackendsTests/RealtimeMessagesTests.swift
+++ b/Tests/TapQVoiceBackendsTests/RealtimeMessagesTests.swift
@@ -10,6 +10,13 @@ final class RealtimeMessagesTests: XCTestCase {
 
     // MARK: - Client events
 
+    /// Reaches into `session.audio.input`, which is where GA moved every setting that used
+    /// to sit flat on the session object.
+    private func inputAudio(_ session: [String: Any]) throws -> [String: Any] {
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        return try XCTUnwrap(audio["input"] as? [String: Any])
+    }
+
     func testSessionUpdateDisablesServerTurnDetection() throws {
         let frame = try RealtimeClientEvent.sessionUpdate(RealtimeSessionConfiguration())
             .encodedFrame()
@@ -17,9 +24,29 @@ final class RealtimeMessagesTests: XCTestCase {
 
         XCTAssertEqual(json["type"] as? String, "session.update")
         let session = try XCTUnwrap(json["session"] as? [String: Any])
-        let detection = try XCTUnwrap(session["turn_detection"] as? [String: Any])
-        XCTAssertEqual(detection["type"] as? String, "none",
-                       "manual-turn mode is the whole reason this adapter exists")
+        XCTAssertEqual(session["type"] as? String, "realtime",
+                       "GA rejects a session object with no discriminator")
+        let input = try inputAudio(session)
+        XCTAssertTrue(input["turn_detection"] is NSNull,
+                      "manual-turn mode is the whole reason this adapter exists")
+    }
+
+    /// The one encoding detail this migration cannot get wrong.
+    ///
+    /// GA's `session.update` merges: a key that is absent keeps whatever the session already
+    /// had. So turning native detection back *off* has to send a literal `null`, not drop
+    /// the key — a dropped key would leave the service's VAD running while TapQ believed it
+    /// had taken turn arbitration back, which is the exact failure the handshake exists to
+    /// prevent.
+    func testManualModeSendsAnExplicitNullRatherThanOmittingTheKey() throws {
+        let frame = try RealtimeClientEvent
+            .sessionUpdate(RealtimeSessionConfiguration(turnDetection: nil)).encodedFrame()
+
+        XCTAssertTrue(frame.contains("\"turn_detection\":null"),
+                      "an omitted key is a no-op merge, not a disable: \(frame)")
+        let input = try inputAudio(try XCTUnwrap(try object(frame)["session"] as? [String: Any]))
+        XCTAssertTrue(input.keys.contains("turn_detection"))
+        XCTAssertTrue(input["turn_detection"] is NSNull)
     }
 
     func testSessionUpdateCarriesTheAudioAndTranscriptionSlice() throws {
@@ -30,11 +57,23 @@ final class RealtimeMessagesTests: XCTestCase {
         let session = try XCTUnwrap(json["session"] as? [String: Any])
 
         XCTAssertEqual(session["model"] as? String, "gpt-realtime-mini")
-        XCTAssertEqual(session["input_audio_format"] as? String, "pcm16")
-        XCTAssertEqual(session["output_audio_format"] as? String, "pcm16")
         XCTAssertEqual(session["instructions"] as? String, "be brief")
-        XCTAssertEqual(session["voice"] as? String, "cedar")
-        let transcription = try XCTUnwrap(session["input_audio_transcription"] as? [String: Any])
+        XCTAssertEqual(session["output_modalities"] as? [String], ["audio"],
+                       "GA takes one modality, and audio carries its own transcript")
+
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        // GA describes an encoding with an object, and accepts only 24 kHz for audio/pcm —
+        // which is what keeps `VoiceAudioFormat.pcm16Mono24k` the right wire format.
+        for side in ["input", "output"] {
+            let format = try XCTUnwrap((audio[side] as? [String: Any])?["format"] as? [String: Any],
+                                       "\(side) needs a format object, not a bare string")
+            XCTAssertEqual(format["type"] as? String, "audio/pcm")
+            XCTAssertEqual(format["rate"] as? Int, 24_000)
+        }
+        XCTAssertEqual((audio["output"] as? [String: Any])?["voice"] as? String, "cedar",
+                       "GA moved the voice under audio.output")
+
+        let transcription = try XCTUnwrap(try inputAudio(session)["transcription"] as? [String: Any])
         XCTAssertEqual(transcription["model"] as? String,
                        RealtimeDefaults.inputTranscriptionModel,
                        "without input transcription the grammar has nothing to match")
@@ -44,9 +83,11 @@ final class RealtimeMessagesTests: XCTestCase {
         let json = try object(
             try RealtimeClientEvent.sessionUpdate(RealtimeSessionConfiguration()).encodedFrame())
         let session = try XCTUnwrap(json["session"] as? [String: Any])
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
 
         XCTAssertNil(session["instructions"])
-        XCTAssertNil(session["voice"], "unset settings stay at the service default")
+        XCTAssertNil((audio["output"] as? [String: Any])?["voice"],
+                     "unset settings stay at the service default")
     }
 
     func testAppendFramesBase64EncodeTheAudio() throws {
@@ -89,30 +130,14 @@ final class RealtimeMessagesTests: XCTestCase {
         let configuration = RealtimeSessionConfiguration(turnDetection: .serverVAD)
         let json = try object(try RealtimeClientEvent.sessionUpdate(configuration).encodedFrame())
         let session = try XCTUnwrap(json["session"] as? [String: Any])
-        let detection = try XCTUnwrap(session["turn_detection"] as? [String: Any])
+        // GA nests it under the input audio config; Beta carried it flat on the session.
+        let detection = try XCTUnwrap(try inputAudio(session)["turn_detection"] as? [String: Any])
 
         XCTAssertEqual(detection["type"] as? String, "server_vad")
         XCTAssertEqual(detection["create_response"] as? Bool, false,
                        "the service may end a turn; it may never author a sentence")
         XCTAssertEqual(detection["interrupt_response"] as? Bool, false,
                        "barge-in stays with the IMU, which knows who spoke")
-    }
-
-    /// The manual direction, byte for byte what it always was.
-    ///
-    /// The new fields are optional so that switching back is not a different frame from the
-    /// one every session has always handshaked with — a `create_response: null` riding along
-    /// would be a wire change nobody asked for.
-    func testTheManualFrameIsUnchangedByTheNewFields() throws {
-        let json = try object(
-            try RealtimeClientEvent.sessionUpdate(
-                RealtimeSessionConfiguration(turnDetection: .disabled)).encodedFrame())
-        let session = try XCTUnwrap(json["session"] as? [String: Any])
-        let detection = try XCTUnwrap(session["turn_detection"] as? [String: Any])
-
-        XCTAssertEqual(detection["type"] as? String, "none")
-        XCTAssertEqual(detection.count, 1,
-                       "manual mode carries nothing but its type: \(detection)")
     }
 
     func testClearIsABareFrame() throws {
@@ -174,11 +199,21 @@ final class RealtimeMessagesTests: XCTestCase {
         }
     }
 
-    func testDecodesResponseCompletionUnderBothSpellings() throws {
+    func testDecodesResponseCompletion() throws {
         XCTAssertEqual(try RealtimeServerEvent.decode(RealtimeFrame.responseDone),
                        .responseCompleted)
+    }
+
+    /// The Beta names for the two response events are gone, not aliased.
+    ///
+    /// Keeping them would read as a compatibility promise to an API that no longer answers,
+    /// and would quietly mask the next rename the way this one was masked: a session that
+    /// decodes an unknown audio event as `.unsupported` plays silence rather than failing.
+    func testRetiredBetaEventNamesAreNotAccepted() throws {
         XCTAssertEqual(try RealtimeServerEvent.decode(#"{"type":"response.completed"}"#),
-                       .responseCompleted)
+                       .unsupported("response.completed"))
+        XCTAssertEqual(try RealtimeServerEvent.decode(#"{"type":"response.audio.delta"}"#),
+                       .unsupported("response.audio.delta"))
     }
 
     func testDecodesErrorEvents() throws {

--- a/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
@@ -75,9 +75,11 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
             XCTAssertEqual(type, "session.update",
                            "the session must be configured before anything else is sent")
             let session = object["session"] as? [String: Any]
-            let detection = session?["turn_detection"] as? [String: Any]
-            XCTAssertEqual(detection?["type"] as? String, "none",
-                           "server-side turn detection must be disabled on the first frame")
+            XCTAssertEqual(session?["type"] as? String, "realtime",
+                           "the GA session object needs its discriminator")
+            let input = ScriptedRealtimeServer.inputAudio(of: session)
+            XCTAssertTrue(input?["turn_detection"] is NSNull,
+                          "server-side turn detection must be disabled on the first frame")
         }
 
         switch type {
@@ -163,6 +165,12 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
 
     var sessionConfiguration: [String: Any]? {
         sent.first { $0["type"] as? String == "session.update" }?["session"] as? [String: Any]
+    }
+
+    /// `session.audio.input`, where GA keeps the format, the transcription model, and turn
+    /// detection. Beta had all three flat on the session object.
+    static func inputAudio(of session: [String: Any]?) -> [String: Any]? {
+        (session?["audio"] as? [String: Any])?["input"] as? [String: Any]
     }
 
     func instructions(ofResponseAt index: Int) -> String? {

--- a/Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedVoiceBackend.swift
@@ -85,6 +85,15 @@ final class ScriptedVoiceBackend: VoiceBackend {
         }
     }
 
+    /// Every mode the caller asked for, in order. Not a `Call`: the fail-through tests
+    /// assert on exact call sequences, and a mode replay landing in the middle of one would
+    /// make them argue about something they are not testing.
+    private(set) var nativeTurnDetection: [Bool] = []
+
+    func setNativeTurnDetection(_ enabled: Bool) {
+        nativeTurnDetection.append(enabled)
+    }
+
     /// Delivers an event to the newest window, or to an older one when a test needs to
     /// prove stale callbacks are dropped.
     func emit(_ event: VoiceBackendEvent, toHandler index: Int? = nil) {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -137,7 +137,8 @@ The selected mode applies to every agent adapter connected to that runtime insta
   because nothing changed.
 - `openai-realtime` requires `OPENAI_API_KEY` in the runtime's environment and refuses to
   start without it, the same way `--question-classifier openai` does. It uses OpenAI's
-  Realtime API, in manual-turn mode wherever TapQ has a turn signal of its own. The ready
+  Realtime API — the GA API at `wss://api.openai.com/v1/realtime`, on the `gpt-realtime`
+  model — in manual-turn mode wherever TapQ has a turn signal of its own. The ready
   block reports `Voice backend: openai-realtime (fail-through: apple)` followed by which of
   the two endpointers the run is starting with — see [Turn detection](#turn-detection).
 
@@ -158,15 +159,16 @@ has a turn signal of its own; see [Turn detection](#turn-detection) below.
 #### Turn detection
 
 The `openai-realtime` session runs with server-side voice activity detection off
-(`turn_detection: none`) and TapQ commits each turn itself, from the IMU endpoint that
-`--imu-turn-control` provides. That is the mode every run with working AirPods uses.
+(`audio.input.turn_detection: null`) and TapQ commits each turn itself, from the IMU
+endpoint that `--imu-turn-control` provides. That is the mode every run with working AirPods
+uses.
 
 With no IMU turn signal — `--imu-turn-control` not passed, or no AirPods streaming — TapQ
 has nothing that can tell when an utterance ended, and on this pipe a transcript does not
 exist until the audio is committed. Rather than leave the wearer talking into a buffer
 nothing will commit until the window times out, TapQ switches the session to the backend's
-own detection: `turn_detection: server_vad` with `create_response: false` and
-`interrupt_response: false`. The service commits the audio at speech-end so a transcript
+own detection: `audio.input.turn_detection` set to `server_vad` with `create_response: false`
+and `interrupt_response: false`. The service commits the audio at speech-end so a transcript
 arrives; it still may not create a response, may not interrupt playback, and may not resolve
 anything. The commit ends an utterance, not the window — the microphone stays open and the
 wearer can keep talking.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -85,7 +85,7 @@ The underlying command syntax is `tapq serve [options]`.
 | `--speech-summarizer PROVIDER` | Condense an agent's final reply into what TapQ says about it: `auto` (default), `apple`, `anthropic`, `openai`, `heuristic`, or `off`. `auto` uses Apple's on-device model when the device is eligible and the deterministic local reduction otherwise. `off` restores the spoken content TapQ had before summaries existed. See [Spoken summaries](#spoken-summaries) |
 | `--voice-backend PROVIDER` | Speech pipe for voice commands: `apple` (default) or `openai-realtime` |
 | `--wearer-gate` | IMU-based wearer-speech attribution gate (default: off). Voice commands must be attributed to the wearer's own jaw vibration; commands from bystanders or other audio sources are rejected. Fails open when the signal is unavailable or degraded. Uses `wearer-speech-calibration.json` when present, provisional thresholds otherwise |
-| `--imu-turn-control` | IMU-based turn control (default: off). Endpointing: wearer speech-end commits the user turn after a short delay. Barge-in: wearer speech-onset during response audio interrupts playback. Both are additive to gesture/tap/timeout resolution. Shares one signal source with `--wearer-gate` |
+| `--imu-turn-control` | IMU-based turn control (default: off). Endpointing: wearer speech-end commits the user turn after a short delay. Barge-in: wearer speech-onset during response audio interrupts playback. Both are additive to gesture/tap/timeout resolution. Shares one signal source with `--wearer-gate`. On `--voice-backend openai-realtime` it also decides who ends user turns: without it, or with no AirPods streaming, the backend's own voice activity detection does — see [Turn detection](#turn-detection) |
 | `--voice-freeform` | Free-form voice answers for selections and multi-option stop questions (default: off). Requires `--voice-backend openai-realtime`. An unmatched final transcript is offered as a free-text reply with mandatory read-back confirmation. Tool approvals and yes/no stop questions stay binary |
 | `--voice-instructions` | Dictated instructions to the agent (default: off). Requires `--wearer-gate`; passing it alone is a startup error. "New instruction" or "tell it to ⟨…⟩" inside an open prompt opens a read-back-and-confirm dictation, and the confirmed sentence is delivered at the agent's next turn boundary. Fail-closed on wearer attribution — the inverse of every other voice path. Claude Code and Codex only. See [Dictated instructions](#dictated-instructions) |
 | `--auto-answer off\|routine` | Delegation filter (default: `off`). `routine` answers `allow` silently, without opening a window, when the stage-2 reasoner called the action routine, its confidence clears the policy floor, and the tool is not on the never-list. Requires `--reasoner` and `--reasoner-mode primary`; both are startup errors when missing. Approvals only. See [Auto-answered approvals](#auto-answered-approvals) |
@@ -137,19 +137,57 @@ The selected mode applies to every agent adapter connected to that runtime insta
   because nothing changed.
 - `openai-realtime` requires `OPENAI_API_KEY` in the runtime's environment and refuses to
   start without it, the same way `--question-classifier openai` does. It uses OpenAI's
-  Realtime API in manual-turn mode. The ready block reports
-  `Voice backend: openai-realtime (fail-through: apple)`.
+  Realtime API, in manual-turn mode wherever TapQ has a turn signal of its own. The ready
+  block reports `Voice backend: openai-realtime (fail-through: apple)` followed by which of
+  the two endpointers the run is starting with — see [Turn detection](#turn-detection).
 
 There is no OpenAI-only mode. The realtime backend is always composed with the Apple stack
 underneath it, so a session that cannot be opened — or that drops mid-window — continues
 on-device rather than leaving the window without a voice channel. Gesture, tap, and
 timeout resolution are unaffected in every case.
 
-Turn arbitration stays on TapQ's side in both modes: server-side voice activity detection
-is disabled (`turn_detection: none`) and TapQ commits each turn itself, so a remote
-endpoint can never decide the wearer has finished speaking. Audio leaves the machine only
-while a response window is open, and the API key is sent as a request header and is not
-logged.
+Window arbitration stays on TapQ's side in both modes, always: a window is resolved by a
+matched transcript, a gesture, a tap, or its timeout, and by nothing else. The backend is
+never allowed to answer a question, resolve an approval, or create a response nobody asked
+for. Audio leaves the machine only while a response window is open, and the API key is sent
+as a request header and is not logged.
+
+Who ends a *user turn* — who decides the wearer stopped talking — depends on whether TapQ
+has a turn signal of its own; see [Turn detection](#turn-detection) below.
+
+#### Turn detection
+
+The `openai-realtime` session runs with server-side voice activity detection off
+(`turn_detection: none`) and TapQ commits each turn itself, from the IMU endpoint that
+`--imu-turn-control` provides. That is the mode every run with working AirPods uses.
+
+With no IMU turn signal — `--imu-turn-control` not passed, or no AirPods streaming — TapQ
+has nothing that can tell when an utterance ended, and on this pipe a transcript does not
+exist until the audio is committed. Rather than leave the wearer talking into a buffer
+nothing will commit until the window times out, TapQ switches the session to the backend's
+own detection: `turn_detection: server_vad` with `create_response: false` and
+`interrupt_response: false`. The service commits the audio at speech-end so a transcript
+arrives; it still may not create a response, may not interrupt playback, and may not resolve
+anything. The commit ends an utterance, not the window — the microphone stays open and the
+wearer can keep talking.
+
+The mode is chosen at each window open from the live state of the motion signal, so AirPods
+connecting or disconnecting mid-run switches it back and forth without a restart. The choice
+is written to the diagnostic log as `turn_detection.native` or `turn_detection.manual` with
+a reason, and a run that *starts* degraded says so on the ready block's `Voice backend:`
+line. Later switches are logged and not spoken.
+
+The privacy delta is real and worth stating plainly: in the degraded mode the remote endpoint
+decides where the wearer's sentences end, and therefore learns the shape of their speech
+timing. It learns it only from audio it was already being sent, and only while a response
+window is open — the microphone rules are unchanged. Running with AirPods and
+`--imu-turn-control` keeps that decision local; running a cloud backend without them is the
+trade this mode makes explicit rather than silently failing.
+
+Backend turn detection is a declared capability, not an OpenAI special case: a backend that
+cannot do it (the Apple stack) is never asked, and a window there resolves exactly as it
+always has, because Apple's recognizer finalizes transcripts from its own silence heuristic
+and never needed a commit to produce one.
 
 #### Conversation sessions
 
@@ -194,16 +232,23 @@ are never simultaneously live.
 #### Transcript timing on the OpenAI path
 
 On the OpenAI Realtime path, transcripts are not available until the audio buffer is
-committed. Under `turn_detection: none`, the server creates the user conversation item —
-and starts input transcription — only on commit. This means there are no mid-turn partial
-transcripts, and the milestone-one "match on partial transcript" resolution path never
-fires before a commit.
+committed. The server creates the user conversation item — and starts input transcription —
+only on commit. This means there are no mid-turn partial transcripts, and the milestone-one
+"match on partial transcript" resolution path never fires before a commit.
 
-Without `--imu-turn-control`, the only turn-ending events are a command match after the
-window-teardown commit, gesture, tap, or timeout. **`--imu-turn-control` is effectively
-required for natural voice resolution on the `openai-realtime` path**, because it commits
-the turn when the wearer stops speaking, which is what makes transcripts — and therefore
-voice resolution — possible before the window timeout.
+So something has to commit while the window is still open, and which something it is depends
+on the mode described under [Turn detection](#turn-detection):
+
+- **With `--imu-turn-control` and AirPods streaming**, the IMU endpoint commits roughly one
+  second after the wearer stops speaking (0.6 s detector hangover plus a 0.4 s delay). The
+  transcript arrives and the grammar matches it.
+- **Without a live IMU turn signal**, the backend's own VAD commits at speech-end and the
+  transcript arrives the same way. Endpoint timing is the service's, not TapQ's, and the
+  privacy delta above applies.
+
+Either way, a window that nothing commits still resolves by gesture, tap, or timeout — those
+paths never depended on a transcript. What the fallback removes is the case where voice was
+the *only* channel the wearer had and it silently did nothing until the window ran out.
 
 #### Wearer-speech features
 


### PR DESCRIPTION
## What

Two changes that together make `--voice-backend openai-realtime` usable without AirPods:

1. **Graceful turn-detection degradation** (eda6544). The realtime path previously had exactly one code path that could commit a user turn at natural speech-end: IMU endpointing (`--imu-turn-control`, fed by AirPods motion). Without AirPods, a spoken answer sat in the input buffer until window teardown — up to the 240 s timeout — with no warning. Now the provider asks, per window, whether TapQ's wearer turn signal is live. If it is, nothing changes: `turn_detection` stays off and TapQ commits turns, exactly as today. If it is not (flag absent, or a confirmed motion loss — including the paired-but-in-case availability lie from #33), the backend's own VAD is enabled with `create_response: false` / `interrupt_response: false`: it may end the *user turn* (commit audio so the transcript arrives), but it can never create a response, and the window still resolves only by transcript match, gesture, tap, or timeout. AirPods connecting or disconnecting mid-run switches the mode at the next window; a confirmed motion loss switches it on the live session so the first window of a no-AirPods run still works.

   This is a deliberate carve-out from the `VoiceBackend` contract's non-negotiable 1, documented in place: when TapQ has no turn signal of its own, the alternative to a remote endpoint hearing your speech-end is a runtime that cannot hear your answer at all. Wearer attribution and resolution authority never move.

2. **GA API migration** (3e6b417). Discovered live while testing 1: OpenAI retired the Beta realtime API. The routing culprit is the `OpenAI-Beta: realtime=v1` header, now removed; the session config moves to the GA nested shape (`session.type`, `audio.input`/`audio.output`, `output_modalities`, format objects, `turn_detection` under input audio with `null` as the off state), and the response audio events take their GA names. One hazard worth review: GA's `session.update` is a merge, and Swift's synthesized Codable omits nil optionals — which would turn the native-to-manual switch into a silent no-op that leaves the server's VAD running while TapQ believes it has turn arbitration back. `RealtimeInputAudioConfiguration` hand-encodes the explicit `"turn_detection": null`, and a test pins the literal substring.

## New contract surface

- `VoiceBackendCapabilities.supportsNativeTurnDetection`
- `VoiceBackend.setNativeTurnDetection(_:)` (explicit on every conformance; `FailThroughVoiceBackend` takes the union and replays the mode onto each session it opens)
- `VoiceBackendEvent.userAudioCommittedByBackend` — records a diagnostic only; deliberately not a state transition and not a resolution
- `VoiceTurnStateMachine.backendCommittedUserTurn()` — legal only in native mode; `unsolicitedBackendCommit` violation otherwise
- `WearerTurnSignalLiveness` — run-scoped "is the IMU endpointer working", optimistic under the flag and retracted only by a confirmed motion loss (never by the availability flag, which lies for paired-but-disconnected AirPods)

## Verified

- Hardware-tested on 2026-08-27 with AirPods paired but in their case (the #33 scenario): ready line reports the degraded mode, `turn_detection.native reason=no_wearer_turn_signal`, GA session opens on `gpt-realtime` with no protocol error, server-VAD commit then transcript then match resolves an approval about half a second after speech-end; a full-sentence "ok skip the command" arrives as one transcript and resolves `skip -> deferToPrompt` (returns the request to the on-screen prompt) instead of false-approving.
- Live GA smoke through the migrated adapter (one connection): handshake acked, both turn-detection modes accepted, commit/transcription cycle sane, response audio flows under the GA event names, clean close.
- `swift build` clean, `check-public-boundary.sh` passes, `package-runtime-app.sh debug` succeeds.
- **Caveat for review:** the dev machine has no Xcode, so `swift test` could not be executed locally — the new/updated tests (+39 functions, 2108 to 2147) are type-checked and were exercised through a standalone probe harness, but this PR's CI run is their first real execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
