### PR TITLE
Hold voice commands that decide something until the transcript stops changing

### DIFF
--- a/Sources/TapQAppleAdapters/VoiceListener.swift
+++ b/Sources/TapQAppleAdapters/VoiceListener.swift
@@ -77,6 +77,19 @@ extension SFSpeechRecognitionTask: VoiceRecognitionTasking {}
     /// listening window before a fresh session can start.
     private var sessionGeneration: UInt64 = 0
     private let diagnostics: TapQDiagnosticEmitter
+    /// Decides *when* a matched command may fire. The recognizer reports a growing
+    /// transcript and this listener tears itself down on the first command it delivers, so
+    /// without the gate the first fragment of a sentence is the whole sentence — which is
+    /// how "ok, skip the command" approved a request on hardware. See
+    /// `VoicePartialCommandGate`.
+    private var gate: VoicePartialCommandGate
+    /// The pending "has the transcript stopped changing yet?" re-ask. Exactly one is armed
+    /// at a time: a fresh transcript supersedes it, and teardown cancels it, so a window
+    /// that has closed can never be resolved by a timer it left behind.
+    private var stabilityRecheck: Task<Void, Never>?
+    /// Monotonic seconds, read only for differences. `systemUptime` rather than wall clock
+    /// so a clock adjustment mid-utterance cannot make a fragment look settled.
+    private let monotonicNow: () -> TimeInterval
     public var preferOnDevice = true
 
     var recognizerLocaleForTesting: String? {
@@ -93,6 +106,8 @@ extension SFSpeechRecognitionTask: VoiceRecognitionTasking {}
     ///   always built, so the audio path is unchanged byte for byte.
     public init(diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
                 voiceProcessingEnabled: Bool = false) {
+        self.gate = VoicePartialCommandGate()
+        self.monotonicNow = { ProcessInfo.processInfo.systemUptime }
         #if canImport(Speech)
         self.recognizer = AppleVoiceSpeechRecognizer(locale: Self.grammarLocale)
         #endif
@@ -106,14 +121,31 @@ extension SFSpeechRecognitionTask: VoiceRecognitionTasking {}
 
     #if canImport(Speech) && canImport(AVFoundation)
     /// Test seam: fakes exercise listener lifecycle without touching Speech or AVFAudio.
+    ///
+    /// - Parameter stabilityWindow: shortened by tests that need the stability re-check to
+    ///   actually elapse. The scheduling under it stays real — the timer, the main-actor
+    ///   hop, and the generation check are the parts a fake clock would stop proving.
     init(
         recognizer: any VoiceSpeechRecognizing,
         makeAudioSource: @escaping @MainActor () -> any VoiceAudioSource,
-        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
+        stabilityWindow: TimeInterval = VoicePartialCommandGate.defaultStabilityWindow
     ) {
         self.recognizer = recognizer
         self.audioSource = VoiceAudioSourceController(makeSource: makeAudioSource)
         self.diagnostics = TapQDiagnosticEmitter(category: "Voice", sink: diagnosticSink)
+        self.gate = VoicePartialCommandGate(stabilityWindow: stabilityWindow)
+        self.monotonicNow = { ProcessInfo.processInfo.systemUptime }
+    }
+
+    /// Test seam: `SFSpeechRecognitionResult` has no initializer a test can use, so the
+    /// recognition callback is driven directly — the same seam `AppleVoiceBackend` opens
+    /// for the same reason.
+    func deliverRecognitionForTesting(transcript: String? = nil, isFinal: Bool = false,
+                                      error: (any Error)? = nil,
+                                      generation: UInt64? = nil) {
+        handleRecognition(transcript: transcript, isFinal: isFinal, error: error,
+                          generation: generation ?? sessionGeneration)
     }
     #endif
 
@@ -201,9 +233,14 @@ extension SFSpeechRecognitionTask: VoiceRecognitionTasking {}
 
         let recognitionTask = recognizer.recognitionTask(with: request) {
             [weak self] result, error in
+            // The result is read here rather than carried across the hop: what the handler
+            // needs is the transcript and its finality, and both are values.
+            let transcript = result?.bestTranscription.formattedString
+            let isFinal = result?.isFinal ?? false
             Task { @MainActor in
                 self?.handleRecognition(
-                    result: result,
+                    transcript: transcript,
+                    isFinal: isFinal,
                     error: error,
                     generation: generation
                 )
@@ -230,33 +267,90 @@ extension SFSpeechRecognitionTask: VoiceRecognitionTasking {}
     }
 
     #if canImport(Speech) && canImport(AVFoundation)
+    /// One recognizer callback — partial or final — offered to the grammar through the
+    /// firing gate.
+    ///
+    /// The grammar still sees every transcript, partial included, and still sees the whole
+    /// utterance so far rather than a delta: nothing about *what* a transcript means has
+    /// moved. What the gate adds is that a command which decides something is delivered
+    /// only once the text behind it has stopped changing, so the leading fragment of a
+    /// sentence can no longer resolve the window and tear the recognizer down before the
+    /// rest of the sentence exists.
     private func handleRecognition(
-        result: SFSpeechRecognitionResult?,
+        transcript: String?,
+        isFinal: Bool,
         error: (any Error)?,
         generation: UInt64
     ) {
         guard running, sessionGeneration == generation else { return }
 
-        if let result,
-           VoiceCommandMatcher.match(result.bestTranscription.formattedString) != nil
-            || result.isFinal {
-            diagnostics.record("transcript.received")
+        if let transcript {
+            switch gate.admit(transcript: transcript, isFinal: isFinal, at: monotonicNow()) {
+            case .fire(let command):
+                diagnostics.record("transcript.received")
+                fire(command, generation: generation)
+                return
+            case .hold(let recheckAfter):
+                diagnostics.record("transcript.received")
+                if error == nil {
+                    // Logged because this is the one delay a wearer can feel, and a "my yes
+                    // did nothing" report should be answerable from the log file alone.
+                    diagnostics.record(
+                        "command.deferred",
+                        fields: [
+                            "reason": "awaiting_stable_transcript",
+                            "recheck_ms": "\(Int((recheckAfter * 1000).rounded()))",
+                        ]
+                    )
+                    scheduleStabilityRecheck(after: recheckAfter, generation: generation)
+                    return
+                }
+                // A failing recognizer will never produce the settled transcript this
+                // candidate is waiting for, so the error below wins and the candidate is
+                // dropped with the session. Only a *matched and settled* command outranks
+                // an error, which is the precedence this path has always had.
+            case .idle:
+                break
+            }
         }
-        if let result,
-           let command = VoiceCommandMatcher.match(
-               result.bestTranscription.formattedString
-           ) {
-            fire(command, generation: generation)
-        } else if error != nil {
+
+        if error != nil {
             teardown(expectedGeneration: generation)
-        } else if let result, result.isFinal {
+        } else if let transcript, isFinal {
             // The user said something the grammar doesn't know — log it so a
             // "voice does nothing" report is diagnosable from the log file.
-            let transcript = result.bestTranscription.formattedString
+            diagnostics.record("transcript.received")
             diagnostics.record(
                 "transcript.rejected",
                 fields: ["reason": "unmatched", "length": "\(transcript.count)"]
             )
+        }
+    }
+
+    /// Arms the single pending re-ask for a held command.
+    ///
+    /// Only one is ever outstanding: a later transcript replaces the question it was going
+    /// to ask, and teardown cancels it, so the timer can never resolve a window that has
+    /// already closed. The generation check on the way back out is the same one every other
+    /// delayed callback in this file makes, for the same reason.
+    private func scheduleStabilityRecheck(after delay: TimeInterval, generation: UInt64) {
+        stabilityRecheck?.cancel()
+        stabilityRecheck = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(max(0, delay) * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.recheckStability(generation: generation)
+        }
+    }
+
+    private func recheckStability(generation: UInt64) {
+        guard running, sessionGeneration == generation else { return }
+        switch gate.recheck(at: monotonicNow()) {
+        case .fire(let command):
+            fire(command, generation: generation)
+        case .hold(let recheckAfter):
+            scheduleStabilityRecheck(after: recheckAfter, generation: generation)
+        case .idle:
+            break
         }
     }
 
@@ -299,6 +393,12 @@ extension SFSpeechRecognitionTask: VoiceRecognitionTasking {}
         sessionGeneration &+= 1
         running = false
         onCommand = nil
+        // A command still waiting for its transcript to settle when the window closes is
+        // one the wearer never got a decision out of. It is dropped rather than flushed:
+        // TapQ fails open, and an unanswered request goes back to the on-screen prompt.
+        stabilityRecheck?.cancel()
+        stabilityRecheck = nil
+        gate.reset()
         #if canImport(AVFoundation)
         audioSource.stop()
         #endif

--- a/Sources/TapQContracts/Inputs.swift
+++ b/Sources/TapQContracts/Inputs.swift
@@ -153,6 +153,36 @@ public struct ResolvedInput: Sendable, Equatable {
 }
 
 public extension VoiceCommand {
+    /// Whether acting on this command changes anything outside the window it was heard in.
+    ///
+    /// The split exists because a streaming recognizer reports a *growing* transcript, and
+    /// the leading fragment of a sentence is very often a command in its own right: the
+    /// first partial of "ok, skip the command" is "OK", which this grammar reads —
+    /// correctly, for that text — as `.yes`. Firing on the fragment approved a request the
+    /// wearer was refusing (observed on hardware, twice, 2026-08-27), so every command that
+    /// decides something waits for a transcript that has stopped changing. See
+    /// `VoicePartialCommandGate`, which is where the waiting is implemented; this property
+    /// only says which side of the line a command sits on.
+    ///
+    /// The four informational commands are exempt, and the exemption is safe for a
+    /// structural reason rather than a probabilistic one: repeating a request, expanding
+    /// it, or answering a question about the fleet resolves nothing and leaves the window
+    /// open, so a fragment that triggers one costs the wearer a re-read at worst — while
+    /// firing them instantly is most of what makes the channel feel alive.
+    ///
+    /// Everything else mutates: the two answers authorize or refuse, `.skip` hands the
+    /// request to the screen, the selection family moves or commits a choice, and both
+    /// free-text cases put words into an agent's session.
+    var mutatesAgentState: Bool {
+        switch self {
+        case .repeatRequest, .details, .status, .whatChanged:
+            return false
+        case .yes, .no, .skip, .next, .previous, .select, .number,
+             .beginInstruction, .freeform:
+            return true
+        }
+    }
+
     var intent: InputIntent {
         switch self {
         case .yes: return .allow

--- a/Sources/TapQDetectionBaseline/VoicePartialCommandGate.swift
+++ b/Sources/TapQDetectionBaseline/VoicePartialCommandGate.swift
@@ -1,0 +1,149 @@
+import Foundation
+import TapQContracts
+
+/// When a matched command is allowed to fire, given that the transcript it matched may
+/// still be growing.
+///
+/// `VoiceCommandMatcher` answers *what* a transcript means. This answers *when* that
+/// meaning can be acted on, and the two questions are genuinely separate: the grammar is
+/// right about "OK" — that text is an approval — and it is right about "ok, skip the
+/// command" — that text is a deferral. What went wrong on hardware was neither answer but
+/// the moment of the question. A streaming recognizer reports the utterance so far, so the
+/// grammar was handed "OK" while the wearer was still saying the rest of the sentence, the
+/// approval fired, and the recognizer was torn down before "skip" existed. The wearer meant
+/// skip; the runtime approved. Observed twice, 2026-08-27.
+///
+/// The rule this gate applies, in one line: a command that decides something fires only on
+/// a transcript that has stopped changing; a command that decides nothing fires at once.
+///
+/// "Stopped changing" is two conditions, either of which is enough:
+///
+/// 1. **The recognizer says so.** A result flagged final is the whole utterance by
+///    definition, and no later text can contradict it, so it fires immediately.
+/// 2. **It has held still long enough.** `SFSpeechRecognizer` fed from a live buffer does
+///    not reliably flag anything final until the audio is closed, which on this path only
+///    happens at teardown — so waiting for finality alone would mean a spoken "yes" never
+///    resolving a window at all. Instead the same match on the same unchanged text, held
+///    for `stabilityWindow`, is treated as settled.
+///
+/// The window is deliberately long enough to cover the gap between two partials of one
+/// fluent sentence, because that gap is exactly what the defect exploited: a wearer part
+/// way through "ok, skip …" must not be read as a wearer who finished saying "ok". The
+/// asymmetry that sets the length is the same one the grammar is built around — a `.no`
+/// that lands half a second late costs a beat of latency, a `.yes` that fires on a
+/// fragment runs an action nobody authorized — so when in doubt this waits.
+///
+/// Growth restarts the window rather than extending the old candidate: text that is still
+/// arriving is a wearer who is still talking, and the command their next word produces is
+/// the one that counts. A transcript that revises down to no match at all drops the
+/// candidate outright and fires nothing, which is TapQ's usual fail-open — an unmatched
+/// transcript leaves the request to the on-screen prompt, and silence is recoverable in a
+/// way a wrong approval is not.
+///
+/// The gate is a value with no clock and no timer of its own: callers pass the time they
+/// read and schedule their own re-check from the interval a `.hold` hands back. That keeps
+/// the whole policy testable at wall-clock speeds and keeps timer ownership with the object
+/// that already owns a session generation to validate the callback against.
+public struct VoicePartialCommandGate {
+    /// What the caller should do with the transcript it just admitted.
+    public enum Outcome: Equatable {
+        /// Deliver this command now.
+        case fire(VoiceCommand)
+        /// A command matched but is not settled yet. Ask again after this interval unless a
+        /// further transcript arrives first, which supersedes the pending re-check.
+        case hold(recheckAfter: TimeInterval)
+        /// Nothing to act on: the transcript matched no command, or none is pending.
+        case idle
+    }
+
+    /// How long a matched, mutating command must sit unchanged before it is treated as
+    /// settled.
+    ///
+    /// 0.7 s is the top of the range this fix was scoped to. It sits above the gap between
+    /// consecutive partials of a fluent sentence — which is what has to be covered for
+    /// "ok, skip the command" to be heard as one sentence rather than two decisions — and
+    /// close enough to the silence thresholds speech endpointers use that a wearer who has
+    /// actually finished speaking does not notice the wait.
+    public static let defaultStabilityWindow: TimeInterval = 0.7
+
+    private let stabilityWindow: TimeInterval
+    private var pending: (command: VoiceCommand, transcript: String, since: TimeInterval)?
+
+    public init(stabilityWindow: TimeInterval = VoicePartialCommandGate.defaultStabilityWindow) {
+        self.stabilityWindow = stabilityWindow
+    }
+
+    /// Offers one recognizer result to the grammar and reports whether its command may fire.
+    ///
+    /// - Parameters:
+    ///   - transcript: the utterance so far, cumulative rather than a delta — the same
+    ///     input `VoiceCommandMatcher` has always been given.
+    ///   - isFinal: whether the recognizer has settled this transcript.
+    ///   - now: a monotonic reading, in seconds. Only differences between readings matter.
+    public mutating func admit(
+        transcript: String,
+        isFinal: Bool,
+        at now: TimeInterval
+    ) -> Outcome {
+        guard let command = VoiceCommandMatcher.match(transcript) else {
+            // The recognizer revised the text away from whatever it used to mean. Holding a
+            // candidate the current transcript no longer supports would fire a command the
+            // wearer's own words have already withdrawn.
+            pending = nil
+            return .idle
+        }
+        guard command.mutatesAgentState else {
+            pending = nil
+            return .fire(command)
+        }
+        if isFinal {
+            pending = nil
+            return .fire(command)
+        }
+        if let candidate = pending,
+           candidate.command == command,
+           candidate.transcript == transcript {
+            return settle(candidate, at: now)
+        }
+        // Either the first sighting of this command or a transcript that is still growing.
+        // Both start the clock over: what matters is how long the text has been still, not
+        // how long some earlier reading of it was.
+        pending = (command, transcript, now)
+        return .hold(recheckAfter: stabilityWindow)
+    }
+
+    /// Re-asks about the held candidate without a new transcript — the case a timer covers.
+    ///
+    /// This is not a nicety. Partials stop arriving the moment the wearer stops speaking,
+    /// so a rule that could only be re-evaluated by the next callback would leave the last
+    /// word of every utterance waiting for a callback that never comes.
+    public mutating func recheck(at now: TimeInterval) -> Outcome {
+        guard let candidate = pending else { return .idle }
+        return settle(candidate, at: now)
+    }
+
+    /// Forgets any held candidate. Called when the window ends: a command that was still
+    /// waiting when the microphone closed is one the wearer never got a decision out of,
+    /// and it must not survive into whatever opens next.
+    public mutating func reset() {
+        pending = nil
+    }
+
+    /// Fires the candidate if it has been still for the whole window, and otherwise hands
+    /// back what is left of it.
+    ///
+    /// The remainder is recomputed rather than assumed so that a re-check arriving a hair
+    /// early — clocks read on two different sources rarely agree to the microsecond —
+    /// simply schedules the sliver again instead of firing early or hanging.
+    private mutating func settle(
+        _ candidate: (command: VoiceCommand, transcript: String, since: TimeInterval),
+        at now: TimeInterval
+    ) -> Outcome {
+        let elapsed = now - candidate.since
+        guard elapsed >= stabilityWindow else {
+            return .hold(recheckAfter: stabilityWindow - elapsed)
+        }
+        pending = nil
+        return .fire(candidate.command)
+    }
+}

--- a/Tests/TapQAppleAdaptersTests/VoiceListenerTests.swift
+++ b/Tests/TapQAppleAdaptersTests/VoiceListenerTests.swift
@@ -389,6 +389,140 @@ final class VoiceListenerTests: XCTestCase {
         )
     }
 
+    // MARK: - Partial transcripts must not fire commands that decide something
+
+    /// The live failure, twice on hardware, 2026-08-27. The wearer says "ok, skip the
+    /// command"; the recognizer's first partial is "OK"; the grammar reads that fragment as
+    /// an approval — correctly, for that text — and the listener used to fire it and tear
+    /// the recognizer down before the word "skip" existed. The wearer meant skip; the
+    /// runtime approved.
+    func testPartialOKThenFinalSkipDefersTheRequestAndNeverApprovesIt() async {
+        let recognizer = FakeRecognizer()
+        let source = FakeAudioSource()
+        let listener = VoiceListener(recognizer: recognizer, makeAudioSource: { source })
+        var commands: [VoiceCommand] = []
+        listener.start { commands.append($0) }
+
+        listener.deliverRecognitionForTesting(transcript: "OK")
+        XCTAssertEqual(commands, [], "an approval matched on a fragment is not an approval")
+        XCTAssertTrue(
+            listener.isRunningForTesting,
+            "the recognizer must still be listening, or the rest of the sentence is lost"
+        )
+
+        listener.deliverRecognitionForTesting(
+            transcript: "ok skip the command",
+            isFinal: true
+        )
+        XCTAssertEqual(commands, [.skip])
+        XCTAssertFalse(listener.isRunningForTesting)
+    }
+
+    func testApprovalOnAPartialIsHeldAndTheSameTextAsFinalApproves() async {
+        let recognizer = FakeRecognizer()
+        let source = FakeAudioSource()
+        let sink = RecordingSink()
+        let listener = VoiceListener(
+            recognizer: recognizer,
+            makeAudioSource: { source },
+            diagnosticSink: sink
+        )
+        var commands: [VoiceCommand] = []
+        listener.start { commands.append($0) }
+
+        listener.deliverRecognitionForTesting(transcript: "yes")
+        XCTAssertEqual(commands, [])
+        let deferred = sink.events.last { $0.name == "command.deferred" }
+        XCTAssertEqual(deferred?.fields["reason"], "awaiting_stable_transcript",
+                       "the one delay a wearer can feel has to be in the log file")
+
+        listener.deliverRecognitionForTesting(transcript: "yes", isFinal: true)
+        XCTAssertEqual(commands, [.yes])
+    }
+
+    /// The stability release. `SFSpeechRecognizer` fed from a live buffer does not reliably
+    /// flag anything final before the audio is closed, so an approval that waited for
+    /// finality alone would never resolve its window at all: text that has stopped changing
+    /// has to be enough.
+    func testApprovalFiresOnceThePartialTranscriptStopsChanging() async {
+        let recognizer = FakeRecognizer()
+        let source = FakeAudioSource()
+        let listener = VoiceListener(
+            recognizer: recognizer,
+            makeAudioSource: { source },
+            stabilityWindow: 0.02
+        )
+        var commands: [VoiceCommand] = []
+        listener.start { commands.append($0) }
+
+        listener.deliverRecognitionForTesting(transcript: "yes")
+        XCTAssertEqual(commands, [], "not before the window has elapsed")
+
+        // Polling rather than an expectation: the re-check lands on a later main-actor
+        // turn, and the house rule is no `XCTestExpectation` for actor hops.
+        var attempts = 400
+        while commands.isEmpty, attempts > 0 {
+            attempts -= 1
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTAssertEqual(commands, [.yes])
+        XCTAssertFalse(listener.isRunningForTesting)
+        XCTAssertEqual(source.stops, 1)
+    }
+
+    /// Informational commands resolve nothing and leave the window open, so a fragment that
+    /// triggers one costs a re-read at worst — and answering instantly is most of what
+    /// makes the channel feel alive.
+    func testInformationalCommandsStillFireOnTheFirstPartial() async {
+        for (transcript, expected) in [("details", VoiceCommand.details),
+                                       ("repeat that", .repeatRequest),
+                                       ("status", .status),
+                                       ("what did you just do", .whatChanged)] {
+            let recognizer = FakeRecognizer()
+            let source = FakeAudioSource()
+            let listener = VoiceListener(recognizer: recognizer, makeAudioSource: { source })
+            var commands: [VoiceCommand] = []
+            listener.start { commands.append($0) }
+
+            listener.deliverRecognitionForTesting(transcript: transcript)
+            XCTAssertEqual(commands, [expected], "'\(transcript)' mutates nothing")
+        }
+    }
+
+    /// One settled transcript and nothing else — the shape a backend that transcribes
+    /// server-side produces. Unchanged by the gate: it fires on arrival.
+    func testASingleFinalTranscriptResolvesTheWindowImmediately() async {
+        let recognizer = FakeRecognizer()
+        let source = FakeAudioSource()
+        let listener = VoiceListener(recognizer: recognizer, makeAudioSource: { source })
+        var commands: [VoiceCommand] = []
+        listener.start { commands.append($0) }
+
+        listener.deliverRecognitionForTesting(transcript: "yes please", isFinal: true)
+        XCTAssertEqual(commands, [.yes])
+    }
+
+    /// A command still waiting for its transcript to settle when the window closes is one
+    /// the wearer never got a decision out of. It is dropped, not flushed — the request goes
+    /// back to the on-screen prompt, which is what TapQ does with every unanswered window.
+    func testAHeldCommandIsDroppedWhenTheWindowCloses() async {
+        let recognizer = FakeRecognizer()
+        let source = FakeAudioSource()
+        let listener = VoiceListener(
+            recognizer: recognizer,
+            makeAudioSource: { source },
+            stabilityWindow: 0.02
+        )
+        var commands: [VoiceCommand] = []
+        listener.start { commands.append($0) }
+
+        listener.deliverRecognitionForTesting(transcript: "yes")
+        listener.stop()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(commands, [], "a closed window must not be resolved by its own timer")
+    }
+
     func testEngineStartFailureLogsStageAndTearsDownCapture() {
         let recognizer = FakeRecognizer()
         let source = FakeAudioSource()

--- a/Tests/TapQDetectionBaselineTests/VoicePartialCommandGateTests.swift
+++ b/Tests/TapQDetectionBaselineTests/VoicePartialCommandGateTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import TapQDetectionBaseline
+import TapQContracts
+
+/// The firing policy for partial transcripts, at the level where it is a pure function of
+/// (text, finality, clock). The listener that owns the timer is covered separately; what is
+/// pinned here is the rule itself.
+final class VoicePartialCommandGateTests: XCTestCase {
+    private let window: TimeInterval = 0.7
+
+    private func makeGate() -> VoicePartialCommandGate {
+        VoicePartialCommandGate(stabilityWindow: window)
+    }
+
+    // MARK: - The reported defect
+
+    /// The live failure, twice on hardware, 2026-08-27: the wearer says "ok, skip the
+    /// command", the recognizer's first partial is "OK", the grammar reads that fragment as
+    /// an approval — correctly, for that text — and the old listener fired it and tore the
+    /// recognizer down before the word "skip" ever existed. The wearer meant skip; the
+    /// runtime approved.
+    ///
+    /// The transcripts below are the shape a streaming recognizer actually produces:
+    /// cumulative, growing, and a command in their own right at every step.
+    func testPartialOKFollowedByFinalSkipSkipsAndNeverApproves() {
+        var gate = makeGate()
+
+        XCTAssertEqual(gate.admit(transcript: "OK", isFinal: false, at: 0),
+                       .hold(recheckAfter: window),
+                       "an approval matched on a fragment must not be delivered")
+        XCTAssertEqual(gate.admit(transcript: "OK skip", isFinal: false, at: 0.35),
+                       .hold(recheckAfter: window),
+                       "the wearer is still talking; the candidate is replaced, not fired")
+        XCTAssertEqual(gate.admit(transcript: "ok skip the command", isFinal: true, at: 0.6),
+                       .fire(.skip))
+    }
+
+    /// The same sentence when the recognizer never flags anything final — the ordinary case
+    /// on a live audio buffer, where finality only arrives at teardown. The deferral still
+    /// wins, and it wins on the stability rule alone.
+    func testPartialOKFollowedByPartialSkipStillSkipsWithoutAnyFinalTranscript() {
+        var gate = makeGate()
+
+        XCTAssertEqual(gate.admit(transcript: "OK", isFinal: false, at: 0),
+                       .hold(recheckAfter: window))
+        XCTAssertEqual(gate.admit(transcript: "ok skip the command", isFinal: false, at: 0.4),
+                       .hold(recheckAfter: window))
+        XCTAssertEqual(gate.recheck(at: 0.4 + window), .fire(.skip))
+    }
+
+    // MARK: - The two answers
+
+    func testApprovalOnAPartialIsHeldAndTheSameTextAsFinalFires() {
+        var gate = makeGate()
+        XCTAssertEqual(gate.admit(transcript: "yes", isFinal: false, at: 0),
+                       .hold(recheckAfter: window))
+        XCTAssertEqual(gate.admit(transcript: "yes", isFinal: true, at: 0.05), .fire(.yes))
+    }
+
+    /// The stability release: text that stops changing is text the wearer has finished
+    /// saying, so a spoken "yes" still resolves its window on a recognizer that never
+    /// finalizes anything.
+    func testApprovalHeldOnPartialsFiresOnceTheTranscriptStopsChanging() {
+        var gate = makeGate()
+        XCTAssertEqual(gate.admit(transcript: "yes", isFinal: false, at: 0),
+                       .hold(recheckAfter: window))
+        XCTAssertEqual(gate.admit(transcript: "yes", isFinal: false, at: 0.3),
+                       .hold(recheckAfter: window - 0.3),
+                       "a repeat of the same text keeps the original clock, not a new one")
+        XCTAssertEqual(gate.admit(transcript: "yes", isFinal: false, at: window), .fire(.yes))
+    }
+
+    /// A re-check that lands a hair early — two clock sources rarely agree to the
+    /// microsecond — reschedules the sliver instead of firing early or hanging.
+    func testAnEarlyRecheckReschedulesTheRemainder() {
+        var gate = makeGate()
+        _ = gate.admit(transcript: "approve", isFinal: false, at: 0)
+        guard case .hold(let remaining) = gate.recheck(at: window - 0.001) else {
+            return XCTFail("an early re-check must hold, not fire")
+        }
+        XCTAssertEqual(remaining, 0.001, accuracy: 0.0001)
+        XCTAssertEqual(gate.recheck(at: window), .fire(.yes))
+    }
+
+    func testDenialIsHeldOnAPartialToo() {
+        var gate = makeGate()
+        XCTAssertEqual(gate.admit(transcript: "no", isFinal: false, at: 0),
+                       .hold(recheckAfter: window))
+        XCTAssertEqual(gate.recheck(at: window), .fire(.no),
+                       "a denial arriving a beat late is the cost this fix accepts")
+    }
+
+    // MARK: - Everything else that decides something
+
+    func testSelectionAndInstructionFamiliesWaitForASettledTranscript() {
+        for (transcript, command) in [("two", VoiceCommand.number(2)),
+                                      ("pick this", .select),
+                                      ("next option", .next),
+                                      ("go back", .previous),
+                                      ("skip", .skip),
+                                      ("tell it to run the tests", .beginInstruction("run the tests"))] {
+            var gate = makeGate()
+            XCTAssertEqual(gate.admit(transcript: transcript, isFinal: false, at: 0),
+                           .hold(recheckAfter: window),
+                           "'\(transcript)' mutates state and must not fire on a fragment")
+            XCTAssertEqual(gate.admit(transcript: transcript, isFinal: true, at: 0.1),
+                           .fire(command))
+        }
+    }
+
+    // MARK: - The informational commands stay instant
+
+    /// Repeating a request, expanding it, or answering a question about the fleet resolves
+    /// nothing and leaves the window open, so there is nothing for a fragment to get wrong
+    /// and every reason to answer at once.
+    func testInformationalCommandsFireOnTheFirstPartial() {
+        for (transcript, command) in [("repeat that", VoiceCommand.repeatRequest),
+                                      ("details", .details),
+                                      ("status", .status),
+                                      ("what did you just do", .whatChanged)] {
+            var gate = makeGate()
+            XCTAssertEqual(gate.admit(transcript: transcript, isFinal: false, at: 0),
+                           .fire(command),
+                           "'\(transcript)' mutates nothing and must stay instant")
+        }
+    }
+
+    // MARK: - Non-matches and withdrawal
+
+    func testUnmatchedTranscriptIsIdleAndDropsAHeldCandidate() {
+        var gate = makeGate()
+        XCTAssertEqual(gate.admit(transcript: "yes", isFinal: false, at: 0),
+                       .hold(recheckAfter: window))
+        XCTAssertEqual(gate.admit(transcript: "yesterday", isFinal: false, at: 0.2), .idle,
+                       "the recognizer revised the word away; the approval goes with it")
+        XCTAssertEqual(gate.recheck(at: 10), .idle)
+    }
+
+    func testResetForgetsAHeldCandidate() {
+        var gate = makeGate()
+        _ = gate.admit(transcript: "yes", isFinal: false, at: 0)
+        gate.reset()
+        XCTAssertEqual(gate.recheck(at: 10), .idle,
+                       "a window that closed must not be resolved by what it was holding")
+    }
+
+    // MARK: - The single-shot shape
+
+    /// A backend that sends one settled transcript and nothing else — the realtime path's
+    /// shape — is unaffected by any of this: every family fires on arrival, exactly as it
+    /// did before the gate existed.
+    func testASingleFinalTranscriptFiresImmediatelyForEveryFamily() {
+        for (transcript, command) in [("yes please", VoiceCommand.yes),
+                                      ("no", .no),
+                                      ("skip", .skip),
+                                      ("three", .number(3)),
+                                      ("details", .details)] {
+            var gate = makeGate()
+            XCTAssertEqual(gate.admit(transcript: transcript, isFinal: true, at: 0),
+                           .fire(command))
+        }
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -585,6 +585,12 @@ when the selected recognizer supports it; otherwise Apple’s Speech framework m
 use Apple’s service. Spoken output uses the macOS system speech synthesizer and
 voice selection.
 
+A command that decides something — both answers, `skip`, and the selection and
+dictation families — is delivered only once the transcript stops changing (about
+0.7 s, or immediately when the recognizer settles it), so the opening fragment of a
+longer sentence is never mistaken for a whole answer. `repeat`, `details`, `status`,
+and the what-changed question decide nothing and still answer on the first partial.
+
 ### Motion recovery and diagnostics
 
 A single CoreMotion disconnect callback is treated as an interruption rather than


### PR DESCRIPTION
## The defect

On the Apple voice path, `VoiceListener` consulted the grammar on **every** recognition callback — partial or final — and tore the recognizer down on the first match. A wearer saying "ok, skip the command" produced the partial transcript "OK", the yes-family matched it, and the approval fired before "skip" existed. **The wearer meant skip; the runtime approved.** Observed live twice on hardware, 2026-08-27.

## The fix

A new portable policy value, `VoicePartialCommandGate`, decides *when* a matched command may fire (the grammar keeps deciding *what* a transcript means):

- A command that **decides something** (yes, no, skip, selections, dictation triggers — `VoiceCommand.mutatesAgentState`) fires only when the transcript has stopped changing: the result is flagged final, **or** the same match on the same unchanged text has held for **0.7 s**. Growth restarts the window — text still arriving is a wearer still talking.
- A command that **decides nothing** (repeat, details, status, what changed) fires instantly on the first partial, as today.
- A transcript that revises down to no match drops the held candidate and fires nothing — the usual fail-open to the on-screen prompt. Window teardown drops it too; a held command is never flushed on close.

Final-only (no stability window) was not an option: `SFSpeechRecognizer` fed from a live buffer does not reliably flag anything final before the audio closes, so a spoken "yes" would never have resolved a window at all.

The gate is clockless and timer-free — callers pass the time and schedule the re-check `hold` hands back — so the whole policy is portable and tested at wall-clock speed on Linux CI. `VoiceListener` owns the one timer, generation-checked and superseded by each next transcript.

## Tests

- Headline regression: partial "OK" followed by final "ok skip the command" → **skip**, never yes (gate + listener variants; the listener test also asserts the recognizer survives the fragment).
- Approval held on a bare partial; released by finality; released by stability; denial and selection families held; informational commands instant; unmatched revision drops the candidate; teardown drops it; single-shot final transcripts (the realtime shape) fire immediately for every family.
- 10 gate tests (portable, run on Linux) + 6 listener tests (macOS target, all async).

## Noted for follow-up (not in this PR)

`VoiceBackendCommandProvider.consume` fires on `.transcriptPartial` the same way the old listener did, and both backends emit partials — so the realtime path has the same latent race. Adopting this gate there is a one-call follow-up, queued behind the in-flight voice-session branch to avoid conflicts.

New diagnostic: `command.deferred` records each held command, so the added latency is readable in a debug log. User-visible change is at most a ~0.7 s pause before a decision command lands; informational commands are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
