### PR TITLE
Route dictated instructions by agent name: "tell Codex to run the tests"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Added
 
+- Name-addressed dictation: "tell Codex to run the tests" queues for Codex rather than for
+  whichever agent's window the wearer is standing in. The accepted shape is a leading
+  `tell ⟨agent⟩ to ⟨…⟩` (a colon, or nothing, may stand in for the `to`), matched
+  case-insensitively against display names TapQ already speaks — "claude" reaches Claude
+  Code. The address is stripped before the read-back, and the read-back and the queued
+  notice both name the resolved agent. A sentence with no address behaves exactly as it did
+  before. Only the instruction channel is routable: approvals, selections, and stop answers
+  still apply to the open window, always.
+- The roster behind it assumes **one live session per adapter**, remembers the most recent
+  session per agent from traffic TapQ already handles, and expires an entry after 30 minutes
+  of silence. When the assumption breaks it fails closed and says so rather than guessing: a
+  second live session for one adapter makes its name ambiguous ("More than one Claude Code
+  session is active — say it from that session's window."), and a name nothing live answers
+  to is refused by name. Neither queues anything anywhere. Ambiguity clears once the rival
+  session ages out. The per-adapter capability table follows the addressee, so a route to
+  Cursor is refused exactly as an in-window dictation there would be. See the
+  [CLI reference](docs/CLI.md#dictated-instructions).
+
 - Voice sessions, behind `--voice-session` (which requires `--voice-instructions`). When an
   agent finishes a turn, its Stop hook long-polls the broker instead of returning: TapQ says
   "Listening." and re-opens a command window until an instruction is queued — delivered as

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -646,6 +646,11 @@ import Darwin
             // and the window goes on listening exactly as it did before the phrase meant
             // anything.
             instructionEnqueue: memory.instructionEnqueue,
+            // Name-addressed dictation ("tell Codex to …"). Composed from the same object
+            // and gated on the same mailbox as the enqueue above, so a run without
+            // `--voice-instructions` has no resolver either and the dictation flow never
+            // looks for an address at all.
+            instructionAddressResolver: memory.instructionAddressResolver,
             voiceTrust: configuration.voiceTrust,
             gestureConfirmation: gestureConfirmation
         )
@@ -693,6 +698,7 @@ import Darwin
             instructionCapability: memory.instructionCapability,
             wearerAttribution: isWearerAttributed,
             instructionEnqueue: memory.instructionEnqueue,
+            instructionAddressResolver: memory.instructionAddressResolver,
             voiceTrust: configuration.voiceTrust,
             gestureConfirmation: gestureConfirmation
         )
@@ -831,6 +837,11 @@ import Darwin
                         instructionCapability: memory.standingInstructionCapability,
                         wearerAttribution: isWearerAttributed,
                         instructionEnqueue: memory.standingInstructionEnqueue,
+                        // The same fleet-wide resolver the request windows take. Who is
+                        // live does not depend on which window is open, and a wearer who
+                        // opened this one themselves is the likeliest to name an agent
+                        // other than the last one TapQ served.
+                        instructionAddressResolver: memory.instructionAddressResolver,
                         voiceTrust: configuration.voiceTrust,
                         gestureConfirmation: gestureConfirmation
                     )
@@ -891,6 +902,11 @@ import Darwin
                         instructionEnqueue: { [weak instructions] text in
                             instructions?.enqueue(text, session: sessionID)
                         },
+                        // Addressing still reaches the whole fleet from here. The held
+                        // boundary is where an unaddressed sentence goes, not a wall around
+                        // it: "tell Codex to …" at a Claude Code boundary is exactly the
+                        // sentence this window exists to make sayable.
+                        instructionAddressResolver: memory.instructionAddressResolver,
                         kind: .voiceSession,
                         voiceTrust: configuration.voiceTrust,
                         gestureConfirmation: gestureConfirmation

--- a/Sources/TapQCLI/AgentRoster.swift
+++ b/Sources/TapQCLI/AgentRoster.swift
@@ -1,0 +1,178 @@
+import Foundation
+import TapQContracts
+
+/// Which session answers to which agent's name, for the length of time TapQ can honestly
+/// claim to know.
+///
+/// This is the roster in its first form, and its whole content is one simplifying
+/// assumption: **at most one live session per adapter**. That assumption is what lets a
+/// wearer say "tell Codex to run the tests" and mean something exact — there is one Codex,
+/// so naming the adapter names the session. The type's real job is not the happy path but
+/// the moment the assumption breaks: a second Codex session makes the name ambiguous, and
+/// an ambiguous name resolves to nothing at all rather than to the newer session.
+///
+/// It is a `Sendable` value type with `mutating` methods, owned by the `@MainActor`
+/// ``ConversationMemory`` — the same shape as ``TapQContextBaseline/SessionContextStore``
+/// and ``TapQContextBaseline/InstructionQueue``, and for the same reason: no lock, no
+/// actor, and no second copy that could disagree about who is live.
+///
+/// Everything it holds is speech-safe by construction, like every other store on this
+/// path. There is nowhere to put a `toolInput`, a `cwd`, or a `permissionMode` — an entry
+/// is an opaque session key, an agent identity TapQ already says out loud, and two
+/// timestamps.
+///
+/// It is bounded by time rather than by count. A count bound would evict a session the
+/// wearer is actively working in as soon as a fleet grew past it; ``liveness`` evicts the
+/// sessions that have stopped talking, which is the same set the wearer has stopped
+/// thinking about.
+public struct AgentRoster: Sendable {
+    /// How long an agent stays addressable by name after TapQ last heard from it.
+    ///
+    /// Thirty minutes is chosen against the failure it prevents rather than against any
+    /// notion of a session's real lifetime, which TapQ cannot observe: nothing on the wire
+    /// says a session ended, so an entry can only ever expire on silence. Too short and a
+    /// wearer who steps away from a long build cannot address it on their return; too long
+    /// and a name keeps resolving to a terminal that was closed an hour ago — the one
+    /// outcome that is worse than a refusal, because the sentence is queued and nothing
+    /// ever delivers it.
+    public static let liveness: TimeInterval = 30 * 60
+
+    /// One agent's live session, in the terms a dictation may be routed by.
+    public struct Entry: Sendable, Equatable {
+        /// The opaque session key an instruction is queued against.
+        public let sessionID: String
+        /// The agent behind it. The whole identity and not just the display name, because
+        /// routing has to ask ``TapQContracts/AgentCapabilities`` whether this adapter has
+        /// a turn boundary at all — a question about the adapter, not about the name.
+        public let agent: AgentIdentity
+        /// When TapQ last saw traffic from this session, from the roster's caller's clock.
+        public let lastSeen: Date
+    }
+
+    /// What a spoken name resolved to. `nil` from ``resolve(name:now:)`` is the third
+    /// answer — nothing live answers to it.
+    public enum Resolution: Sendable, Equatable {
+        /// Exactly one live session answers to the name.
+        case resolved(Entry)
+        /// The adapter has more than one live session, so its name picks out none of them.
+        case ambiguous(agentDisplayName: String)
+    }
+
+    /// The most recently seen session per agent.
+    private var live: [String: Entry] = [:]
+    /// The session each agent had *before* the one in `live`, kept only so ambiguity can
+    /// be detected and, just as importantly, un-detected.
+    ///
+    /// One slot and not a list. The question this map answers is "is there a second live
+    /// session for this agent?", which a third session cannot make any truer — and a list
+    /// would invite a future reader to treat it as a session inventory, which is the
+    /// FleetRoster this type is deliberately not yet.
+    private var displaced: [String: Entry] = [:]
+
+    public init() {}
+
+    // MARK: - Writing
+
+    /// Notes that TapQ just saw traffic from `sessionID`, belonging to `agent`.
+    ///
+    /// Called from wherever conversation memory already observes an agent — a window
+    /// opening, a notification arriving — rather than from a hook of its own. A roster
+    /// that had to be told separately would be a roster that could silently fall behind
+    /// the memory it is supposed to describe.
+    public mutating func note(sessionID: String, agent: AgentIdentity, at now: Date) {
+        let entry = Entry(sessionID: sessionID, agent: agent, lastSeen: now)
+        guard let current = live[agent.id] else {
+            live[agent.id] = entry
+            return
+        }
+        guard current.sessionID != sessionID else {
+            live[agent.id] = entry
+            return
+        }
+        // A different session for an agent that already has one. If the one on record has
+        // gone quiet past the liveness window it is not a rival, it is history: the new
+        // session takes the slot outright and the agent is unambiguous again.
+        if Self.isExpired(current, at: now) {
+            displaced.removeValue(forKey: agent.id)
+        } else {
+            displaced[agent.id] = current
+        }
+        live[agent.id] = entry
+    }
+
+    // MARK: - Reading
+
+    /// The session that answers to `name`, the fact that two do, or `nil` for a name
+    /// nothing live answers to.
+    ///
+    /// Matching is on the display name or its first word, case-insensitively and on
+    /// letters and digits only — "codex", "Codex.", and "CODEX" are one name, and "claude"
+    /// reaches "Claude Code". It is deliberately not fuzzy: a near-miss that routed a
+    /// sentence into the wrong agent's session is the failure this whole path is shaped to
+    /// avoid, and a near-miss that refuses costs the wearer one repeat.
+    ///
+    /// Two adapters answering to the same spoken name resolve to ``Resolution/ambiguous``
+    /// for the same reason two sessions of one adapter do. Nothing shipped collides, but
+    /// the fail-closed answer must not depend on that staying true.
+    public func resolve(name: String, now: Date) -> Resolution? {
+        let spoken = Self.normalized(name)
+        guard !spoken.isEmpty else { return nil }
+        let matches = live.values
+            .filter { !Self.isExpired($0, at: now) && Self.matches(spoken, $0.agent) }
+            .sorted { $0.agent.id < $1.agent.id }
+        guard let match = matches.first else { return nil }
+        guard matches.count == 1 else {
+            return .ambiguous(agentDisplayName: match.agent.displayName)
+        }
+        guard !isAmbiguous(agentID: match.agent.id, at: now) else {
+            return .ambiguous(agentDisplayName: match.agent.displayName)
+        }
+        return .resolved(match)
+    }
+
+    /// The agent's live session, or `nil` when it has none or has gone quiet. For tests
+    /// and diagnostics; routing goes through ``resolve(name:now:)``.
+    public func entry(agentID: String, at now: Date) -> Entry? {
+        guard let entry = live[agentID], !Self.isExpired(entry, at: now) else { return nil }
+        return entry
+    }
+
+    /// Whether a second session has been seen for this agent recently enough that its name
+    /// picks out neither. Reads the clock rather than a stored flag, so an agent becomes
+    /// unambiguous again the moment the rival session ages out — no sweep, no timer, and
+    /// no state that can be left behind by one.
+    public func isAmbiguous(agentID: String, at now: Date) -> Bool {
+        guard let other = displaced[agentID] else { return false }
+        return !Self.isExpired(other, at: now)
+    }
+
+    /// Every agent with a live session, sorted by identifier. For diagnostics.
+    public func liveEntries(at now: Date) -> [Entry] {
+        live.values
+            .filter { !Self.isExpired($0, at: now) }
+            .sorted { $0.agent.id < $1.agent.id }
+    }
+
+    // MARK: - Internals
+
+    private static func isExpired(_ entry: Entry, at now: Date) -> Bool {
+        now.timeIntervalSince(entry.lastSeen) > liveness
+    }
+
+    /// Whether a spoken name picks out this agent: its whole display name, or the first
+    /// word of it.
+    private static func matches(_ spoken: String, _ agent: AgentIdentity) -> Bool {
+        let display = agent.displayName
+        if normalized(display) == spoken { return true }
+        guard let first = display.split(whereSeparator: \.isWhitespace).first else {
+            return false
+        }
+        return normalized(first) == spoken
+    }
+
+    /// Lowercased letters and digits only, so punctuation a recognizer added cannot hide a
+    /// match. The same normalization the dictation flow's address parser compares with.
+    private static func normalized<S: StringProtocol>(_ text: S) -> String {
+        text.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+}

--- a/Sources/TapQCLI/ConversationMemory.swift
+++ b/Sources/TapQCLI/ConversationMemory.swift
@@ -19,9 +19,9 @@ import TapQInteractionBaseline
 ///
 /// Everything it can say is speech-safe by construction. The store's events have nowhere
 /// to put a `toolInput`, a `cwd`, or a `permissionMode`; the registry holds an agent
-/// identity and an opaque session key; and the open-window text is the summary and detail
-/// TapQ already speaks. No composition here needs a redaction pass because no unsafe
-/// field ever reaches it.
+/// identity and an opaque session key; the roster holds the same two and a pair of
+/// timestamps; and the open-window text is the summary and detail TapQ already speaks. No
+/// composition here needs a redaction pass because no unsafe field ever reaches it.
 @MainActor public final class ConversationMemory {
     /// A claim on one open window, surrendered to ``endWindow(_:)``.
     ///
@@ -81,6 +81,21 @@ import TapQInteractionBaseline
     /// against, and guessing between candidates is exactly what this does not do.
     private var lastTarget: (sessionID: String, agent: AgentIdentity)?
 
+    /// Which session answers to which agent's name, so a dictation can be addressed to an
+    /// agent other than the one in front of the wearer.
+    ///
+    /// It is filled from the traffic this object already watches — see ``noteAgentSeen``
+    /// — rather than from a subscription of its own, because a roster that could fall
+    /// behind conversation memory would be a roster that disagreed with what recall says
+    /// out loud. Read only through ``instructionAddressResolver``; nothing else in the
+    /// runtime needs to know who is live.
+    private var roster = AgentRoster()
+
+    /// The clock, kept as well as handed to the store: the roster's liveness window is
+    /// answered in wall time, and tests that drive a virtual clock must be able to age an
+    /// entry out without waiting half an hour.
+    private let clock: @Sendable () -> Date
+
     private var store: SessionContextStore
     private var windows: [WindowToken: OpenWindow] = [:]
     /// Open windows in the order they entered the gate. The gate is FIFO, so the first
@@ -98,7 +113,19 @@ import TapQInteractionBaseline
         instructions: InstructionMailbox? = nil
     ) {
         self.store = SessionContextStore(clock: clock)
+        self.clock = clock
         self.instructions = instructions
+    }
+
+    /// The one place the roster learns that a session is alive.
+    ///
+    /// Both callers are traffic this object already had to observe — a window opening
+    /// (every approval, selection, and stop question) and a notification arriving (the one
+    /// kind of message that never opens a window). Between them they cover every way an
+    /// agent can reach TapQ, which is what makes "TapQ has heard from this session" and
+    /// "this session is in the roster" the same statement.
+    private func noteAgentSeen(sessionID: String, agent: AgentIdentity) {
+        roster.note(sessionID: sessionID, agent: agent, at: clock())
     }
 
     // MARK: - Window lifecycle
@@ -129,6 +156,7 @@ import TapQInteractionBaseline
         )
         openOrder.append(token)
         lastTarget = (sessionID, agent)
