### PR TITLE
Voice-only agent: --voice-trust environment and --voice-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Added
 
+- `--voice-trust wearer|environment` (Rung E), naming whose voice may dictate an
+  instruction. `wearer` is the default and is today's behavior byte for byte. `environment`
+  trusts the microphone as the user for the run this feature was previously unreachable in
+  — AirPods in their case — so `--voice-instructions` no longer requires `--wearer-gate`
+  there, and the fail-closed attribution check is skipped rather than answered. The skip is
+  recorded at both stages the wearer path would have checked
+  (`instruction.trusted_environment`), so it is never silent.
+- **Trust says who may instruct, and nothing else.** Approval grammar, approval read-backs,
+  the fail-open-to-screen rule, and "an instruction authorizes nothing" are identical under
+  both values. The docs state the cost in one sentence: under `environment` anyone audible
+  to the microphone can instruct, and still cannot approve, deny, select, or defer.
+  `--attention imu` still requires `--wearer-gate` under either value — a window that opens
+  on a wearer-speech onset needs the signal that says whose onset it was.
+- Read-backs that stop naming gestures nobody can make: where no motion device is present,
+  the dictation and free-form confirmations become "Say yes to queue it." and "Say yes to
+  send, or no to discard." The wording follows the live motion probe, so AirPods appearing
+  mid-run get the nod offered again on the next read-back. Only composed under
+  `--voice-trust environment`, which is what keeps every default-flag run's spoken output
+  byte-identical. See the [CLI reference](docs/CLI.md#voice-trust).
+
 - A delegation filter, behind `--auto-answer routine` (which requires `--reasoner` and
   `--reasoner-mode primary`; serving refuses to start without both). An approval is
   answered `allow` silently — no window, no prompt, no sound — when the stage-2 reasoner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Added
 
+- Voice sessions, behind `--voice-session` (which requires `--voice-instructions`). When an
+  agent finishes a turn, its Stop hook long-polls the broker instead of returning: TapQ says
+  "Listening." and re-opens a command window until an instruction is queued — delivered as
+  the Stop block, so the agent continues — the wearer says "end voice session", or a
+  ten-minute wait budget expires and the session idles normally. Inside a waiting window an
+  unmatched sentence needs no "tell it to" prefix: it is read back and queued on a spoken
+  yes. That closes the last gap in the instruction channel, where a sentence dictated to an
+  *idle* agent waited for someone to type. See the
+  [CLI reference](docs/CLI.md#voice-sessions).
+- Wire protocol v6 adds one message, `instruction.wait`: identity in, an instruction or
+  nothing out. v5 and v4 peers remain accepted — each bump since v4 has only added a type,
+  leaving every older request shape byte-identical — so an installed shim keeps working
+  against a v6 runtime, and a v6 shim never sends a wait to a runtime that predates it.
+- `tapq integration claude install` now writes a ~620 s `timeout` on the **Stop** hook entry
+  only, sized from the voice-session chain (broker answers at 600 s < shim socket 615 s <
+  hook 620 s). **Reinstall the Claude hooks after upgrading**: a Stop entry written by an
+  older build carries the interaction timeout and would kill a waiting hook part-way
+  through.
+- The instruction loop cap stands down in a voice session, where every boundary is meant to
+  carry an instruction. The four-deep queue cap is unchanged, approvals are untouched, and a
+  runtime that exits releases every waiting hook before it goes — a killed `tapq serve`
+  never leaves a hook parked.
+
 - `--voice-trust wearer|environment` (Rung E), naming whose voice may dictate an
   instruction. `wearer` is the default and is today's behavior byte for byte. `environment`
   trusts the microphone as the user for the run this feature was previously unreachable in

--- a/Executables/tapq-hook/main.swift
+++ b/Executables/tapq-hook/main.swift
@@ -32,6 +32,12 @@ let result = HookShim.handle(stdinData: stdinData, steeringEnabled: {
               approvalSource: nil
           ) != nil else { return false }
     return discovered.steeringEnabled
+}, voiceSessionEnabled: {
+    // Same liveness discipline as steering, for a stronger reason: this answer decides
+    // whether a Stop hook *waits*, and a record left behind by a killed runtime would
+    // park it against a broker nobody is listening on. Fail-closed all the way down —
+    // an unreadable record, an older runtime, or a dead publisher all read as "no".
+    discovery.liveVoiceSessionEnabled()
 }) { message, timeout in
     let (socketPath, token, appVersion, _) = try discovery.readDiscovery()
 
@@ -43,10 +49,15 @@ let result = HookShim.handle(stdinData: stdinData, steeringEnabled: {
 
     // Wire v2 is safe for unchanged legacy events, including strict PreToolUse. Native
     // PermissionRequest requires v3 because a v2 broker cannot distinguish its source
-    // and could apply legacy auto-mode behavior. Unsupported combinations fail open.
+    // and could apply legacy auto-mode behavior. The message type is passed too, so a
+    // type that postdates the broker — `instruction.wait` against a v5 runtime — fails
+    // open here instead of earning an "unknown message type" over the socket. Every type
+    // that predates the instruction channel reports a floor of 1 and negotiates exactly
+    // as it did before.
     guard let outboundVersion = WireProtocol.outboundVersion(
         for: appVersion,
-        approvalSource: approvalSource
+        approvalSource: approvalSource,
+        messageType: message["type"]?.stringValue
     ) else {
         throw ShimVersionError.mismatch(app: appVersion ?? -1, shim: WireProtocol.version)
     }

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -76,6 +76,85 @@ import Darwin
     }
 }
 
+/// Keeps a listening window open for as long as a turn boundary is being held (RH1).
+///
+/// The counterpart to `AttentionArming`, and deliberately shaped like it: the registry
+/// decides *whether* a boundary is held, `CommandWindowController` decides what a window
+/// may do, and this decides that there should be one — and then another, until the hold
+/// ends. Re-opening rather than one long window is what keeps the microphone rules intact:
+/// every window is the same bounded eight seconds the rest of TapQ uses, with the same
+/// gate, the same grammar, and the same half-duplex behavior.
+///
+/// One loop at a time, addressing the boundary that started it. Two agents can be held at
+/// once — nothing prevents it — but TapQ has one microphone and one wearer, and a window
+/// that dictated into whichever session asked most recently would be a way to send the
+/// right sentence to the wrong agent. The second boundary waits out its own budget and the
+/// session idles, which is the honest outcome rather than a guessed one.
+@MainActor private final class VoiceSessionListening {
+    private let waits: InstructionWaitRegistry
+    private let makeController: @MainActor (
+        _ sessionID: String,
+        _ agent: AgentIdentity,
+        _ cue: String?
+    ) -> CommandWindowController
+    private let diagnostics: TapQDiagnosticEmitter
+    private var isRunning = false
+
+    init(waits: InstructionWaitRegistry,
+         diagnosticSink: any TapQDiagnosticSink,
+         makeController: @escaping @MainActor (String, AgentIdentity, String?) -> CommandWindowController) {
+        self.waits = waits
+        self.makeController = makeController
+        self.diagnostics = TapQDiagnosticEmitter(category: "VoiceSession", sink: diagnosticSink)
+    }
+
+    /// Whether a listening loop is running. For diagnostics and tests.
+    var isListening: Bool { isRunning }
+
+    /// Starts listening for the boundary just held, if nothing is listening already.
+    ///
+    /// Called immediately before the caller suspends on the registry, so the loop's first
+    /// turn always sees a registered waiter: both run on this actor, and the registration
+    /// happens in the same actor turn as this call.
+    func begin(sessionID: String, agent: AgentIdentity) {
+        guard !isRunning else {
+            diagnostics.record("listening.already_running", fields: ["session": sessionID])
+            return
+        }
+        isRunning = true
+        diagnostics.record("listening.began", fields: ["agent": agent.id])
+        Task { @MainActor [weak self] in
+            await self?.loop(sessionID: sessionID, agent: agent)
+        }
+    }
+
+    private func loop(sessionID: String, agent: AgentIdentity) async {
+        defer {
+            isRunning = false
+            diagnostics.record("listening.ended")
+        }
+        var windows = 0
+        while waits.isWaiting {
+            // The cue is spoken once, at the boundary. A window that announced itself every
+            // eight seconds would talk over a wearer who is still deciding what to say.
+            let cue = windows == 0 ? CommandWindowController.voiceSessionCue : nil
+            windows += 1
+            let outcome = await makeController(sessionID, agent, cue).run()
+            diagnostics.record("window.finished", fields: [
+                "answers": "\(outcome.answers)",
+                "dictations": "\(outcome.dictations)",
+                "ended": "\(outcome.endedByWearer)",
+            ])
+            guard !outcome.endedByWearer else {
+                // Everything, not just this session: "end voice session" is about the mode
+                // the wearer is in, not about one agent they cannot see the names of.
+                waits.releaseAll()
+                return
+            }
+        }
+    }
+}
+
 /// Headless macOS host composed from TapQ's broker, interaction, and hardware adapters.
 /// The broker and interaction layers remain agent-neutral; installed adapters normalize
 /// Claude Code, Codex, or future agent events before they reach this process.
@@ -94,6 +173,12 @@ import Darwin
     /// reference to it is a weak capture inside a wearer-speech observer, and a local would
     /// be released at the first suspension — leaving the flag on and the feature dead.
     private var attentionArming: AttentionArming?
+    /// Owns the voice session's listening loop for the life of the run, or nil without
+    /// `--voice-session`. A property for the same ARC reason `attentionArming` is one: the
+    /// only other reference to it is a weak capture inside the broker's wait handler, and a
+    /// local would be released at the first suspension — leaving the flag on and every held
+    /// boundary silent.
+    private var voiceSessionListening: VoiceSessionListening?
 
     func serve(
         configuration: TapQRuntimeConfiguration,
@@ -312,7 +397,13 @@ import Darwin
                 sessionPolicy: .conversation(idleClose: 60),
                 supportsBargeIn: true,
                 responseAudio: player,
-                freeformEnabled: configuration.voiceFreeformEnabled,
+                // A voice session needs unmatched transcripts to reach the controller: at a
+                // held boundary the wearer's sentence *is* the instruction, and a provider
+                // that dropped it would leave the mode able to hear only the grammar. The
+                // free-form *answer* path is still `--voice-freeform`'s alone — what this
+                // adds is delivery, and the window decides what to do with it.
+                freeformEnabled: configuration.voiceFreeformEnabled
+                    || configuration.voiceSessionEnabled,
                 isWearerTurnSignalLive: { [turnSignalLiveness] in turnSignalLiveness.isLive },
                 diagnosticSink: diagnostics
             )
@@ -484,6 +575,22 @@ import Darwin
         let instructions: InstructionMailbox? = configuration.voiceInstructionsEnabled
             ? InstructionMailbox(diagnosticSink: diagnostics)
             : nil
+        // The turn boundaries this run is holding open (RH1), or `nil` without
+        // `--voice-session` — in which case discovery advertises nothing, no shim ever
+        // long-polls, and the broker's wait arm answers "no instruction" the moment it is
+        // reached. The registry is the only thing that makes a Stop hook patient, so a run
+        // without one cannot hold anything by accident.
+        let instructionWaits: InstructionWaitRegistry? = configuration.voiceSessionEnabled
+            ? InstructionWaitRegistry(diagnosticSink: diagnostics)
+            : nil
+        // Every way an instruction can arrive — a dictation, `tapq instruct`, the
+        // voice-session window itself — goes through the mailbox, so this is the one place
+        // a held boundary has to be woken from.
+        if let instructionWaits {
+            instructions?.onEnqueued = { [weak instructionWaits] session in
+                instructionWaits?.noteInstructionQueued(session: session)
+            }
+        }
         // What this run remembers about the sessions it serves, and the only thing recall
         // and grounded answers ever read. Built before the controllers because they take
         // its closures; every window below hands it what it may say and nothing else.
@@ -745,6 +852,57 @@ import Darwin
                 + " windows between requests)"
         }
 
+        // -- Voice sessions (RH1) --
+        //
+        // The window a held turn boundary opens. It is the Rung D command window with two
+        // differences, both in `CommandWindowKind.voiceSession`: an unmatched sentence is
+        // dictation rather than silence, and "end voice session" lets the boundary go.
+        // Everything else — the gate, the eight seconds, the grammar, the refusal to
+        // resolve anything — is the same object the attention window is.
+        var voiceSessionStatus: String?
+        if let instructionWaits, let instructions {
+            let listening = VoiceSessionListening(
+                waits: instructionWaits,
+                diagnosticSink: diagnostics,
+                makeController: { sessionID, agent, cue in
+                    CommandWindowController(
+                        // The un-quieted presenter, for the reason the attention window
+                        // uses it: everything said in here answers something the wearer
+                        // just said out loud.
+                        speech: routedSpeech,
+                        arbiter: approvalArbiter,
+                        gate: interactionGate,
+                        cue: cue,
+                        agentDisplayName: agent.displayName,
+                        diagnosticSink: diagnostics,
+                        // The standing responder: there is no request in hand at a
+                        // boundary, and "status" must not describe one that is over.
+                        recallResponder: memory.standingRecallResponder,
+                        // The waiting agent's own capability, not the last one TapQ served:
+                        // this window exists because *this* session's hook is parked, so
+                        // the addressee is known rather than inferred.
+                        instructionCapability: {
+                            AgentCapabilities.of(agent).instructions
+                        },
+                        wearerAttribution: isWearerAttributed,
+                        // Addressed to the held session for the same reason. It is the one
+                        // enqueue path in the runtime that does not go through conversation
+                        // memory's "last request" guess.
+                        instructionEnqueue: { [weak instructions] text in
+                            instructions?.enqueue(text, session: sessionID)
+                        },
+                        kind: .voiceSession,
+                        voiceTrust: configuration.voiceTrust,
+                        gestureConfirmation: gestureConfirmation
+                    )
+                }
+            )
+            voiceSessionListening = listening
+            voiceSessionStatus = "holding turn boundaries up to"
+                + " \(Int(VoiceSessionBudget.brokerWait / 60)) minutes;"
+                + " unmatched speech in a waiting window is dictation"
+        }
+
         let discovery = BrokerRuntimeDiscovery(
             supportDirectory: configuration.brokerDirectory
         )
@@ -1004,6 +1162,11 @@ import Darwin
                 }
                 speech?.speak(notice, priority: .notification, onFinish: nil)
             },
+            // Stood down in a voice session (RH1): every boundary there is *supposed* to
+            // carry an instruction, because the wearer is standing at it dictating them one
+            // at a time. Off — the default — everywhere else, so RC2's cap is untouched for
+            // every run that is not one.
+            suppressesLoopCap: configuration.voiceSessionEnabled,
             // Not assessed, deliberately: a multi-option selection resolves to a *choice*,
             // not an allow/deny, so there is nothing here for a `RequiredConfirmation` to
             // raise — `SelectionController.resolve` has no such parameter. Wiring
@@ -1103,6 +1266,43 @@ import Darwin
                 return instructions.enqueue(
                     submitted.text, session: submitted.sessionID
                 ) != nil
+            },
+            // The held turn boundary (RH1). A Stop hook that has nothing to deliver asks to
+            // wait here instead of returning, and this is where TapQ decides how long and
+            // what it hands back.
+            //
+            // `nil` — let the Stop proceed — is the answer in every case but one: no voice
+            // session composed, nothing queued and nothing arriving inside the budget, or
+            // the wearer ending the session. The one exception is the same delivery the
+            // stop-question path performs, through the same coordinator, so a held boundary
+            // is not a second way for a sentence to reach an agent.
+            onInstructionWait: { [weak self] waiting in
+                guard let instructionWaits else { return nil }
+                // Something may already be queued: the wearer dictated during the agent's
+                // turn and the boundary arrived afterwards. Deliver it without waiting.
+                if let ready = stopQuestions.deliverInstruction(
+                    sessionID: waiting.sessionID, agent: waiting.agent
+                ) {
+                    return ready
+                }
+                // Started before the suspension below, so the loop's first turn sees this
+                // boundary registered.
+                self?.voiceSessionListening?.begin(
+                    sessionID: waiting.sessionID, agent: waiting.agent
+                )
+                switch await instructionWaits.wait(
+                    session: waiting.sessionID,
+                    timeout: VoiceSessionBudget.brokerWait
+                ) {
+                case .instructionQueued:
+                    return stopQuestions.deliverInstruction(
+                        sessionID: waiting.sessionID, agent: waiting.agent
+                    )
+                case .timedOut, .released:
+                    // Budget spent, wearer done, or runtime going away. All three mean the
+                    // same thing to the shim, and it is the safe one: carry on.
+                    return nil
+                }
             }
         )
 
@@ -1110,7 +1310,11 @@ import Darwin
             try server.start()
             try discovery.publish(
                 token: token,
-                steeringEnabled: configuration.steeringEnabled
+                steeringEnabled: configuration.steeringEnabled,
+                // Advertised rather than assumed: a shim that cannot see this field — an
+                // older runtime, a dead one — never long-polls, so the mode cannot be
+                // entered by a hook talking to a runtime that would not answer it.
+                voiceSessionEnabled: configuration.voiceSessionEnabled
             )
         } catch {
             server.stop()
@@ -1190,6 +1394,7 @@ import Darwin
                 ? "environment (any voice the microphone hears may instruct;"
                     + " approvals are unchanged and an instruction authorizes nothing)"
                 : nil,
+            voiceSessionStatus: voiceSessionStatus,
             voiceProcessingStatus: configuration.voiceProcessingEnabled
                 ? "experimental, enabled (half-duplex unchanged)"
                 : nil,
@@ -1201,6 +1406,13 @@ import Darwin
         defer {
             finishShutdownWait()
             startupNotice?.cancel()
+            // Before anything else is torn down: a hook parked on a boundary this runtime
+            // is about to stop answering would otherwise sit there until its own socket
+            // timed out, with the terminal showing a hook in flight and nothing to explain
+            // it. Releasing first means every waiter is answered "carry on" by a broker
+            // that is still listening.
+            instructionWaits?.releaseAll()
+            voiceSessionListening = nil
             turnCoordinator?.stop()
             // Prevent ARC from releasing the wearer-speech source at the
             // waitForShutdown suspension. HeadGestureDetector and every ChildSignal hold

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -499,6 +499,17 @@ import Darwin
         let isWearerAttributed: WearerAttributionQuerying = { [weak wearerAttribution] in
             wearerAttribution?.isWearerAttributedNow ?? false
         }
+        // Composed only under `--voice-trust environment` (RE2), and that is what keeps the
+        // default run byte-identical: with `nil` every read-back asks for a nod exactly as
+        // it always has, whatever the headphones are doing. Under environment trust the
+        // wording follows the same probe the selection controls hint already reads, so a
+        // wearer who puts their AirPods in mid-run is offered the gesture again on the next
+        // read-back without a restart.
+        let gesturesReachable: GestureConfirmationQuerying = {
+            gestures.isMotionCurrentlyAvailable
+        }
+        let gestureConfirmation: GestureConfirmationQuerying? =
+            configuration.voiceTrust == .environment ? gesturesReachable : nil
         let interaction = InteractionController(
             speech: promptSpeech,
             arbiter: approvalArbiter,
@@ -527,7 +538,9 @@ import Darwin
             // returns before it speaks a word — the grammar still matches "tell it to…",
             // and the window goes on listening exactly as it did before the phrase meant
             // anything.
-            instructionEnqueue: memory.instructionEnqueue
+            instructionEnqueue: memory.instructionEnqueue,
+            voiceTrust: configuration.voiceTrust,
+            gestureConfirmation: gestureConfirmation
         )
 
         // The detector reads the *default output device's* volume, which without AirPods is
@@ -572,7 +585,9 @@ import Darwin
             // agent, and dictating never moves the cursor or picks an option.
             instructionCapability: memory.instructionCapability,
             wearerAttribution: isWearerAttributed,
-            instructionEnqueue: memory.instructionEnqueue
+            instructionEnqueue: memory.instructionEnqueue,
+            voiceTrust: configuration.voiceTrust,
+            gestureConfirmation: gestureConfirmation
         )
         let interactionGate = InteractionGate()
 
@@ -708,7 +723,9 @@ import Darwin
                         recallResponder: memory.standingRecallResponder,
                         instructionCapability: memory.standingInstructionCapability,
                         wearerAttribution: isWearerAttributed,
-                        instructionEnqueue: memory.standingInstructionEnqueue
+                        instructionEnqueue: memory.standingInstructionEnqueue,
+                        voiceTrust: configuration.voiceTrust,
+                        gestureConfirmation: gestureConfirmation
                     )
                 }
             )
@@ -1166,6 +1183,13 @@ import Darwin
                 ? nil
                 : "off, no primary reasoner is running"),
             attentionStatus: attentionStatus,
+            // Printed only for the non-default posture, and it states the cost rather than
+            // the setting: an operator reading this line is being told that the room can
+            // instruct, which is the whole of what they traded away.
+            voiceTrustStatus: configuration.voiceTrust == .environment
+                ? "environment (any voice the microphone hears may instruct;"
+                    + " approvals are unchanged and an instruction authorizes nothing)"
+                : nil,
             voiceProcessingStatus: configuration.voiceProcessingEnabled
                 ? "experimental, enabled (half-duplex unchanged)"
                 : nil,

--- a/Sources/TapQBrokerRuntime/BrokerRuntimeDiscovery.swift
+++ b/Sources/TapQBrokerRuntime/BrokerRuntimeDiscovery.swift
@@ -57,12 +57,22 @@ public struct BrokerRuntimeDiscovery: Sendable {
         )
     }
 
