### PR TITLE
Rescue the Linux test-runner's lost main-actor wakeups in ~0.1s

### DIFF
--- a/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendCommandProviderTests.swift
@@ -2,6 +2,28 @@ import XCTest
 @testable import TapQInteractionBaseline
 import TapQContracts
 
+/// Keeps a short timer pending that re-enqueues onto the main actor for the life of the
+/// test process.
+///
+/// The Linux container's runtime nondeterministically loses a main-actor wakeup (the
+/// CLAUDE.md "wedge"): queued main-actor jobs stop being drained and the process sits at
+/// ~0% CPU until a NEW job lands on the main actor. Measured 2026-08-29: a test with an
+/// instant `idleSleep` and no timers of its own stalled for 59.98s and resumed exactly
+/// when an earlier test's real 60-second idle-timer task fired — this suite's
+/// 1s/61s/121s run-to-run variance was that accidental rescue, at 60s granularity, and
+/// the runs slim-check kills as wedged are the same stall with no timer left pending.
+/// This task is the same rescue on purpose, every 100ms, so a lost wakeup costs ~0.1s.
+/// It must be a `@MainActor` task: each sleep completion then resumes onto the main
+/// actor, and that enqueue is what restarts the drain (a detached variant was measured
+/// NOT to rescue — its ticks stay on the global pool). Lazy global, so it starts with
+/// the first `settle()` of the run; never cancelled, because process exit does not wait
+/// for a sleeping task.
+private let executorStallHeartbeat: Task<Void, Never> = Task { @MainActor in
+    while !Task.isCancelled {
+        try? await Task.sleep(for: .milliseconds(100))
+    }
+}
+
 @MainActor
 final class VoiceBackendCommandProviderTests: XCTestCase {
     private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
@@ -150,6 +172,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
     /// The window opens across an `await`, so tests hand the main actor back before
     /// asserting on it.
     private func settle() async {
+        _ = executorStallHeartbeat
         for _ in 0..<4 { await Task.yield() }
     }
 
@@ -1729,7 +1752,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             sessionPolicy: .conversation(idleClose: 60),
             supportsBargeIn: true,
             responseAudio: playback,
-            idleSleep: { try? await Task.sleep(for: .seconds($0)) },
+            idleSleep: { _ in },
             diagnosticSink: sink)
         let tts = FakeSpeechActivity()
         let combinedActivity = CombinedSpeechActivity(tts: tts, playback: playback)
@@ -2345,7 +2368,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             sessionPolicy: .conversation(idleClose: 60),
             supportsBargeIn: true,
             responseAudio: playback,
-            idleSleep: { try? await Task.sleep(for: .seconds($0)) },
+            idleSleep: { _ in },
             diagnosticSink: sink)
     }
 
@@ -2470,7 +2493,7 @@ final class VoiceBackendCommandProviderTests: XCTestCase {
             sessionPolicy: .conversation(idleClose: 60),
             supportsBargeIn: true,
             responseAudio: playback,
-            idleSleep: { try? await Task.sleep(for: .seconds($0)) },
+            idleSleep: { _ in },
             diagnosticSink: sink)
         var received: [VoiceCommand] = []
 

--- a/scripts/slim-check.sh
+++ b/scripts/slim-check.sh
@@ -56,11 +56,14 @@ SLIM_SUITES=(
     ApprovalPathE2ETests               # end-to-end: gesture -> approval -> agent
 )
 
-# Suites that legitimately take real time (they sleep). Everything else in the
-# list finishes in about a second, so anything longer means the process wedged.
-SLIM_SLOW_SUITES=(
-    VoiceBackendCommandProviderTests   # ~61s: exercises the real idle-sleep timer
-)
+# Suites that legitimately take real time (they sleep), space-separated. Everything
+# in the list finishes in about a second, so anything longer means the process
+# wedged. Empty today: VoiceBackendCommandProviderTests used to sit here at ~61s,
+# but that was never the idle-sleep timer — it was the container wedge being
+# rescued at 60s granularity by a pending idle-timer task. The suite now runs its
+# own 100ms main-actor heartbeat (see executorStallHeartbeat in the test file),
+# which does the same rescue in ~0.1s.
+SLIM_SLOW_SUITES=""
 
 FAST_TIMEOUT="${TAPQ_SLIM_FAST_TIMEOUT:-30}"      # first attempt, ordinary suite
 SLOW_TIMEOUT="${TAPQ_SLIM_SLOW_TIMEOUT:-150}"     # first attempt for a slow suite, and every retry
@@ -121,7 +124,7 @@ docker run --rm \
     -w /src \
     -v "${BUILD_VOLUME}":/build \
     -e TAPQ_SLIM_SUITES="${suites[*]}" \
-    -e TAPQ_SLIM_SLOW_SUITES="${SLIM_SLOW_SUITES[*]}" \
+    -e TAPQ_SLIM_SLOW_SUITES="${SLIM_SLOW_SUITES}" \
     -e TAPQ_SLIM_MODE="$mode" \
     -e TAPQ_SLIM_FAST_TIMEOUT="$FAST_TIMEOUT" \
     -e TAPQ_SLIM_SLOW_TIMEOUT="$SLOW_TIMEOUT" \


### PR DESCRIPTION
`VoiceBackendCommandProviderTests` ran in 1s, 61s, or 121s across identical runs, and slim-check budgeted it 150s for that. The 60-second units were never the idle timer doing real work: the container's known wedge is a lost main-actor wakeup, and a pending `@MainActor` timer completion is what rescues it. A test with an instant `idleSleep` and no timers of its own measured a 59.98s stall that ended exactly when an earlier test's real 60-second idle-timer task fired — the suite's variance was that accidental rescue at 60s granularity, and the runs slim-check kills as wedged are the same stall with nothing left pending to fire.

This makes the rescue deliberate: a lazy global `@MainActor` heartbeat task (100ms period) keeps a re-enqueue onto the main actor always pending, so a lost wakeup costs ~0.1s. A detached (global-pool) heartbeat was measured NOT to rescue — the enqueue has to land on the main actor. Measured 20/20 invocations at ≤1s where the same loop previously stalled or wedged roughly one in three.

Also converts the three remaining real 60-second `idleSleep` constructions to the injected instant sleep their siblings use (their timers turn out to have been rescuers, not costs, but instant is the suite's idiom), and empties `SLIM_SLOW_SUITES` in `scripts/slim-check.sh`: the 150s first-attempt budget existed for the disguised wedge, and 30s now cuts a residual stall off five times sooner.

Other slim suites seen wedging (`InstructionWaitRegistryTests`, `OpenAIRealtimeVoiceBackendTests`, `InteractionControllerTests`, `VoiceProviderRouteE2ETests`) can adopt the same heartbeat pattern in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