+        noteAgentSeen(sessionID: sessionID, agent: agent)
         return token
     }
 
@@ -203,6 +231,11 @@ import TapQInteractionBaseline
     /// something the wearer never heard would be inventing a conversation.
     public func record(notification: AgentNotification) {
         store.record(notification: notification)
+        // The only agent message that never opens a window. Without this a session that
+        // has done nothing but announce things would be unaddressable by name, which the
+        // wearer would experience as TapQ not knowing about an agent it had just spoken
+        // about out loud.
+        noteAgentSeen(sessionID: notification.sessionID, agent: notification.agent)
     }
 
     // MARK: - Recall
@@ -321,6 +354,61 @@ import TapQInteractionBaseline
             guard let target = dictationTarget else { return }
             instructions.enqueue(text, session: target.sessionID)
         }
+    }
+
+    // MARK: - Addressed instructions
+
+    /// Resolves a spoken agent name to the session a dictation should be routed to, or
+    /// `nil` when nothing live answers to it.
+    ///
+    /// `nil` for the whole closure — not just for a name — without a mailbox, for the same
+    /// reason ``instructionEnqueue`` is: a run with nowhere to put an instruction has
+    /// nothing to route, and an absent resolver is what makes the dictation flow skip the
+    /// address grammar entirely rather than parse a sentence it cannot act on.
+    ///
+    /// One resolver serves every window. Which sessions are live is a fact about the
+    /// fleet, not about the window the wearer is standing in, so an in-prompt dictation, an
+    /// attention window, and a held voice-session boundary all resolve "Codex" to the same
+    /// session — and a second one of them makes the name ambiguous in all three.
+    ///
+    /// The addressee it hands back can reach exactly one thing: this mailbox, at that
+    /// session. It carries no session identifier the controllers could speak and no
+    /// capability of its own beyond queueing a sentence.
+    public var instructionAddressResolver: InstructionAddressResolving? {
+        guard let instructions else { return nil }
+        return { [self] name in
+            switch roster.resolve(name: name, now: clock()) {
+            case .none:
+                return nil
+            case let .ambiguous(agentDisplayName):
+                return .ambiguous(agentDisplayName: agentDisplayName)
+            case let .resolved(entry):
+                return .resolved(
+                    InstructionAddressee(
+                        agentDisplayName: entry.agent.displayName,
+                        // The same per-adapter table the in-window check reads. Routing is
+                        // a different way to reach an agent, never a different rule about
+                        // which agents can be reached.
+                        acceptsInstructions: AgentCapabilities.of(entry.agent).instructions,
+                        enqueue: { text in
+                            instructions.enqueue(text, session: entry.sessionID)
+                        }
+                    )
+                )
+            }
+        }
+    }
+
+    /// Whether `agentID` currently has more than one live session, which is what makes its
+    /// name unusable for routing. For tests and diagnostics.
+    public func isAgentAmbiguous(_ agentID: String) -> Bool {
+        roster.isAmbiguous(agentID: agentID, at: clock())
+    }
+
+    /// The session that answers to `agentID` right now, or `nil` when none does. For tests
+    /// and diagnostics; routing goes through ``instructionAddressResolver``.
+    public func rosterEntry(agentID: String) -> AgentRoster.Entry? {
+        roster.entry(agentID: agentID, at: clock())
     }
 
     // MARK: - Instructions from a wearer-initiated window (Rung D)

--- a/Sources/TapQDetectionBaseline/VoiceCommandMatcher.swift
+++ b/Sources/TapQDetectionBaseline/VoiceCommandMatcher.swift
@@ -127,6 +127,19 @@ public enum VoiceCommandMatcher {
         "tell it to", "tell claude to", "tell the agent to",
     ]
 
+    /// Words that follow "tell" without naming an agent, so "tell ⟨word⟩ to …" is not an
+    /// address. "me" is here because "tell me more" is the details command; the pronouns
+    /// because "tell it to …" is the prefix above and must keep being stripped as one.
+    ///
+    /// This grammar deliberately does not know which agents exist — that is a fact about
+    /// what is connected right now, which lives in the runtime and changes inside a run.
+    /// All this rule decides is that a *name* was spoken; whether anything answers to it is
+    /// settled later, out loud, by the dictation flow.
+    private static let unaddressedFollowers: Set<String> = [
+        "it", "me", "him", "her", "them", "us", "you", "the", "this", "that",
+        "everyone", "somebody", "someone",
+    ]
+
     /// The dictation branch: the earliest trigger in the transcript, if one survives the
     /// negation guard, plus whatever text follows a capturing prefix.
     ///