-    public func publish(token: String, steeringEnabled: Bool = false) throws {
+    /// - Parameter voiceSessionEnabled: whether this runtime will hold a turn boundary
+    ///   open when a Stop hook asks it to. Published so the shim can decide *not* to ask:
+    ///   a hook that long-polled a runtime with no voice session would be answered
+    ///   immediately, but it would still have opened a socket to find that out on every
+    ///   Stop event of every session on the machine.
+    public func publish(
+        token: String,
+        steeringEnabled: Bool = false,
+        voiceSessionEnabled: Bool = false
+    ) throws {
         let record = DiscoveryRecord(
             socket: socketPath,
             token: token,
             protocolVersion: WireProtocol.version,
             steeringEnabled: steeringEnabled,
+            voiceSessionEnabled: voiceSessionEnabled,
             processID: ProcessInfo.processInfo.processIdentifier
         )
         let encoder = JSONEncoder()
@@ -107,12 +117,14 @@ public struct BrokerRuntimeDiscovery: Sendable {
         let token: String
         let protocolVersion: Int
         let steeringEnabled: Bool
+        let voiceSessionEnabled: Bool
         let processID: Int32
 
         enum CodingKeys: String, CodingKey {
             case socket, token
             case protocolVersion = "protocol_version"
             case steeringEnabled = "steering_enabled"
+            case voiceSessionEnabled = "voice_session"
             case processID = "process_id"
         }
     }

--- a/Sources/TapQBrokerRuntime/BrokerServer.swift
+++ b/Sources/TapQBrokerRuntime/BrokerServer.swift
@@ -21,6 +21,26 @@ public struct BrokerInstruction: Sendable, Equatable {
     }
 }
 
+/// A turn boundary a shim is asking the broker to hold open.
+///
+/// Identity only, like ``BrokerInstruction`` and for the same reason: a request that can
+/// carry nothing but "who is asking, about which session" cannot influence what comes back,
+/// and what comes back is text the wearer already confirmed out loud.
+public struct BrokerInstructionWait: Sendable, Equatable {
+    /// The agent session whose boundary is being held.
+    public let sessionID: String
+    /// The waiter's idempotency handle, echoed into diagnostics.
+    public let requestID: String
+    /// The agent behind the session, when the shim named one.
+    public let agent: AgentIdentity
+
+    public init(sessionID: String, requestID: String, agent: AgentIdentity) {
+        self.sessionID = sessionID
+        self.requestID = requestID
+        self.agent = agent
+    }
+}
+
 /// Authenticated, agent-neutral dispatcher for TapQ's local broker protocol.
 ///
 /// Adapter-specific parsing and presentation arrive already normalized on the wire. The
@@ -35,6 +55,7 @@ public struct BrokerInstruction: Sendable, Equatable {
     private let onSelection: @MainActor (SelectionRequest) async -> SelectionResult
     private let onStopQuestion: @MainActor (StopQuestion) async -> String?
     private let onInstruction: @MainActor (BrokerInstruction) -> Bool
+    private let onInstructionWait: @MainActor (BrokerInstructionWait) async -> String?
     private let stopQuestionDeduplicationWindow: TimeInterval
     private let diagnostics: TapQDiagnosticEmitter
     private var inFlightStopQuestions: [StopQuestionKey: Task<String?, Never>] = [:]
@@ -50,6 +71,9 @@ public struct BrokerInstruction: Sendable, Equatable {
         onSelection: @escaping @MainActor (SelectionRequest) async -> SelectionResult = { _ in .noSelection },
         onStopQuestion: @escaping @MainActor (StopQuestion) async -> String? = { _ in nil },
         onInstruction: @escaping @MainActor (BrokerInstruction) -> Bool = { _ in false },
+        onInstructionWait: @escaping @MainActor (BrokerInstructionWait) async -> String? = {
+            _ in nil
+        },
         stopQuestionDeduplicationWindow: TimeInterval = 5
     ) {
         self.transport = transport
@@ -62,6 +86,10 @@ public struct BrokerInstruction: Sendable, Equatable {
         // Default: no instruction queue is wired, so the channel is closed and every
         // submission is answered with an honest error rather than a silent success.
         self.onInstruction = onInstruction
+        // Default: no voice session is running, so a boundary is answered the instant it
+        // asks and the Stop proceeds — which is what every run without `--voice-session`
+        // does, including one whose shim is newer than its runtime.
+        self.onInstructionWait = onInstructionWait
         self.stopQuestionDeduplicationWindow = max(0, stopQuestionDeduplicationWindow)
         self.diagnostics = TapQDiagnosticEmitter(category: "Broker", sink: diagnosticSink)
     }
@@ -240,6 +268,39 @@ public struct BrokerInstruction: Sendable, Equatable {
             }
             diagnostics.record("instruction.queued", fields: ["id": message.requestID])
             return BrokerResponse.ok.encoded()
+
+        case .instructionWait(let message):
+            // Wire-v6 only, on the same reasoning as `instruction.submit`: a v5 peer cannot
+            // have meant this message, so the version gate is stricter here than the
+            // compatibility check alone would be.
+            guard validate(
+                token: message.token,
+                version: message.protocolVersion,
+                messageType: WireType.instructionWait
+            ) else {
+                return rejection(token: message.token, version: message.protocolVersion)
+            }
+            let agent = message.agent ?? legacyAgent
+            diagnostics.record("instruction_wait.received", fields: [
+                "agent": agent.id,
+                "id": message.requestID,
+            ])
+            // This is the one handler that is *expected* to take minutes. The transport
+            // hands each connection to its own queue and this actor is free across every
+            // suspension inside the host's wait, so a held boundary blocks neither the
+            // accept loop nor another session's approval.
+            let instruction = await onInstructionWait(.init(
+                sessionID: message.sessionID,
+                requestID: message.requestID,
+                agent: agent
+            ))
+            // Only whether one arrived: the reply carries the wearer's own sentence, which
+            // belongs in the agent's session and not in an operational log line.
+            diagnostics.record(
+                instruction == nil ? "instruction_wait.released" : "instruction_wait.delivered",
+                fields: ["id": message.requestID]
+            )
+            return BrokerResponse.instructionWait(instruction: instruction).encoded()
         }
     }
 

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -77,11 +77,15 @@ struct ServeOptions: Equatable {
     /// When enabled, an unmatched final transcript is offered as a free-text reply
     /// with mandatory read-back confirmation (nod to send, shake to discard).
     var voiceFreeformEnabled = false
-    /// Dictated instructions to the agent. Default off; requires `--wearer-gate`, because
-    /// an instruction is free text entering the agent's session and is accepted only from
-    /// a voice the IMU can attribute to the wearer. When off the dictation grammar still
-    /// matches and reaches nothing at all.
+    /// Dictated instructions to the agent. Default off; under `--voice-trust wearer` it
+    /// requires `--wearer-gate`, because an instruction is free text entering the agent's
+    /// session and is accepted only from a voice the IMU can attribute to the wearer. When
+    /// off the dictation grammar still matches and reaches nothing at all.
     var voiceInstructionsEnabled = false
+    /// Whose voice may instruct (RE1). `wearer` is the default and is today's behavior;
+    /// `environment` trusts the microphone as the user, which is what makes dictation work
+    /// with the AirPods in their case. It never touches an approval.
+    var voiceTrust: VoiceTrust = .wearer
     /// Delegation filter (RD1). Default off; requires a stage-2 reasoner in `primary`
     /// mode, because the tier the filter gates on is a decision only a primary reasoner
     /// is allowed to act on. `routine` answers routine approvals silently; every other
@@ -449,6 +453,14 @@ enum CLICommandParser {
                 options.voiceFreeformEnabled = true
             case "--voice-instructions":
                 options.voiceInstructionsEnabled = true
+            case "--voice-trust":
+                let value = try cursor.requireValue(for: argument)
+                guard let trust = VoiceTrust(rawValue: value) else {
+                    throw CLIUsageError(
+                        message: "--voice-trust must be 'wearer' or 'environment'."
+                    )
+                }
+                options.voiceTrust = trust
             case "--auto-answer":
                 let value = try cursor.requireValue(for: argument)
                 guard let mode = AutoAnswerMode(rawValue: value) else {
@@ -483,11 +495,20 @@ enum CLICommandParser {
         // every dictation would be refused, and a wearer would be talking to a feature
         // that had been silently switched off. Refused at startup, like
         // `--voice-freeform` on the Apple backend, rather than accepted and inert.
-        if options.voiceInstructionsEnabled, !options.wearerGateEnabled {
+        //
+        // `--voice-trust environment` is the operator saying the attribution is not wanted
+        // (RE1): there is then nothing to be fail-closed about, so the pairing is dropped
+        // rather than merely tolerated. The error text names the alternative, because a
+        // wearer with no AirPods hitting this message has no other way to learn there is one.
+        if options.voiceInstructionsEnabled,
+           !options.wearerGateEnabled,
+           options.voiceTrust == .wearer {
             throw CLIUsageError(
-                message: "--voice-instructions requires --wearer-gate. A dictated "
-                    + "instruction is accepted only from a voice TapQ can attribute to "
-                    + "the wearer, and the attribution signal comes from the gate."
+                message: "--voice-instructions requires --wearer-gate under "
+                    + "--voice-trust wearer. A dictated instruction is accepted only from "
+                    + "a voice TapQ can attribute to the wearer, and the attribution "
+                    + "signal comes from the gate. Pass --voice-trust environment to "
+                    + "instruct with no AirPods, trusting the microphone as the user."
             )
         }
         // The delegation filter gates on a tier, and a tier is a reasoner decision. Under

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -86,6 +86,10 @@ struct ServeOptions: Equatable {
     /// `environment` trusts the microphone as the user, which is what makes dictation work
     /// with the AirPods in their case. It never touches an approval.
     var voiceTrust: VoiceTrust = .wearer
+    /// Voice sessions (RH1). Default off; requires `--voice-instructions`. TapQ holds the
+    /// agent's turn boundary open and keeps listening, so the next instruction can be
+    /// spoken instead of typed.
+    var voiceSessionEnabled = false
     /// Delegation filter (RD1). Default off; requires a stage-2 reasoner in `primary`
     /// mode, because the tier the filter gates on is a decision only a primary reasoner
     /// is allowed to act on. `routine` answers routine approvals silently; every other
@@ -461,6 +465,8 @@ enum CLICommandParser {
                     )
                 }
                 options.voiceTrust = trust
+            case "--voice-session":
+                options.voiceSessionEnabled = true
             case "--auto-answer":
                 let value = try cursor.requireValue(for: argument)
                 guard let mode = AutoAnswerMode(rawValue: value) else {
@@ -509,6 +515,18 @@ enum CLICommandParser {
                     + "a voice TapQ can attribute to the wearer, and the attribution "
                     + "signal comes from the gate. Pass --voice-trust environment to "
                     + "instruct with no AirPods, trusting the microphone as the user."
+            )
+        }
+        // A voice session is a turn boundary held open for the wearer to speak the next
+        // instruction into. With no queue for that instruction to reach, the hold would be
+        // a hook parked for ten minutes waiting on something that can never arrive —
+        // refused here rather than accepted and left hanging.
+        if options.voiceSessionEnabled, !options.voiceInstructionsEnabled {
+            throw CLIUsageError(
+                message: "--voice-session requires --voice-instructions. A held turn "
+                    + "boundary exists so the wearer can dictate the agent's next "
+                    + "instruction, and without the instruction channel there is nowhere "
+                    + "for one to go."
             )
         }
         // The delegation filter gates on a tier, and a tier is a reasoner decision. Under

--- a/Sources/TapQCLI/RuntimeService.swift
+++ b/Sources/TapQCLI/RuntimeService.swift
@@ -103,6 +103,12 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
     /// When off, nothing composes a queue, the dictation grammar reaches nowhere, and the
     /// broker answers `instruction.submit` with an error.
     public let voiceInstructionsEnabled: Bool
+    /// Whose voice may dictate an instruction (RE1). `wearer` is the default and hosts must
+    /// treat it as today's behavior byte for byte: dictation fail-closed on IMU attribution
+    /// and read-backs that ask for a nod. `environment` skips the attribution check — the
+    /// bypass is recorded, never silent — and narrows the read-backs to speech wherever no
+    /// gesture could arrive. It changes nothing about approvals in either value.
+    public let voiceTrust: VoiceTrust
     /// Whether TapQ may answer routine approvals on the wearer's behalf (RD1). Default
     /// off. Hosts must treat `off` as "compose no filter at all": no policy is loaded, no
     /// audit file is created, and the approval path is the one Rung C shipped.
@@ -145,6 +151,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         imuTurnControlEnabled: Bool = false,
         voiceFreeformEnabled: Bool = false,
         voiceInstructionsEnabled: Bool = false,
+        voiceTrust: VoiceTrust = .wearer,
         autoAnswerMode: AutoAnswerMode = .off,
         attentionMode: AttentionMode = .off,
         voiceProcessingEnabled: Bool = false,
@@ -170,6 +177,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         self.imuTurnControlEnabled = imuTurnControlEnabled
         self.voiceFreeformEnabled = voiceFreeformEnabled
         self.voiceInstructionsEnabled = voiceInstructionsEnabled
+        self.voiceTrust = voiceTrust
         self.autoAnswerMode = autoAnswerMode
         self.attentionMode = attentionMode
         self.voiceProcessingEnabled = voiceProcessingEnabled
@@ -198,6 +206,9 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
     public let autoAnswerStatus: String?
     /// Human-readable always-on attention state; nil when `--attention` was off.
     public let attentionStatus: String?
+    /// Human-readable voice-trust posture; nil under the default `wearer`, whose behavior
+    /// is what every operator already expects and so is worth no line at all.
+    public let voiceTrustStatus: String?
     /// Human-readable voice-processing state; nil when the experimental flag was off.
     public let voiceProcessingStatus: String?
     /// Human-readable quiet-output state; nil when `--quiet` was off.
@@ -216,6 +227,7 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         wearerSpeechStatus: String? = nil,
         autoAnswerStatus: String? = nil,
         attentionStatus: String? = nil,
+        voiceTrustStatus: String? = nil,
         voiceProcessingStatus: String? = nil,
         quietStatus: String? = nil
     ) {
@@ -231,6 +243,7 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         self.wearerSpeechStatus = wearerSpeechStatus
         self.autoAnswerStatus = autoAnswerStatus
         self.attentionStatus = attentionStatus
+        self.voiceTrustStatus = voiceTrustStatus
         self.voiceProcessingStatus = voiceProcessingStatus
         self.quietStatus = quietStatus
     }

--- a/Sources/TapQCLI/RuntimeService.swift
+++ b/Sources/TapQCLI/RuntimeService.swift
@@ -109,6 +109,11 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
     /// bypass is recorded, never silent — and narrows the read-backs to speech wherever no
     /// gesture could arrive. It changes nothing about approvals in either value.
     public let voiceTrust: VoiceTrust
+    /// Whether TapQ holds an agent's turn boundary open and keeps listening (RH1). Default
+    /// off. Hosts must treat `false` as "compose no wait registry and no listening loop":
+    /// discovery then advertises nothing, no shim ever long-polls, and every Stop event
+    /// takes the path it took before voice sessions existed.
+    public let voiceSessionEnabled: Bool
     /// Whether TapQ may answer routine approvals on the wearer's behalf (RD1). Default
     /// off. Hosts must treat `off` as "compose no filter at all": no policy is loaded, no
     /// audit file is created, and the approval path is the one Rung C shipped.
@@ -152,6 +157,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         voiceFreeformEnabled: Bool = false,
         voiceInstructionsEnabled: Bool = false,
         voiceTrust: VoiceTrust = .wearer,
+        voiceSessionEnabled: Bool = false,
         autoAnswerMode: AutoAnswerMode = .off,
         attentionMode: AttentionMode = .off,
         voiceProcessingEnabled: Bool = false,
@@ -178,6 +184,7 @@ public struct TapQRuntimeConfiguration: Sendable, Equatable {
         self.voiceFreeformEnabled = voiceFreeformEnabled
         self.voiceInstructionsEnabled = voiceInstructionsEnabled
         self.voiceTrust = voiceTrust
+        self.voiceSessionEnabled = voiceSessionEnabled
         self.autoAnswerMode = autoAnswerMode
         self.attentionMode = attentionMode
         self.voiceProcessingEnabled = voiceProcessingEnabled
@@ -209,6 +216,8 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
     /// Human-readable voice-trust posture; nil under the default `wearer`, whose behavior
     /// is what every operator already expects and so is worth no line at all.
     public let voiceTrustStatus: String?
+    /// Human-readable voice-session state; nil when `--voice-session` was off.
+    public let voiceSessionStatus: String?
     /// Human-readable voice-processing state; nil when the experimental flag was off.
     public let voiceProcessingStatus: String?
     /// Human-readable quiet-output state; nil when `--quiet` was off.
@@ -228,6 +237,7 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         autoAnswerStatus: String? = nil,
         attentionStatus: String? = nil,
         voiceTrustStatus: String? = nil,
+        voiceSessionStatus: String? = nil,
         voiceProcessingStatus: String? = nil,
         quietStatus: String? = nil
     ) {
@@ -244,6 +254,7 @@ public struct TapQRuntimeEndpoint: Sendable, Equatable {
         self.autoAnswerStatus = autoAnswerStatus
         self.attentionStatus = attentionStatus
         self.voiceTrustStatus = voiceTrustStatus
+        self.voiceSessionStatus = voiceSessionStatus
         self.voiceProcessingStatus = voiceProcessingStatus
         self.quietStatus = quietStatus
     }

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -319,6 +319,7 @@ public struct TapQCLIIO {
             voiceFreeformEnabled: options.voiceFreeformEnabled,
             voiceInstructionsEnabled: options.voiceInstructionsEnabled,
             voiceTrust: options.voiceTrust,
+            voiceSessionEnabled: options.voiceSessionEnabled,
             // Follows `encoderMode`'s precedent: a mode is only meaningful alongside the
             // thing it modes, so a reasoner-less run carries `off` rather than a setting
             // the host would have to re-derive. The parser has already refused the
@@ -365,6 +366,9 @@ public struct TapQCLIIO {
             }
             if let voiceTrustStatus = endpoint.voiceTrustStatus {
                 io.writeOutput("Voice trust: \(voiceTrustStatus)\n")
+            }
+            if let voiceSessionStatus = endpoint.voiceSessionStatus {
+                io.writeOutput("Voice session: \(voiceSessionStatus)\n")
             }
             if let voiceProcessingStatus = endpoint.voiceProcessingStatus {
                 io.writeOutput("Voice processing: \(voiceProcessingStatus)\n")
@@ -1898,6 +1902,20 @@ public struct TapQCLIIO {
                                untouched under either value: anyone audible to the
                                microphone can instruct, and still cannot approve, deny,
                                select, or defer anything.
+      --voice-session          Hold the agent's turn boundary open and keep listening
+                               (default: off). Requires --voice-instructions. When the
+                               agent finishes a turn its Stop hook waits on the broker
+                               instead of returning: TapQ says "Listening." and re-opens
+                               a command window until an instruction is queued (delivered
+                               as the Stop block, so the agent continues), the wearer says
+                               "end voice session", or the ten-minute wait budget expires
+                               and the session idles normally. Inside a waiting window an
+                               unmatched sentence needs no "tell it to" prefix — it is
+                               read back and queued on a spoken yes; status, what changed,
+                               and repeat answer as they always do. The instruction loop
+                               cap does not apply here; the four-deep queue does. Nothing
+                               survives a restart, and a runtime that exits releases every
+                               waiting hook rather than leaving one parked.
       --voice-instructions     Let the wearer dictate an instruction to the agent
                                (default: off). Requires --wearer-gate under
                                --voice-trust wearer. Inside any open

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -318,6 +318,7 @@ public struct TapQCLIIO {
             imuTurnControlEnabled: options.imuTurnControlEnabled,
             voiceFreeformEnabled: options.voiceFreeformEnabled,
             voiceInstructionsEnabled: options.voiceInstructionsEnabled,
+            voiceTrust: options.voiceTrust,
             // Follows `encoderMode`'s precedent: a mode is only meaningful alongside the
             // thing it modes, so a reasoner-less run carries `off` rather than a setting
             // the host would have to re-derive. The parser has already refused the
@@ -361,6 +362,9 @@ public struct TapQCLIIO {
             }
             if let attentionStatus = endpoint.attentionStatus {
                 io.writeOutput("Attention: \(attentionStatus)\n")
+            }
+            if let voiceTrustStatus = endpoint.voiceTrustStatus {
+                io.writeOutput("Voice trust: \(voiceTrustStatus)\n")
             }
             if let voiceProcessingStatus = endpoint.voiceProcessingStatus {
                 io.writeOutput("Voice processing: \(voiceProcessingStatus)\n")
@@ -1880,8 +1884,23 @@ public struct TapQCLIIO {
                                to discard. Tool approvals and yes/no stop questions
                                stay binary — a spoken free-text answer can never
                                authorize an agent action.
+      --voice-trust MODE       Whose voice may dictate an instruction: wearer (default)
+                               or environment. wearer is today's behavior — dictation is
+                               fail-closed on IMU wearer attribution, so a voice TapQ
+                               cannot prove is the wearer's is refused out loud.
+                               environment trusts the microphone as the user, which is
+                               what makes --voice-instructions work with the AirPods in
+                               their case: the attribution check is skipped (recorded as
+                               instruction.trusted_environment, never silent) and the
+                               read-backs stop asking for a nod when no nod can arrive.
+                               The read-back confirmation itself stays — it catches
+                               mis-transcription, not just misattribution. Approvals are
+                               untouched under either value: anyone audible to the
+                               microphone can instruct, and still cannot approve, deny,
+                               select, or defer anything.
       --voice-instructions     Let the wearer dictate an instruction to the agent
-                               (default: off). Requires --wearer-gate. Inside any open
+                               (default: off). Requires --wearer-gate under
+                               --voice-trust wearer. Inside any open
                                prompt, "new instruction" or "tell it to <…>" opens a
                                dictation: TapQ reads the sentence back and queues it
                                only on a nod or a spoken yes, then delivers it at the

--- a/Sources/TapQClaudeAdapter/HookInstaller.swift
+++ b/Sources/TapQClaudeAdapter/HookInstaller.swift
@@ -46,12 +46,20 @@ public struct HookInstaller {
     static let ordinaryToolMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit"
 
     /// Interaction timeout (~240 s) sits under the InteractionBudget.hookTimeout ceiling.
-    /// Stop shares that ceiling: an intercepted question runs a full interaction window.
     /// UserPromptSubmit reads discovery and makes a bounded connection-only liveness probe;
     /// 5 s is generous.
+    ///
+    /// Stop is the exception, and it is written from `VoiceSessionBudget` (~620 s) rather
+    /// than from the interaction chain. A Stop hook does two things: it may run a full
+    /// interaction window for an intercepted question, and — in a voice session — it may
+    /// hold the turn boundary open while the wearer thinks. The second is the longer of the
+    /// two by an order of magnitude, and a hook configured for the first would be killed
+    /// mid-wait, so the entry carries the ceiling that covers both. It costs nothing when
+    /// no voice session is running: a hook that answers in a second is not affected by how
+    /// long it *would* have been allowed to take.
     private static let sharedSpecs: [Spec] = [
         Spec(event: "Notification", matcher: "idle_prompt|permission_prompt", timeout: 10),
-        Spec(event: "Stop", matcher: nil, timeout: InteractionBudget.hookTimeout),
+        Spec(event: "Stop", matcher: nil, timeout: VoiceSessionBudget.hookTimeout),
         Spec(event: "UserPromptSubmit", matcher: nil, timeout: 5),
     ]
 

--- a/Sources/TapQClaudeAdapter/HookShim.swift
+++ b/Sources/TapQClaudeAdapter/HookShim.swift
@@ -32,6 +32,10 @@ public struct HookShim {
     static let approvalTimeout: TimeInterval = InteractionBudget.shimSocketTimeout
     /// Notifications only need a moment.
     static let notifyTimeout: TimeInterval = 8
+    /// How long the shim will hold a turn boundary open waiting for the broker's answer.
+    /// Longer than the broker's own wait budget, so the answer always arrives before the
+    /// socket gives up — and the installer writes a Stop hook `timeout` longer still.
+    static let instructionWaitTimeout: TimeInterval = VoiceSessionBudget.shimSocketTimeout
 
     static let askReason = "No hands-free response; deferring to prompt"
     static let allowReason = "Approved via TapQ"
@@ -44,9 +48,15 @@ public struct HookShim {
     /// Fail-open: emit nothing and exit 0 so Claude Code falls back to its own flow.
     static let passThrough = Result(stdout: nil, exitCode: 0)
 
+    /// - Parameter voiceSessionEnabled: whether the live runtime advertises that it will
+    ///   hold this session's turn boundary open. Read from discovery by the executable, and
+    ///   `false` by default — which is every run without `--voice-session`, every runtime
+    ///   too old to publish the field, and every runtime that is no longer alive. A Stop
+    ///   event then behaves exactly as it did before voice sessions existed.
     public static func handle(
         stdinData: Data,
         steeringEnabled: () -> Bool = { false },
+        voiceSessionEnabled: () -> Bool = { false },
         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
         send: (_ message: [String: JSONValue], _ timeout: TimeInterval) throws -> Data
     ) -> Result {
@@ -61,7 +71,9 @@ public struct HookShim {
         case "PreToolUse":       return handlePreToolUse(data, diagnostics: diagnostics, send: send)
         case "PermissionRequest": return handlePermissionRequest(data, diagnostics: diagnostics, send: send)
         case "Notification":     return handleNotification(data, diagnostics: diagnostics, send: send)
-        case "Stop":             return handleStop(data, diagnostics: diagnostics, send: send)
+        case "Stop":             return handleStop(data, diagnostics: diagnostics,
+                                                   voiceSessionEnabled: voiceSessionEnabled,
+                                                   send: send)
         case "UserPromptSubmit": return handleUserPromptSubmit(steeringEnabled: steeringEnabled)
         default:                 return passThrough
         }
@@ -190,10 +202,14 @@ public struct HookShim {
     private static func handleStop(
         _ data: [String: JSONValue],
         diagnostics: TapQDiagnosticEmitter,
+        voiceSessionEnabled: () -> Bool,
         send: (_ message: [String: JSONValue], _ timeout: TimeInterval) throws -> Data
     ) -> Result {
         switch interceptStopQuestion(data, diagnostics: diagnostics, send: send) {
         case .block(let result):
+            // An answered question already carries the turn on. There is nothing to hold
+            // open: the agent is about to keep working, and the next boundary it produces
+            // is where a voice session picks up again.
             return result
         case .brokerUnreachable:
             // The stop.question send itself failed, so the notification would target
@@ -211,8 +227,62 @@ public struct HookShim {
                 "protocol_version": .number(Double(WireProtocol.version)),
             ]
             _ = try? send(message, notifyTimeout)
+            // Sent *after* the notification, deliberately: that notification is what makes
+            // the runtime announce the turn ended, and the wearer should hear "Claude Code
+            // finished" before they hear "Listening."
+            return waitForInstruction(
+                data,
+                diagnostics: diagnostics,
+                voiceSessionEnabled: voiceSessionEnabled,
+                send: send
+            )
+        }
+    }
+
+    /// The held turn boundary (RH1): ask the broker to keep this Stop open until the wearer
+    /// has something to say, and block the stop with it when they do.
+    ///
+    /// One long-poll round and no loop. The broker answers within its own budget, and every
+    /// answer that is not an instruction — timed out, released by the wearer, runtime gone,
+    /// broker unreachable, a reply this shim cannot read — is a pass-through, which lets the
+    /// session idle exactly as it would have. That is what keeps the failure mode of a voice
+    /// session "the mode quietly ended" rather than "the terminal is stuck".
+    private static func waitForInstruction(
+        _ data: [String: JSONValue],
+        diagnostics: TapQDiagnosticEmitter,
+        voiceSessionEnabled: () -> Bool,
+        send: (_ message: [String: JSONValue], _ timeout: TimeInterval) throws -> Data
+    ) -> Result {
+        guard voiceSessionEnabled() else { return passThrough }
+        let message: [String: JSONValue] = [
+            "type": .string(WireType.instructionWait),
+            "agent": agentIdentity,
+            "session_id": .string(data["session_id"]?.stringValue ?? ""),
+            "request_id": .string(UUID().uuidString),
+            "protocol_version": .number(Double(WireProtocol.version)),
+        ]
+        diagnostics.record("instruction_wait.started")
+
+        let reply: Data
+        do {
+            reply = try send(message, instructionWaitTimeout)
+        } catch {
+            diagnostics.record("instruction_wait.send_failed", level: .warning,
+                               fields: ["error": "\(error)"])
             return passThrough
         }
+        guard let obj = try? JSONDecoder().decode([String: JSONValue].self, from: reply),
+              obj["error"] == nil,
+              obj["wait"]?.stringValue == "instruction",
+              let instruction = obj["instruction"]?.stringValue, !instruction.isEmpty else {
+            diagnostics.record("instruction_wait.released")
+            return passThrough
+        }
+        diagnostics.record("instruction_wait.delivered")
+        // The same Stop block an answered question uses, carrying the reply the runtime
+        // composed. The shim never writes the sentence itself: the text that reaches Claude
+        // is the one the wearer heard read back.
+        return emitStopBlock(instruction)
     }
 
     /// The three outcomes of `interceptStopQuestion`, distinguished so `handleStop`

--- a/Sources/TapQContextBaseline/InstructionQueue.swift
+++ b/Sources/TapQContextBaseline/InstructionQueue.swift
@@ -156,6 +156,18 @@ public struct InstructionQueue: Sendable {
     private var queue: InstructionQueue
     private let diagnostics: TapQDiagnosticEmitter
 
+    /// Fired with the session id after an instruction is actually queued.
+    ///
+    /// One observer, one caller: the wait registry, which has to let go of a held turn
+    /// boundary the moment there is something for it to carry. It lives here rather than at
+    /// each enqueue site because there are three of those — the dictation flow, the wire's
+    /// `instruction.submit`, and the voice-session window — and a boundary that woke for two
+    /// of them and slept through the third would be a bug nobody could reproduce.
+    ///
+    /// Nothing is passed but the session: an observer's job is to notice that the queue
+    /// changed, not to read what the wearer said.
+    public var onEnqueued: (@MainActor (_ session: String) -> Void)?
+
     /// - Parameters:
     ///   - clock: timestamp source for queued instructions, injected by tests.
     ///   - diagnosticSink: where queue events go; the default drops them.
@@ -201,6 +213,7 @@ public struct InstructionQueue: Sendable {
                 "length": "\(instruction.text.count)",
             ])
         }
+        if result.accepted != nil { onEnqueued?(session) }
         return result.accepted
     }
 

--- a/Sources/TapQContextBaseline/InstructionWaitRegistry.swift
+++ b/Sources/TapQContextBaseline/InstructionWaitRegistry.swift
@@ -1,0 +1,156 @@
+import Foundation
+import TapQContracts
+
+/// Why a held turn boundary was let go.
+public enum InstructionWaitOutcome: Sendable, Equatable {
+    /// An instruction was queued for the session. The caller drains the queue; the wait
+    /// itself carries no text, so there is exactly one path an instruction reaches an agent
+    /// by and this is not a second one.
+    case instructionQueued
+    /// The broker's wait budget expired. The Stop proceeds and the session idles normally.
+    case timedOut
+    /// The hold was released without an instruction — the wearer ended the voice session,
+    /// or the runtime is shutting down. Indistinguishable from a timeout to the shim, and
+    /// deliberately so: both mean "nothing is coming, carry on".
+    case released
+}
+
+/// The turn boundaries this runtime is holding open, and the thing that lets them go.
+///
+/// A voice session inverts the instruction channel's timing. Delivery has always happened
+/// *at* a boundary the agent produced, which means an instruction dictated to an idle agent
+/// waits for someone to type; a held boundary is the same delivery with the waiting moved
+/// to the other side of the wire, where it costs a parked hook instead of a lost sentence.
+///
+/// The registry is the whole of that inversion, and it is deliberately small enough to hold
+/// in one's head: a waiter is a continuation and a session id, and there are exactly three
+/// ways for one to be resumed — an instruction arrives, the budget expires, or someone lets
+/// it go. Nothing here reads or writes an instruction. It only says *when*.
+///
+/// `@MainActor`, like the mailbox it lives beside, so the enqueue that wakes a waiter and
+/// the drain that follows it happen in the same actor turn and cannot interleave.
+@MainActor public final class InstructionWaitRegistry {
+    /// A waiting boundary, in the two terms anything here may know about it.
+    private struct Waiter {
+        let sessionID: String
+        let continuation: CheckedContinuation<InstructionWaitOutcome, Never>
+    }
+
+    private var waiters: [UInt64: Waiter] = [:]
+    private var nextID: UInt64 = 0
+    private let sleep: @MainActor (TimeInterval) async -> Void
+    private let diagnostics: TapQDiagnosticEmitter
+
+    /// Fired whenever the number of held boundaries changes, so a host can start listening
+    /// when the first one arrives and stop when the last one leaves.
+    ///
+    /// A callback rather than a poll because the thing it drives is a microphone: a loop
+    /// that polled would either open windows nobody is waiting behind or leave a wearer
+    /// talking to a runtime that had not noticed yet.
+    public var onWaitingChanged: (@MainActor (Int) -> Void)?
+
+    /// - Parameters:
+    ///   - sleep: the wait budget's timer, injected so tests can expire a ten-minute
+    ///     budget without waiting ten minutes.
+    public init(
+        sleep: @escaping @MainActor (TimeInterval) async -> Void = {
+            try? await Task.sleep(for: .seconds($0))
+        },
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.sleep = sleep
+        self.diagnostics = TapQDiagnosticEmitter(category: "InstructionWait", sink: diagnosticSink)
+    }
+
+    // MARK: - Waiting
+
+    /// Holds `session`'s boundary open until something happens to it, and says what.
+    ///
+    /// The timeout task is started before the continuation is stored, and both run on this
+    /// actor, so the entry always exists by the time the budget can expire — a wait can
+    /// never be resumed before it is registered, and a resumed wait is removed before it
+    /// returns, so no continuation is resumed twice.
+    public func wait(session: String, timeout: TimeInterval) async -> InstructionWaitOutcome {
+        nextID &+= 1
+        let id = nextID
+        let budget = Task { @MainActor [weak self, sleep = self.sleep] in
+            await sleep(timeout)
+            guard !Task.isCancelled else { return }
+            self?.resume(id, with: .timedOut)
+        }
+        diagnostics.record("wait.began", fields: [
+            "session": session, "budget": "\(Int(timeout))",
+        ])
+        let outcome = await withCheckedContinuation { continuation in
+            waiters[id] = Waiter(sessionID: session, continuation: continuation)
+            onWaitingChanged?(waiters.count)
+        }
+        budget.cancel()
+        diagnostics.record("wait.ended", fields: [
+            "session": session, "outcome": "\(outcome)",
+        ])
+        return outcome
+    }
+
+    // MARK: - Releasing
+
+    /// Wakes every boundary held for `session`, because something was queued for it.
+    ///
+    /// Called from the mailbox's enqueue observer, so every way an instruction can arrive —
+    /// a dictation, `tapq instruct`, a future device SDK — releases the hold without any of
+    /// them knowing this type exists.
+    public func noteInstructionQueued(session: String) {
+        resumeAll(matching: { $0.sessionID == session }, with: .instructionQueued)
+    }
+
+    /// Lets go of every boundary held for `session` with no instruction: the wearer said
+    /// they were done listening.
+    public func release(session: String) {
+        resumeAll(matching: { $0.sessionID == session }, with: .released)
+    }
+
+    /// Lets go of every held boundary. The runtime's shutdown path calls it, which is what
+    /// keeps a killed runtime from leaving a hook parked until its socket times out.
+    public func releaseAll() {
+        resumeAll(matching: { _ in true }, with: .released)
+    }
+
+    // MARK: - Reading
+
+    /// How many boundaries are held right now.
+    public var waitingCount: Int { waiters.count }
+
+    /// Whether any boundary is held. The listening loop's condition.
+    public var isWaiting: Bool { !waiters.isEmpty }
+
+    /// The sessions being held, in no defined order. A host composing a dictation target
+    /// reads this rather than guessing from conversation memory: the session whose boundary
+    /// is open is the one the wearer is talking into.
+    public var waitingSessions: [String] {
+        Array(Set(waiters.values.map(\.sessionID)))
+    }
+
+    // MARK: - Internals
+
+    private func resume(_ id: UInt64, with outcome: InstructionWaitOutcome) {
+        guard let waiter = waiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(returning: outcome)
+        onWaitingChanged?(waiters.count)
+    }
+
+    private func resumeAll(
+        matching predicate: (Waiter) -> Bool,
+        with outcome: InstructionWaitOutcome
+    ) {
+        let matched = waiters.filter { predicate($0.value) }
+        guard !matched.isEmpty else { return }
+        for (id, waiter) in matched {
+            waiters.removeValue(forKey: id)
+            waiter.continuation.resume(returning: outcome)
+        }
+        diagnostics.record("wait.released", fields: [
+            "count": "\(matched.count)", "outcome": "\(outcome)",
+        ])
+        onWaitingChanged?(waiters.count)
+    }
+}

--- a/Sources/TapQContextBaseline/StopQuestionCoordinator.swift
+++ b/Sources/TapQContextBaseline/StopQuestionCoordinator.swift
@@ -36,6 +36,16 @@ import TapQContracts
     private let announce: AnnounceToWearer?
     private let runSelection: RunSelection
     private let runApproval: RunApproval
+    /// Whether the loop cap is stood down for this run (RH1).
+    ///
+    /// The cap exists because an instruction-bearing stop block restarts the agent's turn,
+    /// which produces another boundary — so a queue of instructions and an agent that does
+    /// nothing with them is a loop. In a voice session that reasoning inverts: every
+    /// boundary is *supposed* to carry an instruction, because the wearer is standing there
+    /// dictating them one at a time, and a cap that fired after three would hold back the
+    /// fourth thing they said and tell them to wait for a boundary that only their own next
+    /// sentence can produce. The four-deep queue bound is untouched and still applies.
+    private let suppressesLoopCap: Bool
     private var answered = AnsweredQuestionStore()
     private var consecutiveAnswers: [String: Int] = [:]
     private var consecutiveInstructions: [String: Int] = [:]
@@ -65,6 +75,9 @@ import TapQContracts
     ///   - instructions: the queue this coordinator drains at turn boundaries.
     ///   - recordInstruction: notes a delivered instruction in conversation memory.
     ///   - announce: says the loop-cap notice out loud.
+    ///   - suppressesLoopCap: `true` only in a voice session (RH1), where every boundary is
+    ///     meant to carry an instruction. `false` — the default and every earlier
+    ///     composition — keeps RC2's three-in-a-row cap exactly as it shipped.
     public init(
         classifier: any ResponseQuestionClassifying,
         summarizer: (any SpokenSummarizing)? = nil,
@@ -72,6 +85,7 @@ import TapQContracts
         instructions: InstructionMailbox? = nil,
         recordInstruction: RecordInstruction? = nil,
         announce: AnnounceToWearer? = nil,
+        suppressesLoopCap: Bool = false,
         runSelection: @escaping RunSelection,
         runApproval: @escaping RunApproval
     ) {
@@ -80,6 +94,7 @@ import TapQContracts
         self.instructions = instructions
         self.recordInstruction = recordInstruction
         self.announce = announce
+        self.suppressesLoopCap = suppressesLoopCap
         self.runSelection = runSelection
         self.runApproval = runApproval
         self.diagnostics = TapQDiagnosticEmitter(
@@ -110,7 +125,7 @@ import TapQContracts
         // were answered in a row, or because no classifier was reachable. The guards
         // exist to stop TapQ from re-answering the agent, and an instruction is not an
         // answer.
-        if let delivery = deliverInstruction(sessionID: sessionID, agent: agent) {
+        if let delivery = deliverQueuedInstruction(sessionID: sessionID, agent: agent) {
             return delivery
         }
 
@@ -216,6 +231,18 @@ import TapQContracts
 
     // MARK: - Instruction delivery (Rung C)
 
+    /// Drains one instruction for a boundary that is not a stop question at all.
+    ///
+    /// The caller is the held-boundary path (RH1): a shim that long-polled the broker and
+    /// is being answered, either because something was already queued when it asked or
+    /// because something arrived while it waited. It is the *same* delivery the stop-question
+    /// path performs — same one-per-boundary rule, same reply template, same memory
+    /// recording, same diagnostics — exposed rather than duplicated, so there is exactly one
+    /// piece of code in TapQ that hands an agent a sentence nobody typed.
+    public func deliverInstruction(sessionID: String, agent: AgentIdentity) -> String? {
+        deliverQueuedInstruction(sessionID: sessionID, agent: agent)
+    }
+
     /// The reply that hands one queued instruction to the agent, or `nil` when this
     /// boundary carries none.
     ///
@@ -223,7 +250,7 @@ import TapQContracts
     /// this reply as its next instruction, so a second one delivered in the same breath
     /// would be read as part of the first; the next boundary is a moment away and it will
     /// take the next one.
-    private func deliverInstruction(
+    private func deliverQueuedInstruction(
         sessionID: String,
         agent: AgentIdentity
     ) -> String? {
@@ -233,7 +260,8 @@ import TapQContracts
             consecutiveInstructions[sessionID] = 0
             return nil
         }
-        guard (consecutiveInstructions[sessionID] ?? 0) < Self.maxConsecutiveInstructions else {
+        guard suppressesLoopCap
+            || (consecutiveInstructions[sessionID] ?? 0) < Self.maxConsecutiveInstructions else {
             diagnostics.record("instruction.loop_cap.suppressed", level: .warning, fields: [
                 "session": sessionID,
                 "cap": "\(Self.maxConsecutiveInstructions)",

--- a/Sources/TapQContracts/VoiceSessionBudget.swift
+++ b/Sources/TapQContracts/VoiceSessionBudget.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// The timing chain for a *held* turn boundary, kept apart from ``InteractionBudget``
+/// because it measures something else entirely.
+///
+///     broker wait budget (600s) < shim socket timeout (615s) < Stop hook timeout (620s)
+///
+/// `InteractionBudget`'s numbers are sized for a question somebody is blocked on: a wearer
+/// has to hear a prompt and answer it before the agent's hook gives up, so every number
+/// there is as small as the interaction allows. Nothing is blocked here. A voice session's
+/// Stop hook is *deliberately* idle — the model is not running, no tokens are being spent,
+/// and the only cost of waiting is that the terminal shows a hook in flight — so the budget
+/// is sized for how long a person plausibly steps away from a conversation instead.
+///
+/// The ordering is the same discipline and exists for the same reason: the broker must
+/// answer before the shim's socket gives up, and the shim must give up before Claude Code
+/// kills the hook, or the wearer's next instruction lands in a socket nobody is reading.
+public enum VoiceSessionBudget {
+    /// How long the broker holds a turn boundary open before answering "no instruction".
+    ///
+    /// One long-poll round, not a loop: at the end of it the Stop proceeds and the session
+    /// idles normally, which is a clean exit from the mode rather than a failure. A wearer
+    /// who wanted longer says the next instruction into the next session.
+    public static let brokerWait: TimeInterval = 600
+    /// How long the shim waits on the broker socket for that answer.
+    public static let shimSocketTimeout: TimeInterval = brokerWait + 15
+    /// The `timeout` written into the Stop hook's configuration. Without it, the agent's
+    /// own default would kill a hook that is doing exactly what it was asked to do.
+    public static let hookTimeout: TimeInterval = shimSocketTimeout + 5
+}

--- a/Sources/TapQInteractionBaseline/CommandWindowController.swift
+++ b/Sources/TapQInteractionBaseline/CommandWindowController.swift
@@ -15,6 +15,22 @@ public enum AttentionMode: String, Sendable, Codable, Equatable, CaseIterable {
     case imu
 }
 
+/// Which of TapQ's two wearer-initiated windows this is.
+///
+/// The difference is what an *unmatched* sentence means. In an attention window (Rung D)
+/// it means nothing — the wearer's recognizer overheard something and TapQ stays quiet. In
+/// a voice-session window the wearer is standing at a turn boundary that is being held open
+/// for them, so an unmatched sentence is the instruction they came to give, and the two
+/// end-phrases are the only way out of the loop that does not involve queueing one.
+public enum CommandWindowKind: Sendable, Equatable {
+    /// The Rung D window: opened by an attributed speech onset between requests. Unmatched
+    /// speech is ignored in silence.
+    case attention
+    /// The Rung H window: opened while a shim waits at a turn boundary. Unmatched speech
+    /// enters the dictation flow with no prefix, and "end voice session" closes the loop.
+    case voiceSession
+}
+
 /// What a command window did. Deliberately three counters and nothing else.
 ///
 /// This type is the structural half of "an attention window can never resolve an agent
@@ -32,15 +48,30 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     /// Dictation flows entered. Whether one reached the agent's inbox is the flow's own
     /// business and is spoken out loud; the window only records that it happened.
     public let dictations: Int
+    /// The wearer said they were done listening ("end voice session", "stop listening").
+    ///
+    /// It does not weaken the guarantee above. The only thing a caller may do with it is
+    /// stop re-opening windows and let a held turn boundary go — which resolves nothing,
+    /// approves nothing, and is exactly what the agent's Stop event would have done on its
+    /// own had TapQ never held it. Always `false` for a `.attention` window.
+    public let endedByWearer: Bool
 
-    public init(answers: Int = 0, ignored: Int = 0, dictations: Int = 0) {
+    public init(
+        answers: Int = 0,
+        ignored: Int = 0,
+        dictations: Int = 0,
+        endedByWearer: Bool = false
+    ) {
         self.answers = answers
         self.ignored = ignored
         self.dictations = dictations
+        self.endedByWearer = endedByWearer
     }
 
     /// Whether the window did anything at all beyond opening and closing.
-    public var isEmpty: Bool { answers == 0 && ignored == 0 && dictations == 0 }
+    public var isEmpty: Bool {
+        answers == 0 && ignored == 0 && dictations == 0 && !endedByWearer
+    }
 }
 
 /// A short, wearer-initiated window opened between agent requests: the wearer said
@@ -79,6 +110,32 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     /// wearer is mid-sentence.
     public nonisolated static let defaultCue = "Yes?"
 
+    /// The opener a voice session uses at a held turn boundary. It says what TapQ is doing
+    /// rather than asking a question, because nothing was asked: the agent finished, and
+    /// the microphone is open for whatever comes next.
+    public nonisolated static let voiceSessionCue = "Listening."
+
+    /// Spoken as the loop lets the boundary go.
+    public nonisolated static let voiceSessionEnded = "Voice session ended."
+
+    /// The sentences that close a voice session, matched on the wearer's own words because
+    /// none of them is in the command grammar: "stop" and "no" arrive as `.deny`, which the
+    /// window already treats as an ending, and everything here is what a wearer says when
+    /// they mean it in more words than that.
+    ///
+    /// Compared on letters only and case-insensitively, the way `VoiceCommandMatcher`
+    /// compares its runs, so punctuation a recognizer adds cannot hide a match.
+    nonisolated static let endPhrases = [
+        "end voice session", "end the voice session", "end session",
+        "stop listening", "stop the voice session", "exit voice session",
+    ]
+
+    /// Whether `text` is one of the phrases that ends a voice session.
+    nonisolated static func endsVoiceSession(_ text: String) -> Bool {
+        let words = text.lowercased().split { !$0.isLetter }.joined(separator: " ")
+        return endPhrases.contains(words)
+    }
+
     /// How many turns one window will take. The deadline is the real bound; this is the
     /// backstop for what the deadline cannot see — a recognizer picking up a nearby
     /// conversation and feeding intent after intent inside the same eight seconds.
@@ -87,10 +144,12 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     private let speech: SpeechPresenting
     private let arbiter: InputArbitrating
     private let gate: InteractionGate
-    /// The opener, or `nil` for a window that should just listen — a host re-opening
-    /// windows in a row would otherwise announce each one over a wearer who is still
-    /// thinking.
+    /// The opener, or `nil` for a window that should just listen. A voice session speaks
+    /// its cue once at the boundary and re-opens silently: eight-second windows that each
+    /// announced themselves would talk over the wearer every time they paused to think.
     private let cue: String?
+    /// Which window this is. `.attention` is the default and the shipped behavior.
+    private let kind: CommandWindowKind
     /// Who a dictated instruction would go to, for the flow's spoken lines. A plain string
     /// because outside a request there is no `AgentIdentity` in hand — this window was
     /// opened by the wearer, not by an agent.
@@ -122,12 +181,14 @@ public struct CommandWindowOutcome: Sendable, Equatable {
                 instructionCapability: InstructionCapabilityChecking? = nil,
                 wearerAttribution: WearerAttributionQuerying? = nil,
                 instructionEnqueue: InstructionDictating? = nil,
+                kind: CommandWindowKind = .attention,
                 voiceTrust: VoiceTrust = .wearer,
                 gestureConfirmation: GestureConfirmationQuerying? = nil) {
         self.speech = speech
         self.arbiter = arbiter
         self.gate = gate
         self.cue = cue
+        self.kind = kind
         self.agentDisplayName = agentDisplayName
         let diagnostics = TapQDiagnosticEmitter(category: "CommandWindow", sink: diagnosticSink)
         self.diagnostics = diagnostics
@@ -152,6 +213,7 @@ public struct CommandWindowOutcome: Sendable, Equatable {
         var answers = 0
         var ignored = 0
         var dictations = 0
+        var endedByWearer = false
         /// What to say on the next listen. Cleared the moment it is handed over, so a
         /// sentence is never spoken twice and never left over after it has been.
         var pending: String? = cue
@@ -179,6 +241,13 @@ public struct CommandWindowOutcome: Sendable, Equatable {
             case .beginInstruction(let text):
                 dictations += 1
                 pending = await dictate(text, until: deadline)
+            case .deny where kind == .voiceSession:
+                // "Stop", "no", "cancel" — at a held boundary the only thing there is to
+                // decline is the holding, so this is how a wearer ends the session in one
+                // word. In an attention window it stays what it has always been: an intent
+                // about a request that does not exist.
+                endedByWearer = true
+                diagnostics.record("voice_session.ended", fields: ["by": "deny"])
             case .allow, .deny, .select, .selectByNumber, .deferToPrompt, .details,
                  .next, .previous:
                 // Every intent whose meaning is "about the request" — and there is no
@@ -188,11 +257,31 @@ public struct CommandWindowOutcome: Sendable, Equatable {
                 ignored += 1
                 diagnostics.record("intent.ignored", fields: ["intent": "\(intent)"])
                 pending = Self.nothingWaiting
+            case .freeform(let text) where kind == .voiceSession:
+                if Self.endsVoiceSession(text) {
+                    endedByWearer = true
+                    diagnostics.record("voice_session.ended", fields: ["by": "phrase"])
+                    break
+                }
+                // The whole point of the mode: at a boundary being held open for them, a
+                // wearer's sentence *is* the instruction, so it enters the same
+                // read-back-and-confirm flow "tell it to …" enters — no prefix, and no
+                // shorter path to the agent's inbox than the one dictation has always had.
+                dictations += 1
+                pending = await dictate(text, until: deadline)
             case .freeform:
                 // Free text with nothing to answer it. Ignored in silence, exactly as the
                 // approval window ignores it when no responder is composed: a wearer whose
                 // recognizer overheard a sentence should not hear TapQ react to it.
                 diagnostics.record("intent.unhandled")
+            }
+            if endedByWearer {
+                // Said now rather than left pending: the loop is over, so there is no next
+                // listen to carry it, and a wearer who ended the session should hear that
+                // it ended.
+                speech.speak(Self.voiceSessionEnded, priority: .notification, onFinish: nil)
+                pending = nil
+                break
             }
         }
         // The window ran out with something still to say (a last answer, or a turn that
@@ -202,7 +291,8 @@ public struct CommandWindowOutcome: Sendable, Equatable {
         diagnostics.record("window.closed", fields: [
             "answers": "\(answers)", "ignored": "\(ignored)", "dictations": "\(dictations)",
         ])
-        return CommandWindowOutcome(answers: answers, ignored: ignored, dictations: dictations)
+        return CommandWindowOutcome(answers: answers, ignored: ignored,
+                                    dictations: dictations, endedByWearer: endedByWearer)
     }
 
     /// One turn: speak (barge-in) and listen for whatever is left of the window.

--- a/Sources/TapQInteractionBaseline/CommandWindowController.swift
+++ b/Sources/TapQInteractionBaseline/CommandWindowController.swift
@@ -87,7 +87,10 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     private let speech: SpeechPresenting
     private let arbiter: InputArbitrating
     private let gate: InteractionGate
-    private let cue: String
+    /// The opener, or `nil` for a window that should just listen — a host re-opening
+    /// windows in a row would otherwise announce each one over a wearer who is still
+    /// thinking.
+    private let cue: String?
     /// Who a dictated instruction would go to, for the flow's spoken lines. A plain string
     /// because outside a request there is no `AgentIdentity` in hand — this window was
     /// opened by the wearer, not by an agent.
@@ -112,13 +115,15 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     public init(speech: SpeechPresenting,
                 arbiter: InputArbitrating,
                 gate: InteractionGate,
-                cue: String = CommandWindowController.defaultCue,
+                cue: String? = CommandWindowController.defaultCue,
                 agentDisplayName: String = "the agent",
                 diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink(),
                 recallResponder: RecallResponding? = nil,
                 instructionCapability: InstructionCapabilityChecking? = nil,
                 wearerAttribution: WearerAttributionQuerying? = nil,
-                instructionEnqueue: InstructionDictating? = nil) {
+                instructionEnqueue: InstructionDictating? = nil,
+                voiceTrust: VoiceTrust = .wearer,
+                gestureConfirmation: GestureConfirmationQuerying? = nil) {
         self.speech = speech
         self.arbiter = arbiter
         self.gate = gate
@@ -130,7 +135,9 @@ public struct CommandWindowOutcome: Sendable, Equatable {
         self.dictation = InstructionDictation(capability: instructionCapability,
                                               attribution: wearerAttribution,
                                               enqueue: instructionEnqueue,
-                                              diagnostics: diagnostics)
+                                              diagnostics: diagnostics,
+                                              trust: voiceTrust,
+                                              gestureConfirmation: gestureConfirmation)
     }
 
     /// Opens the window and runs it to its deadline. Serialized against every other window

--- a/Sources/TapQInteractionBaseline/InteractionController.swift
+++ b/Sources/TapQInteractionBaseline/InteractionController.swift
@@ -191,6 +191,15 @@ public typealias InstructionCapabilityChecking = @MainActor () -> Bool
 /// business accepting dictation.
 public typealias WearerAttributionQuerying = @MainActor () -> Bool
 
+/// Whether a nod or a tap could still confirm something in this window.
+///
+/// Read at the moment a read-back is composed, never at composition time: AirPods come and
+/// go inside a run, and a sentence that tells the wearer to nod when nodding is impossible
+/// is worse than one that tells them nothing. An absent closure — every composition that
+/// predates `--voice-trust environment` — answers yes, which is what keeps the wearer-trust
+/// read-backs byte-identical to the ones this repo has always spoken.
+public typealias GestureConfirmationQuerying = @MainActor () -> Bool
+
 /// Hands a confirmed instruction to whoever queues it for the agent's next turn boundary.
 ///
 /// Text in, nothing out: the dictation path can reach the agent's inbox and nothing else.
@@ -217,6 +226,12 @@ public typealias InstructionDictating = @MainActor (String) -> Void
     let attribution: WearerAttributionQuerying?
     let enqueue: InstructionDictating?
     let diagnostics: TapQDiagnosticEmitter
+    /// Whose voice may instruct. `.wearer` — the default — keeps the fail-closed
+    /// attribution check; `.environment` skips it and says so in the diagnostics.
+    var trust: VoiceTrust = .wearer
+    /// Whether the read-back may still ask for a nod. `nil` means yes, which is the
+    /// wearer-trust composition and the wording every earlier build spoke.
+    var gestureConfirmation: GestureConfirmationQuerying?
 
     /// Spoken when the wearer opened the flow without saying what to dictate.
     static let cue = "Go ahead."
@@ -289,7 +304,7 @@ public typealias InstructionDictating = @MainActor (String) -> Void
         // and `condensed` ends a shortened read-back in an ellipsis, so the wearer hears
         // that they are confirming a sentence longer than the one being spoken.
         let readBack = SpokenText.condensed(instruction, maxWords: 24, maxCharacters: 160)
-        switch await turn("Instruction: '\(SpokenText.sentence(readBack))' Nod or say yes to queue it.") {
+        switch await turn("Instruction: '\(SpokenText.sentence(readBack))' \(confirmCue)") {
         case .allow, .select:
             // Nod, tap, or "yes" — the same dual channel that confirms anything else, and
             // for the same reason: the read-back is the only moment the wearer hears what
@@ -307,9 +322,31 @@ public typealias InstructionDictating = @MainActor (String) -> Void
         }
     }
 
+    /// How the wearer is asked to confirm the read-back.
+    ///
+    /// The dual channel is the default and stays the default: nod, tap, or "yes". It
+    /// narrows to speech alone only where the gesture half cannot arrive — no earbuds, so
+    /// no nod and no tap — because a read-back that asks for a movement the wearer cannot
+    /// make reads as a feature that is broken rather than one that is voice-only.
+    private var confirmCue: String {
+        (gestureConfirmation?() ?? true)
+            ? "Nod or say yes to queue it."
+            : "Say yes to queue it."
+    }
+
     /// The fail-closed check, with the refusal diagnostic attached so both refusal points
     /// report the same event name and differ only in which stage they name.
+    ///
+    /// Under `.environment` there is nothing to check: the run has declared that the
+    /// microphone is the user, so the check is skipped rather than answered. It is recorded
+    /// at each stage the wearer-trust path would have checked, so a log can always say
+    /// which of the two postures a queued instruction was accepted under — the bypass is
+    /// never silent.
     private func isAttributed(stage: String) -> Bool {
+        guard trust != .environment else {
+            diagnostics.record("instruction.trusted_environment", fields: ["stage": stage])
+            return true
+        }
         guard attribution?() ?? false else {
             diagnostics.record("instruction.rejected_unattributed", fields: ["stage": stage])
             return false
@@ -374,7 +411,9 @@ public typealias InstructionDictating = @MainActor (String) -> Void
                 freeformResponder: FreeformQuestionResponding? = nil,
                 instructionCapability: InstructionCapabilityChecking? = nil,
                 wearerAttribution: WearerAttributionQuerying? = nil,
-                instructionEnqueue: InstructionDictating? = nil) {
+                instructionEnqueue: InstructionDictating? = nil,
+                voiceTrust: VoiceTrust = .wearer,
+                gestureConfirmation: GestureConfirmationQuerying? = nil) {
         self.speech = speech
         self.arbiter = arbiter
         self.timeout = timeout
@@ -386,7 +425,9 @@ public typealias InstructionDictating = @MainActor (String) -> Void
         self.dictation = InstructionDictation(capability: instructionCapability,
                                               attribution: wearerAttribution,
                                               enqueue: instructionEnqueue,
-                                              diagnostics: diagnostics)
+                                              diagnostics: diagnostics,
+                                              trust: voiceTrust,
+                                              gestureConfirmation: gestureConfirmation)
     }
 
     /// `requiredConfirmation` is how much the user has to do to approve. `.standard` — the

--- a/Sources/TapQInteractionBaseline/SelectionController.swift
+++ b/Sources/TapQInteractionBaseline/SelectionController.swift
@@ -38,6 +38,9 @@ import TapQContracts
     /// asked to choose between options may still want to say something to the agent, and
     /// nothing about dictating changes which option is under the cursor.
     private let dictation: InstructionDictation
+    /// Whether a nod can still confirm a read-back. Absent — every composition before
+    /// `--voice-trust environment` — answers yes and keeps the wording unchanged.
+    private let gestureConfirmation: GestureConfirmationQuerying?
 
     /// `controlsHint` is consulted on the session's first prompt and on every explicit
     /// repeat, and must answer for the window it is called in. The default teaches the
@@ -52,7 +55,9 @@ import TapQContracts
                 recallResponder: RecallResponding? = nil,
                 instructionCapability: InstructionCapabilityChecking? = nil,
                 wearerAttribution: WearerAttributionQuerying? = nil,
-                instructionEnqueue: InstructionDictating? = nil) {
+                instructionEnqueue: InstructionDictating? = nil,
+                voiceTrust: VoiceTrust = .wearer,
+                gestureConfirmation: GestureConfirmationQuerying? = nil) {
         self.speech = speech
         self.arbiter = arbiter
         self.timeout = timeout
@@ -60,10 +65,22 @@ import TapQContracts
         let diagnostics = TapQDiagnosticEmitter(category: "Selection", sink: diagnosticSink)
         self.diagnostics = diagnostics
         self.recallResponder = recallResponder
+        self.gestureConfirmation = gestureConfirmation
         self.dictation = InstructionDictation(capability: instructionCapability,
                                               attribution: wearerAttribution,
                                               enqueue: instructionEnqueue,
-                                              diagnostics: diagnostics)
+                                              diagnostics: diagnostics,
+                                              trust: voiceTrust,
+                                              gestureConfirmation: gestureConfirmation)
+    }
+
+    /// The free-form read-back's confirmation cue, narrowed to speech where no gesture can
+    /// arrive. Same rule and same reason as the dictation read-back: a sentence that asks
+    /// for a nod the wearer cannot make is worse than one that asks for a word they can say.
+    private var freeformConfirmCue: String {
+        (gestureConfirmation?() ?? true)
+            ? "Nod or say yes to send, shake or say no to discard."
+            : "Say yes to send, or no to discard."
     }
 
     public func resolve(_ request: SelectionRequest, deadline: ContinuousClock.Instant? = nil) async -> SelectionResult {
@@ -145,7 +162,7 @@ import TapQContracts
                 // Read-back confirmation: the wearer spoke a free-text answer.
                 // Speak it back, then wait for nod (confirm) or shake (discard).
                 let condensedText = SpokenText.condensed(text, maxWords: 12, maxCharacters: 96)
-                utterance = "You said: '\(SpokenText.sentence(condensedText))' Nod or say yes to send, shake or say no to discard."
+                utterance = "You said: '\(SpokenText.sentence(condensedText))' \(freeformConfirmCue)"
                 diagnostics.record("freeform.readback",
                                    fields: ["length": "\(text.count)"])
                 let confirmRemaining = deadline.seconds(after: now())

--- a/Sources/TapQInteractionBaseline/VoiceTrust.swift
+++ b/Sources/TapQInteractionBaseline/VoiceTrust.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Whose voice TapQ is willing to take an *instruction* from.
+///
+/// The name is deliberately narrow. This setting says nothing about approvals: an
+/// instruction is text entering an agent's session, an approval authorizes an action, and
+/// the two have never shared a policy. Under either value the approval grammar, the
+/// approval read-backs, and the fail-open-to-screen semantics are exactly what they were.
+///
+/// - ``wearer`` is the default and reproduces today's behavior byte for byte. Dictation is
+///   fail-closed on IMU wearer attribution, so a voice TapQ cannot prove is the wearer's —
+///   including one where the signal cannot answer at all — is refused out loud.
+/// - ``environment`` trades that proof for a stated assumption: with no earbuds in, the
+///   microphone is in a quiet, single-person room and whoever it hears is the user. The
+///   read-back confirmation stays, because it catches mis-transcription and not just
+///   misattribution, and it is the only thing between a stray sentence and an agent's inbox.
+///
+/// The honest cost of ``environment``, which the docs state in the same words: anyone
+/// audible to the microphone can *instruct* — and still cannot approve, deny, select, or
+/// defer anything the wearer would not have.
+public enum VoiceTrust: String, Sendable, Codable, Equatable, CaseIterable {
+    /// Instructions require IMU wearer attribution. The default.
+    case wearer
+    /// The microphone is trusted as the user; the attribution check is skipped and the
+    /// bypass is recorded as `instruction.trusted_environment`.
+    case environment
+}

--- a/Sources/TapQPOSIXBridgeClient/BrokerDiscovery.swift
+++ b/Sources/TapQPOSIXBridgeClient/BrokerDiscovery.swift
@@ -114,6 +114,29 @@ public struct BrokerDiscovery {
                 record.steeringEnabled ?? false)
     }
 
+    /// Whether the live runtime advertises that it will hold a turn boundary open.
+    ///
+    /// Non-throwing and fail-closed at every step — an unreadable record, a record from a
+    /// runtime that predates voice sessions, a publisher that is no longer alive — because
+    /// the only thing this answer can do is make a Stop hook *wait*, and a hook that waits
+    /// on a runtime that will not answer is the one failure mode this whole feature has to
+    /// avoid. Liveness is checked for the same reason steering checks it: a runtime killed
+    /// with SIGKILL cannot remove its own record.
+    public func liveVoiceSessionEnabled() -> Bool {
+        liveVoiceSessionEnabled(socketIsReachable: {
+            UnixSocketClient.canConnect(socketPath: $0)
+        })
+    }
+
+    func liveVoiceSessionEnabled(socketIsReachable: (String) -> Bool) -> Bool {
+        guard let record = try? readRecord(),
+              let processID = record.processID,
+              processID > 0,
+              Self.processIsAlive(processID),
+              socketIsReachable(record.socket) else { return false }
+        return record.voiceSessionEnabled ?? false
+    }
+
     private func readRecord() throws -> DiscoveryRecord {
         let candidates = [discoveryURL] + fallbackDiscoveryURLs
         guard let url = candidates.first(where: {
@@ -149,12 +172,16 @@ public struct BrokerDiscovery {
         let token: String
         let protocolVersion: Int?
         let steeringEnabled: Bool?
+        /// Absent in every record written before voice sessions existed, which decodes to
+        /// nil and reads as `false` — an older runtime is never long-polled.
+        let voiceSessionEnabled: Bool?
         let processID: Int32?
 
         enum CodingKeys: String, CodingKey {
             case socket, token
             case protocolVersion = "protocol_version"
             case steeringEnabled = "steering_enabled"
+            case voiceSessionEnabled = "voice_session"
             case processID = "process_id"
         }
     }

--- a/Sources/TapQWireProtocol/WireMessages.swift
+++ b/Sources/TapQWireProtocol/WireMessages.swift
@@ -12,6 +12,10 @@ public enum WireType {
     /// Wire v5: a dictated instruction queued for delivery at the session's next turn
     /// boundary. Instructions never authorize anything — they are text for the agent.
     public static let instructionSubmit = "instruction.submit"
+    /// Wire v6: a shim asking the broker to hold its session's turn boundary open until an
+    /// instruction exists for it. The reply carries the instruction the boundary should
+    /// deliver, or nothing — in which case the Stop proceeds and the session idles.
+    public static let instructionWait = "instruction.wait"
 }
 
 /// Version of the shim↔broker wire contract. Bump on any incompatible change to the
@@ -20,38 +24,50 @@ public enum WireType {
 /// fails open (shim passes through; broker replies error, which the shim also treats
 /// as pass-through), so a stale binary degrades loudly in logs, never wrongly allows.
 public enum WireProtocol {
-    public static let version = 5
+    public static let version = 6
     /// The immediately preceding protocol remains wire-compatible for messages that do
     /// not depend on `approval_source`. This keeps the legacy macOS runtime fallback useful
     /// for strict-policy and shared events without exposing native PermissionRequest to a
     /// broker that would interpret it as legacy PreToolUse.
     public static let legacyBridgeVersion = 2
-    /// v4 request shapes are identical to v5 for every message type v4 knows about — v5
-    /// only *adds* `instruction.submit`. The broker therefore accepts v4 peers without
-    /// downgrade, keeping every installed v4 shim working against a v5 runtime.
-    public static let previousAcceptedVersion = 4
+    /// Older versions this broker still accepts, newest first.
+    ///
+    /// Both entries earned their place the same way: each bump since v4 has only *added* a
+    /// message type — v5 `instruction.submit`, v6 `instruction.wait` — leaving every
+    /// request shape an older peer knows about byte-identical. An installed shim is a
+    /// binary on someone's disk that they upgrade when they upgrade, so accepting the
+    /// versions whose shapes are still correct is what keeps a runtime upgrade from
+    /// silently disabling their hooks.
+    public static let previousAcceptedVersions = [5, 4]
+    /// The newest of those, for callers that want to name "the version before this one".
+    public static let previousAcceptedVersion = previousAcceptedVersions[0]
 
     /// The first wire version that carried a given message type. Types that predate
-    /// versioning report 1, so they negotiate exactly as they always have; only the v5
-    /// instruction channel is gated, because a v4 broker would reject it as unknown.
+    /// versioning report 1, so they negotiate exactly as they always have; the two
+    /// instruction-channel types are gated, because an older broker would reject each of
+    /// them as an unknown message rather than answer it.
     public static func minimumVersion(for messageType: String) -> Int {
-        messageType == WireType.instructionSubmit ? 5 : 1
+        switch messageType {
+        case WireType.instructionSubmit: return 5
+        case WireType.instructionWait: return 6
+        default: return 1
+        }
     }
 
     /// nil = peer predates versioning; it speaks version 1 de facto.
-    /// The broker accepts both the current version and `previousAcceptedVersion`.
+    /// The broker accepts the current version and every `previousAcceptedVersions` entry.
     public static func isCompatible(_ other: Int?, current: Int = version) -> Bool {
         let peer = other ?? 1
-        return peer == current || (current == version && peer == previousAcceptedVersion)
+        return peer == current || (current == version && previousAcceptedVersions.contains(peer))
     }
 
     /// Selects the version a current shim may safely put on an outbound message.
     /// Brokers themselves continue to require a compatible version via `isCompatible`.
     ///
-    /// `messageType` nil (the default) means "a message type that predates wire v5" —
-    /// every pre-existing caller negotiates exactly as before. Passing a type whose
-    /// `minimumVersion` exceeds what the peer speaks yields nil, so a v5 shim never
-    /// stamps an instruction with a version its broker would misread.
+    /// `messageType` nil (the default) means "a message type that predates the instruction
+    /// channel" — every pre-existing caller negotiates exactly as before. Passing a type
+    /// whose `minimumVersion` exceeds what the peer speaks yields nil, so a current shim
+    /// never stamps an instruction, or a wait, with a version its broker would misread.
     public static func outboundVersion(
         for peerVersion: Int?,
         approvalSource: ApprovalSource?,
@@ -60,9 +76,11 @@ public enum WireProtocol {
         let peer = peerVersion ?? 1
         let floor = messageType.map(minimumVersion(for:)) ?? 1
         if peer == version { return version }
-        guard floor <= previousAcceptedVersion else { return nil }
-        // v5 shim speaks v4 to a v4 broker — the request shapes it knows are identical.
-        if peer == previousAcceptedVersion { return previousAcceptedVersion }
+        // A current shim speaks the older broker's own version back to it — the request
+        // shapes that broker knows are identical — unless the message type postdates it.
+        if previousAcceptedVersions.contains(peer) {
+            return floor <= peer ? peer : nil
+        }
         guard floor <= legacyBridgeVersion else { return nil }
         if peer == legacyBridgeVersion, approvalSource != .permissionRequest {
             return legacyBridgeVersion
@@ -260,6 +278,41 @@ public struct InstructionSubmitMessage: Codable, Sendable, Equatable {
     }
 }
 
+/// A shim asking the broker to hold this session's turn boundary open (wire v6).
+///
+/// Sent by a Stop hook when the runtime has advertised voice-session mode and the boundary
+/// has nothing to deliver yet. The broker answers when an instruction is queued for the
+/// session, when its own wait budget expires, or when it is shutting down; the shim treats
+/// the last two identically and lets the Stop proceed.
+///
+/// It carries less than any other message on this wire — who is asking, and about which
+/// session. There is nothing in it to influence a decision because it asks for no decision:
+/// the only thing it can come back with is text the wearer already had read back to them.
+public struct InstructionWaitMessage: Codable, Sendable, Equatable {
+    public let token: String
+    public let sessionID: String
+    public let requestID: String
+    public let agent: AgentIdentity?
+    public let protocolVersion: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case token, agent
+        case sessionID = "session_id"
+        case requestID = "request_id"
+        case protocolVersion = "protocol_version"
+    }
+
+    public init(token: String, sessionID: String, requestID: String,
+                agent: AgentIdentity? = nil,
+                protocolVersion: Int? = nil) {
+        self.token = token
+        self.sessionID = sessionID
+        self.requestID = requestID
+        self.agent = agent
+        self.protocolVersion = protocolVersion
+    }
+}
+
 /// A decoded request, dispatched on the wire `type` discriminator. Decoding an unknown
 /// `type` throws, so the broker never acts on a message shape it doesn't recognize.
 public enum BrokerRequest: Sendable {
@@ -268,6 +321,7 @@ public enum BrokerRequest: Sendable {
     case selection(SelectionRequestMessage)
     case stopQuestion(StopQuestionMessage)
     case instruction(InstructionSubmitMessage)
+    case instructionWait(InstructionWaitMessage)
 
     private enum TypeKey: String, CodingKey { case type }
 
@@ -292,6 +346,8 @@ extension BrokerRequest: Decodable {
             self = .stopQuestion(try StopQuestionMessage(from: decoder))
         case WireType.instructionSubmit:
             self = .instruction(try InstructionSubmitMessage(from: decoder))
+        case WireType.instructionWait:
+            self = .instructionWait(try InstructionWaitMessage(from: decoder))
         default:
             throw DecodingError.dataCorrupted(
                 .init(codingPath: decoder.codingPath, debugDescription: "Unknown message type \(type)"))
@@ -302,13 +358,17 @@ extension BrokerRequest: Decodable {
 /// The broker's reply. `decision` answers an approval; `ok` acknowledges a notification or
 /// a queued instruction;
 /// `error` rejects a bad/unauthorized message (the shim then fail-opens to `ask`);
-/// `selection` returns the indices and labels the user chose.
+/// `selection` returns the indices and labels the user chose;
+/// `instructionWait` answers a held turn boundary with the instruction it should deliver,
+/// or with nothing at all.
 public enum BrokerResponse: Sendable, Equatable {
     case decision(Decision, reason: String?)
     case ok
     case error(String)
     case selection(indices: [Int], labels: [String], freeText: String? = nil)
     case stopQuestion(reply: String?)
+    /// The reply a held boundary should hand the agent, or `nil` for "nothing arrived".
+    case instructionWait(instruction: String?)
 
     private enum Key: String, CodingKey {
         case decision, reason, ok, error
@@ -316,6 +376,10 @@ public enum BrokerResponse: Sendable, Equatable {
         case selectedLabels = "selected_labels"
         case freeText = "free_text"
         case action, reply
+        /// The wait's own discriminator, deliberately not `action`: a stop question is
+        /// already encoded with an `action`, and two shapes sharing one key would decode
+        /// into whichever case the reader happened to check first.
+        case wait, instruction
     }
 
     public func encoded() -> Data {
@@ -345,6 +409,13 @@ extension BrokerResponse: Codable {
             } else {
                 try c.encode("pass", forKey: .action)
             }
+        case .instructionWait(let instruction):
+            if let instruction {
+                try c.encode("instruction", forKey: .wait)
+                try c.encode(instruction, forKey: .instruction)
+            } else {
+                try c.encode("none", forKey: .wait)
+            }
         }
     }
 
@@ -361,6 +432,12 @@ extension BrokerResponse: Codable {
                   let labels = try c.decodeIfPresent([String].self, forKey: .selectedLabels) {
             let freeText = try c.decodeIfPresent(String.self, forKey: .freeText)
             self = .selection(indices: indices, labels: labels, freeText: freeText)
+        } else if let wait = try c.decodeIfPresent(String.self, forKey: .wait) {
+            self = .instructionWait(
+                instruction: wait == "instruction"
+                    ? try c.decodeIfPresent(String.self, forKey: .instruction)
+                    : nil
+            )
         } else if let action = try c.decodeIfPresent(String.self, forKey: .action) {
             self = .stopQuestion(reply: action == "answer" ? try c.decodeIfPresent(String.self, forKey: .reply) : nil)
         } else {

--- a/Tests/TapQBrokerRuntimeTests/BrokerRuntimeDiscoveryTests.swift
+++ b/Tests/TapQBrokerRuntimeTests/BrokerRuntimeDiscoveryTests.swift
@@ -45,6 +45,26 @@ final class BrokerRuntimeDiscoveryTests: XCTestCase {
         XCTAssertEqual(recordMode & 0o777, 0o600)
     }
 
+    /// The advertisement a Stop hook reads before it is willing to hold a turn boundary
+    /// open. It is published only when the run actually composed one, and a run that did
+    /// not says so explicitly rather than by omission.
+    func testTheVoiceSessionAdvertisementRoundTripsToTheShimSide() throws {
+        let runtime = BrokerRuntimeDiscovery(supportDirectory: directory)
+        try runtime.prepareDirectory()
+        let client = TapQPOSIXBridgeClient.BrokerDiscovery(supportDir: directory)
+
+        try runtime.publish(token: "tok", voiceSessionEnabled: true)
+        XCTAssertTrue(
+            client.liveVoiceSessionEnabled(socketIsReachable: { $0 == runtime.socketPath })
+        )
+
+        try runtime.publish(token: "tok")
+        XCTAssertFalse(
+            client.liveVoiceSessionEnabled(socketIsReachable: { $0 == runtime.socketPath }),
+            "a run without --voice-session must never be long-polled"
+        )
+    }
+
     func testRemoveDeletesDiscoveryRecord() throws {
         let runtime = BrokerRuntimeDiscovery(supportDirectory: directory)
         try runtime.prepareDirectory()

--- a/Tests/TapQCLITests/InstructCommandTests.swift
+++ b/Tests/TapQCLITests/InstructCommandTests.swift
@@ -183,7 +183,7 @@ final class InstructCommandTests: XCTestCase {
         broker.connection = BrokerConnection(
             socketPath: "/tmp/tapq-test.sock",
             token: "t0ken",
-            protocolVersion: WireProtocol.previousAcceptedVersion
+            protocolVersion: 4
         )
         let status = await application(buffer.io, broker: broker)
             .run(arguments: ["instruct", "s-1", "run the tests"])

--- a/Tests/TapQCLITests/VoiceSessionFlagTests.swift
+++ b/Tests/TapQCLITests/VoiceSessionFlagTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import XCTest
+@testable import TapQCLI
+import TapQInteractionBaseline
+
+/// The command-line surface of the voice session (RH1): one flag, one dependency, and the
+/// promise that a run which does not ask for it cannot end up in it.
+final class VoiceSessionFlagTests: XCTestCase {
+    // MARK: - Defaults
+
+    func testVoiceSessionDefaultsOff() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(["serve"]) else {
+            return XCTFail("Expected a serve command.")
+        }
+        XCTAssertFalse(options.voiceSessionEnabled)
+    }
+
+    func testRuntimeConfigurationDefaultsTheSessionOff() {
+        let configuration = TapQRuntimeConfiguration(
+            gestureProfileURL: URL(fileURLWithPath: "/tmp/g.json"),
+            tapProfileURL: URL(fileURLWithPath: "/tmp/t.json")
+        )
+        XCTAssertFalse(configuration.voiceSessionEnabled)
+    }
+
+    // MARK: - Parsing and validation
+
+    /// The lean pairing the mode was designed around: no earbuds, environment trust, and a
+    /// boundary held open for the next sentence.
+    func testTheVoiceOnlyPairingParses() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--voice-trust", "environment", "--voice-instructions",
+            "--voice-session",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertTrue(options.voiceSessionEnabled)
+        XCTAssertTrue(options.voiceInstructionsEnabled)
+        XCTAssertEqual(options.voiceTrust, .environment)
+        XCTAssertFalse(options.wearerGateEnabled)
+    }
+
+    /// It also composes with the wearer-trust posture: a boundary held for someone who is
+    /// wearing their AirPods is the same boundary.
+    func testTheSessionComposesUnderWearerTrustToo() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--wearer-gate", "--voice-instructions", "--voice-session",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertTrue(options.voiceSessionEnabled)
+        XCTAssertEqual(options.voiceTrust, .wearer)
+    }
+
+    /// The dependency that exists so a hook is never parked for ten minutes waiting on a
+    /// queue this run does not have.
+    func testTheSessionRequiresTheInstructionChannel() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse(["serve", "--voice-session"])
+        ) { error in
+            let message = (error as? CLIUsageError)?.message ?? ""
+            XCTAssertTrue(message.contains("--voice-session requires --voice-instructions"),
+                          message)
+        }
+    }
+
+    /// And it is refused even when the trust posture would otherwise have made the run
+    /// legal — the missing piece is the queue, not the attribution.
+    func testTheSessionIsRefusedUnderEnvironmentTrustWithoutInstructions() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse([
+                "serve", "--voice-trust", "environment", "--voice-session",
+            ])
+        )
+    }
+
+    /// A wearer-trust run still has to bring the gate, and the session flag does not excuse
+    /// it: two independent refusals, and the instruction channel's own comes first.
+    func testTheSessionDoesNotWaiveTheWearerTrustGateRequirement() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse([
+                "serve", "--voice-instructions", "--voice-session",
+            ])
+        ) { error in
+            XCTAssertTrue(
+                (error as? CLIUsageError)?.message.contains("requires --wearer-gate") == true
+            )
+        }
+    }
+}

--- a/Tests/TapQCLITests/VoiceTrustFlagTests.swift
+++ b/Tests/TapQCLITests/VoiceTrustFlagTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import XCTest
+@testable import TapQCLI
+import TapQInteractionBaseline
+
+/// The command-line surface of Rung E: one flag, and the startup validation it moves.
+///
+/// `--voice-instructions` has always been refused without `--wearer-gate`, because the
+/// dictation path is fail-closed on an attribution signal only the gate composes. The whole
+/// of Rung E's CLI change is that `--voice-trust environment` is the operator saying they
+/// do not want that signal, which makes the pairing meaningless rather than unsafe — so the
+/// matrix below is the feature, and the `wearer` half of it must not have moved at all.
+final class VoiceTrustFlagTests: XCTestCase {
+    // MARK: - Defaults
+
+    /// The byte-identical promise: a run that says nothing about trust is a wearer-trust run.
+    func testVoiceTrustDefaultsToWearer() throws {
+        guard case .serve(let options) = try CLICommandParser.parse(["serve"]) else {
+            return XCTFail("Expected a serve command.")
+        }
+        XCTAssertEqual(options.voiceTrust, .wearer)
+    }
+
+    func testRuntimeConfigurationDefaultsToWearerTrust() {
+        let configuration = TapQRuntimeConfiguration(
+            gestureProfileURL: URL(fileURLWithPath: "/tmp/g.json"),
+            tapProfileURL: URL(fileURLWithPath: "/tmp/t.json")
+        )
+        XCTAssertEqual(configuration.voiceTrust, .wearer)
+    }
+
+    // MARK: - Parsing
+
+    func testEnvironmentTrustParses() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--voice-trust", "environment", "--voice-instructions",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertEqual(options.voiceTrust, .environment)
+        XCTAssertTrue(options.voiceInstructionsEnabled)
+    }
+
+    func testWearerTrustParsesExplicitly() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--voice-trust", "wearer", "--wearer-gate", "--voice-instructions",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertEqual(options.voiceTrust, .wearer)
+    }
+
+    func testUnknownTrustModeIsRefused() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse(["serve", "--voice-trust", "anyone"])
+        ) { error in
+            XCTAssertEqual(
+                (error as? CLIUsageError)?.message,
+                "--voice-trust must be 'wearer' or 'environment'."
+            )
+        }
+    }
+
+    func testTrustModeRequiresAValue() {
+        XCTAssertThrowsError(try CLICommandParser.parse(["serve", "--voice-trust"]))
+    }
+
+    // MARK: - The validation matrix
+
+    /// Unchanged from Rung C, and the reason the error text now names the alternative: a
+    /// wearer-trust run without the gate would refuse every dictation it accepted the flag
+    /// for.
+    func testInstructionsStillRequireTheGateUnderWearerTrust() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse(["serve", "--voice-instructions"])
+        ) { error in
+            let message = (error as? CLIUsageError)?.message ?? ""
+            XCTAssertTrue(message.contains("requires --wearer-gate"), message)
+            XCTAssertTrue(message.contains("--voice-trust environment"),
+                          "the refusal must name the way out: \(message)")
+        }
+    }
+
+    func testInstructionsStillRequireTheGateWhenWearerTrustIsExplicit() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse([
+                "serve", "--voice-instructions", "--voice-trust", "wearer",
+            ])
+        )
+    }
+
+    /// The rung, in one assertion: with the microphone trusted as the user there is no
+    /// attribution to be fail-closed about, so the pairing is dropped rather than tolerated.
+    func testInstructionsNeedNoGateUnderEnvironmentTrust() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--voice-instructions", "--voice-trust", "environment",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertFalse(options.wearerGateEnabled)
+        XCTAssertTrue(options.voiceInstructionsEnabled)
+    }
+
+    /// Attention is untouched by trust (Rung G is deferred): a window that opens on a
+    /// wearer-speech onset still needs the signal that says whose onset it was.
+    func testAttentionStillRequiresTheGateUnderEnvironmentTrust() {
+        XCTAssertThrowsError(
+            try CLICommandParser.parse([
+                "serve", "--voice-trust", "environment", "--attention", "imu",
+            ])
+        ) { error in
+            XCTAssertTrue(
+                (error as? CLIUsageError)?.message.contains("requires --wearer-gate") == true
+            )
+        }
+    }
+
+    /// Both flags together stay legal: environment trust drops a requirement, it does not
+    /// forbid the gate for anyone who still wants attribution on the command path.
+    func testEnvironmentTrustAndTheGateComposeTogether() throws {
+        guard case .serve(let options) = try CLICommandParser.parse([
+            "serve", "--wearer-gate", "--voice-instructions",
+            "--voice-trust", "environment", "--attention", "imu",
+        ]) else { return XCTFail("Expected a serve command.") }
+        XCTAssertTrue(options.wearerGateEnabled)
+        XCTAssertEqual(options.voiceTrust, .environment)
+        XCTAssertEqual(options.attentionMode, .imu)
+    }
+}

--- a/Tests/TapQClaudeAdapterTests/HookInstallerTests.swift
+++ b/Tests/TapQClaudeAdapterTests/HookInstallerTests.swift
@@ -157,7 +157,7 @@ final class HookInstallerTests: XCTestCase {
         {"hooks":{
           "PreToolUse":[{"matcher":"Bash|Write|Edit|MultiEdit|NotebookEdit|AskUserQuestion","hooks":[{"type":"command","command":"\(quoted)","timeout":\(Int(InteractionBudget.hookTimeout))}]}],
           "Notification":[{"matcher":"idle_prompt|permission_prompt","hooks":[{"type":"command","command":"\(quoted)","timeout":10}]}],
-          "Stop":[{"hooks":[{"type":"command","command":"\(quoted)","timeout":\(Int(InteractionBudget.hookTimeout))}]}],
+          "Stop":[{"hooks":[{"type":"command","command":"\(quoted)","timeout":\(Int(VoiceSessionBudget.hookTimeout))}]}],
           "UserPromptSubmit":[{"hooks":[{"type":"command","command":"\(quoted)","timeout":5}]}]
         }}
         """
@@ -660,9 +660,47 @@ final class HookInstallerTests: XCTestCase {
         let stop = try XCTUnwrap(hooks["Stop"]?.arrayValue?.first)
         let stopHook = try XCTUnwrap(stop["hooks"]?.arrayValue?.first)
         if case .number(let t)? = stopHook["timeout"] {
-            XCTAssertEqual(t, InteractionBudget.hookTimeout)
+            XCTAssertEqual(t, VoiceSessionBudget.hookTimeout)
         } else {
             XCTFail("timeout")
+        }
+    }
+
+    /// The Stop entry is the one hook that may hold a turn boundary open, so its configured
+    /// timeout has to outlast both things it does: a full interaction window for an
+    /// intercepted question, and a ten-minute voice-session wait. A default-sized timeout
+    /// would kill the second mid-wait, and the wearer's next instruction would land in a
+    /// socket nobody is reading.
+    func testTheStopHookTimeoutCoversTheWholeVoiceSessionWait() throws {
+        try installer().install()
+        let hooks = try XCTUnwrap(try read()["hooks"]?.objectValue)
+        let stopHook = try XCTUnwrap(
+            hooks["Stop"]?.arrayValue?.first?["hooks"]?.arrayValue?.first
+        )
+        guard case .number(let timeout)? = stopHook["timeout"] else {
+            return XCTFail("the Stop entry must carry an explicit timeout")
+        }
+        XCTAssertGreaterThan(timeout, VoiceSessionBudget.brokerWait,
+                             "the broker answers at the wait budget; the hook must outlast it")
+        XCTAssertGreaterThan(timeout, VoiceSessionBudget.shimSocketTimeout,
+                             "and outlast the socket the shim gives up on")
+        XCTAssertGreaterThan(timeout, InteractionBudget.hookTimeout,
+                             "an intercepted stop question still runs a full window in here")
+    }
+
+    /// Only the Stop entry. Nothing else in the layout waits for a person to think.
+    func testNoOtherHookGainedTheVoiceSessionTimeout() throws {
+        try installer().install()
+        let hooks = try XCTUnwrap(try read()["hooks"]?.objectValue)
+        for event in ["PreToolUse", "Notification", "UserPromptSubmit"] {
+            let hook = try XCTUnwrap(
+                hooks[event]?.arrayValue?.first?["hooks"]?.arrayValue?.first,
+                "\(event) must still be installed"
+            )
+            guard case .number(let timeout)? = hook["timeout"] else {
+                return XCTFail("\(event) must carry an explicit timeout")
+            }
+            XCTAssertLessThan(timeout, VoiceSessionBudget.brokerWait, event)
         }
     }
 }

--- a/Tests/TapQClaudeAdapterTests/HookShimTests.swift
+++ b/Tests/TapQClaudeAdapterTests/HookShimTests.swift
@@ -256,7 +256,7 @@ final class HookShimTests: XCTestCase {
     }
 
     func testPermissionRequestPassesThroughWhenBrokerRejectsProtocol() {
-        XCTAssertEqual(WireProtocol.version, 5)
+        XCTAssertEqual(WireProtocol.version, 6)
         let input = stdin(#"{"hook_event_name":"PermissionRequest","tool_name":"Bash","tool_input":{}}"#)
         let result = HookShim.handle(stdinData: input) { _, _ in
             Data(#"{"error":"protocol_version"}"#.utf8)

--- a/Tests/TapQClaudeAdapterTests/HookShimVoiceSessionTests.swift
+++ b/Tests/TapQClaudeAdapterTests/HookShimVoiceSessionTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+@testable import TapQClaudeAdapter
+import TapQWireProtocol
+import TapQContracts
+
+/// The held turn boundary, from the shim's side (RH1).
+///
+/// The claim under test is narrow and safety-shaped: the hook waits only when a live
+/// runtime says it will answer, it blocks the Stop only with text that runtime composed,
+/// and every other outcome — no instruction, an error, an unreachable broker, a reply it
+/// cannot read — lets the Stop proceed exactly as it always has. A voice session that goes
+/// wrong has to end as "the mode stopped", never as "the terminal is stuck".
+final class HookShimVoiceSessionTests: XCTestCase {
+    private enum StubError: Error { case unreachable }
+
+    private func stdin(_ json: String) -> Data { Data(json.utf8) }
+
+    /// A Stop event whose transcript holds no question, so the stop-question path passes
+    /// and the wait is the only thing left in the hook.
+    private func stopInput() -> Data {
+        stdin(#"{"hook_event_name":"Stop","session_id":"s1"}"#)
+    }
+
+    /// Writes a one-reply transcript fixture and returns its path.
+    private func transcript(_ assistantText: String) throws -> String {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tapq-voicesession-\(UUID().uuidString).jsonl")
+        let line = #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"\#(assistantText)"}]}}"#
+        try (line + "\n").write(to: url, atomically: true, encoding: .utf8)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url.path
+    }
+
+    private func blockReason(_ stdout: String?) throws -> String? {
+        let obj = try JSONDecoder().decode(
+            [String: JSONValue].self, from: Data((stdout ?? "").utf8)
+        )
+        guard obj["decision"]?.stringValue == "block" else { return nil }
+        return obj["reason"]?.stringValue
+    }
+
+    // MARK: - Only when the runtime says so
+
+    /// The default, and every run without `--voice-session`: the Stop notifies and returns,
+    /// and no socket is opened to find out whether anyone wanted it to wait.
+    func testAStopNeverWaitsUnlessTheRuntimeAdvertisesAVoiceSession() throws {
+        var sentTypes: [String] = []
+        let result = HookShim.handle(stdinData: stopInput()) { message, _ in
+            sentTypes.append(message["type"]?.stringValue ?? "")
+            return Data(#"{"ok":true}"#.utf8)
+        }
+        XCTAssertNil(result.stdout)
+        XCTAssertEqual(sentTypes, ["notification.event"])
+    }
+
+    /// The wait rides after the notification, deliberately: that notification is what makes
+    /// the runtime announce the turn ended, and the wearer hears "Claude Code finished"
+    /// before they hear "Listening."
+    func testTheWaitIsSentAfterTheStopNotification() throws {
+        var sentTypes: [String] = []
+        var waitTimeout: TimeInterval?
+        _ = HookShim.handle(
+            stdinData: stopInput(),
+            voiceSessionEnabled: { true }
+        ) { message, timeout in
+            let type = message["type"]?.stringValue ?? ""
+            sentTypes.append(type)
+            if type == WireType.instructionWait {
+                waitTimeout = timeout
+                XCTAssertEqual(message["session_id"]?.stringValue, "s1")
+                XCTAssertEqual(message["protocol_version"]?.intValue, WireProtocol.version)
+                XCTAssertEqual(message["agent"]?["id"]?.stringValue, "claude-code")
+                XCTAssertFalse(message["request_id"]?.stringValue?.isEmpty ?? true)
+                return Data(#"{"wait":"none"}"#.utf8)
+            }
+            return Data(#"{"ok":true}"#.utf8)
+        }
+        XCTAssertEqual(sentTypes, ["notification.event", WireType.instructionWait])
+        XCTAssertEqual(waitTimeout, HookShim.instructionWaitTimeout)
+        XCTAssertGreaterThan(HookShim.instructionWaitTimeout, VoiceSessionBudget.brokerWait,
+                             "the socket must outlast the broker's own budget")
+    }
+
+    /// The wait carries identity and nothing else. There is no field on it a decision could
+    /// be steered by, which is what makes "the reply is text the wearer confirmed" a
+    /// property of the message rather than of the handler.
+    func testTheWaitCarriesNothingPolicySignificant() throws {
+        var captured: [String: JSONValue]?
+        _ = HookShim.handle(
+            stdinData: stopInput(),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            if message["type"]?.stringValue == WireType.instructionWait { captured = message }
+            return Data(#"{"wait":"none"}"#.utf8)
+        }
+        let message = try XCTUnwrap(captured)
+        for forbidden in ["tool_name", "tool_input", "cwd", "permission_mode",
+                          "approval_source", "text"] {
+            XCTAssertNil(message[forbidden], "\(forbidden) must not ride a wait")
+        }
+    }
+
+    // MARK: - What comes back
+
+    /// The delivery: the broker's instruction becomes the Stop block's reason, verbatim.
+    /// The shim writes none of that sentence — what reaches Claude is what the wearer heard
+    /// read back to them.
+    func testAnInstructionAnswerBlocksTheStopWithTheRuntimesOwnText() throws {
+        let reply = "The user dictated a new instruction via TapQ hands-free: "
+            + "'run the tests again'. Proceed accordingly."
+        let result = HookShim.handle(
+            stdinData: stopInput(),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            guard message["type"]?.stringValue == WireType.instructionWait else {
+                return Data(#"{"ok":true}"#.utf8)
+            }
+            let encoded = BrokerResponse.instructionWait(instruction: reply).encoded()
+            return encoded
+        }
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(try blockReason(result.stdout), reply)
+        let obj = try JSONDecoder().decode(
+            [String: JSONValue].self, from: Data((result.stdout ?? "").utf8)
+        )
+        XCTAssertNil(obj["hookSpecificOutput"],
+                     "Stop block output is top-level, not wrapped")
+    }
+
+    /// The budget expired, or the wearer ended the session. Both look the same here and
+    /// both mean the same thing: carry on.
+    func testANoInstructionAnswerLetsTheStopProceed() throws {
+        let result = HookShim.handle(
+            stdinData: stopInput(),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            message["type"]?.stringValue == WireType.instructionWait
+                ? Data(#"{"wait":"none"}"#.utf8)
+                : Data(#"{"ok":true}"#.utf8)
+        }
+        XCTAssertNil(result.stdout)
+        XCTAssertEqual(result.exitCode, 0)
+    }
+
+    func testAnEmptyInstructionIsTreatedAsNoInstruction() throws {
+        let result = HookShim.handle(
+            stdinData: stopInput(),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            message["type"]?.stringValue == WireType.instructionWait
+                ? Data(#"{"wait":"instruction","instruction":""}"#.utf8)
+                : Data(#"{"ok":true}"#.utf8)
+        }
+        XCTAssertNil(result.stdout, "an empty block reason would restart the turn with nothing")
+    }
+
+    func testABrokerErrorLetsTheStopProceed() throws {
+        let result = HookShim.handle(
+            stdinData: stopInput(),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            message["type"]?.stringValue == WireType.instructionWait
+                ? Data(#"{"error":"protocol_version"}"#.utf8)
+                : Data(#"{"ok":true}"#.utf8)
+        }
+        XCTAssertNil(result.stdout)
+    }
+
+    /// A runtime that died while the hook was parked, or a socket that was never there.
+    /// The hook has to come back on its own rather than hold the session.
+    func testAnUnreachableBrokerLetsTheStopProceed() throws {
+        let result = HookShim.handle(
+            stdinData: stopInput(),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            guard message["type"]?.stringValue == WireType.instructionWait else {
+                return Data(#"{"ok":true}"#.utf8)
+            }
+            throw StubError.unreachable
+        }
+        XCTAssertNil(result.stdout)
+        XCTAssertEqual(result.exitCode, 0)
+    }
+
+    func testAnUnreadableReplyLetsTheStopProceed() throws {
+        let result = HookShim.handle(
+            stdinData: stopInput(),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            message["type"]?.stringValue == WireType.instructionWait
+                ? Data("not json".utf8)
+                : Data(#"{"ok":true}"#.utf8)
+        }
+        XCTAssertNil(result.stdout)
+    }
+
+    // MARK: - Interaction with the stop-question path
+
+    /// An answered question already carries the turn on, so there is nothing to hold open —
+    /// and holding one would put the wearer's next sentence behind an answer the agent has
+    /// not read yet.
+    func testAnAnsweredStopQuestionIsNeverAlsoHeldOpen() throws {
+        let path = try transcript("Which approach? 1) A 2) B")
+        var sentTypes: [String] = []
+        let result = HookShim.handle(
+            stdinData: stdin(#"{"hook_event_name":"Stop","session_id":"s1","permission_mode":"default","transcript_path":"\#(path)"}"#),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            let type = message["type"]?.stringValue ?? ""
+            sentTypes.append(type)
+            return type == WireType.stopQuestion
+                ? Data(#"{"action":"answer","reply":"They chose A"}"#.utf8)
+                : Data(#"{"ok":true}"#.utf8)
+        }
+        XCTAssertEqual(try blockReason(result.stdout), "They chose A")
+        XCTAssertEqual(sentTypes, [WireType.stopQuestion],
+                       "an answered question neither notifies nor waits")
+    }
+
+    /// The broker was unreachable for the stop question, so it is unreachable for the wait
+    /// too. Trying anyway would spend the hook's remaining budget discovering that.
+    func testAnUnreachableStopQuestionSkipsTheWaitEntirely() throws {
+        let path = try transcript("Should I deploy?")
+        var sentTypes: [String] = []
+        let result = HookShim.handle(
+            stdinData: stdin(#"{"hook_event_name":"Stop","session_id":"s1","permission_mode":"default","transcript_path":"\#(path)"}"#),
+            voiceSessionEnabled: { true }
+        ) { message, _ in
+            sentTypes.append(message["type"]?.stringValue ?? "")
+            throw StubError.unreachable
+        }
+        XCTAssertNil(result.stdout)
+        XCTAssertEqual(sentTypes, [WireType.stopQuestion])
+    }
+}

--- a/Tests/TapQContextBaselineTests/InstructionWaitRegistryTests.swift
+++ b/Tests/TapQContextBaselineTests/InstructionWaitRegistryTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import TapQContextBaseline
+import TapQContracts
+
+/// The three ways a held turn boundary can end, and the counting that drives the listening
+/// loop. Every test drives a real `wait` through a real continuation — the only thing
+/// substituted is the budget's timer, because a ten-minute default is not a thing a test
+/// can sit through.
+@MainActor
+final class InstructionWaitRegistryTests: XCTestCase {
+    /// A registry whose budget never expires inside a test: the sleep is a real,
+    /// cancellable suspension, and the registry cancels it the moment the wait ends. Tests
+    /// that are about anything other than the budget use this one.
+    private func patientRegistry() -> InstructionWaitRegistry {
+        InstructionWaitRegistry(sleep: { _ in try? await Task.sleep(for: .seconds(60)) })
+    }
+
+    /// A registry whose budget expires as soon as it is reached. It stands in for ten
+    /// minutes of silence, which is not a thing a test can sit through.
+    private func impatientRegistry() -> InstructionWaitRegistry {
+        InstructionWaitRegistry(sleep: { _ in })
+    }
+
+    /// Lets every pending task reach its next suspension, so a `wait` started in a task has
+    /// certainly registered before the test acts on it.
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    /// The delivery path: an instruction arrives for the held session and the boundary is
+    /// let go immediately.
+    func testAQueuedInstructionReleasesTheBoundary() async {
+        let waits = patientRegistry()
+        let held = Task { await waits.wait(session: "s1", timeout: 600) }
+        await settle()
+
+        XCTAssertTrue(waits.isWaiting)
+        waits.noteInstructionQueued(session: "s1")
+
+        let outcome = await held.value
+        XCTAssertEqual(outcome, .instructionQueued)
+        XCTAssertFalse(waits.isWaiting, "a released boundary is no longer held")
+    }
+
+    /// An instruction for a session nobody is holding must not wake the one that is: two
+    /// agents can be in voice mode at once, and each boundary carries its own session's
+    /// sentences or none at all.
+    func testAnInstructionForAnotherSessionLeavesTheBoundaryHeld() async {
+        let waits = patientRegistry()
+        let held = Task { await waits.wait(session: "s1", timeout: 600) }
+        await settle()
+
+        waits.noteInstructionQueued(session: "s2")
+        await settle()
+        XCTAssertTrue(waits.isWaiting)
+
+        waits.noteInstructionQueued(session: "s1")
+        let outcome = await held.value
+        XCTAssertEqual(outcome, .instructionQueued)
+    }
+
+    /// The budget: one long-poll round, and then the session idles normally. This is a clean
+    /// exit from the mode, which is why it is indistinguishable from a release.
+    func testAnExpiredBudgetEndsTheWait() async {
+        let waits = impatientRegistry()
+        let held = Task { await waits.wait(session: "s1", timeout: 600) }
+
+        let outcome = await held.value
+        XCTAssertEqual(outcome, .timedOut)
+        XCTAssertFalse(waits.isWaiting)
+    }
+
+    /// "End voice session": the wearer is done, and the boundary goes with nothing on it.
+    func testReleasingASessionEndsItsWaitWithNoInstruction() async {
+        let waits = patientRegistry()
+        let held = Task { await waits.wait(session: "s1", timeout: 600) }
+        await settle()
+
+        waits.release(session: "s1")
+
+        let outcome = await held.value
+        XCTAssertEqual(outcome, .released)
+    }
+
+    /// Shutdown. A runtime that exits without doing this leaves a hook parked against a
+    /// socket nobody is listening on, which is the one failure this feature must not have.
+    func testReleasingEverythingAnswersEveryHeldBoundary() async {
+        let waits = patientRegistry()
+        let first = Task { await waits.wait(session: "s1", timeout: 600) }
+        let second = Task { await waits.wait(session: "s2", timeout: 600) }
+        await settle()
+        XCTAssertEqual(waits.waitingCount, 2)
+
+        waits.releaseAll()
+
+        let outcomes = [await first.value, await second.value]
+        XCTAssertEqual(outcomes, [.released, .released])
+        XCTAssertFalse(waits.isWaiting)
+        XCTAssertTrue(waits.waitingSessions.isEmpty)
+    }
+
+    /// The listening loop's trigger. It has to fire on the way up *and* on the way down, or
+    /// TapQ would either listen with nobody waiting or wait with nobody listening.
+    func testTheWaitingCountIsReportedInBothDirections() async {
+        let waits = patientRegistry()
+        var counts: [Int] = []
+        waits.onWaitingChanged = { counts.append($0) }
+
+        let held = Task { await waits.wait(session: "s1", timeout: 600) }
+        await settle()
+        waits.noteInstructionQueued(session: "s1")
+        _ = await held.value
+
+        XCTAssertEqual(counts, [1, 0])
+    }
+
+    func testTheHeldSessionsAreReadableWhileTheyAreHeld() async {
+        let waits = patientRegistry()
+        let held = Task { await waits.wait(session: "s1", timeout: 600) }
+        await settle()
+
+        XCTAssertEqual(waits.waitingSessions, ["s1"])
+
+        waits.releaseAll()
+        _ = await held.value
+    }
+
+    /// Nothing held, nothing to release: the calls are no-ops rather than errors, because
+    /// the shutdown path runs whether or not a session was ever in voice mode.
+    func testReleasingWithNothingHeldIsHarmless() async {
+        let waits = patientRegistry()
+        waits.releaseAll()
+        waits.release(session: "s1")
+        waits.noteInstructionQueued(session: "s1")
+        XCTAssertFalse(waits.isWaiting)
+    }
+}

--- a/Tests/TapQContextBaselineTests/VoiceSessionDeliveryTests.swift
+++ b/Tests/TapQContextBaselineTests/VoiceSessionDeliveryTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+import TapQContracts
+@testable import TapQContextBaseline
+
+/// What a voice session changes about delivery (RH1), and what it does not.
+///
+/// Two claims. A held turn boundary drains the queue through the *same* coordinator the
+/// stop-question path drains it through — same template, same one-per-boundary rule, same
+/// memory recording — so there is one piece of code in TapQ that hands an agent a sentence
+/// nobody typed. And the loop cap, which exists because instruction-bearing blocks can
+/// chase each other, stands down in the one mode where every boundary is meant to carry
+/// one; the four-deep queue bound is untouched.
+@MainActor
+final class VoiceSessionDeliveryTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+    }
+
+    private struct NeverAQuestion: ResponseQuestionClassifying {
+        func classify(_ text: String) async -> ResponseQuestionClassification? { nil }
+    }
+
+    private struct Harness {
+        let coordinator: StopQuestionCoordinator
+        let mailbox: InstructionMailbox
+        let sink: RecordingSink
+        let recorded: () -> [String]
+        let announced: () -> [String]
+    }
+
+    private func makeHarness(voiceSession: Bool) -> Harness {
+        let sink = RecordingSink()
+        let mailbox = InstructionMailbox(diagnosticSink: sink)
+        var recorded: [String] = []
+        var announced: [String] = []
+        let coordinator = StopQuestionCoordinator(
+            classifier: NeverAQuestion(),
+            diagnosticSink: sink,
+            instructions: mailbox,
+            recordInstruction: { _, _, text in recorded.append(text) },
+            announce: { announced.append($0) },
+            suppressesLoopCap: voiceSession,
+            runSelection: { _, _ in .noSelection },
+            runApproval: { _, _ in .ask }
+        )
+        return Harness(
+            coordinator: coordinator,
+            mailbox: mailbox,
+            sink: sink,
+            recorded: { recorded },
+            announced: { announced }
+        )
+    }
+
+    // MARK: - The held boundary drains the same queue
+
+    func testAHeldBoundaryDeliversWithTheRatifiedTemplate() async {
+        let harness = makeHarness(voiceSession: true)
+        harness.mailbox.enqueue("run the tests again", session: "s1")
+
+        let reply = harness.coordinator.deliverInstruction(
+            sessionID: "s1", agent: .claudeCode
+        )
+
+        XCTAssertEqual(
+            reply,
+            "The user dictated a new instruction via TapQ hands-free: "
+                + "'run the tests again'. Proceed accordingly.",
+            "a held boundary and a stop question must hand over identical text"
+        )
+        XCTAssertEqual(harness.recorded(), ["run the tests again"],
+                       "and it is remembered as work handed over")
+        XCTAssertFalse(harness.mailbox.hasPending(session: "s1"))
+    }
+
+    func testAHeldBoundaryWithNothingQueuedDeliversNothing() async {
+        let harness = makeHarness(voiceSession: true)
+        XCTAssertNil(harness.coordinator.deliverInstruction(sessionID: "s1", agent: .claudeCode))
+        XCTAssertEqual(harness.recorded(), [])
+    }
+
+    func testAHeldBoundaryDrainsOnlyItsOwnSession() async {
+        let harness = makeHarness(voiceSession: true)
+        harness.mailbox.enqueue("run the tests again", session: "s1")
+
+        XCTAssertNil(harness.coordinator.deliverInstruction(sessionID: "s2", agent: .claudeCode))
+        XCTAssertTrue(harness.mailbox.hasPending(session: "s1"))
+    }
+
+    func testAHeldBoundaryTakesExactlyOneInstruction() async {
+        let harness = makeHarness(voiceSession: true)
+        harness.mailbox.enqueue("first", session: "s1")
+        harness.mailbox.enqueue("second", session: "s1")
+
+        let reply = harness.coordinator.deliverInstruction(sessionID: "s1", agent: .claudeCode)
+
+        XCTAssertTrue(reply?.contains("'first'") == true)
+        XCTAssertEqual(harness.mailbox.pendingCount(session: "s1"), 1,
+                       "the next boundary is a sentence away and it will take the next one")
+    }
+
+    // MARK: - The loop cap
+
+    /// The rung's bound change: in a voice session the wearer is standing at the boundary
+    /// dictating one sentence at a time, so a cap after three would hold back the fourth
+    /// thing they said and wait for a boundary only their own next sentence can produce.
+    func testTheLoopCapDoesNotFireInAVoiceSession() async {
+        let harness = makeHarness(voiceSession: true)
+        let depth = InstructionQueue.capacity
+        for index in 1...depth {
+            harness.mailbox.enqueue("instruction \(index)", session: "s1")
+        }
+
+        for index in 1...depth {
+            let reply = harness.coordinator.deliverInstruction(
+                sessionID: "s1", agent: .claudeCode
+            )
+            XCTAssertTrue(reply?.contains("'instruction \(index)'") == true,
+                          "boundary \(index) must carry its instruction")
+        }
+
+        XCTAssertFalse(harness.sink.names.contains("instruction.loop_cap.suppressed"))
+        XCTAssertEqual(harness.announced(), [], "and the wearer is never told to wait")
+        XCTAssertFalse(harness.mailbox.hasPending(session: "s1"))
+    }
+
+    /// The same script with the flag off is the shipped RC2 behavior, unchanged: three in a
+    /// row, then a spoken notice and a held instruction.
+    func testTheLoopCapStillFiresWithoutAVoiceSession() async {
+        let harness = makeHarness(voiceSession: false)
+        for index in 1...(StopQuestionCoordinator.maxConsecutiveInstructions + 1) {
+            harness.mailbox.enqueue("instruction \(index)", session: "s1")
+        }
+
+        for _ in 1...StopQuestionCoordinator.maxConsecutiveInstructions {
+            XCTAssertNotNil(harness.coordinator.deliverInstruction(
+                sessionID: "s1", agent: .claudeCode
+            ))
+        }
+
+        XCTAssertNil(harness.coordinator.deliverInstruction(sessionID: "s1", agent: .claudeCode))
+        XCTAssertEqual(harness.mailbox.pendingCount(session: "s1"), 1,
+                       "a suppressed instruction is held, never discarded")
+        XCTAssertTrue(harness.sink.names.contains("instruction.loop_cap.suppressed"))
+        XCTAssertEqual(harness.announced(), [StopQuestionCoordinator.loopCapNotice])
+    }
+
+    /// The queue bound is not the loop cap and does not stand down with it: a fifth
+    /// instruction still drops the oldest, in a voice session as anywhere else.
+    func testTheQueueBoundStillHoldsInAVoiceSession() async {
+        let harness = makeHarness(voiceSession: true)
+        for index in 1...(InstructionQueue.capacity + 1) {
+            harness.mailbox.enqueue("instruction \(index)", session: "s1")
+        }
+
+        XCTAssertEqual(harness.mailbox.pendingCount(session: "s1"), InstructionQueue.capacity)
+        let reply = harness.coordinator.deliverInstruction(sessionID: "s1", agent: .claudeCode)
+        XCTAssertTrue(reply?.contains("'instruction 2'") == true,
+                      "the oldest was dropped to make room for the newest")
+    }
+
+    /// The stop-question path in a voice-session run: an instruction still outranks every
+    /// guard, and the cap being stood down does not change what a boundary carries.
+    func testTheStopQuestionPathIsUnchangedApartFromTheCap() async {
+        let harness = makeHarness(voiceSession: true)
+        harness.mailbox.enqueue("ship it", session: "s1")
+
+        let reply = await harness.coordinator.handle(sessionID: "s1", text: "All done.")
+
+        XCTAssertTrue(reply?.contains("'ship it'") == true)
+    }
+
+    // MARK: - The enqueue observer
+
+    /// The seam the wait registry hangs on: every accepted instruction reports its session,
+    /// and an empty one — which is queued nowhere — reports nothing.
+    func testTheMailboxAnnouncesEveryAcceptedInstruction() async {
+        let mailbox = InstructionMailbox()
+        var announced: [String] = []
+        mailbox.onEnqueued = { announced.append($0) }
+
+        mailbox.enqueue("run the tests", session: "s1")
+        mailbox.enqueue("   \n  ", session: "s1")
+        mailbox.enqueue("push the branch", session: "s2")
+
+        XCTAssertEqual(announced, ["s1", "s2"],
+                       "an empty dictation queues nothing and wakes nobody")
+    }
+}

--- a/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
+++ b/Tests/TapQDetectionE2ETests/DetectionPathHarness.swift
@@ -105,6 +105,12 @@ final class DetectionPathHarness {
     ///     `hear(_:attributed:)` says so. `nil` — the default — composes nothing, leaving
     ///     attribution to `voiceGate`/`wearerAttribution`: today's `MonitorSpeechSignal`
     ///     path. When a test passes both, the scripted gate is the outer one.
+    ///   - voiceTrust: Whose voice may dictate an instruction. `.wearer` — the default —
+    ///     is every composition written before Rung E, and keeps the dictation path
+    ///     fail-closed on `wearerAttribution`.
+    ///   - gestureConfirmation: Whether a nod could still confirm a read-back, as the host
+    ///     answers it from the motion probe under `--voice-trust environment`. `nil` — the
+    ///     default — answers yes and keeps every read-back's wording unchanged.
     ///   - motionAvailable: Whether this session has a motion device, as
     ///     `HeadGestureDetector.isMotionCurrentlyAvailable` answers it for the host. It
     ///     reaches the same two places the host sends it: the swipe channel's eligibility
@@ -121,7 +127,9 @@ final class DetectionPathHarness {
              = { _ in TranscriptVoiceChannel() },
          speechDecorator: @MainActor (RecordingSpeech) -> any SpeechPresenting = { $0 },
          attribution: UtteranceAttribution? = nil,
-         motionAvailable: Bool = true) {
+         motionAvailable: Bool = true,
+         voiceTrust: VoiceTrust = .wearer,
+         gestureConfirmation: GestureConfirmationQuerying? = nil) {
         var pipeline = MotionGesturePipeline(diagnosticSink: diagnostics)
         configure(&pipeline)
         let inputs = PipelineInputAdapter(pipeline: pipeline)
@@ -175,7 +183,9 @@ final class DetectionPathHarness {
             recallResponder: recallResponder, freeformResponder: freeformResponder,
             instructionCapability: instructionCapability,
             wearerAttribution: attributionQuery,
-            instructionEnqueue: instructionEnqueue
+            instructionEnqueue: instructionEnqueue,
+            voiceTrust: voiceTrust,
+            gestureConfirmation: gestureConfirmation
         )
         selection = SelectionController(
             speech: presenter, arbiter: selectionArbiter,
@@ -189,7 +199,9 @@ final class DetectionPathHarness {
             recallResponder: recallResponder,
             instructionCapability: instructionCapability,
             wearerAttribution: attributionQuery,
-            instructionEnqueue: instructionEnqueue
+            instructionEnqueue: instructionEnqueue,
+            voiceTrust: voiceTrust,
+            gestureConfirmation: gestureConfirmation
         )
         let clock = self.clock
         interaction.now = { clock.now }

--- a/Tests/TapQDetectionE2ETests/VoiceSessionE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/VoiceSessionE2ETests.swift
@@ -1,0 +1,323 @@
+import Foundation
+import XCTest
+import TapQBrokerRuntime
+import TapQCLI
+import TapQContextBaseline
+import TapQContracts
+import TapQWireProtocol
+@testable import TapQInteractionBaseline
+
+/// Rung H leg 1 end to end: a Stop hook's wire message goes in, minutes pass, and the
+/// sentence the wearer spoke comes back out as the reply that restarts the agent's turn.
+///
+/// The composition is the runtime's own — a real `BrokerServer` over a real wire message, a
+/// real `InstructionWaitRegistry`, the real `StopQuestionCoordinator` draining the real
+/// `InstructionMailbox` — with the ten-minute budget as the only thing substituted.
+@MainActor
+final class VoiceSessionE2ETests: XCTestCase {
+    private static let session = "s1"
+
+    private struct NeverAQuestion: ResponseQuestionClassifying {
+        func classify(_ text: String) async -> ResponseQuestionClassification? { nil }
+    }
+
+    /// The runtime's own wiring of the wait arm, minus the microphone: anything already
+    /// queued is delivered at once, otherwise the boundary is held until the registry says
+    /// otherwise.
+    private func makeServer(
+        transport: InMemoryBrokerTransport,
+        mailbox: InstructionMailbox,
+        waits: InstructionWaitRegistry,
+        memory: ConversationMemory
+    ) -> BrokerServer {
+        let coordinator = StopQuestionCoordinator(
+            classifier: NeverAQuestion(),
+            instructions: mailbox,
+            recordInstruction: memory.instructionRecorder,
+            suppressesLoopCap: true,
+            runSelection: { _, _ in .noSelection },
+            runApproval: { _, _ in .ask }
+        )
+        mailbox.onEnqueued = { [weak waits] session in
+            waits?.noteInstructionQueued(session: session)
+        }
+        return BrokerServer(
+            transport: transport,
+            token: "tok",
+            onApproval: { _ in .ask },
+            onNotification: { _ in },
+            onStopQuestion: { await coordinator.handle($0) },
+            onInstructionWait: { waiting in
+                if let ready = coordinator.deliverInstruction(
+                    sessionID: waiting.sessionID, agent: waiting.agent
+                ) {
+                    return ready
+                }
+                switch await waits.wait(session: waiting.sessionID, timeout: 600) {
+                case .instructionQueued:
+                    return coordinator.deliverInstruction(
+                        sessionID: waiting.sessionID, agent: waiting.agent
+                    )
+                case .timedOut, .released:
+                    return nil
+                }
+            }
+        )
+    }
+
+    private func patientWaits() -> InstructionWaitRegistry {
+        InstructionWaitRegistry(sleep: { _ in try? await Task.sleep(for: .seconds(60)) })
+    }
+
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    /// The doorbell: the hook asks, nothing is queued, the wearer dictates two minutes
+    /// later, and the wire answers with the instruction rather than with silence.
+    func testAHeldBoundaryIsAnsweredWhenAnInstructionIsQueued() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let waits = patientWaits()
+        let transport = InMemoryBrokerTransport()
+        let server = makeServer(
+            transport: transport, mailbox: mailbox, waits: waits, memory: memory
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let held = Task { try await transport.deliver(Data(Self.waitJSON.utf8)) }
+        await settle()
+        XCTAssertTrue(waits.isWaiting, "the boundary must still be open")
+
+        // What a confirmed dictation does, from any of the three places one can arrive.
+        mailbox.enqueue("also update the changelog", session: Self.session)
+
+        let response = try JSONDecoder().decode(BrokerResponse.self, from: try await held.value)
+        XCTAssertEqual(
+            response,
+            .instructionWait(
+                instruction: "The user dictated a new instruction via TapQ hands-free: "
+                    + "'also update the changelog'. Proceed accordingly."
+            )
+        )
+        XCTAssertFalse(mailbox.hasPending(session: Self.session), "one drains per boundary")
+        XCTAssertEqual(memory.events(session: Self.session).last?.kind, .instruction,
+                       "and it is remembered as work handed over")
+    }
+
+    /// The instruction arrived before the boundary did — the wearer dictated while the agent
+    /// was still working. The hook is answered without waiting at all.
+    func testAnAlreadyQueuedInstructionIsAnsweredImmediately() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let waits = patientWaits()
+        let transport = InMemoryBrokerTransport()
+        let server = makeServer(
+            transport: transport, mailbox: mailbox, waits: waits, memory: memory
+        )
+        try server.start()
+        defer { server.stop() }
+
+        mailbox.enqueue("run the tests again", session: Self.session)
+        let response = try JSONDecoder().decode(
+            BrokerResponse.self, from: try await transport.deliver(Data(Self.waitJSON.utf8))
+        )
+
+        XCTAssertEqual(
+            response,
+            .instructionWait(
+                instruction: "The user dictated a new instruction via TapQ hands-free: "
+                    + "'run the tests again'. Proceed accordingly."
+            )
+        )
+        XCTAssertFalse(waits.isWaiting, "nothing was ever held")
+    }
+
+    /// Ten minutes of silence. The boundary goes, the Stop proceeds, and the session idles
+    /// normally — a clean exit from the mode rather than a failure.
+    func testAnExpiredBudgetAnswersWithNoInstruction() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let waits = InstructionWaitRegistry(sleep: { _ in })
+        let transport = InMemoryBrokerTransport()
+        let server = makeServer(
+            transport: transport, mailbox: mailbox, waits: waits, memory: memory
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let response = try JSONDecoder().decode(
+            BrokerResponse.self, from: try await transport.deliver(Data(Self.waitJSON.utf8))
+        )
+        XCTAssertEqual(response, .instructionWait(instruction: nil))
+    }
+
+    /// The runtime is going away. It answers every held boundary on the way out rather than
+    /// leaving a hook parked against a socket nobody will ever read.
+    func testShutdownAnswersEveryHeldBoundary() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let waits = patientWaits()
+        let transport = InMemoryBrokerTransport()
+        let server = makeServer(
+            transport: transport, mailbox: mailbox, waits: waits, memory: memory
+        )
+        try server.start()
+
+        let held = Task { try await transport.deliver(Data(Self.waitJSON.utf8)) }
+        await settle()
+        XCTAssertTrue(waits.isWaiting)
+
+        // What the runtime's `defer` does, in the order it does it.
+        waits.releaseAll()
+        server.stop()
+
+        let response = try JSONDecoder().decode(BrokerResponse.self, from: try await held.value)
+        XCTAssertEqual(response, .instructionWait(instruction: nil))
+    }
+
+    /// The wearer said "end voice session": the boundary is let go with nothing on it, and
+    /// the queue is untouched because nothing was ever dictated.
+    func testEndingTheSessionReleasesTheBoundaryWithNoInstruction() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let waits = patientWaits()
+        let transport = InMemoryBrokerTransport()
+        let server = makeServer(
+            transport: transport, mailbox: mailbox, waits: waits, memory: memory
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let held = Task { try await transport.deliver(Data(Self.waitJSON.utf8)) }
+        await settle()
+
+        waits.release(session: Self.session)
+
+        let response = try JSONDecoder().decode(BrokerResponse.self, from: try await held.value)
+        XCTAssertEqual(response, .instructionWait(instruction: nil))
+        XCTAssertFalse(waits.isWaiting)
+    }
+
+    /// A held boundary does not block the broker. An approval arriving while a session is
+    /// parked is answered on its own terms, at once.
+    func testAHeldBoundaryDoesNotBlockTheRestOfTheBroker() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let waits = patientWaits()
+        let transport = InMemoryBrokerTransport()
+        let server = makeServer(
+            transport: transport, mailbox: mailbox, waits: waits, memory: memory
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let held = Task { try await transport.deliver(Data(Self.waitJSON.utf8)) }
+        await settle()
+
+        let approval = try JSONDecoder().decode(
+            BrokerResponse.self,
+            from: try await transport.deliver(Data(Self.approvalJSON.utf8))
+        )
+        XCTAssertEqual(approval, .decision(.ask, reason: nil),
+                       "the approval was answered while a boundary was still held")
+
+        waits.releaseAll()
+        _ = try await held.value
+    }
+
+    /// A runtime with no voice session composed answers the wait the moment it arrives.
+    /// A newer shim talking to it therefore behaves exactly like an older one.
+    func testARuntimeWithoutAVoiceSessionNeverHoldsAnything() async throws {
+        let transport = InMemoryBrokerTransport()
+        let server = BrokerServer(
+            transport: transport,
+            token: "tok",
+            onApproval: { _ in .ask },
+            onNotification: { _ in }
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let response = try JSONDecoder().decode(
+            BrokerResponse.self, from: try await transport.deliver(Data(Self.waitJSON.utf8))
+        )
+        XCTAssertEqual(response, .instructionWait(instruction: nil))
+    }
+
+    /// The version gate: a peer that stamped v5 cannot have meant a v6 message, and a
+    /// broker that accepted one would be reading a shape that peer never wrote.
+    func testAWaitStampedWithAnOlderVersionIsRejected() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let waits = patientWaits()
+        let transport = InMemoryBrokerTransport()
+        let server = makeServer(
+            transport: transport, mailbox: mailbox, waits: waits, memory: memory
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let response = try JSONDecoder().decode(
+            BrokerResponse.self,
+            from: try await transport.deliver(Data(Self.staleWaitJSON.utf8))
+        )
+        XCTAssertEqual(response, .error("protocol_version"))
+        XCTAssertFalse(waits.isWaiting, "a rejected wait must not hold anything")
+    }
+
+    /// And the older messages a v5 shim does send still work against this runtime, which is
+    /// the whole point of accepting the previous versions.
+    func testAnOlderShimsStopQuestionStillWorks() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let waits = patientWaits()
+        let transport = InMemoryBrokerTransport()
+        let server = makeServer(
+            transport: transport, mailbox: mailbox, waits: waits, memory: memory
+        )
+        try server.start()
+        defer { server.stop() }
+
+        mailbox.enqueue("ship it", session: Self.session)
+        let response = try JSONDecoder().decode(
+            BrokerResponse.self,
+            from: try await transport.deliver(Data(Self.stopQuestionJSON.utf8))
+        )
+        XCTAssertEqual(
+            response,
+            .stopQuestion(reply: "The user dictated a new instruction via TapQ hands-free: "
+                + "'ship it'. Proceed accordingly.")
+        )
+    }
+
+    // MARK: - Fixtures
+
+    /// What a Claude Stop hook sends when the runtime advertises a voice session.
+    private static let waitJSON = """
+        {"type":"instruction.wait","token":"tok","protocol_version":6,\
+        "agent":{"id":"claude-code","display_name":"Claude Code"},\
+        "session_id":"s1","request_id":"w1"}
+        """
+
+    /// The same message from a shim that speaks the previous wire version.
+    private static let staleWaitJSON = """
+        {"type":"instruction.wait","token":"tok","protocol_version":5,\
+        "agent":{"id":"claude-code","display_name":"Claude Code"},\
+        "session_id":"s1","request_id":"w1"}
+        """
+
+    private static let stopQuestionJSON = """
+        {"type":"stop.question","token":"tok","protocol_version":5,\
+        "agent":{"id":"claude-code","display_name":"Claude Code"},\
+        "session_id":"s1","text":"All done — the tests are green.","request_id":"q1"}
+        """
+
+    private static let approvalJSON = """
+        {"type":"approval.request","token":"tok","protocol_version":6,\
+        "agent":{"id":"claude-code","display_name":"Claude Code"},\
+        "session_id":"s2","tool_name":"Bash","tool_input":{},\
+        "approval_source":"pre_tool_use","request_id":"r1"}
+        """
+}

--- a/Tests/TapQDetectionE2ETests/VoiceTrustE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/VoiceTrustE2ETests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import XCTest
+import TapQBrokerRuntime
+import TapQCLI
+import TapQContextBaseline
+import TapQContracts
+import TapQDetectionBaseline
+import TapQWireProtocol
+@testable import TapQInteractionBaseline
+
+/// Rung E end to end: the run a wearer starts with their AirPods in the case.
+///
+/// The composition is the runtime's own minus the microphone, exactly as
+/// `InstructionPathE2ETests` composes it — same grammar, same queue, same coordinator, same
+/// wire — with one difference and one difference only: `--voice-trust environment`, and
+/// therefore no attribution signal at all. The suite exists to pin what that buys (a
+/// dictation that reaches the agent) and what it must not cost (an approval that behaves
+/// any differently).
+@MainActor
+final class VoiceTrustE2ETests: XCTestCase {
+    private static let session = "s1"
+
+    private func request(summary: String = "run npm test") -> ApprovalRequest {
+        ApprovalRequest(
+            id: "r1", sessionID: Self.session, agent: .claudeCode, toolName: "Bash",
+            summary: summary, detail: "npm test"
+        )
+    }
+
+    /// The whole rung, wire to wire: no AirPods, no attribution, a spoken sentence, a spoken
+    /// yes, and an agent that is told about it at its next turn boundary.
+    ///
+    /// Note what is *not* here: a nod. There is no motion device in this session, so the
+    /// read-back never mentions one and the confirmation is the wearer's own "yes" through
+    /// the real grammar.
+    func testEnvironmentTrustDictationReachesTheAgentWithNoAttributionSignal() async throws {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let harness = DetectionPathHarness(
+            instructionCapability: memory.instructionCapability,
+            // The fail-closed answer, every time it is asked. Under environment trust it is
+            // never asked, which is the claim.
+            wearerAttribution: { false },
+            instructionEnqueue: memory.instructionEnqueue,
+            motionAvailable: false,
+            voiceTrust: .environment,
+            gestureConfirmation: { false }
+        )
+
+        let approval = request()
+        let decision = Task {
+            await memory.withWindow(
+                sessionID: approval.sessionID,
+                agent: approval.agent,
+                summary: approval.summary,
+                detail: approval.detail
+            ) {
+                await harness.interaction.resolve(approval)
+            }
+        }
+        let opened = await harness.waitForWindow(1)
+        XCTAssertTrue(opened, "the approval opened no input window")
+
+        harness.hear("tell it to run the tests again")
+
+        let readBackWindow = await harness.waitForWindow(2)
+        XCTAssertTrue(readBackWindow, "the read-back must re-listen")
+        XCTAssertTrue(
+            harness.speech.said("Instruction: 'run the tests again.' Say yes to queue it."),
+            "the read-back must not ask for a gesture nobody can make: "
+                + "\(harness.speech.spoken.map(\.text))"
+        )
+        XCTAssertTrue(mailbox.pending(session: Self.session).isEmpty,
+                      "nothing may be queued before the wearer confirms it")
+
+        harness.hear("yes")
+        let resumed = await harness.waitForWindow(3)
+        XCTAssertTrue(resumed, "queueing must resume the window")
+        XCTAssertTrue(harness.speech.said("Queued for Claude Code."))
+        XCTAssertEqual(mailbox.pending(session: Self.session).map(\.text),
+                       ["run the tests again"])
+        XCTAssertTrue(harness.diagnostics.events.contains {
+            $0.name == "instruction.trusted_environment"
+        }, "the bypass must be diagnosable")
+        XCTAssertFalse(harness.diagnostics.events.contains {
+            $0.name == "instruction.rejected_unattributed"
+        })
+
+        // The approval the wearer was asked about is untouched by all of it, and answering
+        // it is still what ends the window.
+        harness.hear("no")
+        let outcome = await decision.value
+        harness.assertWatchdogDidNotFire()
+        XCTAssertEqual(outcome, .deny, "dictation must never resolve the request")
+
+        // The turn boundary, on the wire, over the runtime's own coordinator.
+        let coordinator = StopQuestionCoordinator(
+            classifier: NeverAQuestion(),
+            instructions: mailbox,
+            recordInstruction: memory.instructionRecorder,
+            runSelection: { _, _ in .noSelection },
+            runApproval: { _, _ in .ask }
+        )
+        let transport = InMemoryBrokerTransport()
+        let server = BrokerServer(
+            transport: transport,
+            token: "tok",
+            onApproval: { _ in .ask },
+            onNotification: { _ in },
+            onStopQuestion: { await coordinator.handle($0) }
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let responseData = try await transport.deliver(Data(Self.stopQuestionJSON.utf8))
+        let response = try JSONDecoder().decode(BrokerResponse.self, from: responseData)
+        XCTAssertEqual(
+            response,
+            .stopQuestion(reply: "The user dictated a new instruction via TapQ hands-free: "
+                + "'run the tests again'. Proceed accordingly."),
+            "the boundary must carry the instruction the room dictated"
+        )
+    }
+
+    /// The same session, the same missing signal, under the default posture: refused out
+    /// loud and queued nowhere. This is the test that would fail if environment trust ever
+    /// leaked into a default-flag run.
+    func testTheSameDictationIsStillRefusedUnderWearerTrust() async {
+        let mailbox = InstructionMailbox()
+        let memory = ConversationMemory(instructions: mailbox)
+        let harness = DetectionPathHarness(
+            instructionCapability: memory.instructionCapability,
+            wearerAttribution: { false },
+            instructionEnqueue: memory.instructionEnqueue,
+            motionAvailable: false
+        )
+
+        let approval = request()
+        let decision = Task {
+            await memory.withWindow(
+                sessionID: approval.sessionID,
+                agent: approval.agent,
+                summary: approval.summary
+            ) {
+                await harness.interaction.resolve(approval)
+            }
+        }
+        let opened = await harness.waitForWindow(1)
+        XCTAssertTrue(opened)
+
+        harness.hear("tell it to run the tests again")
+
+        let refusalWindow = await harness.waitForWindow(2)
+        XCTAssertTrue(refusalWindow, "a refusal must re-listen, not resolve")
+        XCTAssertTrue(
+            harness.speech.said("I can't confirm that was you — instruction discarded."),
+            "spoke: \(harness.speech.spoken.map(\.text))"
+        )
+        XCTAssertTrue(mailbox.pending(session: Self.session).isEmpty)
+
+        harness.hear("yes")
+        let outcome = await decision.value
+        harness.assertWatchdogDidNotFire()
+        XCTAssertEqual(outcome, .allow, "the wearer's own request still answers normally")
+    }
+
+    /// Trust is a policy about instructions. An approval spoken into an environment-trust
+    /// run resolves through exactly the path it always did, including the fail-open one.
+    func testEnvironmentTrustLeavesTheApprovalPathAlone() async {
+        let harness = DetectionPathHarness(
+            motionAvailable: false,
+            voiceTrust: .environment,
+            gestureConfirmation: { false }
+        )
+        let decision = Task { await harness.interaction.resolve(self.request()) }
+        let opened = await harness.waitForWindow(1)
+        XCTAssertTrue(opened)
+
+        harness.hear("no")
+
+        let outcome = await decision.value
+        harness.assertWatchdogDidNotFire()
+        XCTAssertEqual(outcome, .deny)
+        XCTAssertTrue(harness.speech.spoken.contains { $0.text.contains("run npm test") })
+    }
+
+    // MARK: - Fixtures
+
+    /// The wire message a Claude stop hook sends at the end of a turn.
+    private static let stopQuestionJSON = """
+        {"type":"stop.question","token":"tok","protocol_version":5,\
+        "agent":{"id":"claude-code","display_name":"Claude Code"},\
+        "session_id":"s1","text":"All done — the tests are green.","request_id":"q1"}
+        """
+
+    /// The classifier that finds no question in the agent's reply, so the only reply the
+    /// boundary can produce is the queued sentence.
+    private struct NeverAQuestion: ResponseQuestionClassifying {
+        func classify(_ text: String) async -> ResponseQuestionClassification? { nil }
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/CommandWindowControllerTests.swift
+++ b/Tests/TapQInteractionBaselineTests/CommandWindowControllerTests.swift
@@ -91,15 +91,24 @@ final class CommandWindowControllerTests: XCTestCase {
 
     // MARK: - It cannot resolve anything
 
-    /// The type-level half of the claim. Every stored property is a count: there is no
-    /// field an allow, a deny, or a chosen option could ride out on.
+    /// The type-level half of the claim. Every stored property is a count or the
+    /// end-of-listening marker: there is no field an allow, a deny, or a chosen option
+    /// could ride out on. `endedByWearer` is a `Bool` by design — a flag can say "stop
+    /// re-opening windows", and nothing else; a payload could not be smuggled through it.
     func testOutcomeCannotCarryADecision() async {
-        let outcome = CommandWindowOutcome(answers: 1, ignored: 2, dictations: 3)
+        let outcome = CommandWindowOutcome(
+            answers: 1, ignored: 2, dictations: 3, endedByWearer: true
+        )
         let children = Array(Mirror(reflecting: outcome).children)
-        XCTAssertEqual(children.count, 3)
+        XCTAssertEqual(children.count, 4)
         for child in children {
-            XCTAssertTrue(child.value is Int,
-                          "\(child.label ?? "?") is not a count — the window may have grown a way to resolve something")
+            if child.label == "endedByWearer" {
+                XCTAssertTrue(child.value is Bool,
+                              "endedByWearer must stay a bare flag — anything richer could carry a decision")
+            } else {
+                XCTAssertTrue(child.value is Int,
+                              "\(child.label ?? "?") is not a count — the window may have grown a way to resolve something")
+            }
         }
     }
 

--- a/Tests/TapQInteractionBaselineTests/VoiceSessionWindowTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceSessionWindowTests.swift
@@ -1,0 +1,264 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+/// The waiting window (RH1): the attention window with two differences, and no third.
+///
+/// A wearer standing at a held turn boundary is there to say the agent's next instruction,
+/// so an unmatched sentence is dictation rather than silence, and there is a way to say
+/// they are done. Everything else — the grammar, the eight seconds, the refusal to resolve
+/// anything, the read-back before anything is queued — is the window Rung D shipped, and
+/// half of this file is the assertion that it still is.
+@MainActor
+final class VoiceSessionWindowTests: XCTestCase {
+    @MainActor
+    private final class FakeSpeech: SpeechPresenting {
+        var spoken: [String] = []
+        func speak(_ text: String, priority: SpeechPriority, onFinish: (() -> Void)?) {
+            spoken.append(text)
+            onFinish?()
+        }
+        func stopAll() {}
+        func said(containing needle: String) -> Bool {
+            spoken.contains { $0.contains(needle) }
+        }
+    }
+
+    @MainActor
+    private final class ScriptedArbiter: InputArbitrating {
+        private let script: [InputIntent?]
+        private(set) var calls = 0
+        init(_ script: [InputIntent?]) { self.script = script }
+        func listen(timeout: TimeInterval) async -> InputIntent? {
+            defer { calls += 1 }
+            return calls < script.count ? script[calls] : nil
+        }
+    }
+
+    @MainActor
+    private final class Inbox {
+        var queued: [String] = []
+        var enqueue: InstructionDictating { { [self] text in queued.append(text) } }
+    }
+
+    private func window(
+        _ script: [InputIntent?],
+        speech: FakeSpeech,
+        inbox: Inbox? = nil,
+        kind: CommandWindowKind,
+        cue: String? = CommandWindowController.voiceSessionCue
+    ) -> CommandWindowController {
+        CommandWindowController(
+            speech: speech,
+            arbiter: ScriptedArbiter(script),
+            gate: InteractionGate(),
+            cue: cue,
+            agentDisplayName: "Claude Code",
+            instructionCapability: { true },
+            wearerAttribution: { true },
+            instructionEnqueue: inbox?.enqueue,
+            kind: kind
+        )
+    }
+
+    // MARK: - An unmatched sentence is the instruction
+
+    /// The rung, in one window: no prefix, a read-back, a spoken yes, and the sentence is in
+    /// the queue that a held boundary drains.
+    func testAnUnmatchedSentenceIsDictatedWithNoPrefix() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let outcome = await window(
+            [.freeform("also update the changelog"), .allow],
+            speech: speech, inbox: inbox, kind: .voiceSession
+        ).run()
+
+        XCTAssertEqual(inbox.queued, ["also update the changelog"])
+        XCTAssertTrue(speech.said(containing: "Instruction: 'also update the changelog.'"),
+                      "spoke: \(speech.spoken)")
+        XCTAssertTrue(speech.said(containing: "Queued for Claude Code."))
+        XCTAssertEqual(outcome.dictations, 1)
+        XCTAssertFalse(outcome.endedByWearer)
+    }
+
+    /// Nothing is queued on the strength of a sentence alone. The read-back is the whole
+    /// safety of dictating without a prefix, so a declined one sends nothing.
+    func testADeclinedReadBackQueuesNothing() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        _ = await window(
+            [.freeform("delete the branch"), .deny],
+            speech: speech, inbox: inbox, kind: .voiceSession
+        ).run()
+
+        XCTAssertEqual(inbox.queued, [])
+        XCTAssertTrue(speech.said(containing: "Instruction discarded."))
+    }
+
+    /// The Rung D window is untouched: an overheard sentence there is still ignored in
+    /// silence, and nothing reaches the queue.
+    func testAnAttentionWindowStillIgnoresUnmatchedSpeech() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let outcome = await window(
+            [.freeform("also update the changelog"), .allow],
+            speech: speech, inbox: inbox, kind: .attention,
+            cue: CommandWindowController.defaultCue
+        ).run()
+
+        XCTAssertEqual(inbox.queued, [])
+        XCTAssertEqual(outcome.dictations, 0)
+        XCTAssertFalse(speech.said(containing: "Instruction:"))
+    }
+
+    /// The prefixes did not go anywhere. They still open dictation, in either window.
+    func testThePrefixStillWorksInsideAWaitingWindow() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        _ = await window(
+            [.beginInstruction("run the tests again"), .allow],
+            speech: speech, inbox: inbox, kind: .voiceSession
+        ).run()
+
+        XCTAssertEqual(inbox.queued, ["run the tests again"])
+    }
+
+    // MARK: - The grammar still answers
+
+    func testGrammarCommandsAnswerAsTheyAlwaysHave() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let controller = CommandWindowController(
+            speech: speech,
+            arbiter: ScriptedArbiter([.status, nil]),
+            gate: InteractionGate(),
+            cue: CommandWindowController.voiceSessionCue,
+            recallResponder: { _ in "Nothing is waiting." },
+            instructionCapability: { true },
+            wearerAttribution: { true },
+            instructionEnqueue: inbox.enqueue,
+            kind: .voiceSession
+        )
+
+        let outcome = await controller.run()
+
+        XCTAssertEqual(outcome.answers, 1)
+        XCTAssertEqual(inbox.queued, [], "a matched command is not a dictation")
+        XCTAssertTrue(speech.said(containing: "Nothing is waiting."))
+    }
+
+    /// A waiting window is still a window that cannot resolve anything: "yes" with nothing
+    /// on the table is answered, not acted on.
+    func testAWaitingWindowStillCannotApproveAnything() async {
+        let speech = FakeSpeech()
+        let outcome = await window(
+            [.allow, .select, nil], speech: speech, kind: .voiceSession
+        ).run()
+
+        XCTAssertEqual(outcome.ignored, 2)
+        XCTAssertFalse(outcome.endedByWearer)
+        XCTAssertTrue(speech.said(containing: CommandWindowController.nothingWaiting))
+    }
+
+    // MARK: - Ending the session
+
+    func testEveryEndPhraseClosesTheLoop() async {
+        for phrase in CommandWindowController.endPhrases {
+            let speech = FakeSpeech()
+            let inbox = Inbox()
+            let outcome = await window(
+                [.freeform(phrase), .allow],
+                speech: speech, inbox: inbox, kind: .voiceSession
+            ).run()
+
+            XCTAssertTrue(outcome.endedByWearer, "'\(phrase)' must end the session")
+            XCTAssertEqual(inbox.queued, [], "'\(phrase)' is not an instruction")
+            XCTAssertTrue(speech.said(containing: CommandWindowController.voiceSessionEnded))
+        }
+    }
+
+    func testAnEndPhraseIsMatchedThroughPunctuationAndCasing() async {
+        let speech = FakeSpeech()
+        let outcome = await window(
+            [.freeform("End voice session."), nil], speech: speech, kind: .voiceSession
+        ).run()
+        XCTAssertTrue(outcome.endedByWearer)
+    }
+
+    /// "Stop", "no", "cancel" all arrive as a denial, and at a held boundary the only thing
+    /// there is to decline is the holding.
+    func testADenialEndsTheSession() async {
+        let speech = FakeSpeech()
+        let outcome = await window([.deny, .allow], speech: speech, kind: .voiceSession).run()
+
+        XCTAssertTrue(outcome.endedByWearer)
+        XCTAssertTrue(speech.said(containing: CommandWindowController.voiceSessionEnded))
+    }
+
+    /// The same denial in an attention window means what it always did: there is no request
+    /// here to say no to.
+    func testADenialInAnAttentionWindowIsStillJustIgnored() async {
+        let speech = FakeSpeech()
+        let outcome = await window(
+            [.deny, nil], speech: speech, kind: .attention,
+            cue: CommandWindowController.defaultCue
+        ).run()
+
+        XCTAssertFalse(outcome.endedByWearer)
+        XCTAssertEqual(outcome.ignored, 1)
+        XCTAssertTrue(speech.said(containing: CommandWindowController.nothingWaiting))
+    }
+
+    /// A sentence that merely mentions the words is not the phrase: ending the session is
+    /// an exact thing to say, so an instruction about it is still an instruction.
+    func testASentenceAboutEndingIsStillDictated() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let outcome = await window(
+            [.freeform("write a test for the end voice session path"), .allow],
+            speech: speech, inbox: inbox, kind: .voiceSession
+        ).run()
+
+        XCTAssertFalse(outcome.endedByWearer)
+        XCTAssertEqual(inbox.queued, ["write a test for the end voice session path"])
+    }
+
+    /// Ending stops the window there and then: nothing after it is heard, because there is
+    /// nothing left to hear it for.
+    func testTheWindowStopsListeningOnceTheSessionEnds() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let arbiter = ScriptedArbiter([.freeform("stop listening"),
+                                       .freeform("also update the changelog"), .allow])
+        let controller = CommandWindowController(
+            speech: speech, arbiter: arbiter, gate: InteractionGate(),
+            cue: CommandWindowController.voiceSessionCue,
+            instructionCapability: { true },
+            wearerAttribution: { true },
+            instructionEnqueue: inbox.enqueue,
+            kind: .voiceSession
+        )
+
+        let outcome = await controller.run()
+
+        XCTAssertTrue(outcome.endedByWearer)
+        XCTAssertEqual(inbox.queued, [])
+        XCTAssertEqual(arbiter.calls, 1, "the loop ended with the phrase")
+    }
+
+    // MARK: - The cue
+
+    /// The boundary announces itself once; a re-opened window listens in silence, because a
+    /// window that said "Listening." every eight seconds would talk over the wearer.
+    func testAReopenedWindowSaysNothing() async {
+        let speech = FakeSpeech()
+        _ = await window([nil], speech: speech, kind: .voiceSession, cue: nil).run()
+        XCTAssertEqual(speech.spoken, [])
+    }
+
+    func testTheFirstWindowSpeaksTheListeningCue() async {
+        let speech = FakeSpeech()
+        _ = await window([nil], speech: speech, kind: .voiceSession).run()
+        XCTAssertEqual(speech.spoken, [CommandWindowController.voiceSessionCue])
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/VoiceTrustDictationTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceTrustDictationTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+/// Rung E at the controller level: what `--voice-trust environment` changes about a
+/// dictation, and — the larger half of the suite — everything it must leave alone.
+///
+/// Two claims run through it. An environment-trust run accepts the sentence a wearer-trust
+/// run would have refused, and says in the diagnostics that it did. And nothing about an
+/// *approval* moves: the cues, the confirmation channels, and the fail-open timeout are the
+/// ones this repo has always had, because trust is a policy about instructions and an
+/// instruction has never authorized anything.
+@MainActor
+final class VoiceTrustDictationTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        func fields(of name: String) -> [[String: String]] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.filter { $0.name == name }.map(\.fields)
+        }
+    }
+
+    @MainActor
+    private final class FakeSpeech: SpeechPresenting {
+        var spoken: [String] = []
+        func speak(_ text: String, priority: SpeechPriority, onFinish: (() -> Void)?) {
+            spoken.append(text)
+            onFinish?()
+        }
+        func stopAll() {}
+        func said(containing needle: String) -> Bool {
+            spoken.contains { $0.contains(needle) }
+        }
+    }
+
+    @MainActor
+    private final class ScriptedArbiter: InputArbitrating {
+        private let script: [InputIntent?]
+        private(set) var calls = 0
+        init(_ script: [InputIntent?]) { self.script = script }
+        func listen(timeout: TimeInterval) async -> InputIntent? {
+            defer { calls += 1 }
+            return calls < script.count ? script[calls] : nil
+        }
+    }
+
+    @MainActor
+    private final class Inbox {
+        var queued: [String] = []
+        var enqueue: InstructionDictating { { [self] text in queued.append(text) } }
+    }
+
+    private func request() -> ApprovalRequest {
+        ApprovalRequest(id: "1", sessionID: "s1", agent: .claudeCode, toolName: "Bash",
+                        summary: "run npm test", detail: "full detail")
+    }
+
+    private func controller(
+        _ script: [InputIntent?],
+        speech: FakeSpeech,
+        sink: RecordingSink = RecordingSink(),
+        inbox: Inbox,
+        trust: VoiceTrust,
+        gestures: GestureConfirmationQuerying? = nil
+    ) -> InteractionController {
+        InteractionController(
+            speech: speech, arbiter: ScriptedArbiter(script), diagnosticSink: sink,
+            instructionCapability: { true },
+            // Deliberately the refusing answer everywhere in this file: it is what makes
+            // "environment trust queued it anyway" mean something.
+            wearerAttribution: { false },
+            instructionEnqueue: inbox.enqueue,
+            voiceTrust: trust,
+            gestureConfirmation: gestures
+        )
+    }
+
+    // MARK: - The bypass
+
+    /// The rung: a dictation no attribution signal would have accepted reaches the queue,
+    /// after the same read-back and the same spoken confirmation as always.
+    func testEnvironmentTrustQueuesADictationAttributionWouldHaveRefused() async {
+        let speech = FakeSpeech()
+        let sink = RecordingSink()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.beginInstruction("run the tests again"), .allow, .deny],
+            speech: speech, sink: sink, inbox: inbox, trust: .environment
+        )
+
+        let decision = await controller.resolve(request())
+
+        XCTAssertEqual(inbox.queued, ["run the tests again"])
+        XCTAssertTrue(speech.said(containing: "Queued for Claude Code."))
+        XCTAssertEqual(decision, .deny,
+                       "the confirming yes was spent inside the flow, as it always is")
+    }
+
+    /// The bypass is never silent: both stages the wearer-trust path would have checked
+    /// record that trust was environmental instead, so a log can always say which posture
+    /// a queued instruction was accepted under.
+    func testTheBypassIsRecordedAtEveryStageAttributionWouldHaveChecked() async {
+        let sink = RecordingSink()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.beginInstruction("open a pull request"), .allow, .deny],
+            speech: FakeSpeech(), sink: sink, inbox: inbox, trust: .environment
+        )
+
+        _ = await controller.resolve(request())
+
+        XCTAssertEqual(sink.fields(of: "instruction.trusted_environment").map { $0["stage"] },
+                       ["begin", "text"])
+        XCTAssertFalse(sink.names.contains("instruction.rejected_unattributed"),
+                       "there is nothing to reject when nothing was checked")
+    }
+
+    /// The regression guard for every default-flag run: the identical script under wearer
+    /// trust is still refused out loud, and still queues nothing.
+    func testWearerTrustStillRefusesTheSameDictation() async {
+        let speech = FakeSpeech()
+        let sink = RecordingSink()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.beginInstruction("run the tests again"), .allow, .deny],
+            speech: speech, sink: sink, inbox: inbox, trust: .wearer
+        )
+
+        _ = await controller.resolve(request())
+
+        XCTAssertEqual(inbox.queued, [])
+        XCTAssertTrue(speech.said(containing: "I can't confirm that was you"))
+        XCTAssertEqual(sink.fields(of: "instruction.rejected_unattributed").map { $0["stage"] },
+                       ["begin"])
+        XCTAssertFalse(sink.names.contains("instruction.trusted_environment"))
+    }
+
+    // MARK: - Read-back wording
+
+    /// The default composition — every run before this rung — asks for the nod exactly as
+    /// it always did.
+    func testTheDefaultReadBackStillAsksForANod() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.beginInstruction("ship it"), .allow, .deny],
+            speech: speech, inbox: inbox, trust: .environment
+        )
+
+        _ = await controller.resolve(request())
+
+        XCTAssertTrue(speech.said(containing: "Instruction: 'ship it.' Nod or say yes to queue it."),
+                      "spoke: \(speech.spoken)")
+    }
+
+    /// With no earbuds there is no nod and no tap, and a read-back that asks for one is
+    /// telling the wearer to do something that cannot resolve anything.
+    func testTheReadBackNeverMentionsNoddingWhenNoddingIsImpossible() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.beginInstruction("ship it"), .allow, .deny],
+            speech: speech, inbox: inbox, trust: .environment, gestures: { false }
+        )
+
+        _ = await controller.resolve(request())
+
+        XCTAssertTrue(speech.said(containing: "Instruction: 'ship it.' Say yes to queue it."),
+                      "spoke: \(speech.spoken)")
+        XCTAssertFalse(speech.spoken.contains { $0.contains("Nod") })
+        XCTAssertEqual(inbox.queued, ["ship it"], "and the spoken yes still queues it")
+    }
+
+    /// AirPods that are in: the gesture half is offered again, because it works again.
+    func testTheReadBackOffersTheNodWhileGesturesCanStillArrive() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.beginInstruction("ship it"), .allow, .deny],
+            speech: speech, inbox: inbox, trust: .environment, gestures: { true }
+        )
+
+        _ = await controller.resolve(request())
+
+        XCTAssertTrue(speech.said(containing: "Nod or say yes to queue it."))
+    }
+
+    // MARK: - Approvals are untouched
+
+    /// The invariant this whole rung is written under. Trust says who may *instruct*; an
+    /// escalated approval still collects two independent channels, and the cues that ask
+    /// for them are the ones the repo already shipped.
+    func testEnvironmentTrustChangesNothingAboutAnEscalatedApproval() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.allow, .allow, nil], speech: speech, inbox: inbox, trust: .environment
+        )
+
+        let decision = await controller.resolve(
+            request(), requiredConfirmation: .gestureAndVoice
+        )
+
+        XCTAssertEqual(decision, .ask,
+                       "two provenance-free allows may not satisfy two channels")
+        XCTAssertTrue(speech.said(containing: "Risky action. Say yes to confirm."))
+        XCTAssertTrue(speech.said(containing: "Deferring to the screen."))
+        XCTAssertEqual(inbox.queued, [])
+    }
+
+    /// And the ordinary approval still resolves on the first allow under either posture.
+    func testEnvironmentTrustLeavesAStandardApprovalAlone() async {
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.allow], speech: FakeSpeech(), inbox: inbox, trust: .environment
+        )
+        let decision = await controller.resolve(request())
+        XCTAssertEqual(decision, .allow)
+    }
+}

--- a/Tests/TapQPOSIXBridgeClientTests/BrokerDiscoveryTests.swift
+++ b/Tests/TapQPOSIXBridgeClientTests/BrokerDiscoveryTests.swift
@@ -36,6 +36,48 @@ final class BrokerDiscoveryTests: XCTestCase {
         )
     }
 
+    /// The advertisement a Stop hook reads before it is willing to wait. Everything about
+    /// it fails closed, because the only thing a `true` can do is make a hook park itself.
+    func testVoiceSessionIsAdvertisedOnlyByALiveRuntimeThatSaysSo() throws {
+        let record = """
+        {"socket":"/tmp/tapq.sock","token":"tok","protocol_version":\(WireProtocol.version),\
+        "voice_session":true,"process_id":\(ProcessInfo.processInfo.processIdentifier)}
+        """
+        try Data(record.utf8).write(to: discovery.discoveryURL)
+        XCTAssertTrue(
+            discovery.liveVoiceSessionEnabled(socketIsReachable: { $0 == "/tmp/tapq.sock" })
+        )
+        XCTAssertFalse(
+            discovery.liveVoiceSessionEnabled(socketIsReachable: { _ in false }),
+            "a socket nobody answers is a runtime that cannot answer a wait either"
+        )
+    }
+
+    func testARuntimeThatPredatesVoiceSessionsIsNeverWaitedOn() throws {
+        let record = """
+        {"socket":"/tmp/tapq.sock","token":"tok","protocol_version":5,\
+        "steering_enabled":true,"process_id":\(ProcessInfo.processInfo.processIdentifier)}
+        """
+        try Data(record.utf8).write(to: discovery.discoveryURL)
+        XCTAssertFalse(
+            discovery.liveVoiceSessionEnabled(socketIsReachable: { _ in true }),
+            "an absent voice_session key must read as no"
+        )
+    }
+
+    func testAMissingDiscoveryRecordIsNeverWaitedOn() {
+        XCTAssertFalse(discovery.liveVoiceSessionEnabled(socketIsReachable: { _ in true }))
+    }
+
+    func testARecordFromADeadPublisherIsNeverWaitedOn() throws {
+        let record = """
+        {"socket":"/tmp/tapq.sock","token":"tok","protocol_version":\(WireProtocol.version),\
+        "voice_session":true,"process_id":999999}
+        """
+        try Data(record.utf8).write(to: discovery.discoveryURL)
+        XCTAssertFalse(discovery.liveVoiceSessionEnabled(socketIsReachable: { _ in true }))
+    }
+
     func testLegacyDiscoveryWithoutVersionReadsAsNil() throws {
         let legacy = #"{"socket":"/tmp/x.sock","token":"tok"}"#
         try Data(legacy.utf8).write(to: discovery.discoveryURL)

--- a/Tests/TapQWireProtocolTests/WireProtocolTests.swift
+++ b/Tests/TapQWireProtocolTests/WireProtocolTests.swift
@@ -328,7 +328,7 @@ final class WireProtocolTests: XCTestCase {
         )
         XCTAssertEqual(encoded["session_id"]?.stringValue, "s")
         XCTAssertEqual(encoded["request_id"]?.stringValue, "r")
-        XCTAssertEqual(encoded["protocol_version"]?.intValue, 5)
+        XCTAssertEqual(encoded["protocol_version"]?.intValue, 6)
         XCTAssertNil(encoded["sessionID"])
         XCTAssertNil(encoded["requestID"])
         // The instruction channel carries text and nothing policy-significant.

--- a/Tests/TapQWireProtocolTests/WireProtocolTests.swift
+++ b/Tests/TapQWireProtocolTests/WireProtocolTests.swift
@@ -112,7 +112,7 @@ final class WireProtocolTests: XCTestCase {
     }
 
     func testCompatibilityRule() {
-        XCTAssertFalse(WireProtocol.isCompatible(nil), "v1-de-facto peers must fail a v5 check")
+        XCTAssertFalse(WireProtocol.isCompatible(nil), "v1-de-facto peers must fail a v6 check")
         XCTAssertTrue(WireProtocol.isCompatible(WireProtocol.version))
         XCTAssertFalse(WireProtocol.isCompatible(WireProtocol.version + 1))
     }
@@ -128,27 +128,41 @@ final class WireProtocolTests: XCTestCase {
         XCTAssertFalse(WireProtocol.isCompatible(3))
         // 4: accepted (backward compat — v5 only adds instruction.submit)
         XCTAssertTrue(WireProtocol.isCompatible(4))
-        // 5: accepted (current)
+        // 5: accepted (backward compat — v6 only adds instruction.wait)
         XCTAssertTrue(WireProtocol.isCompatible(5))
+        // 6: accepted (current)
+        XCTAssertTrue(WireProtocol.isCompatible(6))
     }
 
-    func testInstalledV4ShimIsStillAcceptedByTheV5Wire() {
-        XCTAssertEqual(WireProtocol.previousAcceptedVersion, 4)
-        XCTAssertTrue(
-            WireProtocol.isCompatible(WireProtocol.previousAcceptedVersion),
-            "an installed v4 shim must keep working against a v5 runtime"
-        )
-        // …and a v5 shim keeps speaking v4 to a broker that has not been upgraded yet.
-        XCTAssertEqual(WireProtocol.outboundVersion(for: 4, approvalSource: nil), 4)
+    func testInstalledOlderShimsAreStillAcceptedByTheCurrentWire() {
+        XCTAssertEqual(WireProtocol.previousAcceptedVersion, 5)
+        XCTAssertEqual(WireProtocol.previousAcceptedVersions, [5, 4])
+        for installed in WireProtocol.previousAcceptedVersions {
+            XCTAssertTrue(
+                WireProtocol.isCompatible(installed),
+                "an installed v\(installed) shim must keep working against a v6 runtime"
+            )
+            // …and a current shim keeps speaking that version back to a broker that has
+            // not been upgraded yet.
+            XCTAssertEqual(
+                WireProtocol.outboundVersion(for: installed, approvalSource: nil),
+                installed
+            )
+        }
     }
 
     func testShimNegotiatesV2OnlyForLegacySafeMessages() {
-        // v5 shim → v5 broker: speak v5
+        // v6 shim → v6 broker: speak v6
+        XCTAssertEqual(
+            WireProtocol.outboundVersion(for: 6, approvalSource: .permissionRequest),
+            6
+        )
+        // v6 shim → v5 broker: speak v5 (request shapes identical)
         XCTAssertEqual(
             WireProtocol.outboundVersion(for: 5, approvalSource: .permissionRequest),
             5
         )
-        // v5 shim → v4 broker: speak v4 (request shapes identical)
+        // v6 shim → v4 broker: speak v4 (request shapes identical)
         XCTAssertEqual(
             WireProtocol.outboundVersion(for: 4, approvalSource: .permissionRequest),
             4
@@ -177,17 +191,19 @@ final class WireProtocolTests: XCTestCase {
         )
         XCTAssertNil(WireProtocol.outboundVersion(for: nil, approvalSource: nil))
         // Unknown future version: nil
-        XCTAssertNil(WireProtocol.outboundVersion(for: 6, approvalSource: nil))
+        XCTAssertNil(WireProtocol.outboundVersion(for: 7, approvalSource: nil))
     }
 
-    func testInstructionSubmitOnlyNegotiatesWithACurrentBroker() {
-        // Only a v5 peer may be handed an instruction — older brokers reject the type.
-        XCTAssertEqual(
-            WireProtocol.outboundVersion(
-                for: 5, approvalSource: nil, messageType: WireType.instructionSubmit
-            ),
-            5
-        )
+    func testInstructionSubmitOnlyNegotiatesWithABrokerThatKnowsIt() {
+        // v5 is where instruction.submit landed, so v5 and v6 peers may both be handed one.
+        for peer in [6, 5] {
+            XCTAssertEqual(
+                WireProtocol.outboundVersion(
+                    for: peer, approvalSource: nil, messageType: WireType.instructionSubmit
+                ),
+                peer
+            )
+        }
         for peer in [4, 3, 2, 1] {
             XCTAssertNil(
                 WireProtocol.outboundVersion(
@@ -203,12 +219,38 @@ final class WireProtocolTests: XCTestCase {
         )
     }
 
+    /// The wait is v6-only: a v5 broker would answer an unknown message type, and a hook
+    /// that long-polled it would have to discover that over a socket. The negotiation says
+    /// no first.
+    func testInstructionWaitOnlyNegotiatesWithAVoiceSessionBroker() {
+        XCTAssertEqual(WireProtocol.minimumVersion(for: WireType.instructionWait), 6)
+        XCTAssertEqual(
+            WireProtocol.outboundVersion(
+                for: 6, approvalSource: nil, messageType: WireType.instructionWait
+            ),
+            6
+        )
+        for peer in [5, 4, 3, 2, 1] {
+            XCTAssertNil(
+                WireProtocol.outboundVersion(
+                    for: peer, approvalSource: nil, messageType: WireType.instructionWait
+                ),
+                "a v\(peer) broker cannot be sent instruction.wait"
+            )
+        }
+        XCTAssertNil(
+            WireProtocol.outboundVersion(
+                for: nil, approvalSource: nil, messageType: WireType.instructionWait
+            )
+        )
+    }
+
     func testMessageTypeGatingLeavesPreV5TypesNegotiatingAsBefore() {
         // Passing an older type must reproduce the type-less negotiation exactly.
         for type in [WireType.approval, WireType.notification,
                      WireType.selection, WireType.stopQuestion] {
             XCTAssertEqual(WireProtocol.minimumVersion(for: type), 1)
-            for peer: Int? in [nil, 1, 2, 3, 4, 5, 6] {
+            for peer: Int? in [nil, 1, 2, 3, 4, 5, 6, 7] {
                 XCTAssertEqual(
                     WireProtocol.outboundVersion(
                         for: peer, approvalSource: .preToolUse, messageType: type
@@ -228,8 +270,8 @@ final class WireProtocolTests: XCTestCase {
         XCTAssertFalse(WireProtocol.isCompatible(1, current: 2))
     }
 
-    func testVersionIsFiveAndRejectsPreApprovalSourcePeers() {
-        XCTAssertEqual(WireProtocol.version, 5)
+    func testVersionIsSixAndRejectsPreApprovalSourcePeers() {
+        XCTAssertEqual(WireProtocol.version, 6)
         XCTAssertFalse(WireProtocol.isCompatible(2),
                        "v2 peers do not understand policy-significant approval_source")
     }
@@ -327,5 +369,80 @@ final class WireProtocolTests: XCTestCase {
             let decoded = try JSONDecoder().decode(BrokerResponse.self, from: response.encoded())
             XCTAssertEqual(decoded, response)
         }
+    }
+
+    // MARK: - The held turn boundary (wire v6)
+
+    func testInstructionWaitDecodesFromTheDiscriminator() throws {
+        let json = #"{"type":"instruction.wait","token":"abc","session_id":"s1","request_id":"r1","agent":{"id":"claude-code","display_name":"Claude Code"},"protocol_version":6}"#
+        let request = try BrokerRequest(from: Data(json.utf8))
+        guard case .instructionWait(let message) = request else {
+            return XCTFail("expected an instruction wait")
+        }
+        XCTAssertEqual(message.token, "abc")
+        XCTAssertEqual(message.sessionID, "s1")
+        XCTAssertEqual(message.requestID, "r1")
+        XCTAssertEqual(message.agent?.id, "claude-code")
+        XCTAssertEqual(message.protocolVersion, 6)
+    }
+
+    /// The message asks for a decision it cannot influence, and this is the structural
+    /// half of that: there is nowhere on it for a tool, an input, or a permission mode.
+    func testInstructionWaitCarriesNothingPolicySignificant() throws {
+        let message = InstructionWaitMessage(
+            token: "t", sessionID: "s", requestID: "r", protocolVersion: WireProtocol.version
+        )
+        let encoded = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: JSONEncoder().encode(message)
+        )
+        for forbidden in ["tool_name", "tool_input", "cwd", "permission_mode",
+                          "approval_source", "text"] {
+            XCTAssertNil(encoded[forbidden], "\(forbidden) must not exist on a wait")
+        }
+    }
+
+    func testInstructionWaitRoundTripsThroughTheDiscriminator() throws {
+        let message = InstructionWaitMessage(
+            token: "t", sessionID: "s", requestID: "r",
+            agent: .claudeCode, protocolVersion: WireProtocol.version
+        )
+        var encoded = try JSONDecoder().decode(
+            [String: JSONValue].self,
+            from: JSONEncoder().encode(message)
+        )
+        encoded["type"] = .string(WireType.instructionWait)
+        let request = try BrokerRequest(from: try JSONEncoder().encode(encoded))
+        guard case .instructionWait(let decoded) = request else {
+            return XCTFail("expected an instruction wait")
+        }
+        XCTAssertEqual(decoded, message)
+    }
+
+    func testInstructionWaitResponsesRoundTrip() throws {
+        for response: BrokerResponse in [
+            .instructionWait(instruction: nil),
+            .instructionWait(instruction: "The user dictated a new instruction: 'ship it'."),
+        ] {
+            let decoded = try JSONDecoder().decode(BrokerResponse.self, from: response.encoded())
+            XCTAssertEqual(decoded, response)
+        }
+    }
+
+    /// The wait reply and the stop-question reply both say "here is what to hand the
+    /// agent", and they must never be read as each other: one blocks a stop with an answer
+    /// the wearer gave, the other with an instruction they dictated.
+    func testAWaitReplyIsNeverReadAsAStopQuestionReply() throws {
+        let wait = try JSONDecoder().decode(
+            BrokerResponse.self,
+            from: BrokerResponse.instructionWait(instruction: "do the thing").encoded()
+        )
+        XCTAssertEqual(wait, .instructionWait(instruction: "do the thing"))
+
+        let stop = try JSONDecoder().decode(
+            BrokerResponse.self,
+            from: BrokerResponse.stopQuestion(reply: "do the thing").encoded()
+        )
+        XCTAssertEqual(stop, .stopQuestion(reply: "do the thing"))
     }
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,7 +87,8 @@ The underlying command syntax is `tapq serve [options]`.
 | `--wearer-gate` | IMU-based wearer-speech attribution gate (default: off). Voice commands must be attributed to the wearer's own jaw vibration; commands from bystanders or other audio sources are rejected. Fails open when the signal is unavailable or degraded. Uses `wearer-speech-calibration.json` when present, provisional thresholds otherwise |
 | `--imu-turn-control` | IMU-based turn control (default: off). Endpointing: wearer speech-end commits the user turn after a short delay. Barge-in: wearer speech-onset during response audio interrupts playback. Both are additive to gesture/tap/timeout resolution. Shares one signal source with `--wearer-gate`. On `--voice-backend openai-realtime` it also decides who ends user turns: without it, or with no AirPods streaming, the backend's own voice activity detection does — see [Turn detection](#turn-detection) |
 | `--voice-freeform` | Free-form voice answers for selections and multi-option stop questions (default: off). Requires `--voice-backend openai-realtime`. An unmatched final transcript is offered as a free-text reply with mandatory read-back confirmation. Tool approvals and yes/no stop questions stay binary |
-| `--voice-instructions` | Dictated instructions to the agent (default: off). Requires `--wearer-gate`; passing it alone is a startup error. "New instruction" or "tell it to ⟨…⟩" inside an open prompt opens a read-back-and-confirm dictation, and the confirmed sentence is delivered at the agent's next turn boundary. Fail-closed on wearer attribution — the inverse of every other voice path. Claude Code and Codex only. See [Dictated instructions](#dictated-instructions) |
+| `--voice-instructions` | Dictated instructions to the agent (default: off). Requires `--wearer-gate` under `--voice-trust wearer`; passing it alone is a startup error there. "New instruction" or "tell it to ⟨…⟩" inside an open prompt opens a read-back-and-confirm dictation, and the confirmed sentence is delivered at the agent's next turn boundary. Fail-closed on wearer attribution — the inverse of every other voice path. Claude Code and Codex only. See [Dictated instructions](#dictated-instructions) |
+| `--voice-trust wearer\|environment` | Whose voice may dictate an instruction (default: `wearer`). `wearer` is today's behavior byte for byte: dictation is fail-closed on IMU wearer attribution. `environment` trusts the microphone as the user — `--voice-instructions` then needs no `--wearer-gate`, the attribution check is skipped (recorded as `instruction.trusted_environment`), and read-backs stop asking for a nod where no nod can arrive. Approvals are untouched under either value. See [Voice trust](#voice-trust) |
 | `--auto-answer off\|routine` | Delegation filter (default: `off`). `routine` answers `allow` silently, without opening a window, when the stage-2 reasoner called the action routine, its confidence clears the policy floor, and the tool is not on the never-list. Requires `--reasoner` and `--reasoner-mode primary`; both are startup errors when missing. Approvals only. See [Auto-answered approvals](#auto-answered-approvals) |
 | `--attention off\|imu` | Always-on attention (default: `off`). `imu` holds the motion subscription open between requests so an attributed wearer-speech onset opens a short command window that can answer questions and take dictation but can never approve, deny, or select. Requires `--wearer-gate`. Costs continuous IMU power. See [Attention windows](#attention-windows) |
 | `--voice-processing` | Experimental, macOS-only (default: off). Enables Apple's voice-processing IO — echo cancellation and automatic gain control — on the capture input node. Half-duplex is unchanged. See [Voice processing (experimental)](#voice-processing-experimental) |
@@ -306,11 +307,57 @@ free-text answer can never authorize an agent action. The read-back confirmation
 deliberate safety measure: a stray sentence becoming an agent instruction is worse than one
 extra nod.
 
+#### Voice trust
+
+`--voice-trust` names whose voice may put an instruction into an agent's session. It is a
+policy about *instructions only*: nothing in it reaches an approval, a selection, or a
+deferral, under either value.
+
+- `wearer` (default) is the posture every earlier build had. Dictation is fail-closed on
+  IMU wearer attribution, so it needs `--wearer-gate` and it needs AirPods that are
+  actually streaming.
+- `environment` trusts the microphone as the user. It exists for the run this whole
+  feature was unreachable in — earbuds in their case, laptop on a desk — and it makes the
+  assumption explicit rather than leaving dictation silently refusing everything.
+
+```bash
+tapq serve --voice-backend openai-realtime --voice-trust environment --voice-instructions
+```
+
+Under `environment`:
+
+- `--voice-instructions` no longer requires `--wearer-gate`.
+- The attribution check is skipped rather than answered. The skip is recorded at both
+  points the wearer-trust path would have checked (`instruction.trusted_environment`, with
+  `stage=begin` and `stage=text`), so a log can always say which posture a queued
+  instruction was accepted under. It is never silent.
+- Read-backs stop naming gestures that cannot arrive: with no motion device, "Instruction:
+  '⟨text⟩'. Say yes to queue it." and "You said: '⟨text⟩'. Say yes to send, or no to
+  discard." The wording follows the live motion probe, so AirPods that appear mid-run get
+  the nod offered again on the next read-back.
+- The read-back confirmation itself stays, always. It catches mis-transcription, not just
+  misattribution, and it is the only thing between a stray sentence and an agent's inbox.
+
+The honest cost, stated once: under `environment`, **anyone audible to the microphone can
+instruct** — and still cannot approve, deny, select, or defer anything. Approval grammar,
+approval read-backs, and the fail-open-to-screen rule are identical in both postures, and
+an instruction authorizes nothing in either. Use it in a room you would be comfortable
+leaving your terminal unlocked in.
+
+Attention windows are not affected: `--attention imu` still requires `--wearer-gate` under
+either trust value, because a window that opens on a wearer-speech onset needs the signal
+that says whose onset it was. Acoustic attention is a later rung.
+
+The ready block prints `Voice trust: environment (…)` when the non-default posture is in
+force. There is no line under `wearer` — nothing changed.
+
 #### Dictated instructions
 
 `--voice-instructions` lets the wearer say something *to* the agent rather than answer
-what it asked. It requires `--wearer-gate`; passing it alone is a startup error, because
-the attribution signal the whole feature is fail-closed on comes from the gate.
+what it asked. Under the default `--voice-trust wearer` it requires `--wearer-gate`;
+passing it alone is a startup error there, because the attribution signal the whole
+feature is fail-closed on comes from the gate. Under `--voice-trust environment` the
+pairing is dropped — see [Voice trust](#voice-trust).
 
 ```bash
 tapq serve --wearer-gate --voice-instructions
@@ -323,7 +370,8 @@ Inside any open prompt:
    instruction, in the wearer's own words.
 2. Without captured text, TapQ says "Go ahead." and takes the next spoken turn as the
    instruction.
-3. TapQ reads it back: "Instruction: '⟨text⟩'. Nod or say yes to queue it."
+3. TapQ reads it back: "Instruction: '⟨text⟩'. Nod or say yes to queue it." — or "Say yes
+   to queue it." where no gesture can arrive; see [Voice trust](#voice-trust).
 4. A nod, a double tap, or "yes" queues it — "Queued for ⟨agent⟩." Anything else discards
    it — "Instruction discarded." Silence discards it without a word.
 
@@ -331,9 +379,9 @@ The prompt the wearer was answering is untouched by all of this. The confirming 
 consumed inside the dictation, the request is still waiting when the flow ends, and the
 window's deadline is never extended: dictating cannot buy more time to decide.
 
-**Instructing fails closed; authorizing fails open.** A voice TapQ cannot attribute to the
-wearer — including one where the signal cannot say whose it is — is refused out loud ("I
-can't confirm that was you — instruction discarded.", diagnostic
+**Instructing fails closed; authorizing fails open.** Under `--voice-trust wearer`, a voice
+TapQ cannot attribute to the wearer — including one where the signal cannot say whose it is
+— is refused out loud ("I can't confirm that was you — instruction discarded.", diagnostic
 `instruction.rejected_unattributed`). Voice *approvals* keep failing open in the same
 state, because the agent's on-screen prompt is their backstop. A queued instruction has no
 such backstop, so "we cannot tell who spoke" and "that was not the wearer" have the same

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -39,7 +39,7 @@ tapq version --json
 The JSON form includes the CLI version and wire protocol version:
 
 ```json
-{"name":"tapq","version":"0.5.0-beta.2","wire_protocol":5}
+{"name":"tapq","version":"0.5.0-beta.2","wire_protocol":6}
 ```
 
 The project is pre-1.0. Machine-readable formats are designed for automation,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -88,6 +88,7 @@ The underlying command syntax is `tapq serve [options]`.
 | `--imu-turn-control` | IMU-based turn control (default: off). Endpointing: wearer speech-end commits the user turn after a short delay. Barge-in: wearer speech-onset during response audio interrupts playback. Both are additive to gesture/tap/timeout resolution. Shares one signal source with `--wearer-gate`. On `--voice-backend openai-realtime` it also decides who ends user turns: without it, or with no AirPods streaming, the backend's own voice activity detection does — see [Turn detection](#turn-detection) |
 | `--voice-freeform` | Free-form voice answers for selections and multi-option stop questions (default: off). Requires `--voice-backend openai-realtime`. An unmatched final transcript is offered as a free-text reply with mandatory read-back confirmation. Tool approvals and yes/no stop questions stay binary |
 | `--voice-instructions` | Dictated instructions to the agent (default: off). Requires `--wearer-gate` under `--voice-trust wearer`; passing it alone is a startup error there. "New instruction" or "tell it to ⟨…⟩" inside an open prompt opens a read-back-and-confirm dictation, and the confirmed sentence is delivered at the agent's next turn boundary. Fail-closed on wearer attribution — the inverse of every other voice path. Claude Code and Codex only. See [Dictated instructions](#dictated-instructions) |
+| `--voice-session` | Hold the agent's turn boundary open and keep listening (default: off). Requires `--voice-instructions`. When a turn ends, the Stop hook waits on the broker instead of returning: TapQ says "Listening." and re-opens a command window until an instruction is queued (delivered as the Stop block, so the agent continues), the wearer ends the session, or the ten-minute wait budget expires and the session idles. Inside a waiting window an unmatched sentence needs no "tell it to" prefix. See [Voice sessions](#voice-sessions) |
 | `--voice-trust wearer\|environment` | Whose voice may dictate an instruction (default: `wearer`). `wearer` is today's behavior byte for byte: dictation is fail-closed on IMU wearer attribution. `environment` trusts the microphone as the user — `--voice-instructions` then needs no `--wearer-gate`, the attribution check is skipped (recorded as `instruction.trusted_environment`), and read-backs stop asking for a nod where no nod can arrive. Approvals are untouched under either value. See [Voice trust](#voice-trust) |
 | `--auto-answer off\|routine` | Delegation filter (default: `off`). `routine` answers `allow` silently, without opening a window, when the stage-2 reasoner called the action routine, its confidence clears the policy floor, and the tool is not on the never-list. Requires `--reasoner` and `--reasoner-mode primary`; both are startup errors when missing. Approvals only. See [Auto-answered approvals](#auto-answered-approvals) |
 | `--attention off\|imu` | Always-on attention (default: `off`). `imu` holds the motion subscription open between requests so an attributed wearer-speech onset opens a short command window that can answer questions and take dictation but can never approve, deny, or select. Requires `--wearer-gate`. Costs continuous IMU power. See [Attention windows](#attention-windows) |
@@ -401,13 +402,17 @@ Bounds, all deliberate:
 - Three instruction-bearing boundaries in a row, then delivery pauses with a spoken notice
   until a boundary carries something else (`instruction.loop_cap.suppressed`). A stop reply
   restarts the agent's turn, and Claude's stop hook has no `stop_hook_active` flag to lean
-  on.
+  on. Stood down under `--voice-session`, where every boundary is meant to carry one; the
+  four-deep queue bound is not.
 - Claude Code and Codex only. Cursor and OpenCode have no turn boundary to deliver into,
   and dictating at one of them is refused by name: "Instructions aren't supported for
   OpenCode." See the [capability matrix](INTEGRATIONS.md#agent-capability-matrix).
 - Dictation works only while a window is open, for the same reason recall does: the
   microphone is live only during a bounded response window.
 - Nothing survives a restart. A queued, undelivered instruction is gone with the process.
+- Delivery waits for a boundary the agent produces, so an instruction dictated to an idle
+  agent waits for someone to type — unless the run is holding one open; see
+  [Voice sessions](#voice-sessions).
 
 While instructions are waiting, "who's waiting?" says so: `"Claude Code: run the test
 suite. Nothing else waiting. 1 instruction queued."` Once delivered, "what changed?"
@@ -416,6 +421,75 @@ as work done.
 
 Without the flag, nothing composes a queue: the grammar still matches the phrase, it
 reaches nowhere, nothing is spoken, and the window goes on listening.
+
+#### Voice sessions
+
+`--voice-session` is the difference between dictating *into* a conversation and having one.
+Without it, an instruction reaches the agent at its next turn boundary — and an idle agent
+produces no boundaries, so a sentence spoken after it finished waits for someone to type.
+With it, TapQ holds that boundary open and keeps listening.
+
+```bash
+tapq serve --voice-backend openai-realtime \
+  --voice-trust environment --voice-instructions --voice-session
+```
+
+It requires `--voice-instructions`; passing it alone is a startup error, because a held
+boundary exists so a dictated instruction can reach the agent and without the queue there
+is nowhere for one to go. It works under either trust posture — the pairing above is the
+one it was designed around, which is a desk, no earbuds, and no keyboard.
+
+What happens at the end of a turn:
+
+1. The agent finishes. Its Stop hook does what it always did — an intercepted question
+   still runs its own interaction — and then, instead of returning, sends
+   `instruction.wait` to the broker and waits.
+2. TapQ announces the turn as usual ("Claude Code finished"), then says "Listening." and
+   opens a command window. Windows re-open, silently, for as long as the boundary is held.
+3. Inside a waiting window: `status`, `what changed`, and `repeat` answer as they always
+   do; "tell it to ⟨…⟩" still opens a dictation; and **an unmatched sentence is treated as
+   dictation directly** — "Instruction: '⟨text⟩'. Say yes to queue it." A spoken yes queues
+   it, anything else discards it.
+4. A queued instruction releases the hook, which blocks the Stop with the usual reply, and
+   the agent continues its turn with it. The next boundary is a moment away.
+5. Saying "end voice session" or "stop listening" — or simply "no" — closes the loop:
+   "Voice session ended.", the hook is released with nothing, and the session idles.
+6. Ten minutes of silence do the same thing without a word. One long-poll round, not a
+   loop: the budget expiring is a clean exit from the mode, not a failure.
+
+Bounds and behavior, all deliberate:
+
+- **The instruction loop cap does not apply.** Three instruction-bearing boundaries in a
+  row is a loop everywhere else; here every boundary is *supposed* to carry one. The
+  four-deep queue cap is unchanged.
+- **Approvals are untouched.** A tool call during a voice session opens the same approval
+  window, with the same grammar and the same fail-open-to-screen. Nothing about holding a
+  boundary lets a sentence authorize anything.
+- **One session at a time.** Two agents can be held at once, but TapQ has one microphone:
+  the listening loop addresses the boundary that started it, and a second held session
+  waits out its own budget rather than being answered by a window that might be talking
+  about the other one.
+- **Claude Code only, for now.** The Codex adapter's Stop path does not long-poll yet.
+- **Nothing survives a restart**, and a runtime that exits releases every waiting hook
+  before it goes, so a killed `tapq serve` never leaves a hook parked. A hook that cannot
+  reach the broker at all lets the Stop proceed, as it always has.
+- The terminal shows a hook in flight for as long as a boundary is held. That is the mode
+  being visible, not a stall — typing into the session ends it the ordinary way.
+
+The prefix-free dictation needs transcripts, so it is meaningful only on
+`--voice-backend openai-realtime`: the mode composes free-form delivery on its own where
+the backend can produce it. On the Apple path a waiting window still hears the grammar and
+still takes a prefixed "tell it to ⟨…⟩", which is the honest capability gap until intent
+routing lands.
+
+The hook timing chain for a held boundary is its own, and wider than the interaction one:
+the broker answers at 600 s, the shim's socket gives up at 615 s, and
+`tapq integration claude install` writes a `timeout` of 620 s on the **Stop** entry only.
+Reinstall the Claude hooks after upgrading — a Stop entry written by an older build carries
+the interaction timeout and would kill a waiting hook part-way through.
+
+The ready block prints `Voice session: holding turn boundaries up to 10 minutes; …` when
+the flag is on.
 
 ### Auto-answered approvals
 
@@ -1081,11 +1155,20 @@ receives the text as feedback, not as a structured selection, and may interpret 
 discretion.
 
 Wire protocol v4 records whether an approval came from `PreToolUse` or
-`PermissionRequest`. The broker accepts both v4 and v3 requests; v3 shims continue to
-work and simply never see the `free_text` response field. Strict and shared messages can
-temporarily use a discovered legacy wire protocol v2 runtime. Native permission requests
-never downgrade to v2 and remain in Claude’s normal dialog when no compatible runtime is
-available.
+`PermissionRequest`. The current wire is v6; the broker also accepts v5 and v4 requests,
+because each bump since v4 has only *added* a message type — v5 `instruction.submit`, v6
+`instruction.wait` — leaving every request shape an older shim knows about unchanged. An
+installed older shim therefore keeps working against a newer runtime, and a current shim
+never sends one of the newer messages to a runtime that predates it. Strict and shared
+messages can temporarily use a discovered legacy wire protocol v2 runtime. Native
+permission requests never downgrade to v2 and remain in Claude’s normal dialog when no
+compatible runtime is available.
+
+The `Stop` entry is installed with an explicit `timeout` of 620 s — wider than every other
+hook, because it is the one that may hold a turn boundary open for a
+[voice session](#voice-sessions). Reinstall after upgrading: an entry written by an older
+build carries the interaction timeout and would kill a waiting hook part-way through.
+`tapq integration claude status` reports `partial` until it is rewritten.
 
 ### Structured-question steering
 

--- a/docs/VOICE_ONLY_AGENT_PLAN.md
+++ b/docs/VOICE_ONLY_AGENT_PLAN.md
@@ -1,0 +1,231 @@
+# TapQ Voice-Only Agent Plan — Rungs E–H
+
+*Draft 2026-08-27. Written against `main` @ `ec536ec` (post PR #33; assumes PR #34's
+server-VAD fallback and GA realtime migration are merged). Successor to
+`docs/VOICE_AGENT_PLAN.md` (Rungs A–D, all merged 2026-08-18). This plan takes the
+shipped instruction channel and attention machinery and removes their one shared
+assumption: that AirPods are in the wearer's ears.*
+
+> **Amendment, 2026-08-27 — lean scope for the first ship.** What is being built now is
+> **Rung E in full** (`--voice-trust wearer|environment`, §4) and a **lean Rung H leg 1**
+> (`--voice-session`, §7): a long-polling Stop hook, a broker that answers a held turn
+> boundary, and a listening window in which an unmatched sentence is dictation. **Rung F
+> (intent routing, §5), Rung G (`--attention acoustic`, §6), and Rung H leg 2 (owned
+> sessions) are deferred** and nothing in this pass builds toward them. Attention still
+> requires an IMU; the dictation prefixes still exist and still work everywhere they do
+> today. The sections below describe the whole plan and are unchanged; this note says which
+> parts of it are code.
+
+---
+
+## 0. End state (what Rung H buys, in plain words)
+
+You sit down at your desk — no earbuds — and say "start on the dark mode thing."
+Claude Code, which was idle, starts working. While it works you talk to it like a
+colleague: "how's it going," "skip that file," "also update the changelog." When it
+needs permission it asks out loud and you say yes or no. When it finishes it tells
+you, and waits — for your next sentence, not your next keystroke. Nothing in the
+flow requires touching the keyboard, and nothing you say can authorize an action
+without the same read-back or approval step that exists today.
+
+Rungs A–D made TapQ a chief of staff in your ear. Rungs E–H make the ear optional.
+
+## 1. Starting point (verified 2026-08-27)
+
+What exists and works: the full Rung A–D surface — dictated instructions with
+read-back confirm and turn-boundary delivery (`--voice-instructions`), attention
+windows (`--attention imu`), spoken summaries, session recall, auto-answer; plus
+PR #34's no-AirPods realtime path (backend server VAD commits turns when no IMU
+signal exists, GA API).
+
+Why none of it adds up to a voice-only agent today:
+
+- `--voice-instructions` hard-requires `--wearer-gate` and **fails closed on IMU
+  wearer attribution** — with no AirPods streaming, every dictation is refused.
+- `--attention` has exactly two values, `off` and `imu`. Without the earbud motion
+  stream there is no way to open a window when no agent is prompting.
+- Dictation is triggered by grammar prefixes ("tell it to…", "new instruction") —
+  an arbitrary sentence without a trigger is free-form Q&A at best.
+- Delivery is a Stop-event block: an instruction to an *idle* agent queues forever,
+  because an idle agent produces no turn boundaries until someone types.
+
+Seams already built and waiting:
+
+- `MicrophonePumpVoiceBackend.onInputLevel` — the inert acoustic-endpointer hook
+  from M2, exactly where a local onset detector taps in.
+- The GA realtime session is conversation-scoped and already long-lived; only mic
+  ownership is windowed. GA `session.update` tooling config is one message away.
+- The Rung D command window (`AttentionWindow`) is onset-source-agnostic in shape:
+  the IMU is one trigger, not the design.
+- The Claude shim already blocks Stop to deliver instructions; the wire and broker
+  already carry `instruction.submit` from any process (`tapq instruct`).
+
+## 2. The policy change this plan is built on (ratify first)
+
+**Decision: when no IMU device is streaming, TapQ may assume a quiet, single-person
+environment.** Owner's call, 2026-08-27: "when AirPods is not connected we can
+assume the user is in a quiet and isolated space."
+
+Concretely, one new flag names the posture:
+
+- `--voice-trust wearer` (default) — today's behavior, byte for byte. Instructions
+  fail closed on attribution; attention requires IMU.
+- `--voice-trust environment` — the mic is trusted as the user. Instructions and
+  attention work with no AirPods. Read-back confirmation is kept (it catches
+  mis-transcription, not just misattribution); the attribution check is skipped.
+
+What does **not** change under either value, ever: an instruction authorizes
+nothing. Approvals keep their own grammar, their own read-back, and their own
+fail-open-to-screen semantics. The docs state the tradeoff in one honest sentence:
+under `environment`, anyone audible to the microphone can instruct — but still
+cannot approve, deny, select, or defer anything the wearer wouldn't.
+
+## 3. Prior art (why the shapes below are low-risk)
+
+Surveyed GitHub 2026-08-27 for voice layers over coding agents. Nobody has TapQ's
+approval semantics, attribution, or broker — but three mechanisms are proven in
+the wild and are borrowed outright:
+
+| Mechanism | Proven by | Borrowed into |
+|---|---|---|
+| Stop-hook blocking loop: hook returns the next spoken command as the Stop-block reason; session never idles | mckaywrigley/claude-code-voice (hook source read and verified) | Rung H leg 1, improved: the hook long-polls the broker instead of owning the mic, so silence costs zero model turns |
+| Realtime model does intent routing via a declared tool ("forward instruction to the agent") | dhuynh95/duck_talk | Rung F |
+| Spawn-and-own sessions: map conversations to headless CLI/SDK sessions, resume by id | alexknowshtml/cord, Terobyte/codeflow, omnara-ai/omnara | Rung H leg 2 |
+
+Rejected: OS-level keystroke injection into the terminal (thepradip/micoracle) —
+works, but depends on window focus and accessibility permissions, and bypasses the
+wire. Wrong posture for a broker-based product.
+
+## 4. Rung E — voice-only mode (drop the gates)
+
+*Goal: everything Rung C/D shipped works with AirPods in the case.*
+
+Scope:
+
+1. **`--voice-trust wearer|environment`** as §2. Under `environment`:
+   `--voice-instructions` no longer requires `--wearer-gate`; the
+   `instruction.rejected_unattributed` path is bypassed (a diagnostic records that
+   trust was environmental); dictation confirm accepts spoken "yes" alone — the
+   nod/double-tap paths simply don't exist and are not mentioned in read-backs.
+2. **Spoken-confirm parity sweep:** every flow whose confirm mentions a gesture
+   (free-form nod-to-send, dictation queue confirm) gets a voice-only phrasing
+   when no IMU device is present.
+3. **Startup validation matrix** updated: `--voice-instructions` alone is valid
+   with `--voice-trust environment`; still an error under `wearer` (unchanged).
+
+Exit: dictation end-to-end on the no-AirPods realtime path — speak "tell it to run
+the tests again" during a window, hear the read-back, say yes, watch delivery at
+the next boundary. E2E suite gains a voice-only-trust trace. Default-flag runs
+byte-identical to today.
+
+## 5. Rung F — intent routing (kill the prefixes)
+
+*Goal: an arbitrary sentence during a window becomes the right thing — answer,
+question, or instruction — without magic words.*
+
+Scope:
+
+1. **Realtime path: tool-calling.** Declare tools on the GA session
+   (`session.update`): `submit_instruction(text)`, and optionally
+   `ask_status()` mapping to existing recall intents. An unmatched utterance the
+   deterministic grammar didn't claim goes to the model; a `submit_instruction`
+   call feeds the *existing* read-back-confirm-queue flow — the model routes, it
+   never delivers. No tool call → today's behavior (grounded Q&A / free-form).
+2. **Grammar stays first.** Matched commands never reach the model. The approval
+   grammar cannot be expressed as a tool; there is no `approve` tool to call.
+3. **Apple path unchanged** this rung: prefixes remain the trigger (the on-device
+   recognizer has no tool-calling). Documented as the honest capability gap.
+
+Exit: "run the tests again after" — no prefix — is read back as an instruction and
+queued, on the realtime path; "what's it doing" gets a status answer; a matched
+"yes" still resolves instantly without touching the model. Transcript tests pin
+that no tool call can resolve an approval.
+
+## 6. Rung G — always listening (`--attention acoustic`)
+
+*Goal: speak whenever you want, not only when a window happens to be open.*
+
+Two-tier design — the long-lived part is local; the cloud session opens on demand:
+
+1. **Tier 1, persistent, on-device, free:** the capture engine stays alive between
+   windows; a local onset detector (RMS energy via the `onInputLevel` seam, or
+   Apple VAD) watches for speech. Nothing leaves the machine while idle.
+2. **Tier 2, on onset:** open a standard Rung D command window — same "Yes?", same
+   eight seconds, same recall/dictation/no-resolution rules — with
+   `--voice-trust environment` standing in for the attribution the IMU onset used
+   to provide. All window machinery is reused; only the trigger is new.
+3. **Optional wake phrase** (`--attention acoustic --wake-phrase "hey tapq"`) via
+   persistent on-device SFSpeechRecognizer, if bare energy onset proves
+   trigger-happy even in a quiet room. Decide from a week of real use, not upfront.
+4. **Half-duplex preserved:** tier 1 pauses while TapQ speaks (the existing
+   self-hearing gate, applied to the persistent engine).
+
+Deliberately not in scope: holding the OpenAI realtime session streaming during
+idle (billed silence, self-hearing against server VAD, server-side session
+lifetime). Revisit only if window-open latency annoys in practice.
+
+Exit: with an idle agent and no AirPods, saying "status" from across the desk gets
+"Nothing is waiting." within a second or two; a dictated instruction from a cold
+start reaches the queue. Mac-only power cost measured and documented.
+
+## 7. Rung H — the long-lived agent (idle delivery)
+
+*Goal: "start on the dark mode thing" moves an idle agent. The doorbell.*
+
+**Leg 1 — voice-first sessions (long-poll Stop hook).** For a session the user has
+put in voice mode:
+
+1. The Claude shim's Stop handler, instead of returning when the instruction queue
+   is empty, **long-polls the broker**: "hold my turn boundary open until the next
+   instruction arrives." When one arrives — minutes later, from a Rung G window —
+   the shim returns the existing Stop-block with the instruction as reason, and
+   the agent continues. Silence burns zero model turns (the hook is waiting, the
+   model is not running). This is TapQ's shipped delivery mechanism with patience.
+2. **Mode is explicit and per-session:** entered by voice ("start voice session")
+   or flag, exited the same way or by keyboard. While waiting, the terminal shows
+   a hook in flight — the session is deliberately voice-first; typing exits the
+   mode cleanly rather than fighting it.
+3. **Plumbing:** a `wait_for_instruction` long-poll on the wire; the integration
+   installer writes an explicit large hook `timeout` for the Stop entry; heartbeat
+   so a killed runtime releases the hook instead of hanging the session.
+4. **Bounds revisit** (the old RC caps were sized for steering): loop-cap paused in
+   voice-session mode — every boundary is *supposed* to carry an instruction; the
+   four-deep queue stands.
+
+**Leg 2 — owned sessions (start from nothing).** "New task: ⟨…⟩" with no live
+session spawns one — headless `claude -p` with TapQ's hooks installed, session id
+mapped cord-style so later instructions and approvals target it. TapQ becomes the
+launcher only for sessions it creates; existing keyboard-started sessions keep leg
+1. Ships after leg 1 proves the conversation loop.
+
+Exit (leg 1): agent finishes a task, announces it, sits in voice mode; two minutes
+of silence; "tell it to also update the changelog" spoken into an acoustic window
+lands without a keystroke — demoed end to end on one Mac. Exit (leg 2): "new task"
+from a cold start to first approval question, hands-free throughout.
+
+## 8. Decisions and gates
+
+| # | Decision / gate | Recommended | Needed by |
+|---|---|---|---|
+| 1 | `--voice-trust environment`: mic-as-user posture, instructions never authorize | Ratify §2 as written | E |
+| 2 | Model routes, never delivers: tool calls feed the read-back flow, no approval tool exists | Ratify as invariant | F |
+| 3 | Always-listening is local-first; cloud audio flows only after onset | Ratify (privacy is the point) | G |
+| 4 | Voice-session mode is explicit, per-session, keyboard-escapable | Ratify | H |
+| 5 | Wake phrase: decide after a week of `--attention acoustic` use | Defer with data | G promotion |
+| 6 | Apple-path partial-transcript race (deferred 2026-08-27) | Fix before promoting any rung to default — a voice-only agent amplifies a false-approve | E–H promotion |
+
+## 9. Sequencing
+
+```
+E (drop gates) ──► F (intent routing) ──► G (attention acoustic) ──► H (long-lived)
+   │                    │                       │                     ▲       ▲
+   │                    └── realtime only ──────┘                     │       │
+   ├── smallest; unblocks hands-on testing of everything after ───────┘       │
+   └── Apple partial-race fix (parallel, independent) ── gates promotion ─────┘
+```
+
+E is days and makes every later rung testable on this desk with no hardware. F
+rides entirely on the GA session config. G reuses Rung D's window wholesale. H
+leg 1 is a patient version of shipped code; leg 2 is the only genuinely new
+surface and goes last. Each rung: own flags, own smoke checklist, CI green, same
+discipline as A–D.


### PR DESCRIPTION
Implements the lean first ship of [docs/VOICE_ONLY_AGENT_PLAN.md](../blob/feat/voice-only-session/docs/VOICE_ONLY_AGENT_PLAN.md) (added in this PR): **Rung E in full** and a **lean Rung H leg 1**. Rungs F (intent routing), G (acoustic attention), and H leg 2 (owned sessions) are deferred — the plan's dated amendment says exactly which parts are code.

## Rung E — `--voice-trust wearer|environment`

One flag names the trust posture:

- `wearer` (default) — today's behavior, byte for byte. Instructions fail closed on IMU wearer attribution; `--voice-instructions` still requires `--wearer-gate`.
- `environment` — the mic is trusted as the user (owner's call, 2026-08-27: no AirPods streaming ⇒ quiet, single-person space). `--voice-instructions` works with the AirPods in their case: the fail-closed attribution check is skipped (diagnostic `instruction.trusted_environment`), and read-backs narrow to speech-only phrasing ("Say yes to queue it.") when a live motion probe says no gesture can arrive.

Unchanged under both values, forever: **an instruction authorizes nothing.** Approval grammar, approval read-backs, and approval fail-open semantics are untouched.

## Voice sessions — `--voice-session`

The doorbell for a finishing agent: instead of going idle after its turn, the agent waits for your next sentence.

- **Shim:** on Stop, when the runtime advertises voice sessions and nothing is queued, the Claude hook long-polls a new `instruction.wait` (one request, 10-minute budget). Instruction → the existing Stop-block delivery; timeout, error, or unreachable runtime → the Stop passes through and the session idles normally. Fail direction is always "behave like today".
- **Runtime:** while a boundary is held, TapQ keeps a listening window open ("Listening.", spoken once). Inside it, grammar commands work as always — and an **unmatched sentence is dictation**: read back, confirmed with a spoken "yes", queued, delivered at the held boundary. No "tell it to" prefix needed. "End voice session" / "stop listening" releases the boundary.
- **Wire v6** (`instruction.wait`), accepting v5 and v4 — older shims keep working. The installer writes an explicit Stop-hook timeout (620 s) sized to the wait budget; re-run `tapq integration claude install` on existing installs.
- The instruction loop-cap stands down in voice-session mode (every boundary is supposed to carry an instruction there); the four-deep queue cap stands. A dying runtime releases every held boundary — no orphaned hooks.

The lean pairing: `tapq serve --voice-trust environment --voice-instructions --voice-session`.

## Tests

~90 new tests across CLI validation (the full flag matrix), dictation trust bypass, the voice-session window (unmatched→dictation only inside a waiting window, end-phrases, loop-cap standdown), the wait registry (enqueue/timeout/shutdown release), shim behavior (deliver, pass-through on every failure), wire v6 compat, installer fixtures, and E2E traces for both features. All `@MainActor` test methods are async (Linux discovery rule).

## Known limits (deliberate, documented)

- One listening loop at a time; a second held session waits out its budget.
- Existing hook installs read as `partial` until reinstalled (Stop timeout changed).
- Hardware smoke (mic-window cadence during a held boundary) still pending — flags are off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