@@ -134,25 +147,62 @@ public enum VoiceCommandMatcher {
     /// what the wearer dictated is what the agent should be asked to do, in their own
     /// casing and punctuation, not in the apostrophe-stripped lowercase this grammar
     /// compares on. `nil` text means the flow opens and waits for the sentence.
+    ///
+    /// One trigger captures from its *own* first word rather than from the word after it:
+    /// "tell ⟨name⟩ to …", where ⟨name⟩ is a word this grammar does not already handle.
+    /// The address has to survive into the captured text because only the runtime knows
+    /// which agents are live, and a prefix stripped here would have thrown the name away
+    /// before anyone could resolve it.
     private static func beginInstruction(
         in raw: String,
         tokens: [(word: String, range: Range<String.Index>)]
     ) -> VoiceCommand? {
         let words = tokens.map(\.word)
-        var best: (start: Int, end: Int, capturing: Bool)?
+        /// `captureFrom` is the token index the instruction text starts at, or `nil` for a
+        /// trigger that opens the flow without supplying any.
+        var best: (start: Int, captureFrom: Int?)?
+        func consider(_ start: Int, captureFrom: Int?) {
+            // Strictly earlier wins, so a tie at the same word keeps the trigger that was
+            // considered first — which is what makes the addressed rule below a fallback
+            // for names the explicit prefixes do not already cover.
+            guard best.map({ start < $0.start }) ?? true else { return }
+            best = (start, captureFrom)
+        }
         func consider(_ run: String, capturing: Bool) {
             guard let start = firstIndex(ofRun: run, in: words) else { return }
-            guard best.map({ start < $0.start }) ?? true else { return }
-            best = (start, start + run.split(separator: " ").count, capturing)
+            let end = start + run.split(separator: " ").count
+            consider(start, captureFrom: capturing ? end : nil)
         }
         for run in instructionPrefixes { consider(run, capturing: true) }
         for run in instructionOpeners { consider(run, capturing: false) }
+        if let addressed = firstAddressedInstruction(in: words) {
+            consider(addressed, captureFrom: addressed)
+        }
         guard let match = best else { return nil }
         guard Set(words[..<match.start]).isDisjoint(with: negationWords) else { return nil }
-        guard match.capturing, match.end < tokens.count else { return .beginInstruction(nil) }
-        let text = raw[tokens[match.end].range.lowerBound...]
+        guard let captureFrom = match.captureFrom, captureFrom < tokens.count else {
+            return .beginInstruction(nil)
+        }
+        let text = raw[tokens[captureFrom].range.lowerBound...]
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return .beginInstruction(text.isEmpty ? nil : text)
+    }
+
+    /// Where "tell ⟨name⟩ to ⟨something⟩" begins, or `nil` when the transcript has no such
+    /// run.
+    ///
+    /// Three words and a fourth, all required. "Tell" alone would swallow "tell me more";
+    /// the trailing "to" is what separates an address from a sentence that merely opens
+    /// with the word; and the fourth word is the instruction, without which there is
+    /// nothing to route.
+    private static func firstAddressedInstruction(in words: [String]) -> Int? {
+        guard words.count >= 4 else { return nil }
+        for start in 0...(words.count - 4) where words[start] == "tell" {
+            guard !unaddressedFollowers.contains(words[start + 1]) else { continue }
+            guard words[start + 2] == "to" else { continue }
+            return start
+        }
+        return nil
     }
 
     /// The apostrophe spellings a transcript can carry. Recognizers emit the typographic

--- a/Sources/TapQInteractionBaseline/CommandWindowController.swift
+++ b/Sources/TapQInteractionBaseline/CommandWindowController.swift
@@ -181,6 +181,7 @@ public struct CommandWindowOutcome: Sendable, Equatable {
                 instructionCapability: InstructionCapabilityChecking? = nil,
                 wearerAttribution: WearerAttributionQuerying? = nil,
                 instructionEnqueue: InstructionDictating? = nil,
+                instructionAddressResolver: InstructionAddressResolving? = nil,
                 kind: CommandWindowKind = .attention,
                 voiceTrust: VoiceTrust = .wearer,
                 gestureConfirmation: GestureConfirmationQuerying? = nil) {
@@ -197,6 +198,7 @@ public struct CommandWindowOutcome: Sendable, Equatable {
                                               attribution: wearerAttribution,
                                               enqueue: instructionEnqueue,
                                               diagnostics: diagnostics,
+                                              resolveAddress: instructionAddressResolver,
                                               trust: voiceTrust,
                                               gestureConfirmation: gestureConfirmation)
     }

--- a/Sources/TapQInteractionBaseline/InstructionAddressing.swift
+++ b/Sources/TapQInteractionBaseline/InstructionAddressing.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// Where a name-addressed instruction would go, as the host answers for it.
+///
+/// The three fields are everything the dictation flow is allowed to know about another
+/// agent: the name it says out loud, whether that agent has a turn boundary to deliver
+/// into, and one closure that can put a sentence in its queue. There is deliberately no
+/// session identifier here and no `AgentIdentity` — the flow never speaks either, and a
+/// field it cannot see is a field it cannot leak into a read-back.
+///
+/// `enqueue` is the same ``InstructionDictating`` the in-window path takes, for the same
+/// reason: text in, nothing out. Routing changes which queue a sentence lands in and
+/// nothing else — a routed dictation can no more allow, deny, or select than an
+/// unaddressed one.
+public struct InstructionAddressee {
+    /// The resolved agent's display name, for the read-back and the queued notice.
+    public let agentDisplayName: String
+    /// Whether ``TapQContracts/AgentCapabilities`` says this agent can receive an
+    /// instruction at all. Answered by the host rather than looked up here, because the
+    /// controllers stay ignorant of the adapter table — the same reason
+    /// ``InstructionCapabilityChecking`` is a closure.
+    public let acceptsInstructions: Bool
+    /// Queues the instruction for this agent's next turn boundary.
+    public let enqueue: InstructionDictating
+
+    public init(
+        agentDisplayName: String,
+        acceptsInstructions: Bool,
+        enqueue: @escaping InstructionDictating
+    ) {
+        self.agentDisplayName = agentDisplayName
+        self.acceptsInstructions = acceptsInstructions
+        self.enqueue = enqueue
+    }
+}
+
+/// What a spoken agent name resolved to.
+///
+/// Two cases and a `nil`, which is three answers: this agent, *which* one, and no such
+/// agent. The middle case exists because the roster behind this seam assumes one live
+/// session per adapter, and the honest thing to do when that assumption breaks is to say
+/// so — not to pick the newer session and hope. Both non-resolutions refuse the dictation;
+/// neither falls back to the window's own target, because a wearer who named an agent
+/// meant that agent.
+public enum InstructionAddressResolution {
+    /// The name belongs to exactly one live session.
+    case resolved(InstructionAddressee)
+    /// The name belongs to an adapter with more than one live session, so it names no one
+    /// session. Carries the display name so the refusal can say which agent is doubled.
+    case ambiguous(agentDisplayName: String)
+}
+
+/// Resolves a spoken agent name to the session a dictation should be routed to, or `nil`
+/// when nothing live answers to that name.
+///
+/// A closure for the reason every other seam on this path is one: which sessions exist is
+/// something the runtime's conversation memory tracks, and the controllers must stay
+/// ignorant of it. It is also the whole extension point — a future fleet roster that
+/// tracks sessions properly replaces what is behind this closure without the dictation
+/// flow learning a thing.
+///
+/// An absent resolver is not a refusal, it is the composition that predates addressing:
+/// the flow never looks for an address at all, and every dictation goes to the window's
+/// own target exactly as it always has.
+public typealias InstructionAddressResolving =
+    @MainActor (String) -> InstructionAddressResolution?
+
+/// The leading address on a dictated sentence: "tell Codex to run the tests".
+///
+/// Deliberately the smallest grammar that covers what a wearer actually says, and
+/// deliberately deterministic — no model, no fuzzy matching, no scoring. A dictation that
+/// is misread as an address costs the wearer a refusal they can hear and repeat; one that
+/// silently routed to the wrong agent would cost them a sentence in a session they were
+/// not looking at.
+///
+/// The parse is anchored at the start of the sentence and nowhere else. "Ask Claude Code
+/// to tell Codex to stop" is one instruction for one agent, and a grammar that scanned for
+/// "tell" anywhere would have cut it in half.
+enum InstructionAddress {
+    /// A recognized address and what remained of the sentence.
+    struct Parsed: Equatable {
+        /// The spoken name, punctuation trimmed, in the wearer's own casing — it is read
+        /// back in the refusal when nothing answers to it.
+        let name: String
+        /// The instruction itself, with the address removed. Never empty.
+        let rest: String
+    }
+
+    /// The word that opens an address. One word, because a second phrasing is a second
+    /// thing that can be misheard, and "tell ⟨agent⟩ to …" is the phrasing the dictation
+    /// grammar already teaches.
+    static let opener = "tell"
+
+    /// What may separate the name from the instruction: "tell Codex **to** run the tests",
+    /// or a colon the wearer's recognizer punctuated in. Neither is required — a bare
+    /// "tell Codex run the tests" reads the first word as the name — but requiring one of
+    /// them for a *multi-word* name is what keeps the fallback from swallowing a sentence.
+    static let separator = "to"
+
+    /// How many words an agent name may run to. Three covers every shipped display name
+    /// and leaves room for one a host adds; past that, an unseparated sentence is being
+    /// read as a name.
+    static let maxNameWords = 3
+
+    /// Words that follow "tell" without naming anyone.
+    ///
+    /// This set is what makes an unaddressed sentence stay unaddressed. "Tell it to run
+    /// the tests" and "tell me what changed" both open with the address shape and neither
+    /// is one, so the parse must decline them rather than refuse a dictation the wearer
+    /// phrased exactly as this repo has always taught.
+    ///
+    /// A real agent name is deliberately *not* in here, "claude" included: a name that
+    /// resolves is an address, and the one-breath forms the dictation grammar already
+    /// strips ("tell claude to …") never reach this parser with their prefix intact.
+    static let unaddressed: Set<String> = [
+        "it", "me", "him", "her", "them", "us", "you", "the", "this", "that",
+        "everyone", "somebody", "someone",
+    ]
+
+    /// The address on `text`, or `nil` when it carries none — which is every sentence the
+    /// wearer has ever dictated, and is why `nil` means "behave exactly as before".
+    static func parse(_ text: String) -> Parsed? {
+        let words = Self.words(in: text)
+        // "tell", a name, and something to say: fewer words than that is not an address.
+        guard words.count >= 3, normalized(words[0].text) == opener else { return nil }
+        guard !unaddressed.contains(normalized(words[1].text)) else { return nil }
+
+        // Where the name ends and the instruction begins. The fallback — one word of name,
+        // no separator — is what makes "tell Codex run the tests" work.
+        var nameEnd = 2
+        var restStart = 2
+        for index in 1...min(maxNameWords, words.count - 1) {
+            if words[index].text.hasSuffix(":") {
+                nameEnd = index + 1
+                restStart = index + 1
+                break
+            }
+            if index > 1, normalized(words[index].text) == separator {
+                nameEnd = index
+                restStart = index + 1
+                break
+            }
+        }
+        guard restStart < words.count else { return nil }
+
+        let name = words[1..<nameEnd]
+            .map { $0.text.trimmingCharacters(in: .punctuationCharacters) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        guard !name.isEmpty else { return nil }
+
+        let rest = text[words[restStart].range.lowerBound...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rest.isEmpty else { return nil }
+        return Parsed(name: name, rest: rest)
+    }
+
+    /// Lowercased letters and digits only, so a recognizer's punctuation cannot hide a
+    /// match. The same normalization the runtime's roster compares names with.
+    static func normalized<S: StringProtocol>(_ text: S) -> String {
+        text.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    /// Whitespace-separated words paired with where they sit in the *original* string.
+    ///
+    /// The pairing is what lets the instruction be taken from `text` rather than rebuilt
+    /// from the words: what the wearer said is going to a language model, and rebuilding
+    /// would cost it the casing and punctuation that carry meaning ("readme" is not
+    /// "README"). The same reason ``TapQDetectionBaseline/VoiceCommandMatcher`` keeps
+    /// ranges into the raw transcript.
+    private static func words(
+        in text: String
+    ) -> [(text: Substring, range: Range<String.Index>)] {
+        var result: [(text: Substring, range: Range<String.Index>)] = []
+        var index = text.startIndex
+        while index < text.endIndex {
+            guard !text[index].isWhitespace else {
+                index = text.index(after: index)
+                continue
+            }
+            let start = index
+            while index < text.endIndex, !text[index].isWhitespace {
+                index = text.index(after: index)
+            }
+            result.append((text: text[start..<index], range: start..<index))
+        }
+        return result
+    }
+}

--- a/Sources/TapQInteractionBaseline/InteractionController.swift
+++ b/Sources/TapQInteractionBaseline/InteractionController.swift
@@ -226,6 +226,10 @@ public typealias InstructionDictating = @MainActor (String) -> Void
     let attribution: WearerAttributionQuerying?
     let enqueue: InstructionDictating?
     let diagnostics: TapQDiagnosticEmitter
+    /// Resolves a spoken agent name to somewhere else to send this sentence. `nil` — the
+    /// default, and every composition written before addressing existed — means the flow
+    /// never looks for an address, and every dictation goes to the window's own target.
+    var resolveAddress: InstructionAddressResolving?
     /// Whose voice may instruct. `.wearer` — the default — keeps the fail-closed
     /// attribution check; `.environment` skips it and says so in the diagnostics.
     var trust: VoiceTrust = .wearer
@@ -244,6 +248,29 @@ public typealias InstructionDictating = @MainActor (String) -> Void
     /// with the earbuds in and settled. Which of the two refused is in the diagnostic, and
     /// naming it out loud would only teach a bystander how to be believed.
     static let unattributedRefusal = "I can't confirm that was you — instruction discarded."
+
+    /// The refusal for an address nobody answers to: an agent TapQ has never served, or
+    /// one whose session has gone quiet past the roster's liveness window.
+    ///
+    /// It names the name back rather than listing who *is* live, because the list is a
+    /// sentence that grows with the fleet and the wearer's remedy is the same either way —
+    /// say it again, or say it from that session's window. The name is bounded before it
+    /// is spoken: it is the wearer's own speech, and a mis-segmented transcript could
+    /// otherwise put a paragraph in it.
+    static func unknownAgentRefusal(_ name: String) -> String {
+        let spoken = SpokenText.condensed(name, maxWords: 4, maxCharacters: 40)
+        return "I don't know an agent called \(spoken) — instruction discarded."
+    }
+
+    /// The refusal that says the one-session-per-adapter assumption broke.
+    ///
+    /// Fail closed and say why. TapQ knows two live sessions answer to this name and has
+    /// no way to ask which was meant, so it refuses the routing and points at the one
+    /// place where the addressee is unambiguous by construction — that session's own
+    /// window, where a dictation needs no address at all.
+    static func ambiguousAgentRefusal(_ agent: String) -> String {
+        "More than one \(agent) session is active — say it from that session's window."
+    }
 
     /// Runs the flow to completion, returning the sentence the caller should speak on its
     /// next listen — `nil` when there is nothing to say.
@@ -298,27 +325,100 @@ public typealias InstructionDictating = @MainActor (String) -> Void
         // opening the flow does not make the next voice in the room theirs.
         guard isAttributed(stage: "text") else { return Self.unattributedRefusal }
 
+        // Where this sentence is going, and under whose name it is read back. Both are the
+        // window's own until an address says otherwise — which is what keeps an unaddressed
+        // dictation byte-identical to the one this repo has always spoken.
+        var target = agent
+        var deliver = enqueue
+        var text = instruction
+        switch route(instruction) {
+        case .unaddressed:
+            break
+        case let .routed(addressee, rest):
+            target = addressee.agentDisplayName
+            deliver = addressee.enqueue
+            text = rest
+        case let .refused(sentence):
+            return sentence
+        }
+
         // The read-back is bounded; what gets queued is not. Truncating the instruction to
         // fit the sentence would change what the agent is asked to do ("run the tests but
         // not the slow ones" → "run the tests but"), which is worse than a long utterance —
         // and `condensed` ends a shortened read-back in an ellipsis, so the wearer hears
         // that they are confirming a sentence longer than the one being spoken.
-        let readBack = SpokenText.condensed(instruction, maxWords: 24, maxCharacters: 160)
+        //
+        // What is read back is the routed text, under the routed name: an address that has
+        // been stripped must not be spoken back as part of the sentence, and a wearer
+        // confirming a routed dictation must hear which agent they are confirming it for.
+        let readBack = SpokenText.condensed(text, maxWords: 24, maxCharacters: 160)
         switch await turn("Instruction: '\(SpokenText.sentence(readBack))' \(confirmCue)") {
         case .allow, .select:
             // Nod, tap, or "yes" — the same dual channel that confirms anything else, and
             // for the same reason: the read-back is the only moment the wearer hears what
             // the agent is about to be told.
-            enqueue(instruction)
+            deliver(text)
             diagnostics.record("instruction.queued",
-                               fields: ["agent": agent, "characters": "\(instruction.count)"])
-            return "Queued for \(agent)."
+                               fields: ["agent": target, "characters": "\(text.count)"])
+            return "Queued for \(target)."
         case .none:
             diagnostics.record("instruction.discarded", fields: ["reason": "silence"])
             return nil
         default:
             diagnostics.record("instruction.discarded", fields: ["reason": "declined"])
             return Self.discardedNotice
+        }
+    }
+
+    /// What an address on the dictated sentence did.
+    private enum Routing {
+        /// No address, or no resolver composed. The window's own target stands.
+        case unaddressed
+        /// The address named one live session; the instruction is what was left of it.
+        case routed(InstructionAddressee, text: String)
+        /// The address named no one, two someones, or an agent with no turn boundary.
+        /// Nothing is queued and the sentence is what the wearer hears.
+        case refused(String)
+    }
+
+    /// Reads a leading "tell ⟨agent⟩ to …" and decides where the sentence goes.
+    ///
+    /// Every non-resolution refuses rather than falling back to the window's own target.
+    /// A wearer who named an agent meant that agent, and quietly delivering their sentence
+    /// somewhere else is the one outcome that cannot be heard and corrected — they would
+    /// hear "Queued for ⟨other agent⟩" only after confirming a read-back they had already
+    /// approved for someone else.
+    ///
+    /// Diagnostics carry the resolved agent's name and never the wearer's words: an
+    /// unresolved name is speech, and speech belongs in the read-back and the refusal, not
+    /// in an operational log line.
+    private func route(_ instruction: String) -> Routing {
+        guard let resolveAddress, let address = InstructionAddress.parse(instruction) else {
+            return .unaddressed
+        }
+        guard let resolution = resolveAddress(address.name) else {
+            diagnostics.record("instruction.unknown_agent")
+            return .refused(Self.unknownAgentRefusal(address.name))
+        }
+        switch resolution {
+        case let .ambiguous(agentDisplayName):
+            diagnostics.record("instruction.ambiguous_agent",
+                               fields: ["agent": agentDisplayName])
+            return .refused(Self.ambiguousAgentRefusal(agentDisplayName))
+        case let .resolved(addressee):
+            // The per-adapter table applies to the agent the sentence is *going* to, not
+            // to the one that happened to open the window. Refused by name, in the same
+            // words an in-window dictation at that agent would have heard.
+            guard addressee.acceptsInstructions else {
+                diagnostics.record("instruction.unsupported_agent",
+                                   fields: ["agent": addressee.agentDisplayName])
+                return .refused(
+                    "Instructions aren't supported for \(addressee.agentDisplayName)."
+                )
+            }
+            diagnostics.record("instruction.routed",
+                               fields: ["agent": addressee.agentDisplayName])
+            return .routed(addressee, text: address.rest)
         }
     }
 
@@ -412,6 +512,7 @@ public typealias InstructionDictating = @MainActor (String) -> Void
                 instructionCapability: InstructionCapabilityChecking? = nil,
                 wearerAttribution: WearerAttributionQuerying? = nil,
                 instructionEnqueue: InstructionDictating? = nil,
+                instructionAddressResolver: InstructionAddressResolving? = nil,
                 voiceTrust: VoiceTrust = .wearer,
                 gestureConfirmation: GestureConfirmationQuerying? = nil) {
         self.speech = speech
@@ -426,6 +527,7 @@ public typealias InstructionDictating = @MainActor (String) -> Void
                                               attribution: wearerAttribution,
                                               enqueue: instructionEnqueue,
                                               diagnostics: diagnostics,
+                                              resolveAddress: instructionAddressResolver,
                                               trust: voiceTrust,
                                               gestureConfirmation: gestureConfirmation)
     }

--- a/Sources/TapQInteractionBaseline/SelectionController.swift
+++ b/Sources/TapQInteractionBaseline/SelectionController.swift
@@ -56,6 +56,7 @@ import TapQContracts
                 instructionCapability: InstructionCapabilityChecking? = nil,
                 wearerAttribution: WearerAttributionQuerying? = nil,
                 instructionEnqueue: InstructionDictating? = nil,
+                instructionAddressResolver: InstructionAddressResolving? = nil,
                 voiceTrust: VoiceTrust = .wearer,
                 gestureConfirmation: GestureConfirmationQuerying? = nil) {
         self.speech = speech
@@ -70,6 +71,7 @@ import TapQContracts
                                               attribution: wearerAttribution,
                                               enqueue: instructionEnqueue,
                                               diagnostics: diagnostics,
+                                              resolveAddress: instructionAddressResolver,
                                               trust: voiceTrust,
                                               gestureConfirmation: gestureConfirmation)
     }

--- a/Tests/TapQCLITests/InstructionMemoryTests.swift
+++ b/Tests/TapQCLITests/InstructionMemoryTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 import TapQContextBaseline
 import TapQContracts
+import TapQInteractionBaseline
 @testable import TapQCLI
 
 /// The runtime's instruction seams: which session a dictation is addressed to, which
@@ -107,6 +108,241 @@ final class InstructionMemoryTests: XCTestCase {
             "Claude Code was told to run the tests again."
         )
         XCTAssertEqual(memory.events(session: "s1").first?.kind, .instruction)
+    }
+
+    // MARK: - The roster behind name-addressed dictation
+
+    /// The map is filled from traffic conversation memory already watches: a window
+    /// opening puts that session on the roster under its agent's name.
+    func testAWindowPutsItsSessionOnTheRoster() async {
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: InstructionMailbox())
+
+        let claude = memory.beginWindow(
+            sessionID: "s1", agent: .claudeCode, summary: "run npm test"
+        )
+        memory.endWindow(claude)
+        let codex = memory.beginWindow(
+            sessionID: "s2", agent: .codex, summary: "push the branch"
+        )
+        memory.endWindow(codex)
+
+        XCTAssertEqual(memory.rosterEntry(agentID: AgentIdentity.claudeCode.id)?.sessionID,
+                       "s1")
+        XCTAssertEqual(memory.rosterEntry(agentID: AgentIdentity.codex.id)?.sessionID, "s2")
+        XCTAssertNil(memory.rosterEntry(agentID: AgentIdentity.cursor.id),
+                     "an agent TapQ has never heard from is not addressable")
+    }
+
+    /// The other way an agent reaches TapQ. A session that has only ever announced things
+    /// is still a session the wearer can name.
+    func testANotificationAlsoPutsASessionOnTheRoster() async {
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: InstructionMailbox())
+
+        memory.record(
+            notification: AgentNotification(sessionID: "s9", agent: .codex, kind: .finished)
+        )
+
+        XCTAssertEqual(memory.rosterEntry(agentID: AgentIdentity.codex.id)?.sessionID, "s9")
+    }
+
+    /// Entries expire on silence, because nothing on the wire ever says a session ended.
+    /// Past the liveness window the name stops resolving rather than routing a sentence
+    /// into a terminal that was closed an hour ago.
+    func testAQuietSessionAgesOffTheRoster() async {
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: InstructionMailbox())
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s1", agent: .codex, summary: "push the branch")
+        )
+        XCTAssertNotNil(resolve("Codex", with: memory))
+
+        clock.advance(by: AgentRoster.liveness + 1)
+
+        XCTAssertNil(memory.rosterEntry(agentID: AgentIdentity.codex.id))
+        XCTAssertNil(resolve("Codex", with: memory),
+                     "a name nothing live answers to resolves to nothing")
+    }
+
+    /// The guard. A second session for one adapter breaks the one-session-per-adapter
+    /// assumption the whole feature rests on, and the honest answer is to refuse the name
+    /// rather than pick the newer session.
+    func testASecondSessionMakesTheAgentsNameAmbiguous() async {
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: InstructionMailbox())
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s1", agent: .claudeCode, summary: "run npm test")
+        )
+        XCTAssertFalse(memory.isAgentAmbiguous(AgentIdentity.claudeCode.id))
+
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s2", agent: .claudeCode, summary: "push it")
+        )
+
+        XCTAssertTrue(memory.isAgentAmbiguous(AgentIdentity.claudeCode.id))
+        switch resolve("Claude", with: memory) {
+        case .ambiguous(let name):
+            XCTAssertEqual(name, "Claude Code")
+        default:
+            XCTFail("two live sessions must not resolve to either of them")
+        }
+    }
+
+    /// Two requests from the *same* session are what parallel tool calls look like, and
+    /// they must not make the agent unaddressable.
+    func testTwoWindowsOnOneSessionAreNotAmbiguous() async {
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: InstructionMailbox())
+        let first = memory.beginWindow(
+            sessionID: "s1", agent: .claudeCode, summary: "run npm test"
+        )
+        let second = memory.beginWindow(
+            sessionID: "s1", agent: .claudeCode, summary: "read the file"
+        )
+        defer {
+            memory.endWindow(first)
+            memory.endWindow(second)
+        }
+
+        XCTAssertFalse(memory.isAgentAmbiguous(AgentIdentity.claudeCode.id))
+        XCTAssertNotNil(resolve("Claude Code", with: memory))
+    }
+
+    /// Ambiguity is a fact about *now*, read from the clock rather than latched: once the
+    /// rival session has gone quiet the name picks out one session again.
+    func testAmbiguityClearsOnceTheOtherSessionAgesOut() async {
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: InstructionMailbox())
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s1", agent: .claudeCode, summary: "run npm test")
+        )
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s2", agent: .claudeCode, summary: "push it")
+        )
+        XCTAssertTrue(memory.isAgentAmbiguous(AgentIdentity.claudeCode.id))
+
+        clock.advance(by: AgentRoster.liveness + 1)
+        // The surviving session speaks again; the one it displaced has expired out.
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s2", agent: .claudeCode, summary: "run it again")
+        )
+
+        XCTAssertFalse(memory.isAgentAmbiguous(AgentIdentity.claudeCode.id))
+        switch resolve("claude", with: memory) {
+        case .resolved(let addressee):
+            XCTAssertEqual(addressee.agentDisplayName, "Claude Code")
+        default:
+            XCTFail("one live session answers to the name again")
+        }
+    }
+
+    /// What the resolver hands back can reach exactly one thing: the named session's
+    /// queue. Nothing lands in the window the wearer is standing in.
+    func testTheResolvedAddresseeQueuesForTheNamedSession() async {
+        let mailbox = InstructionMailbox()
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: mailbox)
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s2", agent: .codex, summary: "push the branch")
+        )
+        let token = memory.beginWindow(
+            sessionID: "s1", agent: .claudeCode, summary: "run npm test"
+        )
+        defer { memory.endWindow(token) }
+
+        switch resolve("codex", with: memory) {
+        case .resolved(let addressee):
+            XCTAssertTrue(addressee.acceptsInstructions)
+            addressee.enqueue("run the tests")
+        default:
+            return XCTFail("Codex is live and unambiguous")
+        }
+
+        XCTAssertEqual(mailbox.pending(session: "s2").map(\.text), ["run the tests"])
+        XCTAssertEqual(mailbox.pendingCount(session: "s1"), 0,
+                       "the open window's session was not the addressee")
+    }
+
+    /// RC6 by another route. The per-adapter table follows the agent a sentence is going
+    /// *to*, so a name-routed dictation at Cursor is refused exactly as an in-window one
+    /// would be.
+    func testAnAgentWithNoTurnBoundaryResolvesButRefusesInstructions() async {
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: InstructionMailbox())
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s3", agent: .cursor, summary: "edit the file")
+        )
+
+        switch resolve("Cursor", with: memory) {
+        case .resolved(let addressee):
+            XCTAssertFalse(addressee.acceptsInstructions)
+        default:
+            XCTFail("Cursor is live; it just cannot be instructed")
+        }
+    }
+
+    /// The same switch that makes the dictation grammar inert makes addressing inert:
+    /// without a mailbox there is nothing to route to, so there is no resolver at all.
+    func testWithoutAMailboxThereIsNoResolver() async {
+        let memory = ConversationMemory()
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s1", agent: .codex, summary: "push the branch")
+        )
+        XCTAssertNil(memory.instructionAddressResolver)
+    }
+
+    /// The resolver is a fact about the fleet, never about the request in hand. Nothing on
+    /// it can answer a question the interaction gate asks — there is no `Decision` and no
+    /// `SelectionResult` anywhere in its shape — and the window's own target is untouched
+    /// by anything the roster knows.
+    func testRoutingDoesNotDisturbTheWindowsOwnTarget() async {
+        let mailbox = InstructionMailbox()
+        let clock = SettableClock()
+        let memory = ConversationMemory(clock: clock.read, instructions: mailbox)
+        memory.endWindow(
+            memory.beginWindow(sessionID: "s2", agent: .codex, summary: "push the branch")
+        )
+        let token = memory.beginWindow(
+            sessionID: "s1", agent: .claudeCode, summary: "run npm test"
+        )
+        defer { memory.endWindow(token) }
+
+        memory.instructionEnqueue?("run the tests again")
+
+        XCTAssertEqual(memory.standingAgentDisplayName, "Claude Code")
+        XCTAssertTrue(memory.instructionCapability())
+        XCTAssertEqual(mailbox.pendingCount(session: "s1"), 1,
+                       "an unaddressed dictation still goes to the open window")
+        XCTAssertEqual(mailbox.pendingCount(session: "s2"), 0)
+    }
+
+    private func resolve(
+        _ name: String,
+        with memory: ConversationMemory
+    ) -> InstructionAddressResolution? {
+        memory.instructionAddressResolver?(name)
+    }
+}
+
+/// A clock a test can move by hand, so the roster's half-hour liveness window can be
+/// crossed without waiting for it.
+private final class SettableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    var read: @Sendable () -> Date {
+        { [self] in
+            lock.lock()
+            defer { lock.unlock() }
+            return now
+        }
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.lock()
+        defer { lock.unlock() }
+        now = now.addingTimeInterval(seconds)
     }
 }
 

--- a/Tests/TapQDetectionBaselineTests/VoiceCommandMatcherInstructionTests.swift
+++ b/Tests/TapQDetectionBaselineTests/VoiceCommandMatcherInstructionTests.swift
@@ -74,6 +74,44 @@ final class VoiceCommandMatcherInstructionTests: XCTestCase {
                        .beginInstruction(nil))
     }
 
+    // MARK: - Addressing another agent
+
+    /// "Tell ⟨name⟩ to …" for a name this grammar does not already handle captures the
+    /// *whole* run, address included. Which agents exist changes inside a run and is not
+    /// something a grammar can know; stripping the name here would throw it away before
+    /// anything could resolve it.
+    func testAnAddressedInstructionKeepsItsAddress() {
+        XCTAssertEqual(VoiceCommandMatcher.match("tell Codex to run the tests"),
+                       .beginInstruction("tell Codex to run the tests"))
+        XCTAssertEqual(VoiceCommandMatcher.match("tell Cursor to open the file"),
+                       .beginInstruction("tell Cursor to open the file"))
+    }
+
+    /// The prefixes that were already here still strip, so an unaddressed dictation reaches
+    /// the flow exactly as it always has.
+    func testTheExistingPrefixesStillStrip() {
+        XCTAssertEqual(VoiceCommandMatcher.match("tell it to run the tests"),
+                       .beginInstruction("run the tests"))
+        XCTAssertEqual(VoiceCommandMatcher.match("tell Claude to run the tests"),
+                       .beginInstruction("run the tests"))
+    }
+
+    /// The shapes that are not an address. "Tell me" is still the details command, a
+    /// pronoun is still not a name, and "tell ⟨name⟩" with nothing to say is not a
+    /// dictation at all.
+    func testAddressingDoesNotClaimSentencesThatOnlyStartWithTell() {
+        XCTAssertEqual(VoiceCommandMatcher.match("tell me more"), .details)
+        XCTAssertNil(VoiceCommandMatcher.match("tell them to wait"),
+                     "a pronoun is not a name, and this grammar has no rule for it")
+        XCTAssertNil(VoiceCommandMatcher.match("tell Codex"))
+    }
+
+    /// A negator in front of an addressed instruction blocks it for the same reason it
+    /// blocks every other dictation: the wearer is refusing to send anything.
+    func testANegatedAddressDoesNotDictate() {
+        XCTAssertEqual(VoiceCommandMatcher.match("don't tell Codex to run the tests"), .no)
+    }
+
     // MARK: - Negation
 
     /// The named case: a wearer refusing to send anything must not open dictation, and must

--- a/Tests/TapQInteractionBaselineTests/InstructionAddressingTests.swift
+++ b/Tests/TapQInteractionBaselineTests/InstructionAddressingTests.swift
@@ -1,0 +1,309 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+/// Name-addressed dictation: "tell Codex to run the tests" inside a window that belongs to
+/// somebody else.
+///
+/// Two claims run through every test here. A sentence with no address behaves exactly as it
+/// did before addressing existed — same target, same read-back, same words — and an address
+/// that does not resolve to exactly one live agent queues nothing at all. Between them they
+/// are the whole safety story: routing can move a sentence, and it can refuse to, and it can
+/// never decide anything about the request the window was opened for.
+@MainActor
+final class InstructionAddressingTests: XCTestCase {
+    private typealias FakeSpeech = InstructionDictationTests.FakeSpeech
+    private typealias ScriptedArbiter = InstructionDictationTests.ScriptedArbiter
+    private typealias Inbox = InstructionDictationTests.Inbox
+
+    /// Stands in for the runtime's roster. Deliberately a dictionary and a flag rather than
+    /// the real ``AgentRoster``: what is under test here is what the *flow* does with each
+    /// of the three answers, and a fake that can produce all three on demand proves that
+    /// without also re-testing liveness arithmetic.
+    @MainActor
+    final class Roster {
+        /// Spoken name → (display name, whether the adapter can be instructed).
+        var agents: [String: (display: String, instructable: Bool)] = [
+            "codex": (display: "Codex", instructable: true),
+            "claude": (display: "Claude Code", instructable: true),
+        ]
+        /// Spoken names that name more than one live session.
+        var ambiguous: Set<String> = []
+        /// What was routed where, newest last.
+        var queued: [(agent: String, text: String)] = []
+        private(set) var namesAsked: [String] = []
+
+        var resolver: InstructionAddressResolving {
+            { [self] name in
+                namesAsked.append(name)
+                let key = name.lowercased()
+                if ambiguous.contains(key) {
+                    return .ambiguous(agentDisplayName: agents[key]?.display ?? name)
+                }
+                guard let agent = agents[key] else { return nil }
+                return .resolved(
+                    InstructionAddressee(
+                        agentDisplayName: agent.display,
+                        acceptsInstructions: agent.instructable,
+                        enqueue: { [self] text in
+                            queued.append((agent: agent.display, text: text))
+                        }
+                    )
+                )
+            }
+        }
+    }
+
+    private func request() -> ApprovalRequest {
+        ApprovalRequest(id: "1", sessionID: "s1", agent: .claudeCode, toolName: "Bash",
+                        summary: "run npm test", detail: "full detail")
+    }
+
+    private func controller(
+        _ script: [InputIntent?],
+        speech: FakeSpeech,
+        inbox: Inbox,
+        roster: Roster?
+    ) -> InteractionController {
+        InteractionController(
+            speech: speech,
+            arbiter: ScriptedArbiter(script),
+            instructionCapability: { true },
+            wearerAttribution: { true },
+            instructionEnqueue: inbox.enqueue,
+            instructionAddressResolver: roster?.resolver
+        )
+    }
+
+    // MARK: - The grammar
+
+    func testTellAgentToCapturesTheNameAndTheRest() async {
+        let parsed = InstructionAddress.parse("tell Codex to run the tests")
+        XCTAssertEqual(parsed?.name, "Codex")
+        XCTAssertEqual(parsed?.rest, "run the tests")
+    }
+
+    /// A colon is what a recognizer punctuates an address with, and a bare name with no
+    /// separator is what a wearer says when they are in a hurry. Both read as one word of
+    /// name and the rest as the instruction.
+    func testTheColonAndBareFormsParseTheSameWay() async {
+        XCTAssertEqual(InstructionAddress.parse("tell Codex: run the tests")?.rest,
+                       "run the tests")
+        XCTAssertEqual(InstructionAddress.parse("tell Codex: run the tests")?.name, "Codex")
+        XCTAssertEqual(InstructionAddress.parse("tell Codex run the tests")?.name, "Codex")
+        XCTAssertEqual(InstructionAddress.parse("tell Codex run the tests")?.rest,
+                       "run the tests")
+    }
+
+    /// A display name that is two words is still one name.
+    func testAMultiWordNameIsTakenUpToTheSeparator() async {
+        let parsed = InstructionAddress.parse("tell Claude Code to open a pull request")
+        XCTAssertEqual(parsed?.name, "Claude Code")
+        XCTAssertEqual(parsed?.rest, "open a pull request")
+    }
+
+    /// The wearer's own words survive the parse, for the reason the dictation grammar keeps
+    /// them: a language model is going to read this, and "readme" is not "README".
+    func testTheInstructionKeepsItsCasingAndPunctuation() async {
+        XCTAssertEqual(
+            InstructionAddress.parse("Tell Codex to update the README, then push.")?.rest,
+            "update the README, then push."
+        )
+    }
+
+    /// Every shape that is not an address. These are the sentences a wearer has always
+    /// dictated, and each of them must stay unaddressed rather than become a refusal.
+    func testSentencesThatAreNotAddressesParseToNothing() async {
+        for text in ["run the tests again",
+                     "tell it to run the tests",
+                     "tell me what changed",
+                     "tell the agent to stop after this file",
+                     "tell them to wait",
+                     "tell Codex",
+                     "tell Codex to"] {
+            XCTAssertNil(InstructionAddress.parse(text), text)
+        }
+    }
+
+    /// Anchored at the start and nowhere else: an instruction is allowed to contain the
+    /// word "tell", and cutting one in half at the second occurrence would deliver a
+    /// fragment.
+    func testAnAddressIsOnlyReadAtTheStartOfTheSentence() async {
+        XCTAssertNil(InstructionAddress.parse("ask Claude Code to tell Codex to stop"))
+    }
+
+    // MARK: - Routing through the window
+
+    func testAnAddressedDictationIsQueuedForTheNamedAgent() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let roster = Roster()
+        let controller = self.controller(
+            [.beginInstruction("tell Codex to run the tests"), .allow, .deny],
+            speech: speech, inbox: inbox, roster: roster
+        )
+        let decision = await controller.resolve(request())
+
+        XCTAssertEqual(roster.queued.map(\.text), ["run the tests"],
+                       "the address is stripped before the agent ever sees it")
+        XCTAssertEqual(roster.queued.map(\.agent), ["Codex"])
+        XCTAssertEqual(inbox.queued, [], "and nothing reached the window's own session")
+        XCTAssertEqual(decision, .deny, "the request is answered by the input after the flow")
+    }
+
+    /// RD-era read-backs named the window's agent because there was only ever one. A routed
+    /// dictation must name the agent it is actually going to, in both sentences the wearer
+    /// hears.
+    func testTheReadBackAndTheNoticeNameTheResolvedAgent() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.beginInstruction("tell Codex to run the tests"), .allow, .deny],
+            speech: speech, inbox: inbox, roster: Roster()
+        )
+        _ = await controller.resolve(request())
+
+        XCTAssertTrue(speech.said(containing: "Instruction: 'run the tests.'"),
+                      "the wearer confirms the sentence the agent will receive")
+        XCTAssertTrue(speech.said(containing: "Queued for Codex."))
+        XCTAssertFalse(speech.said(containing: "Queued for Claude Code."))
+    }
+
+    /// The unchanged path, pinned as a whole sentence: with a resolver composed, a sentence
+    /// carrying no address is queued where it always was, under the name it always had.
+    func testAnUnaddressedDictationIsUntouchedByTheResolver() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let roster = Roster()
+        let controller = self.controller(
+            [.beginInstruction("run the tests again"), .allow, .deny],
+            speech: speech, inbox: inbox, roster: roster
+        )
+        _ = await controller.resolve(request())
+
+        XCTAssertEqual(inbox.queued, ["run the tests again"])
+        XCTAssertEqual(roster.queued.count, 0)
+        XCTAssertEqual(roster.namesAsked, [], "the resolver was never even consulted")
+        XCTAssertTrue(speech.said(containing: "Queued for Claude Code."))
+    }
+
+    // MARK: - Fail closed
+
+    /// A name nothing answers to. It is refused rather than delivered to the window's own
+    /// agent: the wearer named someone, and quietly sending their sentence elsewhere is the
+    /// one outcome they cannot hear and correct.
+    func testAnUnknownAgentIsRefusedAndQueuesNothing() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let roster = Roster()
+        let controller = self.controller(
+            [.beginInstruction("tell Aider to run the tests"), .allow, .deny],
+            speech: speech, inbox: inbox, roster: roster
+        )
+        let decision = await controller.resolve(request())
+
+        XCTAssertEqual(inbox.queued, [])
+        XCTAssertEqual(roster.queued.count, 0)
+        XCTAssertTrue(speech.said(containing: "I don't know an agent called Aider"))
+        XCTAssertEqual(decision, .allow, "and the refusal did not answer the request")
+    }
+
+    /// The guard, spoken. Two live sessions answer to the name, so TapQ refuses the routing
+    /// and says where the addressee *is* unambiguous.
+    func testAnAmbiguousAgentIsRefusedWithTheReasonSaidOutLoud() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let roster = Roster()
+        roster.ambiguous = ["claude"]
+        let controller = self.controller(
+            [.beginInstruction("tell Claude to run the tests"), .allow, .deny],
+            speech: speech, inbox: inbox, roster: roster
+        )
+        let decision = await controller.resolve(request())
+
+        XCTAssertEqual(inbox.queued, [])
+        XCTAssertEqual(roster.queued.count, 0)
+        XCTAssertTrue(speech.said(
+            containing: "More than one Claude Code session is active"
+        ))
+        XCTAssertEqual(decision, .allow)
+    }
+
+    /// RC6 follows the addressee. Cursor has no turn boundary to deliver into, and a
+    /// name-route to it is refused in the same words an in-window dictation there would
+    /// have heard.
+    func testARouteToAnAgentThatCannotBeInstructedIsRefusedByName() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let roster = Roster()
+        roster.agents["cursor"] = (display: "Cursor", instructable: false)
+        let controller = self.controller(
+            [.beginInstruction("tell Cursor to run the tests"), .allow, .deny],
+            speech: speech, inbox: inbox, roster: roster
+        )
+        _ = await controller.resolve(request())
+
+        XCTAssertEqual(inbox.queued, [])
+        XCTAssertEqual(roster.queued.count, 0)
+        XCTAssertTrue(speech.said(containing: "Instructions aren't supported for Cursor."))
+    }
+
+    /// Without a resolver — every composition that predates addressing — the address is not
+    /// even looked for, and the sentence is queued whole exactly as it used to be.
+    func testWithoutAResolverTheAddressIsJustWords() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let controller = self.controller(
+            [.beginInstruction("tell Codex to run the tests"), .allow, .deny],
+            speech: speech, inbox: inbox, roster: nil
+        )
+        _ = await controller.resolve(request())
+
+        XCTAssertEqual(inbox.queued, ["tell Codex to run the tests"])
+        XCTAssertTrue(speech.said(containing: "Queued for Claude Code."))
+    }
+
+    // MARK: - Decisions are not routable
+
+    /// The separation this feature must not weaken. Every intent that resolves a request is
+    /// answered by the window, never by the dictation flow, so nothing the wearer says
+    /// about another agent can allow, deny, or select in this one — and the confirming
+    /// "yes" inside a routed read-back is spent there, exactly as it is for an unaddressed
+    /// dictation.
+    func testAddressedDictationCannotResolveTheRequest() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let roster = Roster()
+        let controller = self.controller(
+            [.beginInstruction("tell Codex to deploy"), .allow, .deny],
+            speech: speech, inbox: inbox, roster: roster
+        )
+        let decision = await controller.resolve(request())
+
+        XCTAssertEqual(decision, .deny,
+                       "the allow that confirmed the read-back never reached the request")
+        XCTAssertEqual(roster.queued.map(\.text), ["deploy"])
+    }
+
+    /// A refused route leaves the window exactly where it was: still waiting for the answer
+    /// it opened for, with its budget spent only on the turns that were taken.
+    func testARefusedRouteLeavesTheRequestWaiting() async {
+        let speech = FakeSpeech()
+        let inbox = Inbox()
+        let arbiter = ScriptedArbiter(
+            [.beginInstruction("tell Aider to deploy"), .allow]
+        )
+        let controller = InteractionController(
+            speech: speech,
+            arbiter: arbiter,
+            instructionCapability: { true },
+            wearerAttribution: { true },
+            instructionEnqueue: inbox.enqueue,
+            instructionAddressResolver: Roster().resolver
+        )
+        let decision = await controller.resolve(request())
+
+        XCTAssertEqual(decision, .allow)
+        XCTAssertEqual(arbiter.calls, 2, "the refusal cost one turn, not the window")
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,7 +87,7 @@ The underlying command syntax is `tapq serve [options]`.
 | `--wearer-gate` | IMU-based wearer-speech attribution gate (default: off). Voice commands must be attributed to the wearer's own jaw vibration; commands from bystanders or other audio sources are rejected. Fails open when the signal is unavailable or degraded. Uses `wearer-speech-calibration.json` when present, provisional thresholds otherwise |
 | `--imu-turn-control` | IMU-based turn control (default: off). Endpointing: wearer speech-end commits the user turn after a short delay. Barge-in: wearer speech-onset during response audio interrupts playback. Both are additive to gesture/tap/timeout resolution. Shares one signal source with `--wearer-gate`. On `--voice-backend openai-realtime` it also decides who ends user turns: without it, or with no AirPods streaming, the backend's own voice activity detection does — see [Turn detection](#turn-detection) |
 | `--voice-freeform` | Free-form voice answers for selections and multi-option stop questions (default: off). Requires `--voice-backend openai-realtime`. An unmatched final transcript is offered as a free-text reply with mandatory read-back confirmation. Tool approvals and yes/no stop questions stay binary |
-| `--voice-instructions` | Dictated instructions to the agent (default: off). Requires `--wearer-gate` under `--voice-trust wearer`; passing it alone is a startup error there. "New instruction" or "tell it to ⟨…⟩" inside an open prompt opens a read-back-and-confirm dictation, and the confirmed sentence is delivered at the agent's next turn boundary. Fail-closed on wearer attribution — the inverse of every other voice path. Claude Code and Codex only. See [Dictated instructions](#dictated-instructions) |
+| `--voice-instructions` | Dictated instructions to the agent (default: off). Requires `--wearer-gate` under `--voice-trust wearer`; passing it alone is a startup error there. "New instruction" or "tell it to ⟨…⟩" inside an open prompt opens a read-back-and-confirm dictation, and the confirmed sentence is delivered at the agent's next turn boundary. A leading "tell ⟨agent⟩ to ⟨…⟩" addresses another live session by name, and refuses out loud when the name is unknown or names more than one session. Fail-closed on wearer attribution — the inverse of every other voice path. Claude Code and Codex only. See [Dictated instructions](#dictated-instructions) |
 | `--voice-session` | Hold the agent's turn boundary open and keep listening (default: off). Requires `--voice-instructions`. When a turn ends, the Stop hook waits on the broker instead of returning: TapQ says "Listening." and re-opens a command window until an instruction is queued (delivered as the Stop block, so the agent continues), the wearer ends the session, or the ten-minute wait budget expires and the session idles. Inside a waiting window an unmatched sentence needs no "tell it to" prefix. See [Voice sessions](#voice-sessions) |
 | `--voice-trust wearer\|environment` | Whose voice may dictate an instruction (default: `wearer`). `wearer` is today's behavior byte for byte: dictation is fail-closed on IMU wearer attribution. `environment` trusts the microphone as the user — `--voice-instructions` then needs no `--wearer-gate`, the attribution check is skipped (recorded as `instruction.trusted_environment`), and read-backs stop asking for a nod where no nod can arrive. Approvals are untouched under either value. See [Voice trust](#voice-trust) |
 | `--auto-answer off\|routine` | Delegation filter (default: `off`). `routine` answers `allow` silently, without opening a window, when the stage-2 reasoner called the action routine, its confidence clears the policy floor, and the tool is not on the never-list. Requires `--reasoner` and `--reasoner-mode primary`; both are startup errors when missing. Approvals only. See [Auto-answered approvals](#auto-answered-approvals) |
@@ -413,6 +413,54 @@ Bounds, all deliberate:
 - Delivery waits for a boundary the agent produces, so an instruction dictated to an idle
   agent waits for someone to type — unless the run is holding one open; see
   [Voice sessions](#voice-sessions).
+
+##### Addressing another agent by name
+
+A dictation normally goes to the agent whose window is open — or, in a wearer-initiated
+window, to the last agent TapQ served. Naming an agent overrides that:
+
+```
+"tell Codex to run the integration tests"
+"tell Codex: run the integration tests"
+"tell Codex run the integration tests"
+```
+
+The accepted shape is a leading `tell ⟨agent⟩ to ⟨instruction⟩`, with a colon or nothing at
+all in place of the `to`. The name is matched case-insensitively against the display names
+TapQ already speaks, or the first word of one — "claude" reaches Claude Code. The address
+is stripped before anything else happens, so the agent receives `run the integration
+tests`, and the read-back and the queued notice both name the agent it is going to:
+`"Instruction: 'run the integration tests.' Nod or say yes to queue it."` → `"Queued for
+Codex."`
+
+Everything else about the flow is unchanged. A sentence with no address behaves exactly as
+it always has; the confirming nod is still spent inside the dictation; and a routed
+instruction still authorizes nothing — approvals, selections, and stop answers always apply
+to the window in front of the wearer and can never be addressed anywhere.
+
+The three prefix forms that predate addressing — "tell it to ⟨…⟩", "tell Claude to ⟨…⟩",
+"tell the agent to ⟨…⟩" — still mean "the agent in front of me" and are stripped before the
+address is ever looked for, so nothing an existing user says changes meaning.
+
+**One session per adapter.** The roster behind this is deliberately small: it remembers the
+most recent session per agent, filled from traffic TapQ already handles (a window opening,
+a notification arriving), and an entry expires after 30 minutes of silence — nothing on the
+wire ever says a session ended, so silence is the only signal there is. Naming an agent
+therefore names a session only while that assumption holds.
+
+**When it does not hold, TapQ refuses rather than guesses.** Two live sessions for one
+adapter make its name ambiguous, and the dictation is declined out loud: `"More than one
+Claude Code session is active — say it from that session's window."` A name nothing live
+answers to is declined the same way: `"I don't know an agent called Aider — instruction
+discarded."` In both cases nothing is queued anywhere — the sentence does not quietly fall
+back to the window's own agent, because a sentence delivered to the wrong session is the
+one mistake the wearer cannot hear. Say it again from that session's own window, where the
+addressee needs no name at all. Ambiguity clears on its own once the rival session has been
+silent for the liveness window.
+
+The per-adapter capability table still applies to whoever the sentence is going *to*, so
+`"tell Cursor to …"` is refused with the same sentence an in-window dictation there would
+have heard: `"Instructions aren't supported for Cursor."`
 
 While instructions are waiting, "who's waiting?" says so: `"Claude Code: run the test
 suite. Nothing else waiting. 1 instruction queued."` Once delivered, "what changed?"

--- a/docs/FLEET_ROSTER_PLAN.md
+++ b/docs/FLEET_ROSTER_PLAN.md
@@ -1,0 +1,106 @@
+# Fleet roster: routing instructions across agent sessions
+
+Status: design agreed 2026-08-27. Rung E (single-session v0) in implementation;
+the full roster (rung F) is designed but deliberately deferred.
+
+## Problem
+
+TapQ triages a fleet but cannot command one. Every wire message carries a
+`sessionID` and an `AgentIdentity`, the gate serializes attention, and the wearer
+can hear who is waiting — but a dictated instruction can only be addressed
+implicitly: the session whose window is open (`dictationTarget`), or the last
+session served (`standingTarget`). "Tell Codex to run the tests" while a Claude
+window is open has nowhere to go.
+
+There is also no roster: TapQ only knows sessions that have *asked* something
+(wait registry, context store, instruction queue). A session quietly working has
+never been seen.
+
+## Invariants that do not move, in any rung
+
+- **InteractionGate stays FIFO.** One spoken window at a time; routing never
+  touches attention scheduling.
+- **Decisions stay pinned.** Approvals, selections, and stop-answers always apply
+  to the open window. Only the instruction channel is routable — the resolver is
+  structurally unreachable from any decision path.
+- **Delivery is unchanged.** Per-session `InstructionMailbox` (cap 4, drop-oldest),
+  `InstructionWaitRegistry` held Stop boundaries, delivery at a turn boundary.
+- **Redaction by construction.** Anything the roster stores is speech-safe:
+  session ID, agent identity, timestamps, display labels. No `toolInput`, no
+  `cwd`, no `permissionMode` — the types have nowhere to put them.
+- **The read-back is the safety mechanism.** A routed instruction's read-back
+  names the resolved target ("Queued for Codex."), so a misroute is caught out
+  loud before anything is queued. No confidence scores.
+
+## Rung E (v0, shipping now): one session per adapter
+
+Assumption: each adapter has at most one active session. Under it, "the last
+session this agent contacted us from" *is* the session, and the entire roster
+collapses to a per-agent map inside `ConversationMemory`:
+
+- `agentID → (sessionID, AgentIdentity, lastSeen)`, updated as a side effect of
+  traffic TapQ already observes. Liveness is a last-seen expiry (~30 min).
+  No wire change, no adapter hooks, no new module.
+- **Resolver seam.** Target resolution is a closure/protocol in the style of
+  `InstructionCapabilityChecking` / `InstructionDictating`, so rung F's roster
+  replaces the map behind the same interface without touching grammar, read-back,
+  or tests.
+- **Grammar (deterministic, minimal).** A leading "tell <agent> to …" address,
+  matched case-insensitively against live display names ("claude" matches
+  "Claude Code" when unambiguous). The address is stripped before queueing. No
+  address → exactly today's behavior.
+- **The guard (the one piece of complexity kept).** If a second distinct session
+  ID is observed for the same agent inside the liveness window, that agent is
+  *ambiguous*: name-routing for it is refused — fail closed, out loud, and
+  nothing is queued anywhere ("More than one Claude Code session is active —
+  say it from that session's window"). Refusal, not fallback: silently
+  delivering to a guessed session is the exact failure this design exists to
+  prevent. The assumption is known-false in TapQ's primary scenario (people run
+  multiple Claude Code sessions), so it must degrade honestly, never misroute
+  silently. Ambiguity clears when the stale session expires.
+- Capability checks still apply: a name-route to an agent whose adapter does not
+  accept instructions is refused by name, exactly like today's in-window refusal.
+
+Scope: one PR, essentially confined to `TapQCLI` (map + resolver + grammar +
+read-back + status wording) and its tests.
+
+## Rung F (full roster, deferred): multiple sessions per agent
+
+Built only when someone actually hits the two-sessions-per-agent wall.
+
+- **`FleetRoster`** — a bounded, in-memory store in the house style (`Sendable`
+  value type with caps, `@MainActor`-owned, FIFO/LRU eviction, last-seen expiry):
+  session ID, agent, first/last-seen, speakable label. Populated two ways:
+  - *Passively* (~80%): `roster.noteSeen(session, agent)` on every message the
+    broker already dispatches.
+  - *Announce* (the remaining 20%): wire v7 adds `session.announce`
+    (started/ended), gated by `minimumVersion` exactly like `instruction.submit`
+    (v5) and `instruction.wait` (v6). Claude Code adapter first
+    (SessionStart/SessionEnd hook specs in `HookInstaller`); every other agent
+    stays passive and appears on first activity.
+- **Speakable labels** are display name + stable ordinal ("Claude Code two") —
+  session IDs are opaque and never spoken. Task-derived labels ("the one running
+  tests") are a later, model-assisted rung.
+- **Resolver stays heuristic**: named agent with exactly one live match → route;
+  exactly one live session total → route; otherwise fall back or ask one
+  disambiguation question ("Claude Code one or two?"). A model enters the
+  routing path only in a rung beyond F, grounded on `SessionContextStore`
+  digests (already speech-safe).
+- **Fleet status line**: `SessionRecall` grows a roster-fed line — "Three
+  sessions running: two Claude Code, one Codex. Codex is waiting." — within the
+  existing `statusCharacterLimit`.
+- Module diff: `TapQWireProtocol` (v7 + announce), `TapQClaudeAdapter` (hook
+  specs + shim announce), `TapQBrokerRuntime` (one arm + `onSessionEvent`
+  callback), `TapQContextBaseline` (`FleetRoster`), `TapQCLI` (resolver reads
+  roster; ordinal labels; disambiguation question).
+- Known seam with existing caps: the roster may know sessions
+  `SessionContextStore` (cap 8, first-seen eviction) has evicted; recall then
+  degrades to "nothing recorded", same as today.
+
+## Explicitly out of scope (all rungs so far)
+
+- Roster persistence or heartbeats — expiry is the whole liveness story.
+- Orchestration / fan-out: one utterance targets exactly one session. A full
+  orchestrator needs conversation state and output prose the voice-agent gap
+  analysis (docs/VOICE_AGENT_PLAN.md) already flags as missing.
+- Routing anything other than instructions.


### PR DESCRIPTION
Rung E of the fleet-roster plan (added here as `docs/FLEET_ROSTER_PLAN.md`): the wearer can address a dictated instruction to an agent by name, under the simplifying assumption that each adapter has at most one active session. No wire protocol change, no adapter hooks, no new modules outside TapQCLI/TapQInteractionBaseline.

## What it does

- **"tell Codex to run the tests"** routes the instruction to Codex's session from any window; the read-back names the resolved target ("Queued for Codex."). Grammar also accepts `tell <agent>: ...` and a bare `tell <agent> ...` fallback; names match case-insensitively against the display name or its first word ("claude" → Claude Code). Pronouns ("tell it to…", "tell me more") are never treated as names.
- **No address → byte-identical behavior to today.**

## How

- `AgentRoster` (new): per-agent `(sessionID, agent, lastSeen)` map populated from traffic ConversationMemory already observes, with a 30-minute liveness expiry — the "roster v0".
- `InstructionAddressing` (new): the resolver seam (closure-style, like the existing dictation hooks) plus the deterministic parser, so the future full FleetRoster (rung F in the plan) slots in behind the same interface.
- One capturing rule added to `VoiceCommandMatcher` so an addressed sentence reaches dictation with its address intact; all pre-existing strip-prefixes behave exactly as before.

## Fail-closed guard

The one-session assumption is known-false in the primary multi-Claude scenario, so it degrades honestly rather than misrouting: a second live session for the same agent makes that name ambiguous, and name-routing is refused out loud ("More than one Claude Code session is active — say it from that session's window") with **nothing queued**. Ambiguity clears when the stale session expires. Unknown names and agents without instruction support are likewise refused by name. Decisions (approvals, selections, stop-answers) stay pinned to the open window — only the instruction channel is routable.

## Testing

29 new tests (grammar, roster liveness/ambiguity, routing, refusals, decision isolation, matcher regressions). All touched suites green per-suite in the `swift:6.0` Linux container; the full single-binary `swift test` run hits the known Docker-on-arm64 `@MainActor` hang, which reproduces on unmodified `main` — x86_64 CI is the real verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
