### PR TITLE
TapQ agent M1: durable wearer memory and transcript answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Added
 
+- **Ask about the work out loud** (`--voice-backend openai-realtime` only). "What did the
+  tests say?", "what command did you run?", "what did it decide about the migration?" —
+  TapQ reads the agent's own session transcript and answers, in one sentence, spoken in the
+  run's voice. Claude Code's hooks already carry the path to their session file; the shim now
+  forwards it as an optional wire field (no protocol bump, inert to older peers), and the
+  runtime tails the file from a byte offset, tolerating the rewrites compaction performs. The
+  answer is one call to the narration model over slices selected by recency and by the words
+  of the question, capped per answer, and it is spoken word for word. Selecting a cloud voice
+  backend is the consent for TapQ to read those transcripts: on the Apple path there is no
+  store, the tool is never declared, and the forwarded path reaches nothing. Two failure
+  classes, kept apart — a transcript TapQ cannot read is said out loud and the session
+  carries on; a failed cloud call breaks the run's voice rather than producing a half-answer.
+  See [`docs/TRANSCRIPT_CONTEXT_PLAN.md`](docs/TRANSCRIPT_CONTEXT_PLAN.md).
+
 - **Silence is never an answer** (ratified 2026-08-28). A request the wearer directs at TapQ
   that cannot be carried out is now always answered out loud; speech that was not directed at
   TapQ — chatter, thinking aloud, a sentence meant for an agent — is still left alone. Saying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Added
 
+- **TapQ remembers its own conversation with you** (`--voice-backend openai-realtime`
+  only). What you said, what TapQ said back, what was approved or denied, and which
+  instructions reached which agent are appended to `wearer-conversation.jsonl` in the
+  runtime directory, and a bounded recent slice of it joins the model's per-turn context.
+  So "do the thing I asked you about earlier" now survives a dropped voice session and a
+  restarted runtime, where before it survived only as long as the socket did. Your own
+  words are kept verbatim — they are short, and a summary of the thing you want recalled is
+  the one thing that cannot recall it. Speech-safe by construction, not by filter: the file
+  records only what was spoken or heard, and tool inputs, working directories, and
+  permission modes are never spoken. It keeps 30 days or a couple of megabytes, whichever
+  comes first, dropping the oldest; `tapq memory clear` wipes it on demand. The Apple voice
+  backend composes no store and writes no file. See
+  [`docs/TAPQ_AGENT_PLAN.md`](docs/TAPQ_AGENT_PLAN.md) (Pillar A, milestone M1).
+
 - **Silence is never an answer** (ratified 2026-08-28). A request the wearer directs at TapQ
   that cannot be carried out is now always answered out loud; speech that was not directed at
   TapQ — chatter, thinking aloud, a sentence meant for an agent — is still left alone. Saying

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -384,6 +384,15 @@ import Darwin
         /// this is non-nil, so with no cloud to call there is nothing to disable and no flag
         /// to read — the classifier and the spoken summarizer keep every boundary they had.
         var boundaryNarrator: (any BoundaryNarrating)?
+        /// The connected agents' session transcripts, on the model-backed path only.
+        ///
+        /// nil on the Apple path, and that nil is load-bearing twice over: the broker gets
+        /// no callback to hand a forwarded transcript path to, so nothing is ever read from
+        /// disk; and the voice provider gets no answerer, so `ask_about_work` is never
+        /// declared and a call for it is a protocol failure rather than a feature that
+        /// quietly worked. TapQ persists nothing here — offsets and a bounded tail, both of
+        /// which die with this object.
+        var transcriptStore: TranscriptStore?
         switch configuration.voiceBackend {
         case .apple:
             rawVoice = VoiceListener(
@@ -457,6 +466,37 @@ import Darwin
                 playbackDependent?.notePlaybackUnavailable(detail: detail)
             }
             playback = player
+
+            // -- Transcript context (TRANSCRIPT_CONTEXT_PLAN.md, phase 1) --
+            //
+            // Composed here and nowhere else. Selecting a cloud voice backend *is* the
+            // consent for TapQ to read connected agents' sessions (maintainer, 2026-08-28),
+            // so the store, the answer model, and the `ask_about_work` declaration all hang
+            // off this branch: on the Apple path there is no store, the tool is not
+            // declared, and the wire field the shim now sends reaches a broker with nowhere
+            // to put it. Structurally absent, not disabled.
+            //
+            // The key is guaranteed present — `VoiceBackendFactory.select` above threw
+            // without it — and re-read from the environment for the same reason narration
+            // re-reads it below: this composes from exactly the environment the pipe did.
+            guard let transcriptKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines), !transcriptKey.isEmpty else {
+                throw VoiceBackendConfigurationError.missingOpenAIAPIKey
+            }
+            let store = TranscriptStore(diagnosticSink: diagnostics)
+            transcriptStore = store
+            let answerer = TranscriptQuestionAnswerer(
+                store: store,
+                // The narration-family model, the same client and the same key: one cloud
+                // call per question, decided by prompt rather than by code, and speech out
+                // the other end.
+                model: OpenAINarrationModel(
+                    apiKey: transcriptKey,
+                    model: OpenAINarrationModel.resolvedModel(),
+                    diagnosticSink: diagnostics
+                ),
+                diagnosticSink: diagnostics
+            )
             let provider = VoiceBackendCommandProvider(
                 backend: broken,
                 // No matcher, and the absence is the feature. Ratified 2026-08-28: for the
@@ -479,6 +519,13 @@ import Darwin
                 freeformEnabled: configuration.voiceFreeformEnabled
                     || configuration.voiceSessionEnabled,
                 isWearerTurnSignalLive: { [turnSignalLiveness] in turnSignalLiveness.isLive },
+                // Present, so `ask_about_work` is declared to every session this provider
+                // opens. The provider knows nothing about transcripts beyond this closure:
+                // it asks a question and gets back a sentence, a spoken refusal, or a
+                // failure to break on.
+                answerWorkQuestion: { [answerer] question, agent in
+                    await answerer.answer(question: question, agentDisplayName: agent)
+                },
                 diagnosticSink: diagnostics
             )
             // A sentence the specified backend cannot say is not a cue to say it in a
@@ -497,6 +544,14 @@ import Darwin
             // rather than quietly resuming keyword matching.
             provider.onIntentPipelineFailed = { [weak broken] detail in
                 broken?.noteBackendFailed(reason: "intent tool protocol: \(detail)")
+            }
+            // The third sibling, same latch. The cloud call behind `ask_about_work` is the
+            // narration model on the narration endpoint with the narration key, so its
+            // failure gets narration's answer: break, loudly, once. A transcript that cannot
+            // be *read* never arrives here — that is spoken to the wearer and the session
+            // lives, which is the whole of the two-class failure posture.
+            provider.onWorkAnswerFailed = { [weak broken] reason in
+                broken?.noteBackendFailed(reason: "work answer: \(reason)")
             }
             backendProvider = provider
             rawVoice = provider
@@ -1530,6 +1585,15 @@ import Darwin
                     // broken, or the runtime going away. All of them mean the same thing to
                     // the shim, and it is the safe one: carry on.
                     return .none
+                }
+            },
+            // Where a session's transcript is, forwarded by the shim on messages it already
+            // sends. `nil` without a store — the Apple path — so the field arrives, decodes,
+            // and reaches nothing. Attaching is idempotent and cheap: every hook event
+            // carries the path, and the store tails from its own byte offset.
+            onTranscriptPath: transcriptStore.map { store in
+                { attachment in
+                    store.attach(session: attachment.sessionID, path: attachment.path)
                 }
             }
         )

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -1123,6 +1123,72 @@ import Darwin
             )
         }
 
+        // -- TapQ's own memory (docs/TAPQ_AGENT_PLAN.md, Pillar A, milestone M1) --
+        //
+        // The durable record of the dialogue TapQ has with the wearer: what they said,
+        // what TapQ said back, what was decided, and which instructions reached which
+        // agent. Third file in this directory and the same discipline as the other two —
+        // 0600 inside the 0700 runtime directory, never leaves the machine — but the first
+        // one TapQ reads back, which is what the bounded recent window below is for.
+        //
+        // `nil` on the Apple path, and that nil is the whole of "structurally absent, not
+        // disabled": with no store there is nothing to record into and no window to read,
+        // so the three hooks are never assigned, `currentGrounding` finds no memory block
+        // to append, and a run on that path leaves no file behind. There is no flag.
+        let wearerMemory: WearerConversationStore? =
+            configuration.voiceBackend == .openaiRealtime
+                ? WearerConversationStore(
+                    directory: discovery.supportDirectory,
+                    diagnosticSink: diagnostics
+                )
+                : nil
+        if let wearerMemory, let backendProvider {
+            // Every sentence TapQ speaks, at the moment it goes out to be spoken. The hook
+            // sits inside the provider's existing grounding bookkeeping, which already
+            // returns early on the grammar path — so this records the model-backed
+            // session's speech and cannot reach an Apple one even by miswiring.
+            backendProvider.onSpokenToWearer = { text in
+                wearerMemory.recordSpokenSentence(text)
+            }
+            // Every final transcript, verbatim (ratified 2026-08-29). On this path a
+            // transcript decides nothing — intent arrives separately as a tool call — so
+            // what is being recorded is exactly what it claims to be: the words the wearer
+            // said, with no inference attached.
+            backendProvider.onTranscriptFinal = { transcript, _ in
+                wearerMemory.recordWearerUtterance(transcript)
+            }
+            // The consumption half of M1: a bounded recent window joins the per-turn
+            // grounding, so "the thing I asked you earlier" still resolves after the
+            // realtime session has been recycled out from under the conversation.
+            backendProvider.wearerMemoryGrounding = {
+                WearerConversationRecall.grounding(for: wearerMemory.recentWindow())
+            }
+        }
+        /// Remembers how a selection window resolved, in the terms it was spoken in.
+        ///
+        /// A closure rather than a store method, because the mapping from a
+        /// `SelectionResult` to a sentence is knowledge about this runtime's request types
+        /// and the store deliberately accepts neither — it takes speech-cleared strings, so
+        /// that no future caller can hand it a request and hope it remembers which fields
+        /// are unspeakable.
+        let rememberSelection: @MainActor (SelectionRequest, SelectionResult) -> Void = {
+            request, result in
+            guard let wearerMemory else { return }
+            let outcome: String
+            if let freeText = result.freeText, !freeText.isEmpty, result.choices.isEmpty {
+                outcome = "answered " + freeText
+            } else if result.choices.isEmpty {
+                outcome = "deferred"
+            } else {
+                outcome = "chose " + result.choices.map(\.label).joined(separator: ", ")
+            }
+            wearerMemory.recordDecision(
+                agentDisplayName: request.agent.displayName,
+                summary: request.question,
+                outcome: outcome
+            )
+        }
+
         // Every approval the runtime resolves goes through here — a broker tool call and
         // a yes/no question the stop coordinator raised alike. "Primary" has to mean every
         // approval, not the broker's: a question like "should I delete the old backups?"
@@ -1312,6 +1378,16 @@ import Darwin
                 await runApproval(request, deadline, makeContext)
             }
             memory.record(approval: request, decision: decision)
+            // The same resolution, kept durably (Pillar A). Session memory answers "what
+            // changed in this session?" while a window is open; this answers "what did we
+            // decide?" after the session, the realtime connection, and the runtime have
+            // all been replaced. Only the fields TapQ has already spoken are passed.
+            wearerMemory?.recordDecision(
+                agentDisplayName: request.agent.displayName,
+                summary: request.summary,
+                outcome: Self.spokenOutcome(of: decision),
+                toolName: request.toolName
+            )
             return decision
         }
 
@@ -1338,7 +1414,17 @@ import Darwin
             // coordinator's handling, ahead of the repeat and classifier guards, because
             // an instruction is not an answer to anything the agent asked.
             instructions: instructions,
-            recordInstruction: memory.instructionRecorder,
+            // Session memory first, exactly as before; then the durable record, so "you
+            // told Codex to rerun the failing suite" outlives the session that heard it.
+            // Both are recorded at delivery, not at dictation — an instruction still
+            // waiting in the mailbox may yet be dropped at capacity.
+            recordInstruction: { session, agent, text in
+                memory.recordInstruction(session: session, agent: agent, text: text)
+                wearerMemory?.recordInstruction(
+                    agentDisplayName: agent.displayName,
+                    text: text
+                )
+            },
             // Two things come through here now. Without a narrator it is what it always
             // was: the status line about TapQ holding an instruction back, spoken at
             // notification priority in the run's voice. With one it is also the narrated
@@ -1393,6 +1479,7 @@ import Darwin
                 // Recorded as a stop answer when the wearer spoke one, and as the
                 // selection it is when they picked a label.
                 memory.recordStopSelection(request, result: result)
+                rememberSelection(request, result)
                 return result
             },
             // The coordinator hands over an `ApprovalRequest` whose `summary` is the
@@ -1455,6 +1542,7 @@ import Darwin
                     }
                 }
                 memory.record(selection: request, result: result)
+                rememberSelection(request, result)
                 return result
             },
             onStopQuestion: { question in
@@ -1687,6 +1775,20 @@ import Darwin
     ) throws -> TapQTapCalibrationProfile? {
         guard store.exists(.tap) else { return nil }
         return try store.loadTap()
+    }
+
+    /// One resolved approval, in the word the wearer would use for it.
+    ///
+    /// `.ask` is "deferred" and not "asked": from the wearer's side nothing was decided
+    /// hands-free and the agent's own prompt took over, which is what
+    /// ``SessionContextEvent/Outcome/deferred`` already means. A timed-out window lands
+    /// here too.
+    private static func spokenOutcome(of decision: Decision) -> String {
+        switch decision {
+        case .allow: return "approved"
+        case .deny: return "denied"
+        case .ask: return "deferred"
+        }
     }
 
     private func waitForShutdown() async {

--- a/Package.swift
+++ b/Package.swift
@@ -272,6 +272,21 @@ var targets: [Target] = [
         ],
         swiftSettings: swiftSettings
     ),
+    // TapQ's own memory (docs/TAPQ_AGENT_PLAN.md, Pillar A). Its own target because the
+    // thing under test spans three of them — the store and its recall live in the context
+    // baseline, the grounding join is in the interaction baseline's provider, and
+    // `tapq memory clear` is in the CLI — and a store that persisted correctly while
+    // grounding nothing would pass in any one of them alone.
+    .testTarget(
+        name: "TapQWearerMemoryTests",
+        dependencies: [
+            "TapQCLI",
+            "TapQContextBaseline",
+            "TapQContracts",
+            "TapQInteractionBaseline",
+        ],
+        swiftSettings: swiftSettings
+    ),
 ]
 
 // Apple acquisition and synthesis frameworks are intentionally absent from Linux's

--- a/Sources/TapQBrokerRuntime/BrokerServer.swift
+++ b/Sources/TapQBrokerRuntime/BrokerServer.swift
@@ -64,6 +64,25 @@ public enum BrokerInstructionWaitResolution: Sendable, Equatable {
     case none
 }
 
+/// A shim telling the broker where a session's transcript lives on local disk.
+///
+/// Carried alongside messages the shim already sends rather than as a message of its own,
+/// because it is not an event: it is a fact about a session that every event happens to
+/// know. Identity and a path, and nothing that could influence a decision — the broker
+/// hands it straight to the host and decides nothing from it.
+public struct BrokerTranscriptAttachment: Sendable, Equatable {
+    public let sessionID: String
+    public let agent: AgentIdentity
+    /// The transcript file's path, exactly as the agent's hook reported it.
+    public let path: String
+
+    public init(sessionID: String, agent: AgentIdentity, path: String) {
+        self.sessionID = sessionID
+        self.agent = agent
+        self.path = path
+    }
+}
+
 /// Authenticated, agent-neutral dispatcher for TapQ's local broker protocol.
 ///
 /// Adapter-specific parsing and presentation arrive already normalized on the wire. The
@@ -80,6 +99,14 @@ public enum BrokerInstructionWaitResolution: Sendable, Equatable {
     private let onInstruction: @MainActor (BrokerInstruction) -> Bool
     private let onInstructionWait:
         @MainActor (BrokerInstructionWait) async -> BrokerInstructionWaitResolution
+    /// Where a host learns that a session has a readable transcript, or `nil` where the
+    /// composition has nowhere to put one.
+    ///
+    /// `nil` is the Apple path and it is structural: the wire field still arrives, and
+    /// nothing in this process ever looks at it. There is no flag to leave off and no store
+    /// to leave empty — the callback simply does not exist, which is the same shape every
+    /// other cloud-only pillar takes.
+    private let onTranscriptPath: (@MainActor (BrokerTranscriptAttachment) -> Void)?
     private let stopQuestionDeduplicationWindow: TimeInterval
     private let diagnostics: TapQDiagnosticEmitter
     private var inFlightStopQuestions: [StopQuestionKey: Task<String?, Never>] = [:]
@@ -97,6 +124,7 @@ public enum BrokerInstructionWaitResolution: Sendable, Equatable {
         onInstruction: @escaping @MainActor (BrokerInstruction) -> Bool = { _ in false },
         onInstructionWait: @escaping @MainActor (BrokerInstructionWait) async
             -> BrokerInstructionWaitResolution = { _ in .none },
+        onTranscriptPath: (@MainActor (BrokerTranscriptAttachment) -> Void)? = nil,
         stopQuestionDeduplicationWindow: TimeInterval = 5
     ) {
         self.transport = transport
@@ -113,6 +141,9 @@ public enum BrokerInstructionWaitResolution: Sendable, Equatable {
         // asks and the Stop proceeds — which is what every run without `--voice-session`
         // does, including one whose shim is newer than its runtime.
         self.onInstructionWait = onInstructionWait
+        // Default nil: no transcript store, so the field is read off the wire by `Codable`
+        // and goes nowhere.
+        self.onTranscriptPath = onTranscriptPath
         self.stopQuestionDeduplicationWindow = max(0, stopQuestionDeduplicationWindow)
         self.diagnostics = TapQDiagnosticEmitter(category: "Broker", sink: diagnosticSink)
     }
@@ -150,6 +181,13 @@ public enum BrokerInstructionWaitResolution: Sendable, Equatable {
                 ])
                 return BrokerResponse.error("approval_source").encoded()
             }
+            // Before the auto-mode short-circuit: under `acceptEdits` or
+            // `bypassPermissions` every tool call is answered here and never reaches the
+            // wearer, and a run in one of those modes would otherwise learn where the
+            // transcript is only at its first turn boundary — after a wearer could already
+            // have asked about the work.
+            noteTranscript(message.transcriptPath, sessionID: message.sessionID,
+                           agent: message.agent ?? legacyAgent)
             if approvalSource == .preToolUse,
                Self.isAutoMode(message.permissionMode, toolName: message.toolName) {
                 diagnostics.record("approval.auto_pass", fields: [
@@ -201,6 +239,10 @@ public enum BrokerInstructionWaitResolution: Sendable, Equatable {
             case .stop: kind = .finished
             }
             let agent = message.agent ?? legacyAgent
+            // Before the announcement: a Stop is the event that most often *first* tells
+            // TapQ where a session's transcript is, and attaching after the host has already
+            // announced the boundary would leave the very next question unanswerable.
+            noteTranscript(message.transcriptPath, sessionID: message.sessionID, agent: agent)
             onNotification(.init(
                 sessionID: message.sessionID,
                 agent: agent,
@@ -244,6 +286,7 @@ public enum BrokerInstructionWaitResolution: Sendable, Equatable {
                 "agent": agent.id,
                 "chars": "\(message.text.count)",
             ])
+            noteTranscript(message.transcriptPath, sessionID: message.sessionID, agent: agent)
             let question = StopQuestion(
                 sessionID: message.sessionID,
                 agent: agent,
@@ -341,6 +384,18 @@ public enum BrokerInstructionWaitResolution: Sendable, Equatable {
                 return BrokerResponse.instructionWait(instruction: nil).encoded()
             }
         }
+    }
+
+    /// Hands a transcript path to the host, when there is a path and a host that wants one.
+    ///
+    /// Deliberately not validated here: whether the file exists, is readable, or parses is
+    /// the store's question, and answering it on the broker's connection thread would put
+    /// disk I/O in the path of every approval.
+    private func noteTranscript(_ path: String?, sessionID: String, agent: AgentIdentity) {
+        guard let onTranscriptPath else { return }
+        guard let path, !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !sessionID.isEmpty else { return }
+        onTranscriptPath(.init(sessionID: sessionID, agent: agent, path: path))
     }
 
     /// Strict policy routes every matched tool call through TapQ, so the broker is where

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -15,6 +15,7 @@ enum CLIHelpTopic: Equatable {
     case integration
     case instruct
     case policy
+    case memory
 }
 
 enum CaptureFormat: String, Equatable {
@@ -122,6 +123,25 @@ struct PolicyShowOptions: Equatable {
 
 enum PolicyCommand: Equatable {
     case show(PolicyShowOptions)
+}
+
+/// Options for `tapq memory clear`.
+///
+/// The on-demand wipe of TapQ's own conversation memory (`WearerConversationStore`,
+/// Pillar A of docs/TAPQ_AGENT_PLAN.md). Deliberately the only memory verb: the record is
+/// TapQ's private dialogue with its wearer, and a `show` subcommand would turn a file the
+/// wearer can already `cat` into a supported way to print somebody's spoken history.
+struct MemoryClearOptions: Equatable {
+    /// Runtime directory the record sits in, matching `serve --broker-dir` and
+    /// `instruct --broker-dir` — so a run served with an override is cleared with the
+    /// same one rather than silently leaving its file behind.
+    var brokerDirectoryPath: String?
+    /// Skips the confirmation prompt, exactly as `calibration reset --yes` does.
+    var confirmed = false
+}
+
+enum MemoryCommand: Equatable {
+    case clear(MemoryClearOptions)
 }
 
 /// Options for `tapq instruct`, the debug/SDK seam that submits an instruction without a
@@ -282,6 +302,8 @@ enum CLICommand: Equatable {
     case integration(IntegrationOptions)
     /// Inspect the auto-answer policy `serve` would run under.
     case policy(PolicyCommand)
+    /// Manage TapQ's own record of what it and the wearer have said to each other.
+    case memory(MemoryCommand)
 }
 
 struct CLIUsageError: Error, LocalizedError, Equatable {
@@ -322,6 +344,8 @@ enum CLICommandParser {
             return try parseIntegration(rest)
         case "policy":
             return try parsePolicy(rest)
+        case "memory":
+            return try parseMemory(rest)
         default:
             throw CLIUsageError(message: "Unknown command '\(first)'.")
         }
@@ -341,6 +365,7 @@ enum CLICommandParser {
         case "integration": return .integration
         case "instruct": return .instruct
         case "policy": return .policy
+        case "memory": return .memory
         default: throw CLIUsageError(message: "Unknown help topic '\(topic)'.")
         }
     }
@@ -588,6 +613,37 @@ enum CLICommandParser {
             }
         }
         return .policy(.show(options))
+    }
+
+    /// `tapq memory clear [--broker-dir PATH] [--yes]`.
+    ///
+    /// One action, and an unknown one is refused by name rather than falling through to
+    /// help: `tapq memory show` failing quietly with usage text would read like a command
+    /// that did nothing, and this is a verb whose whole job is to destroy something.
+    private static func parseMemory(_ arguments: [String]) throws -> CLICommand {
+        guard let action = arguments.first else { return .help(.memory) }
+        if action == "--help" || action == "-h" { return .help(.memory) }
+        guard action == "clear" else {
+            throw CLIUsageError(
+                message: "Unknown memory action '\(action)'. Available actions: 'clear'."
+            )
+        }
+        let rest = Array(arguments.dropFirst())
+        if isHelp(rest) { return .help(.memory) }
+
+        var options = MemoryClearOptions()
+        var cursor = ArgumentCursor(rest)
+        while let argument = cursor.pop() {
+            switch argument {
+            case "--broker-dir":
+                options.brokerDirectoryPath = try cursor.requireValue(for: argument)
+            case "--yes", "-y":
+                options.confirmed = true
+            default:
+                throw CLIUsageError(message: "Unknown memory clear option '\(argument)'.")
+            }
+        }
+        return .memory(.clear(options))
     }
 
     /// `tapq instruct <session-id> <text…>`.

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -6,6 +6,9 @@ import TapQContracts
 import TapQCursorAdapter
 import TapQDetectionBaseline
 import TapQOpenCodeAdapter
+// `tapq memory clear` resolves the runtime directory the same way the hook shims do, so
+// the record it removes is the one `serve` was appending to.
+import TapQPOSIXBridgeClient
 import TapQWireProtocol
 
 public enum TapQVersion {
@@ -174,6 +177,8 @@ public struct TapQCLIIO {
             return try runInstruct(options)
         case .policy(let command):
             try runPolicy(command)
+        case .memory(let command):
+            runMemory(command)
         }
         return 0
     }
@@ -182,6 +187,54 @@ public struct TapQCLIIO {
         switch command {
         case .show(let options): try showAutoAnswerPolicy(options)
         }
+    }
+
+    private func runMemory(_ command: MemoryCommand) {
+        switch command {
+        case .clear(let options): clearWearerConversation(options)
+        }
+    }
+
+    /// Wipes TapQ's own record of what it and the wearer have said to each other.
+    ///
+    /// It opens the store rather than deleting the path, so the file this removes is by
+    /// construction the file `serve` would have appended to — including under a
+    /// `--broker-dir` override, where a hand-written path would clear the wrong one.
+    ///
+    /// Never throws. A record that is not there is not an error (the honest answer is that
+    /// there was nothing to clear), and a removal the filesystem refused is reported by
+    /// the store's own diagnostics, which is the same posture every other local-file
+    /// failure on this path takes.
+    private func clearWearerConversation(_ options: MemoryClearOptions) {
+        let directory = options.brokerDirectoryPath.map(resolvedURL(for:))
+            ?? BrokerDiscovery.defaultSupportDirectory(
+                environment: environment,
+                homeDirectory: homeDirectory
+            )
+        let store = WearerConversationStore(directory: directory)
+        let entries = store.entries().count
+        guard FileManager.default.fileExists(atPath: store.fileURL.path) else {
+            outputLine("No conversation memory found at \(store.fileURL.path).")
+            return
+        }
+        if !options.confirmed {
+            // Says how much is about to go, because "27 entries" and "6,000 entries" are
+            // different decisions and the file is not one a person reads at a glance.
+            io.writeError(
+                "Remove \(entries) remembered exchange(s) at \(store.fileURL.path)? [y/N] "
+            )
+            let response = io.readInput()?
+                .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard response == "y" || response == "yes" else {
+                outputLine("Conversation memory kept.")
+                return
+            }
+        }
+        guard store.clear() else {
+            outputLine("Could not remove \(store.fileURL.path).")
+            return
+        }
+        outputLine("Conversation memory cleared from \(store.fileURL.path).")
     }
 
     /// Prints the policy `serve --auto-answer routine` would actually run under.
@@ -1778,6 +1831,7 @@ public struct TapQCLIIO {
         case .integration: return integrationHelp
         case .instruct: return instructHelp
         case .policy: return policyHelp
+        case .memory: return memoryHelp
         }
     }
 
@@ -1796,6 +1850,7 @@ public struct TapQCLIIO {
       serve         Run the local agent-agnostic TapQ broker
       instruct      Queue an instruction for a session on a running broker (debug)
       integration   Manage agent integrations
+      memory        Clear what TapQ remembers of its conversation with you
       policy        Show the auto-answer policy serving would use
       version       Print the TapQ CLI version
 
@@ -2035,6 +2090,28 @@ public struct TapQCLIIO {
 
     There is no `policy set`. The file is small and hand-written on purpose — widening
     what TapQ may answer for you should take an editor, not a shell one-liner.
+    """
+
+    private static let memoryHelp = """
+    Clear what TapQ remembers of its own conversation with you.
+
+    USAGE
+      tapq memory clear [--broker-dir PATH] [--yes]
+
+    OPTIONS
+      --broker-dir PATH   Clear the record in a specific runtime directory
+      --yes, -y           Skip the confirmation prompt
+
+    On `--voice-backend openai-realtime`, TapQ keeps `wearer-conversation.jsonl` in the
+    runtime directory (0600, inside the 0700 directory): what you said, what TapQ said
+    back, what was approved or denied, and which instructions reached which agent. It is
+    what lets "the thing I asked you earlier" survive a dropped voice session or a
+    restart. Nothing else is in it — a tool's input, a working directory, and a permission
+    mode are never spoken, so they are never written here either.
+
+    It rotates itself: entries older than 30 days are dropped, and the file is held to a
+    couple of megabytes, whichever comes first. This command is the on-demand wipe. The
+    Apple voice backend writes no such file at all.
     """
 
     private static let captureHelp = """

--- a/Sources/TapQClaudeAdapter/HookShim.swift
+++ b/Sources/TapQClaudeAdapter/HookShim.swift
@@ -179,6 +179,7 @@ public struct HookShim {
             "request_id": .string(requestID),
             "summary": .string(summary),
             "detail": .string(detail),
+            "transcript_path": transcriptPath(data),
             "protocol_version": .number(Double(WireProtocol.version)),
         ]
 
@@ -208,6 +209,7 @@ public struct HookShim {
             "session_id": .string(data["session_id"]?.stringValue ?? ""),
             "event": .string(classifyNotification(data)),
             "summary": data["message"] ?? .null,
+            "transcript_path": transcriptPath(data),
             "protocol_version": .number(Double(WireProtocol.version)),
         ]
         _ = try? send(message, notifyTimeout)
@@ -239,6 +241,7 @@ public struct HookShim {
                 "session_id": .string(data["session_id"]?.stringValue ?? ""),
                 "event": .string("stop"),
                 "summary": .null,
+                "transcript_path": transcriptPath(data),
                 "protocol_version": .number(Double(WireProtocol.version)),
             ]
             _ = try? send(message, notifyTimeout)
@@ -393,6 +396,7 @@ public struct HookShim {
             "session_id": .string(data["session_id"]?.stringValue ?? ""),
             "request_id": .string(UUID().uuidString),
             "text": .string(String(text.suffix(16_384))),
+            "transcript_path": .string(transcriptPath),
             "protocol_version": .number(Double(WireProtocol.version)),
         ]
 
@@ -545,6 +549,27 @@ public struct HookShim {
     }
 
     // MARK: - Helpers
+
+    /// The session transcript's path as the hook reported it, or `.null`.
+    ///
+    /// Every Claude Code hook invocation carries `transcript_path`, and the shim already
+    /// opens it for the final assistant message; forwarding the *path* lets the runtime tail
+    /// the same file for itself instead of the shim reading it twice for two purposes.
+    ///
+    /// A location, never content. The shim does not read the file for this, does not check
+    /// that it exists, and does not decide anything from it — a broker with no transcript
+    /// store ignores the field entirely, which is every run on the Apple path.
+    ///
+    /// `.null` for the two cases that mean the same thing: a hook payload without the field,
+    /// and one whose value is blank. Encoding null rather than omitting the key keeps the
+    /// message shape fixed, and `Codable` reads it as the `nil` it is.
+    private static func transcriptPath(_ data: [String: JSONValue]) -> JSONValue {
+        guard let path = data["transcript_path"]?.stringValue,
+              !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .null
+        }
+        return .string(path)
+    }
 
     /// Claude Code surfaces a notification as a human-readable `message`; one that mentions
     /// permission/approval is a permission prompt, otherwise it's an idle "waiting for you".

--- a/Sources/TapQContextBaseline/OpenAINarrationModel.swift
+++ b/Sources/TapQContextBaseline/OpenAINarrationModel.swift
@@ -29,7 +29,7 @@ import TapQContracts
 ///
 /// The API key is never logged, and neither is the request body or the agent's output:
 /// diagnostics carry counts, lengths, statuses, and timings only.
-public struct OpenAINarrationModel: BoundaryNarrating {
+public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering {
     /// The maintainer-specified narration model (ratified 2026-08-28).
     public static let defaultModel = "gpt-5.6-luna"
     /// The single override seam. No CLI flag: the model id is an operational detail of a
@@ -41,6 +41,13 @@ public struct OpenAINarrationModel: BoundaryNarrating {
     /// this runs, so a slow narration costs latency and nothing else — while a tight bound
     /// would break the run's voice pipe over a busy minute at the provider.
     public static let defaultTimeout: TimeInterval = 15
+    /// One boundary utterance: a sentence or two of speech.
+    static let narrationOutputTokens = 512
+    /// One answer about the work. Larger than a boundary utterance because the wearer asked
+    /// a question and the honest answer to "what did the tests say?" is sometimes a list of
+    /// failures, and because a cap that clips is a cap that lies about what the history
+    /// contained.
+    static let answerOutputTokens = 1_024
 
     /// The model id for this run: the environment override when set and non-blank,
     /// otherwise ``defaultModel``.
@@ -103,12 +110,84 @@ public struct OpenAINarrationModel: BoundaryNarrating {
             "items": "\(request.items.count)",
             "model": model,
         ])
+        let (text, latency) = try await perform(
+            body: makeBody(
+                instructions: NarrationContract.instructions,
+                input: NarrationContract.input(for: request),
+                schemaName: NarrationContract.schemaName,
+                schema: NarrationContract.outputSchema,
+                maxOutputTokens: Self.narrationOutputTokens
+            ),
+            label: "narration"
+        )
+        let utterance: NarrationUtterance
+        do {
+            utterance = try NarrationContract.decode(text)
+        } catch let failure as NarrationFailure {
+            diagnostics.record("narration.response_rejected", level: .warning, fields: [
+                "latency_ms": latency,
+                "model": model,
+                "reason": failure.reason,
+            ])
+            throw failure
+        }
+        diagnostics.record("narration.spoken", fields: [
+            "latency_ms": latency,
+            "length": "\(utterance.text.count)",
+            "mode_hint": utterance.mode.rawValue,
+            "model": model,
+        ])
+        return utterance
+    }
 
+    /// Answers one question about an agent's work from the slices it was given
+    /// (`docs/TRANSCRIPT_CONTEXT_PLAN.md`).
+    ///
+    /// The same client as narration, deliberately: the same model family, the same key, the
+    /// same endpoint, the same strict-schema decoding, and — the part that matters — the
+    /// same failure posture. A separate client would be a second place for this call to
+    /// learn how to degrade.
+    public func answer(_ request: WorkQuestionRequest) async throws -> String {
+        let (text, latency) = try await perform(
+            body: makeBody(
+                instructions: WorkAnswerContract.instructions,
+                input: WorkAnswerContract.input(for: request),
+                schemaName: WorkAnswerContract.schemaName,
+                schema: WorkAnswerContract.outputSchema,
+                maxOutputTokens: Self.answerOutputTokens
+            ),
+            label: "ask"
+        )
+        do {
+            return try WorkAnswerContract.decode(text)
+        } catch let failure as NarrationFailure {
+            diagnostics.record("ask.response_rejected", level: .warning, fields: [
+                "latency_ms": latency,
+                "model": model,
+                "reason": failure.reason,
+            ])
+            throw failure
+        }
+    }
+
+    /// One request against the Responses API, with the timeout race, the status check, and
+    /// the `output_text` extraction every caller of this endpoint needs.
+    ///
+    /// Shared rather than duplicated because the failure posture is what is actually being
+    /// reused: both callers are voice-pipeline calls whose every unhappy answer must reach
+    /// the same latch, and two copies of this would be two chances for one of them to
+    /// quietly degrade instead.
+    ///
+    /// - Parameter label: the diagnostic name prefix — `narration` or `ask` — so an
+    ///   operator can tell which call failed without either caller inventing its own
+    ///   transport logging.
+    /// - Returns: the response's text payload and the call's latency in milliseconds.
+    private func perform(body: [String: Any], label: String) async throws -> (String, String) {
         let httpRequest: URLRequest
         do {
-            httpRequest = try makeRequest(for: request)
+            httpRequest = try makeRequest(body: body)
         } catch {
-            diagnostics.record("narration.request_invalid", level: .warning)
+            diagnostics.record("\(label).request_invalid", level: .warning)
             throw NarrationFailure.transport("request could not be encoded")
         }
 
@@ -134,7 +213,7 @@ public struct OpenAINarrationModel: BoundaryNarrating {
 
         switch result {
         case .timedOut:
-            diagnostics.record("narration.timeout", level: .warning, fields: [
+            diagnostics.record("\(label).timeout", level: .warning, fields: [
                 "latency_ms": latency,
                 "model": model,
                 "timeout_s": "\(Int(timeout))",
@@ -142,7 +221,7 @@ public struct OpenAINarrationModel: BoundaryNarrating {
             throw NarrationFailure.timedOut
 
         case .failed:
-            diagnostics.record("narration.failed", level: .warning, fields: [
+            diagnostics.record("\(label).failed", level: .warning, fields: [
                 "latency_ms": latency,
                 "model": model,
             ])
@@ -150,52 +229,54 @@ public struct OpenAINarrationModel: BoundaryNarrating {
 
         case let .response(data, response):
             guard (200..<300).contains(response.statusCode) else {
-                diagnostics.record("narration.http_error", level: .warning, fields: [
+                diagnostics.record("\(label).http_error", level: .warning, fields: [
                     "latency_ms": latency,
                     "model": model,
                     "status": "\(response.statusCode)",
                 ])
                 throw NarrationFailure.http(status: response.statusCode)
             }
-            let utterance: NarrationUtterance
             do {
-                utterance = try Self.decodeResponse(data)
+                return (try Self.decodeResponse(data), latency)
             } catch let failure as NarrationFailure {
-                diagnostics.record("narration.response_rejected", level: .warning, fields: [
+                diagnostics.record("\(label).response_rejected", level: .warning, fields: [
                     "latency_ms": latency,
                     "model": model,
                     "reason": failure.reason,
                 ])
                 throw failure
             }
-            diagnostics.record("narration.spoken", fields: [
-                "latency_ms": latency,
-                "length": "\(utterance.text.count)",
-                "mode_hint": utterance.mode.rawValue,
-                "model": model,
-            ])
-            return utterance
         }
     }
 
-    private func makeRequest(for request: NarrationRequest) throws -> URLRequest {
-        let body: [String: Any] = [
+    /// The Responses API body, minus the two things that differ per call: what the model is
+    /// told to do, and the schema it must fill.
+    private func makeBody(
+        instructions: String,
+        input: String,
+        schemaName: String,
+        schema: [String: Any],
+        maxOutputTokens: Int
+    ) -> [String: Any] {
+        [
             "model": model,
-            "instructions": NarrationContract.instructions,
-            "input": NarrationContract.input(for: request),
-            "max_output_tokens": 512,
+            "instructions": instructions,
+            "input": input,
+            "max_output_tokens": maxOutputTokens,
             "reasoning": ["effort": "none"],
             "store": false,
             "text": [
                 "format": [
                     "type": "json_schema",
-                    "name": NarrationContract.schemaName,
+                    "name": schemaName,
                     "strict": true,
-                    "schema": NarrationContract.outputSchema,
+                    "schema": schema,
                 ],
             ],
         ]
+    }
 
+    private func makeRequest(body: [String: Any]) throws -> URLRequest {
         var httpRequest = URLRequest(url: endpoint, timeoutInterval: timeout)
         httpRequest.httpMethod = "POST"
         httpRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -204,7 +285,9 @@ public struct OpenAINarrationModel: BoundaryNarrating {
         return httpRequest
     }
 
-    private static func decodeResponse(_ data: Data) throws -> NarrationUtterance {
+    /// The `status`/`incomplete_details`/`refusal` triad, then the text payload. Which
+    /// contract that text has to satisfy is the caller's business.
+    private static func decodeResponse(_ data: Data) throws -> String {
         guard let response = try? JSONDecoder().decode(ResponseBody.self, from: data),
               response.status == "completed",
               response.error == nil,
@@ -219,7 +302,7 @@ public struct OpenAINarrationModel: BoundaryNarrating {
         guard let text = content.first(where: { $0.type == "output_text" })?.text else {
             throw NarrationFailure.malformedResponse
         }
-        return try NarrationContract.decode(text)
+        return text
     }
 
     private static func liveSend(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {

--- a/Sources/TapQContextBaseline/TranscriptQuestionAnswerer.swift
+++ b/Sources/TapQContextBaseline/TranscriptQuestionAnswerer.swift
@@ -1,0 +1,155 @@
+import Foundation
+import TapQContracts
+
+/// Answers `ask_about_work`: reads the session's transcript, selects slices, asks the
+/// narration-family model, and hands back the sentence TapQ will speak.
+///
+/// It is the join between the two halves of Pillar B and holds the failure line between
+/// them (`docs/TRANSCRIPT_CONTEXT_PLAN.md`):
+///
+/// - a transcript that cannot be read is ``WorkQuestionOutcome/unavailable(_:)`` — spoken,
+///   logged at error level, and *not* a voice break. The pipe is fine; a rotated file is
+///   not a reason to end the wearer's session.
+/// - a cloud call that fails is ``WorkQuestionOutcome/failed(_:)`` — TapQ says nothing and
+///   the caller breaks the run's voice, the same latch narration reaches. There is no
+///   half-answer assembled from the slices, because that would be TapQ inventing an answer
+///   about the wearer's work.
+///
+/// Diagnostics carry lengths and counts only: never a question, never an excerpt, never
+/// agent output, never the key.
+@MainActor public final class TranscriptQuestionAnswerer {
+    /// Spoken when no hook has told TapQ where this session's transcript is — an agent
+    /// whose shim predates the field, or a session TapQ has not seen an event from yet.
+    public static let notAttachedNotice =
+        "I can't see that session's history, so I can't answer that."
+    /// Spoken when the path is known but the file will not open: deleted, moved, or
+    /// unreadable.
+    public static let unreadableNotice =
+        "I can't read the session history right now, so I can't answer that."
+    /// Spoken when the file opened and there was nothing legible in it.
+    public static let emptyNotice =
+        "There's nothing in that session's history I can read yet."
+
+    private let store: TranscriptStore
+    private let model: any WorkQuestionAnswering
+    private let characterBudget: Int
+    private let resolveSession: @MainActor (String?) -> String?
+    private let diagnostics: TapQDiagnosticEmitter
+
+    /// - Parameter resolveSession: turns the agent name the wearer used, if any, into the
+    ///   session whose transcript answers the question. The default ignores the name and
+    ///   uses the session TapQ has most recently read from, which is exact with one agent
+    ///   connected — the shipping case — and is where rung F's roster will plug in when
+    ///   several are. Naming an agent TapQ cannot route to therefore answers about the
+    ///   active session rather than refusing; that is an M1 limitation, recorded here and
+    ///   in the plan.
+    public init(
+        store: TranscriptStore,
+        model: any WorkQuestionAnswering,
+        characterBudget: Int = TranscriptSliceSelection.defaultCharacterBudget,
+        resolveSession: (@MainActor (String?) -> String?)? = nil,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.store = store
+        self.model = model
+        self.characterBudget = characterBudget
+        self.resolveSession = resolveSession ?? { [store] _ in store.mostRecentlyActiveSession() }
+        self.diagnostics = TapQDiagnosticEmitter(category: "Transcript", sink: diagnosticSink)
+    }
+
+    /// The seam the voice provider calls. Never throws: every failure is one of the two
+    /// outcomes above, because a thrown error at a tool call is a peer left parked.
+    public func answer(question: String, agentDisplayName: String?) async -> WorkQuestionOutcome {
+        let question = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        diagnostics.record("ask.requested", fields: [
+            "question_length": "\(question.count)",
+            "agent_named": "\(agentDisplayName?.isEmpty == false)",
+        ])
+        guard !question.isEmpty else {
+            return unavailable(.empty, notice: Self.emptyNotice)
+        }
+        guard let session = resolveSession(agentDisplayName) else {
+            return unavailable(.notAttached, notice: Self.notAttachedNotice)
+        }
+
+        var entries: [TranscriptEntry]
+        switch store.entries(session: session) {
+        case .success(let read):
+            entries = read
+        case .failure(let reason):
+            return unavailable(reason, notice: Self.notice(for: reason))
+        }
+        // A saturated tail means there is older history on disk, and the wearer may be
+        // asking about it. This is the on-demand re-read: one bounded pass over the file,
+        // taken only when the bound was actually reached, so an ordinary session pays
+        // nothing for it.
+        if entries.count >= store.tailLimit,
+           case .success(let wider) = store.reread(session: session),
+           wider.count > entries.count {
+            entries = wider
+        }
+
+        let selection = TranscriptSliceSelection.select(
+            entries: entries, question: question, budget: characterBudget
+        )
+        guard !selection.slices.isEmpty else {
+            return unavailable(.empty, notice: Self.emptyNotice)
+        }
+        if selection.droppedEntries > 0 || selection.droppedCharacters > 0 {
+            diagnostics.record("ask.dropped", fields: [
+                "entries": "\(selection.droppedEntries)",
+                "chars": "\(selection.droppedCharacters)",
+            ])
+        }
+
+        let started = ContinuousClock.now
+        do {
+            let answer = try await model.answer(WorkQuestionRequest(
+                question: question,
+                agentDisplayName: agentDisplayName,
+                slices: selection.slices
+            ))
+            diagnostics.record("ask.answered", fields: [
+                "latency_ms": Self.milliseconds(from: started),
+                "slices": "\(selection.slices.count)",
+                "length": "\(answer.count)",
+            ])
+            return .answered(answer)
+        } catch {
+            let reason = (error as? NarrationFailure)?.reason ?? "unknown"
+            // Error, not warning: the wearer asked a question and is going to be told the
+            // voice channel is broken instead of hearing an answer.
+            diagnostics.record("ask.failed", level: .error, fields: [
+                "latency_ms": Self.milliseconds(from: started),
+                "slices": "\(selection.slices.count)",
+                "reason": reason,
+            ])
+            return .failed(reason)
+        }
+    }
+
+    private func unavailable(
+        _ reason: TranscriptUnavailability, notice: String
+    ) -> WorkQuestionOutcome {
+        // The store records this too, where it can say which session; recorded again here
+        // because this is the one that corresponds to a wearer standing there having asked.
+        diagnostics.record("transcript.unavailable", level: .error,
+                           fields: ["reason": reason.rawValue])
+        return .unavailable(notice)
+    }
+
+    private static func notice(for reason: TranscriptUnavailability) -> String {
+        switch reason {
+        case .notAttached: return notAttachedNotice
+        case .unreadable: return unreadableNotice
+        case .empty: return emptyNotice
+        }
+    }
+
+    private static func milliseconds(from start: ContinuousClock.Instant) -> String {
+        let components = start.duration(to: .now).components
+        let milliseconds = Double(components.seconds) * 1_000
+            + Double(components.attoseconds) / 1e15
+        return String(format: "%.0f", milliseconds)
+    }
+}

--- a/Sources/TapQContextBaseline/TranscriptSliceSelection.swift
+++ b/Sources/TapQContextBaseline/TranscriptSliceSelection.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Which parts of a session's history are handed to the answer model, and what was left
+/// out.
+///
+/// No embeddings, deliberately (`docs/TRANSCRIPT_CONTEXT_PLAN.md` phase 1): the answer
+/// model reads generous slices happily, and an index would be a second thing to keep in
+/// sync with a file that rewrites itself. What is here instead is two rules —
+///
+/// 1. **Recency wins.** The newest entries are always taken, because the overwhelming
+///    majority of what a wearer asks about is what just happened ("what did the tests
+///    say?").
+/// 2. **Then relevance, for the rest of the budget.** Older entries are ranked by how many
+///    of the question's own words they contain, so "what did you decide about the
+///    migration?" can reach back past the last twenty lines.
+///
+/// — and one budget, because a 100k-character answer prompt is generous and a 10MB one is a
+/// timeout. Everything dropped is counted and reported; nothing dropped is ever quoted.
+public enum TranscriptSliceSelection {
+    /// The per-answer cap from the plan.
+    public static let defaultCharacterBudget = 100_000
+    /// How many of the newest entries are taken before relevance is consulted at all.
+    public static let recencyFloor = 20
+    /// The most one entry may spend. A single `cat` of a lock file must not evict the
+    /// twenty lines around it; the rest of that entry is reported as dropped characters.
+    public static let entryCharacterCap = 8_000
+    /// Words too short or too common to say anything about relevance. Deliberately tiny:
+    /// three-letter technical words ("npm", "git", "CI") are exactly what a wearer's
+    /// question hangs on, so the floor is length, not a dictionary.
+    static let stopWords: Set<String> = [
+        "the", "and", "was", "were", "did", "does", "what", "when", "why", "how", "you",
+        "your", "that", "this", "there", "with", "for", "from", "about", "into", "have",
+        "has", "had", "are", "any", "all", "just", "then", "than", "them", "they", "its",
+        "our", "out", "get", "got", "say", "said", "tell", "told", "can", "could", "would",
+        "should", "please", "hey", "tapq",
+    ]
+
+    public struct Result: Sendable, Equatable {
+        public let slices: [WorkQuestionSlice]
+        /// How many entries did not fit. Counts only — the plan's diagnostics rule is that
+        /// what was dropped is reported by number and length, never by content.
+        public let droppedEntries: Int
+        /// How many characters those entries would have contributed, plus whatever was
+        /// trimmed off entries that were kept but capped.
+        public let droppedCharacters: Int
+
+        public init(slices: [WorkQuestionSlice], droppedEntries: Int, droppedCharacters: Int) {
+            self.slices = slices
+            self.droppedEntries = droppedEntries
+            self.droppedCharacters = droppedCharacters
+        }
+    }
+
+    public static func select(
+        entries: [TranscriptEntry],
+        question: String,
+        budget: Int = TranscriptSliceSelection.defaultCharacterBudget,
+        recencyFloor: Int = TranscriptSliceSelection.recencyFloor,
+        entryCap: Int = TranscriptSliceSelection.entryCharacterCap
+    ) -> Result {
+        guard !entries.isEmpty, budget > 0 else {
+            return Result(slices: [], droppedEntries: entries.count,
+                          droppedCharacters: entries.reduce(0) { $0 + $1.length })
+        }
+        let keywords = self.keywords(in: question)
+        // 1-based, so a diagnostic and the model's own "excerpt 7" agree with each other.
+        let numbered = entries.enumerated().map { (index: $0.offset + 1, entry: $0.element) }
+
+        var kept: [Int: String] = [:]
+        var trimmed = 0
+        var spent = 0
+
+        func take(_ index: Int, _ entry: TranscriptEntry) -> Bool {
+            guard kept[index] == nil else { return true }
+            let (text, dropped) = cap(entry.rendered, at: entryCap)
+            guard spent + text.count <= budget else { return false }
+            kept[index] = text
+            spent += text.count
+            trimmed += dropped
+            return true
+        }
+
+        // Recency first, newest backwards, so a budget that runs out loses the oldest of
+        // the recent window rather than the newest.
+        for (index, entry) in numbered.suffix(max(0, recencyFloor)).reversed() {
+            _ = take(index, entry)
+        }
+
+        // Then relevance over everything else, best first, newer entries breaking ties.
+        if !keywords.isEmpty {
+            let scored = numbered
+                .filter { kept[$0.index] == nil }
+                .map { (index: $0.index, entry: $0.entry, score: score($0.entry, keywords)) }
+                .filter { $0.score > 0 }
+                .sorted { ($0.score, $0.index) > ($1.score, $1.index) }
+            for candidate in scored {
+                // Not `break`: a later, smaller entry may still fit where this one did not,
+                // and skipping it would leave budget unspent for no reason.
+                _ = take(candidate.index, candidate.entry)
+            }
+        }
+
+        let slices = kept.keys.sorted().map { WorkQuestionSlice(index: $0, text: kept[$0] ?? "") }
+        let droppedEntries = numbered.filter { kept[$0.index] == nil }
+        return Result(
+            slices: slices,
+            droppedEntries: droppedEntries.count,
+            droppedCharacters: droppedEntries.reduce(0) { $0 + $1.entry.length } + trimmed
+        )
+    }
+
+    /// Truncates one entry, saying how much was removed. The marker is inside the text the
+    /// model reads, so it cannot mistake a cut for the end of the output.
+    static func cap(_ text: String, at limit: Int) -> (String, Int) {
+        guard limit > 0, text.count > limit else { return (text, 0) }
+        let dropped = text.count - limit
+        return (String(text.prefix(limit)) + "\n…[\(dropped) characters not shown]", dropped)
+    }
+
+    static func keywords(in question: String) -> Set<String> {
+        let words = question.lowercased()
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber && $0 != "." && $0 != "/" })
+            .map(String.init)
+        return Set(words.filter { $0.count >= 3 && !stopWords.contains($0) })
+    }
+
+    static func score(_ entry: TranscriptEntry, _ keywords: Set<String>) -> Int {
+        let haystack = entry.searchText
+        return keywords.reduce(0) { $0 + (haystack.contains($1) ? 1 : 0) }
+    }
+}

--- a/Sources/TapQContextBaseline/TranscriptStore.swift
+++ b/Sources/TapQContextBaseline/TranscriptStore.swift
@@ -1,0 +1,457 @@
+import Foundation
+import TapQContracts
+
+/// One line of an agent session's transcript, parsed into the parts a question can be
+/// answered from.
+///
+/// Unlike every other type in this module, this one **may** carry tool input and tool
+/// output. That is the transcript decision (ratified 2026-08-28,
+/// `docs/TRANSCRIPT_CONTEXT_PLAN.md`): under a cloud voice backend TapQ may *read* an
+/// agent's full session and answer questions from it. The redaction contract is not
+/// weakened, it is scoped — it remains the rule for local surfaces, for event memory, and
+/// for anything TapQ says unprompted. Nothing here is ever spoken; only the answer model's
+/// reply is, and only in answer to a question the wearer asked.
+public struct TranscriptEntry: Sendable, Equatable {
+    public enum Role: String, Sendable, Equatable {
+        case user
+        case assistant
+        /// A tool result carried back to the agent.
+        case toolResult = "tool_result"
+        /// A line whose `type` this build does not model — a summary, a system note.
+        /// Carried rather than dropped: it is still session history.
+        case other
+    }
+
+    public let role: Role
+    /// The line's prose, with content blocks joined. Empty for a pure tool call.
+    public let text: String
+    /// The tool the assistant asked for, when this line is a tool use.
+    public let toolName: String?
+    /// The tool's arguments, as the JSON text the agent wrote.
+    public let toolInput: String?
+    /// The tool's output, as the agent received it.
+    public let toolOutput: String?
+    public let timestamp: Date?
+
+    public init(
+        role: Role,
+        text: String,
+        toolName: String? = nil,
+        toolInput: String? = nil,
+        toolOutput: String? = nil,
+        timestamp: Date? = nil
+    ) {
+        self.role = role
+        self.text = text
+        self.toolName = toolName
+        self.toolInput = toolInput
+        self.toolOutput = toolOutput
+        self.timestamp = timestamp
+    }
+
+    /// The entry as one block of the answer model's input.
+    public var rendered: String {
+        var parts: [String] = []
+        switch role {
+        case .user: parts.append("[user]")
+        case .assistant: parts.append("[assistant]")
+        case .toolResult: parts.append("[tool result]")
+        case .other: parts.append("[note]")
+        }
+        if let toolName, !toolName.isEmpty { parts.append("tool: \(toolName)") }
+        if !text.isEmpty { parts.append(text) }
+        if let toolInput, !toolInput.isEmpty { parts.append("input: \(toolInput)") }
+        if let toolOutput, !toolOutput.isEmpty { parts.append("output: \(toolOutput)") }
+        return parts.joined(separator: "\n")
+    }
+
+    /// Everything a relevance score reads, lowercased once.
+    var searchText: String {
+        ([text, toolName ?? "", toolInput ?? "", toolOutput ?? ""])
+            .joined(separator: " ")
+            .lowercased()
+    }
+
+    var length: Int { rendered.count }
+}
+
+/// Why a session's transcript could not be read.
+public enum TranscriptUnavailability: String, Error, Sendable, Equatable {
+    /// No hook has told TapQ where this session's transcript is. Every path the shim
+    /// forwards is optional, and a peer too old to send one lands here.
+    case notAttached = "not_attached"
+    /// The path was forwarded but nothing can be opened at it — deleted, moved, or on a
+    /// volume this process cannot read.
+    case unreadable
+    /// The file opened but no line in it parsed.
+    case empty
+}
+
+/// The transcripts of the agent sessions this runtime is serving, tailed incrementally.
+///
+/// ## What is stored, and for how long
+///
+/// TapQ persists **nothing**: the agent's own transcript file is the store. What is held
+/// here is a byte offset per session and a bounded in-memory tail of parsed entries, and
+/// both die with the runtime. That is the whole storage design from
+/// `docs/TRANSCRIPT_CONTEXT_PLAN.md`, and it is why a `tapq memory clear` has nothing to do
+/// here — there is nothing of the agent's that TapQ kept.
+///
+/// ## Tolerating a file that rewrites itself
+///
+/// Claude Code compacts sessions, which rewrites the transcript in place. Two things
+/// therefore cannot be assumed: that the file only grows, and that an offset taken before a
+/// rewrite still points at the same conversation. So every read checks both — a file
+/// shorter than the offset, and an offset that is not immediately after a newline — and
+/// re-syncs from the top when either fails. Re-syncing is cheap and losing the tail is not,
+/// so the check is unconditional rather than a recovery path.
+@MainActor public final class TranscriptStore {
+    /// How many parsed entries a session keeps in memory. A generous tail: the answer path
+    /// caps by characters, not entries, and re-reading from disk for a question that could
+    /// have been answered from memory is the expensive mistake.
+    public nonisolated static let defaultTailEntryLimit = 400
+    /// The most that is read from disk in one go. A tail longer than this means the file
+    /// grew by megabytes between reads (a compaction, or a first attach to a long session);
+    /// the read then starts at the last window rather than parsing the whole history.
+    public nonisolated static let defaultReadWindowBytes = 4 * 1024 * 1024
+    /// How often `transcript.tailed` is emitted, in reads per line. Tailing happens on every
+    /// hook event, and a log line per approval would drown the file it is in.
+    static let tailDiagnosticEvery = 20
+
+    private struct Session {
+        var path: String
+        var offset: UInt64 = 0
+        var entries: [TranscriptEntry] = []
+        var reads = 0
+        var malformedLines = 0
+    }
+
+    private var sessions: [String: Session] = [:]
+    private let tailEntryLimit: Int
+    private let readWindowBytes: Int
+    private let diagnostics: TapQDiagnosticEmitter
+
+    public init(
+        tailEntryLimit: Int = TranscriptStore.defaultTailEntryLimit,
+        readWindowBytes: Int = TranscriptStore.defaultReadWindowBytes,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.tailEntryLimit = max(1, tailEntryLimit)
+        self.readWindowBytes = max(1024, readWindowBytes)
+        self.diagnostics = TapQDiagnosticEmitter(category: "Transcript", sink: diagnosticSink)
+    }
+
+    /// Sessions TapQ has been told the transcript path for. For diagnostics and tests.
+    public var attachedSessions: [String] { sessions.keys.sorted() }
+
+    public func path(session: String) -> String? { sessions[session]?.path }
+
+    /// Records where a session's transcript lives, and reads whatever is already in it.
+    ///
+    /// Idempotent for the same path — every hook event carries it, so this is called
+    /// constantly — and a *different* path for a known session resets the offset and the
+    /// tail, because it is a different file and an offset into the old one means nothing.
+    public func attach(session: String, path: String) {
+        let path = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !session.isEmpty, !path.isEmpty else { return }
+        if let existing = sessions[session] {
+            guard existing.path != path else {
+                tail(session: session)
+                return
+            }
+            diagnostics.record("transcript.reattached", fields: ["session": Self.tag(session)])
+        }
+        sessions[session] = Session(path: path)
+        diagnostics.record("transcript.attached", fields: ["session": Self.tag(session)])
+        tail(session: session)
+    }
+
+    /// Reads whatever has been appended since the last read.
+    @discardableResult
+    public func tail(session: String) -> Int {
+        guard var state = sessions[session] else { return 0 }
+        guard let handle = FileHandle(forReadingAtPath: state.path) else {
+            diagnostics.record("transcript.unavailable", level: .error, fields: [
+                "session": Self.tag(session),
+                "reason": TranscriptUnavailability.unreadable.rawValue,
+            ])
+            return 0
+        }
+        defer { try? handle.close() }
+        guard let size = try? handle.seekToEnd() else { return 0 }
+
+        var start = state.offset
+        var resynced: String?
+        if size < state.offset {
+            // The file shrank: compaction rewrote it, or the session was restarted onto the
+            // same path. Everything held is about a conversation that no longer exists.
+            resynced = "truncated"
+            start = 0
+            state.entries.removeAll()
+        } else if state.offset > 0, !Self.endsALine(handle, before: state.offset) {
+            // The offset survived the size check but no longer sits after a newline, so it
+            // is pointing into the middle of a line of some *other* content. A rewrite that
+            // happened to leave the file longer looks exactly like this.
+            resynced = "offset_invalid"
+            start = 0
+            state.entries.removeAll()
+        }
+        if size - start > UInt64(readWindowBytes) {
+            // Far behind: read the last window and give up on the gap rather than parsing
+            // megabytes at a turn boundary. Starting mid-line is harmless — the fragment
+            // fails to parse and is counted.
+            start = size - UInt64(readWindowBytes)
+            if resynced == nil { resynced = "window_clamped" }
+        }
+        guard start <= size, (try? handle.seek(toOffset: start)) != nil,
+              let data = try? handle.readToEnd(), !data.isEmpty else {
+            state.offset = size
+            sessions[session] = state
+            return 0
+        }
+
+        let (entries, malformed, consumed) = Self.parse(data)
+        state.offset = start + UInt64(consumed)
+        state.malformedLines += malformed
+        state.entries.append(contentsOf: entries)
+        if state.entries.count > tailEntryLimit {
+            state.entries.removeFirst(state.entries.count - tailEntryLimit)
+        }
+        state.reads += 1
+        sessions[session] = state
+
+        if let resynced {
+            diagnostics.record("transcript.resynced", level: .warning, fields: [
+                "session": Self.tag(session), "reason": resynced,
+            ])
+        }
+        // Throttled: every hook event tails, and one line per approval would swamp the log.
+        if !entries.isEmpty, state.reads % Self.tailDiagnosticEvery == 1 {
+            diagnostics.record("transcript.tailed", level: .debug, fields: [
+                "session": Self.tag(session),
+                "bytes": "\(consumed)",
+                "entries": "\(entries.count)",
+                "malformed": "\(malformed)",
+            ])
+        }
+        return entries.count
+    }
+
+    /// The session's in-memory tail, oldest first, after reading anything new.
+    ///
+    /// This is the "on-demand re-read" seam: the caller asks at question time, the store
+    /// reads whatever the agent wrote since the last hook event, and the answer is composed
+    /// from a tail that is current rather than from whatever happened to be cached.
+    public func entries(session: String) -> Result<[TranscriptEntry], TranscriptUnavailability> {
+        guard let state = sessions[session] else { return .failure(.notAttached) }
+        guard FileManager.default.isReadableFile(atPath: state.path) else {
+            diagnostics.record("transcript.unavailable", level: .error, fields: [
+                "session": Self.tag(session),
+                "reason": TranscriptUnavailability.unreadable.rawValue,
+            ])
+            return .failure(.unreadable)
+        }
+        tail(session: session)
+        let entries = sessions[session]?.entries ?? []
+        guard !entries.isEmpty else {
+            diagnostics.record("transcript.unavailable", level: .error, fields: [
+                "session": Self.tag(session),
+                "reason": TranscriptUnavailability.empty.rawValue,
+            ])
+            return .failure(.empty)
+        }
+        return .success(entries)
+    }
+
+    /// How many entries a session's in-memory tail holds. A caller that has been handed
+    /// exactly this many knows there may be older history on disk, which is the one thing it
+    /// needs in order to decide whether ``reread(session:bytes:)`` is worth a file read.
+    public var tailLimit: Int { tailEntryLimit }
+
+    /// Re-reads a wider window straight off disk, without touching the checkpoint or the
+    /// in-memory tail.
+    ///
+    /// The tail is bounded so a session that runs all day does not become a heap the runtime
+    /// carries around; this is the other half of that bargain. A question whose answer is
+    /// older than the tail — "what did you decide about the migration, two hundred tool calls
+    /// ago?" — is answered by going back to the file, which is the store TapQ never had to
+    /// keep a copy of.
+    ///
+    /// Bounded by `bytes` for the same reason the incremental read is: parsing an entire
+    /// long session at a turn boundary is a timeout, not a better answer.
+    public func reread(
+        session: String,
+        bytes: Int? = nil
+    ) -> Result<[TranscriptEntry], TranscriptUnavailability> {
+        guard let state = sessions[session] else { return .failure(.notAttached) }
+        guard let handle = FileHandle(forReadingAtPath: state.path) else {
+            diagnostics.record("transcript.unavailable", level: .error, fields: [
+                "session": Self.tag(session),
+                "reason": TranscriptUnavailability.unreadable.rawValue,
+            ])
+            return .failure(.unreadable)
+        }
+        defer { try? handle.close() }
+        let window = UInt64(max(1024, bytes ?? readWindowBytes))
+        guard let size = try? handle.seekToEnd() else { return .failure(.unreadable) }
+        let start = size > window ? size - window : 0
+        guard (try? handle.seek(toOffset: start)) != nil,
+              let data = try? handle.readToEnd(), !data.isEmpty else {
+            return .failure(.empty)
+        }
+        let (entries, malformed, _) = Self.parse(data)
+        guard !entries.isEmpty else { return .failure(.empty) }
+        diagnostics.record("transcript.reread", level: .debug, fields: [
+            "session": Self.tag(session),
+            "bytes": "\(data.count)",
+            "entries": "\(entries.count)",
+            "malformed": "\(malformed)",
+        ])
+        return .success(entries)
+    }
+
+    /// The one session to answer about when the caller named no agent: the session that has
+    /// most recently been tailed. With one agent connected — the shipping case — there is
+    /// no other candidate, and with several the caller is expected to resolve the name
+    /// first.
+    public func mostRecentlyActiveSession() -> String? {
+        sessions.max { ($0.value.reads, $0.key) < ($1.value.reads, $1.key) }?.key
+    }
+
+    /// Forgets a session. Called when a run ends; nothing on disk is touched.
+    public func detach(session: String) {
+        sessions.removeValue(forKey: session)
+    }
+
+    // MARK: - Parsing
+
+    /// Parses whole lines out of `data`, returning the entries, the count of lines nothing
+    /// was kept from, and how many bytes were consumed.
+    ///
+    /// "Nothing kept" covers both a line that is not JSON and a line that is JSON but
+    /// carries no prose, no tool call, and no tool output — a bare summary record, a hook
+    /// marker. Both are reported under `malformed` because from the answer's side they are
+    /// the same fact: that many lines of the file contributed nothing.
+    ///
+    /// A trailing partial line is deliberately *not* consumed: the agent writes lines
+    /// atomically but a read can land mid-write, and re-reading those bytes next time is
+    /// how a half-written line becomes a whole one instead of a permanent parse failure.
+    static func parse(_ data: Data) -> (entries: [TranscriptEntry], malformed: Int, consumed: Int) {
+        var entries: [TranscriptEntry] = []
+        var malformed = 0
+        var consumed = 0
+        var lineStart = data.startIndex
+        for index in data.indices where data[index] == UInt8(ascii: "\n") {
+            let line = data[lineStart..<index]
+            consumed = data.distance(from: data.startIndex, to: index) + 1
+            lineStart = data.index(after: index)
+            guard !line.isEmpty else { continue }
+            if let entry = parseLine(Data(line)) {
+                entries.append(entry)
+            } else {
+                malformed += 1
+            }
+        }
+        return (entries, malformed, consumed)
+    }
+
+    /// Claude Code's JSONL: one object per line, `type` naming the speaker and `message`
+    /// carrying either a string or an array of content blocks.
+    static func parseLine(_ data: Data) -> TranscriptEntry? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let type = (object["type"] as? String) ?? ""
+        let message = object["message"] as? [String: Any]
+        let timestamp = (object["timestamp"] as? String).flatMap(Self.parseTimestamp)
+
+        var texts: [String] = []
+        var toolName: String?
+        var toolInput: String?
+        var toolOutput: String?
+
+        if let content = message?["content"] as? String {
+            texts.append(content)
+        } else if let blocks = message?["content"] as? [[String: Any]] {
+            for block in blocks {
+                switch block["type"] as? String {
+                case "text":
+                    if let text = block["text"] as? String { texts.append(text) }
+                case "tool_use":
+                    toolName = block["name"] as? String
+                    if let input = block["input"],
+                       let encoded = try? JSONSerialization.data(withJSONObject: input) {
+                        toolInput = String(decoding: encoded, as: UTF8.self)
+                    }
+                case "tool_result":
+                    toolOutput = Self.flatten(block["content"])
+                default:
+                    break
+                }
+            }
+        }
+
+        let text = texts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        let role: TranscriptEntry.Role
+        switch type {
+        case "assistant": role = .assistant
+        case "user": role = toolOutput == nil ? .user : .toolResult
+        case "": return nil
+        default: role = .other
+        }
+        // A line with nothing in any of the four fields carries no history — a bare
+        // `summary` record, a hook marker — and would only spend the answer's character cap.
+        guard !text.isEmpty || toolName != nil || toolOutput != nil else { return nil }
+        return TranscriptEntry(
+            role: role,
+            text: text,
+            toolName: toolName,
+            toolInput: toolInput,
+            toolOutput: toolOutput,
+            timestamp: timestamp
+        )
+    }
+
+    /// Tool results arrive as a string, as content blocks, or as something else entirely.
+    private static func flatten(_ content: Any?) -> String? {
+        if let text = content as? String { return text }
+        if let blocks = content as? [[String: Any]] {
+            let texts = blocks.compactMap { $0["text"] as? String }
+            return texts.isEmpty ? nil : texts.joined(separator: "\n")
+        }
+        if let content, let encoded = try? JSONSerialization.data(withJSONObject: content) {
+            return String(decoding: encoded, as: UTF8.self)
+        }
+        return nil
+    }
+
+    private static let timestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let plainTimestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static func parseTimestamp(_ text: String) -> Date? {
+        timestampFormatter.date(from: text) ?? plainTimestampFormatter.date(from: text)
+    }
+
+    /// Whether the byte before `offset` is a newline — the one cheap way to notice that a
+    /// rewrite left a stale offset pointing into the middle of a line.
+    private static func endsALine(_ handle: FileHandle, before offset: UInt64) -> Bool {
+        guard offset > 0, (try? handle.seek(toOffset: offset - 1)) != nil,
+              let byte = try? handle.read(upToCount: 1), byte.count == 1 else { return false }
+        return byte[byte.startIndex] == UInt8(ascii: "\n")
+    }
+
+    /// A session identifier is opaque to the wearer and is never spoken; in a log it is
+    /// still an identifier, so only a short prefix goes in a diagnostic field.
+    private static func tag(_ session: String) -> String {
+        String(session.prefix(8))
+    }
+}

--- a/Sources/TapQContextBaseline/WearerConversationRecall.swift
+++ b/Sources/TapQContextBaseline/WearerConversationRecall.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Turns the durable wearer-dialogue record into the one thing milestone M1 does with it:
+/// a bounded recent window joined to the realtime model's per-turn grounding.
+///
+/// Deterministic — same entries in, same characters out, no model in the path — for the
+/// reason ``SessionRecall`` is: what the model is told about the wearer's history must be
+/// reproducible, testable, and impossible to confuse with something a model invented.
+/// Every field it reads is speech-safe by construction (see ``WearerDialogueEntry``), so
+/// the composed block needs no redaction pass.
+///
+/// M2 adds per-question retrieval over the older history; this type deliberately has no
+/// opinion about that. It renders a window.
+public enum WearerConversationRecall {
+    /// How many entries the window may carry. Twelve is roughly the last three or four
+    /// exchanges — enough for "the thing I asked you earlier" to be in it, short enough
+    /// that the open question stays the most prominent thing in the prompt.
+    public static let windowEntryLimit = 12
+    /// The whole window's character budget, applied newest-first so what survives a tight
+    /// budget is always the most recent thing said.
+    public static let windowCharacterLimit = 1_200
+
+    /// The heading the window is filed under, verbatim, so a test can pin it and a reader
+    /// of the log can find it.
+    ///
+    /// It says three things on purpose: that this is *earlier* than the window's own
+    /// brief, that it is TapQ's own memory rather than an agent's transcript, and that
+    /// the tail of it may repeat the sentences the grounding lists separately as "what
+    /// TapQ has just said". The overlap is real and harmless — both halves are things the
+    /// wearer heard — and a model told to expect it will not read the repetition as two
+    /// separate events.
+    public static let heading = """
+        Earlier in TapQ's conversation with the wearer, oldest first. This is TapQ's own \
+        memory, kept across voice sessions and restarts; the last lines may repeat what \
+        TapQ has just said.
+        """
+
+    /// The grounding block for a window, or `nil` when there is no history to state.
+    ///
+    /// `nil` rather than an empty string or a "nothing yet" sentence: the per-turn
+    /// grounding already says what TapQ has said since the last window, and adding a line
+    /// announcing an empty memory would spend prompt on the absence of a fact.
+    public static func grounding(for entries: [WearerDialogueEntry]) -> String? {
+        guard !entries.isEmpty else { return nil }
+        var lines = [heading]
+        for (offset, entry) in entries.enumerated() {
+            lines.append("  \(offset + 1). \(line(for: entry))")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// One entry as the model reads it.
+    ///
+    /// Wearer utterances are quoted and verbatim (ratified 2026-08-29). The quotation
+    /// marks are not decoration: they are what tells the model that the words inside are
+    /// the wearer's own and not TapQ describing them, which is the difference between
+    /// recalling a request and paraphrasing one.
+    public static func line(for entry: WearerDialogueEntry) -> String {
+        switch entry.kind {
+        case .wearerSaid:
+            return "Wearer: \"\(entry.text)\""
+        case .tapqSaid:
+            return "TapQ: \(entry.text)"
+        case .decision:
+            return "Decision: " + decisionClause(entry)
+        case .instruction:
+            return entry.agentDisplayName.isEmpty
+                ? "TapQ delivered an instruction: \(entry.text)"
+                : "TapQ told \(entry.agentDisplayName): \(entry.text)"
+        default:
+            // A kind this build does not know — an M3 directive read by an M1 binary. It
+            // is rendered as itself rather than dropped: a line the model can read is
+            // strictly better than a hole in the history, and dropping it would make the
+            // numbering lie about what is in the file.
+            return entry.kind.rawValue + ": " + entry.text
+        }
+    }
+
+    /// "approved Bash for Claude Code: swift test" — the subject of a decision, in the
+    /// order a person says it.
+    private static func decisionClause(_ entry: WearerDialogueEntry) -> String {
+        var clause = entry.outcome.isEmpty ? "resolved" : entry.outcome
+        if !entry.toolName.isEmpty { clause += " " + entry.toolName }
+        if !entry.agentDisplayName.isEmpty { clause += " for " + entry.agentDisplayName }
+        if !entry.text.isEmpty { clause += ": " + entry.text }
+        return clause
+    }
+}

--- a/Sources/TapQContextBaseline/WearerConversationStore.swift
+++ b/Sources/TapQContextBaseline/WearerConversationStore.swift
@@ -1,0 +1,544 @@
+import Foundation
+import TapQContracts
+
+/// What kind of thing one durable dialogue entry records.
+///
+/// A string newtype rather than an `enum`, and that is the whole of the M3 migration
+/// story: milestone 3 adds standing directives (`WearerDialogueKind.directive`, one
+/// `static let` here plus one recorder), and a file written by that build stays readable
+/// by this one — an unrecognized kind decodes into a value that round-trips and renders
+/// as itself, instead of failing the line and taking the wearer's history with it. A
+/// closed `enum` would have made the same addition a file-format break.
+public struct WearerDialogueKind: RawRepresentable, Codable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    /// Something the wearer said, as the recognizer finalized it. Stored verbatim
+    /// (maintainer-ratified 2026-08-29): wearer utterances are short, and a summary of
+    /// "the thing I asked you earlier" is exactly the thing that cannot be recalled.
+    public static let wearerSaid = WearerDialogueKind(rawValue: "wearer_said")
+    /// A sentence TapQ handed the backend to read aloud — a prompt, a read-back, a
+    /// refusal, a narrated boundary. One kind for all of them, because from the wearer's
+    /// side they are one thing: what TapQ said.
+    public static let tapqSaid = WearerDialogueKind(rawValue: "tapq_said")
+    /// A resolved approval, selection, or stop question, with the subject it decided.
+    public static let decision = WearerDialogueKind(rawValue: "decision")
+    /// An instruction that actually reached an agent, in full.
+    public static let instruction = WearerDialogueKind(rawValue: "instruction")
+}
+
+/// One line of the durable record of TapQ's own dialogue with the wearer.
+///
+/// **Speech-safe by construction, and structurally so.** Every text field here arrives
+/// from a surface that was already cleared for speech: `text` is either something the
+/// wearer said into the microphone, something TapQ sent to the backend to be read out
+/// loud, or the spoken summary of a request — the same three sources
+/// ``SessionContextEvent`` draws on. There is nowhere in this type to put a `toolInput`,
+/// a `cwd`, or a `permissionMode`, so the redaction guarantee needs no filter and no
+/// review: an unsafe field cannot be spelled.
+///
+/// Optional-looking fields are empty strings rather than `nil`. A JSONL file a person
+/// greps reads better with a stable key set, and "no agent" and "the empty agent name"
+/// are the same fact.
+public struct WearerDialogueEntry: Sendable, Equatable {
+    /// Per-entry cap on `text` and `subject`.
+    ///
+    /// Generous — roughly eighty words, several times what anyone says in one breath —
+    /// and present for the reason ``SessionRecall/questionCharacterLimit`` is: a
+    /// recognizer that runs away with a nearby conversation must not be able to turn one
+    /// utterance into a page of prompt. It does not conflict with
+    /// NARRATION_MODEL_PLAN's no-truncation rule, which governs the agent's copy of a
+    /// dictated instruction; this is a spoken recall surface, and the same plan already
+    /// records `SessionContextStore` capping its own for that reason.
+    public static let textCharacterLimit = 480
+
+    public let kind: WearerDialogueKind
+    /// When it was said, heard, or resolved, from the store's clock.
+    public let timestamp: Date
+    /// The utterance, verbatim, or a decision's subject phrase ("swift test").
+    public let text: String
+    /// The agent's display name ("Claude Code"), never its opaque session identifier.
+    /// Empty when the entry is not about one agent.
+    public let agentDisplayName: String
+    /// How a decision resolved, in the wearer's terms ("approved"). Empty otherwise.
+    public let outcome: String
+    /// The tool name as the adapter rendered it ("Bash"). Empty otherwise.
+    public let toolName: String
+
+    public init(
+        kind: WearerDialogueKind,
+        timestamp: Date,
+        text: String,
+        agentDisplayName: String = "",
+        outcome: String = "",
+        toolName: String = ""
+    ) {
+        self.kind = kind
+        self.timestamp = timestamp
+        self.text = SpokenSummaryText.truncated(
+            SpokenSummaryText.normalized(text),
+            limit: Self.textCharacterLimit
+        )
+        self.agentDisplayName = SpokenSummaryText.truncated(
+            SpokenSummaryText.normalized(agentDisplayName),
+            limit: SpokenSummary.sentenceCharacterLimit
+        )
+        // Capped like `text` and for the same reason: a selection's outcome carries the
+        // wearer's own spoken answer ("answered use the staging branch"), so it is a text
+        // field wearing a label's name.
+        self.outcome = SpokenSummaryText.truncated(
+            SpokenSummaryText.normalized(outcome),
+            limit: Self.textCharacterLimit
+        )
+        self.toolName = SpokenSummaryText.truncated(
+            SpokenSummaryText.normalized(toolName),
+            limit: SpokenSummary.sentenceCharacterLimit
+        )
+    }
+}
+
+extension WearerDialogueEntry: Codable {
+    enum CodingKeys: String, CodingKey {
+        case timestamp = "ts"
+        case kind
+        case text
+        case agentDisplayName = "agent"
+        case outcome
+        case toolName = "tool"
+    }
+
+    /// Written by hand rather than synthesized so a line survives the schema growing
+    /// around it: every field but `kind` and `ts` is decoded with a default, so an entry
+    /// written by an older build (or by a newer one, whose extra keys are ignored) still
+    /// reads. This is the other half of ``WearerDialogueKind``'s open rawValue — together
+    /// they are what "no migration for M3" means.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let stamp = try container.decode(String.self, forKey: .timestamp)
+        guard let timestamp = WearerConversationTimestamp.date(from: stamp) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .timestamp,
+                in: container,
+                debugDescription: "Not an ISO 8601 timestamp: \(stamp)"
+            )
+        }
+        self.init(
+            kind: try container.decode(WearerDialogueKind.self, forKey: .kind),
+            timestamp: timestamp,
+            text: try container.decodeIfPresent(String.self, forKey: .text) ?? "",
+            agentDisplayName: try container.decodeIfPresent(
+                String.self, forKey: .agentDisplayName
+            ) ?? "",
+            outcome: try container.decodeIfPresent(String.self, forKey: .outcome) ?? "",
+            toolName: try container.decodeIfPresent(String.self, forKey: .toolName) ?? ""
+        )
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(WearerConversationTimestamp.string(from: timestamp), forKey: .timestamp)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(text, forKey: .text)
+        try container.encode(agentDisplayName, forKey: .agentDisplayName)
+        try container.encode(outcome, forKey: .outcome)
+        try container.encode(toolName, forKey: .toolName)
+    }
+}
+
+/// The one timestamp format the durable record is written and read in.
+///
+/// Fractional seconds so a burst — a prompt, an answer, and a confirmation inside one
+/// second — keeps the order it happened in, which is the order the recent window is read
+/// back in. Shared by the writer and the reader so a file this build wrote is a file this
+/// build can read, which is not automatic when each side builds its own formatter.
+enum WearerConversationTimestamp {
+    private static let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static func string(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+
+    static func date(from string: String) -> Date? {
+        formatter.date(from: string)
+    }
+}
+
+/// TapQ's own memory: the durable, append-only record of the dialogue it has had with the
+/// wearer (Pillar A of docs/TAPQ_AGENT_PLAN.md, milestone M1).
+///
+/// **How this differs from the conversation-memory rung already in the tree.**
+/// `SessionContextStore` (and `SessionRecall`, and `ConversationMemory` in `TapQCLI`)
+/// remember *the agents' requests*: a bounded in-memory ring, per agent session, holding
+/// what each session asked and how it was answered, evicted at sixteen events and eight
+/// sessions, gone when the process exits. They answer "what changed in this session?"
+/// while a window is open. This store remembers *the conversation*: what the wearer said
+/// and what TapQ said back, across sessions, across realtime-session recycles, and across
+/// runtime restarts, on disk. They overlap on decisions and instructions by design — a
+/// decision is both an event in a session and a thing TapQ and the wearer settled — and
+/// nothing reads one to answer the other's question. Neither is a cache of the other.
+///
+/// **Speech-safe by construction.** The recording API takes spoken text, heard text, and
+/// already-spoken decision fields; it takes no request object, no event payload, and no
+/// adapter-supplied field. See ``WearerDialogueEntry``.
+///
+/// **Bounded by rotation, both ways.** Entries older than ``retention`` (30 days,
+/// maintainer-ratified 2026-08-29) are dropped, and the file is held under
+/// ``maximumBytes``; whichever binds first, binds. Rotation *compacts in place* — the
+/// oldest entries are dropped and the survivors rewritten — rather than moving the live
+/// file aside the way `AutoAnswerLog` and `ReasonerShadowLog` do. Those two are read by a
+/// person after the fact, so a generation moved to `.1.jsonl` is still there to read;
+/// this one is read by TapQ *on the next turn*, and a rotation that emptied the live file
+/// would erase the wearer's recent history at the exact moment it got interesting.
+///
+/// **The file is mirrored in memory.** The recent window is read on the per-turn
+/// grounding path, immediately before the microphone opens, so it must not touch the
+/// disk; the whole file (at most ``maximumBytes``) is loaded once at construction and
+/// kept. Disk writes are appends, and a full rewrite only at a rotation.
+///
+/// **Every file failure is swallowed and diagnosed.** Consistent with the plan's failure
+/// posture: a cloud call failing breaks the voice pipe, a local file problem is loud in
+/// the log and the session stays alive. TapQ forgetting is not a reason for TapQ to stop
+/// listening.
+@MainActor public final class WearerConversationStore {
+    /// `nonisolated` throughout: these are the store's defaults, and a default argument is
+    /// evaluated at the *call site*, which is not on the main actor when a test or a
+    /// composition names one.
+    public nonisolated static let fileName = "wearer-conversation.jsonl"
+    /// 30 days, ratified 2026-08-29 as the retention default.
+    public nonisolated static let defaultRetention: TimeInterval = 30 * 24 * 60 * 60
+    /// "A few MB", and the smaller of the two bounds in practice: 2 MB is on the order of
+    /// ten thousand utterances, which is far more conversation than thirty days holds.
+    public nonisolated static let defaultMaximumBytes = 2 * 1_024 * 1_024
+
+    /// After a size rotation the file is left at this fraction of the cap, so the next
+    /// append does not rotate again — and the one after that, and the one after that.
+    nonisolated static let compactionFraction = 0.75
+
+    private struct Line {
+        let entry: WearerDialogueEntry
+        /// The encoded byte length, newline included, so the size bound is measured in the
+        /// bytes actually on disk rather than in characters.
+        let bytes: Int
+    }
+
+    public let fileURL: URL
+    public let retention: TimeInterval
+    public let maximumBytes: Int
+
+    private let clock: @Sendable () -> Date
+    private let diagnostics: TapQDiagnosticEmitter
+    private let encoder: JSONEncoder
+    private let decoder = JSONDecoder()
+    private var lines: [Line] = []
+    private var byteCount = 0
+
+    /// - Parameters:
+    ///   - directory: the runtime's application-support directory — the same `0700`
+    ///     directory the discovery record, the shadow log, and the auto-answer log live
+    ///     in. The store never creates it; the runtime has already prepared it, and a
+    ///     store that made its own would be a store that wrote outside the runtime's
+    ///     permissions.
+    ///   - clock: timestamp source, injected by tests.
+    ///   - retention: how far back entries are kept.
+    ///   - maximumBytes: the live file's ceiling.
+    public init(
+        directory: URL,
+        clock: @escaping @Sendable () -> Date = { Date() },
+        retention: TimeInterval = defaultRetention,
+        maximumBytes: Int = defaultMaximumBytes,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.fileURL = directory.appendingPathComponent(Self.fileName)
+        self.clock = clock
+        self.retention = retention
+        self.maximumBytes = maximumBytes
+        self.diagnostics = TapQDiagnosticEmitter(
+            category: "WearerMemory",
+            sink: diagnosticSink
+        )
+        let encoder = JSONEncoder()
+        // The same two options every other JSONL TapQ writes uses: sorted keys so the file
+        // is diffable across runs, unescaped slashes so a person reading it sees prose.
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        self.encoder = encoder
+        load()
+    }
+
+    // MARK: - Recording
+
+    /// Records something the wearer said, verbatim.
+    public func recordWearerUtterance(_ text: String) {
+        append(.init(kind: .wearerSaid, timestamp: clock(), text: text))
+    }
+
+    /// Records a sentence TapQ said to the wearer.
+    ///
+    /// Called at the moment it goes out to be spoken, not when it was written, so the
+    /// record is in the order the wearer heard it — the same discipline the per-turn
+    /// grounding already follows.
+    public func recordSpokenSentence(_ text: String) {
+        append(.init(kind: .tapqSaid, timestamp: clock(), text: text))
+    }
+
+    /// Records a resolved decision and what it was about.
+    ///
+    /// The parameters are the ones TapQ has already said out loud — the agent's display
+    /// name, the request's spoken summary, the tool name as the adapter rendered it — and
+    /// deliberately not the request itself. A caller cannot hand this an `ApprovalRequest`
+    /// and hope the store remembers which of its fields are unspeakable.
+    public func recordDecision(
+        agentDisplayName: String,
+        summary: String,
+        outcome: String,
+        toolName: String = ""
+    ) {
+        append(.init(
+            kind: .decision,
+            timestamp: clock(),
+            text: summary,
+            agentDisplayName: agentDisplayName,
+            outcome: outcome,
+            toolName: toolName
+        ))
+    }
+
+    /// Records an instruction at the moment it reached an agent, in full.
+    ///
+    /// On delivery rather than on dictation, for the reason
+    /// ``SessionContextStore/recordInstruction(session:agent:text:)`` gives: until the
+    /// turn boundary comes around a queued instruction may still be dropped at capacity,
+    /// and remembering one the agent never received would be inventing a conversation.
+    public func recordInstruction(agentDisplayName: String, text: String) {
+        append(.init(
+            kind: .instruction,
+            timestamp: clock(),
+            text: text,
+            agentDisplayName: agentDisplayName,
+            outcome: "delivered"
+        ))
+    }
+
+    /// Appends an already-built entry. The seam every recorder above goes through, and the
+    /// one an M3 directive recorder will go through unchanged.
+    public func append(_ entry: WearerDialogueEntry) {
+        guard !entry.text.isEmpty || !entry.outcome.isEmpty else {
+            diagnostics.record("append.skipped", fields: ["reason": "empty"])
+            return
+        }
+        guard let line = encoded(entry) else { return }
+        lines.append(Line(entry: entry, bytes: line.count))
+        byteCount += line.count
+        if enforceBounds() {
+            // A rotation has already rewritten the file, this entry included.
+            return
+        }
+        appendToFile(line)
+    }
+
+    // MARK: - Reading
+
+    /// Every retained entry, oldest first.
+    public func entries() -> [WearerDialogueEntry] {
+        lines.map(\.entry)
+    }
+
+    /// The newest entries, oldest first, bounded by both a count and a character budget.
+    ///
+    /// Two bounds because they fail differently: a count keeps the window from being a
+    /// transcript, and a character budget keeps a handful of long utterances from
+    /// spending the whole prompt. The character budget is applied from the newest end
+    /// backwards, so what survives is always the most recent thing said — the entries the
+    /// wearer is most likely to mean by "earlier".
+    public func recentWindow(
+        limit: Int = WearerConversationRecall.windowEntryLimit,
+        characterBudget: Int = WearerConversationRecall.windowCharacterLimit
+    ) -> [WearerDialogueEntry] {
+        guard limit > 0, characterBudget > 0 else { return [] }
+        var window: [WearerDialogueEntry] = []
+        var spent = 0
+        for line in lines.suffix(limit).reversed() {
+            let cost = WearerConversationRecall.line(for: line.entry).count
+            if spent + cost > characterBudget { break }
+            spent += cost
+            window.append(line.entry)
+        }
+        return window.reversed()
+    }
+
+    /// The bytes the live file currently holds, as the store accounts for them. For tests
+    /// and diagnostics.
+    public var storedByteCount: Int { byteCount }
+
+    // MARK: - Clearing
+
+    /// Wipes the record: the file and everything held in memory. `tapq memory clear`.
+    ///
+    /// - Returns: whether there was a file to remove, so the command can tell the user
+    ///   "cleared" from "there was nothing there" rather than claiming both.
+    @discardableResult
+    public func clear() -> Bool {
+        lines.removeAll()
+        byteCount = 0
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: fileURL.path) else { return false }
+        do {
+            try fileManager.removeItem(at: fileURL)
+            diagnostics.record("cleared")
+            return true
+        } catch {
+            diagnostics.record("clear_failed", level: .warning, fields: [
+                "error": String(describing: error),
+            ])
+            return false
+        }
+    }
+
+    // MARK: - Bounds
+
+    /// Drops what neither bound allows and rewrites the file when anything went.
+    ///
+    /// - Returns: whether a rewrite happened, which tells ``append(_:)`` its line is
+    ///   already on disk.
+    private func enforceBounds() -> Bool {
+        let cutoff = clock().addingTimeInterval(-retention)
+        let kept = lines.drop { $0.entry.timestamp < cutoff }
+        var survivors = Array(kept)
+        let expired = lines.count - survivors.count
+
+        var overflowed = 0
+        if survivors.reduce(0, { $0 + $1.bytes }) > maximumBytes {
+            // Compact past the cap rather than to it, so the next append does not rotate
+            // again — and the several thousand after it do not either.
+            let target = Int(Double(maximumBytes) * Self.compactionFraction)
+            var total = survivors.reduce(0) { $0 + $1.bytes }
+            // Never the last one. A single entry larger than the cap is not a reason to
+            // forget the thing the wearer just said — the file is a couple of megabytes
+            // and an entry is at most a few hundred characters, so this is a guard against
+            // a pathological configuration rather than against traffic.
+            while total > target, survivors.count > 1 {
+                total -= survivors.removeFirst().bytes
+                overflowed += 1
+            }
+        }
+
+        guard expired > 0 || overflowed > 0 else { return false }
+        lines = survivors
+        byteCount = survivors.reduce(0) { $0 + $1.bytes }
+        diagnostics.record("rotated", fields: [
+            "expired": "\(expired)",
+            "overflowed": "\(overflowed)",
+            "kept": "\(survivors.count)",
+        ])
+        rewriteFile()
+        return true
+    }
+
+    // MARK: - File
+
+    private func encoded(_ entry: WearerDialogueEntry) -> Data? {
+        do {
+            var line = try encoder.encode(entry)
+            line.append(0x0A)
+            return line
+        } catch {
+            diagnostics.record("encode_failed", level: .warning, fields: [
+                "error": String(describing: error),
+            ])
+            return nil
+        }
+    }
+
+    /// Reads the file into memory once, at construction, and applies both bounds to what
+    /// it found — so a runtime restarting after a fortnight away starts with the file
+    /// already pruned rather than pruning it at the first thing the wearer says.
+    private func load() {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        guard let data = try? Data(contentsOf: fileURL) else {
+            diagnostics.record("load_failed", level: .warning, fields: [
+                "reason": "unreadable",
+                "path": fileURL.path,
+            ])
+            return
+        }
+        var skipped = 0
+        for raw in data.split(separator: 0x0A) {
+            let line = Data(raw)
+            guard !line.isEmpty else { continue }
+            guard let entry = try? decoder.decode(WearerDialogueEntry.self, from: line) else {
+                // A torn last line after a crash, or a line from a build that changed the
+                // format incompatibly. One bad line is not a reason to forget the wearer's
+                // month, so it is counted and stepped over.
+                skipped += 1
+                continue
+            }
+            lines.append(Line(entry: entry, bytes: line.count + 1))
+        }
+        byteCount = lines.reduce(0) { $0 + $1.bytes }
+        diagnostics.record("loaded", fields: [
+            "entries": "\(lines.count)",
+            "skipped": "\(skipped)",
+            "bytes": "\(byteCount)",
+        ])
+        // A rewrite here also drops the unreadable lines, which is the only way they ever
+        // leave the file.
+        if !enforceBounds(), skipped > 0 {
+            rewriteFile()
+        }
+    }
+
+    private func appendToFile(_ line: Data) {
+        let fileManager = FileManager.default
+        do {
+            guard fileManager.fileExists(atPath: fileURL.path) else {
+                guard fileManager.createFile(
+                    atPath: fileURL.path,
+                    contents: line,
+                    attributes: [.posixPermissions: 0o600]
+                ) else {
+                    throw CocoaError(.fileWriteUnknown)
+                }
+                return
+            }
+            let handle = try FileHandle(forWritingTo: fileURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: line)
+        } catch {
+            diagnostics.record("write_failed", level: .warning, fields: [
+                "error": String(describing: error),
+            ])
+        }
+    }
+
+    /// Rewrites the whole file from what is held in memory, atomically.
+    ///
+    /// `Data.write(options: .atomic)` rather than a hand-rolled temp-and-move: a rotation
+    /// that crashed halfway would otherwise leave a truncated file where the wearer's
+    /// history was.
+    private func rewriteFile() {
+        var data = Data()
+        for line in lines {
+            guard let encoded = encoded(line.entry) else { continue }
+            data.append(encoded)
+        }
+        do {
+            try data.write(to: fileURL, options: [.atomic])
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+        } catch {
+            diagnostics.record("rewrite_failed", level: .warning, fields: [
+                "error": String(describing: error),
+            ])
+        }
+    }
+}

--- a/Sources/TapQContextBaseline/WorkQuestionAnswering.swift
+++ b/Sources/TapQContextBaseline/WorkQuestionAnswering.swift
@@ -1,0 +1,139 @@
+import Foundation
+import TapQContracts
+
+/// One transcript entry selected as evidence for an answer, in the order it happened.
+public struct WorkQuestionSlice: Sendable, Equatable {
+    /// The entry's position in the tail it was taken from, so the model reads the history
+    /// in order and a diagnostic can say *which* slices were used without quoting any.
+    public let index: Int
+    public let text: String
+
+    public init(index: Int, text: String) {
+        self.index = index
+        self.text = text
+    }
+}
+
+/// A wearer's question about an agent's work, with the history it is to be answered from.
+public struct WorkQuestionRequest: Sendable, Equatable {
+    /// The question in the wearer's own words, as the realtime model reported it.
+    public let question: String
+    /// The agent whose work this is, by display name only — "Claude Code", never a session
+    /// identifier. `nil` when only one agent is connected and the wearer named nobody.
+    public let agentDisplayName: String?
+    /// The selected history, oldest first.
+    public let slices: [WorkQuestionSlice]
+
+    public init(question: String, agentDisplayName: String?, slices: [WorkQuestionSlice]) {
+        self.question = question
+        self.agentDisplayName = agentDisplayName
+        self.slices = slices
+    }
+}
+
+/// A model that answers a question from transcript slices and nothing else.
+///
+/// It throws rather than returning `nil`, for the reason ``BoundaryNarrating`` does: there
+/// is no local heuristic behind it to fall back to, and an implementation that cannot
+/// answer must say so loudly enough for the caller to break the run's voice pipe.
+public protocol WorkQuestionAnswering: Sendable {
+    func answer(_ request: WorkQuestionRequest) async throws -> String
+}
+
+/// The guidance prompt and the structured-output contract for transcript answers.
+///
+/// Shared by every provider so the same bytes go out whichever one is composed, and so the
+/// redaction and quoting rules have one place a test can read them from.
+public enum WorkAnswerContract {
+    public static let schemaName = "tapq_work_answer"
+
+    /// The whole of what the answer model is told to do.
+    ///
+    /// Four rules, each of which exists because of a specific way this can go wrong:
+    /// inventing work that never happened, paraphrasing a command the wearer has to type,
+    /// answering a question the history does not cover, and reading a key out loud.
+    ///
+    /// The last one is documented as **best effort**, deliberately. The structural
+    /// redaction guarantee remains only where it always was — the local path, event memory,
+    /// unprompted speech. Here the model has been handed tool output because the wearer
+    /// asked what the tool said, and a prompt is the only thing standing between "read me
+    /// the output" and reading out a token that happened to be in it. Saying so plainly is
+    /// better than implying a guarantee this path does not have.
+    public static let instructions = """
+        You are the voice of TapQ, a hands-free assistant a person wears while a coding \
+        agent works for them. Their hands and eyes are busy; they cannot see a screen. You \
+        are given part of a coding agent's session history and one question the wearer \
+        asked out loud about it. You write the single answer TapQ will speak. Your output \
+        is spoken aloud word for word, so write speech, not prose: no markdown, no bullet \
+        points, no headings, no emoji, no stage directions.
+
+        Rules:
+
+        - Answer only from the history you were given. Never infer what the agent probably \
+        did, never fill a gap from general knowledge about the tools involved, and never \
+        describe work that is not in the history.
+        - If the history does not answer the question, say so plainly and briefly — "that \
+        isn't in what I can see of the session" — and stop. A short honest miss is worth \
+        more to someone who cannot look at a screen than a confident guess.
+        - Quote technical tokens exactly: file paths, command lines, flags, identifiers, \
+        error codes, test counts, version numbers. Never round a number, never abbreviate \
+        a path, never "fix" a spelling inside one. If a command is long, it is still better \
+        to say it than to describe it.
+        - Never read out anything that looks like a credential — an API key, a token, a \
+        password, a bearer string, a private key — even when asked to read output word for \
+        word. Say that the output contains a key and carry on with the rest of it.
+        - Keep it to what was asked. Lead with the answer, add only the detail that makes \
+        it usable, and do not offer to do anything further.
+        """
+
+    public static let outputSchema: [String: Any] = [
+        "type": "object",
+        "properties": [
+            "answer": [
+                "type": "string",
+                "description": "The exact words TapQ will speak. Plain spoken text.",
+            ],
+        ],
+        "required": ["answer"],
+        "additionalProperties": false,
+    ]
+
+    /// Renders the question and its slices into the model's input.
+    ///
+    /// Composed here rather than in a provider so every provider sends the same bytes and a
+    /// test that asks "what crossed the boundary?" has one place to look.
+    public static func input(for request: WorkQuestionRequest) -> String {
+        var lines: [String] = []
+        if let agent = request.agentDisplayName, !agent.isEmpty {
+            lines.append("Agent: \(agent)")
+        }
+        lines.append("Session history, oldest first (\(request.slices.count) excerpts, "
+            + "not necessarily contiguous):")
+        for slice in request.slices {
+            lines.append("--- excerpt \(slice.index)")
+            lines.append(slice.text)
+        }
+        lines.append("--- end of history")
+        lines.append("The wearer asked: \(request.question)")
+        return lines.joined(separator: "\n")
+    }
+
+    /// Decodes a provider's JSON payload into the sentence TapQ will speak.
+    ///
+    /// Whitespace is collapsed — a spoken line has no use for newlines — and nothing is
+    /// shortened. The model was asked for an answer and this is the answer; a cap here
+    /// would clip the very thing the wearer asked to hear.
+    public static func decode(_ text: String) throws -> String {
+        guard let data = text.data(using: .utf8),
+              let extraction = try? JSONDecoder().decode(Extraction.self, from: data) else {
+            throw NarrationFailure.malformedResponse
+        }
+        let spoken = SpokenSummaryText.normalized(extraction.answer)
+        guard !spoken.isEmpty else { throw NarrationFailure.emptyOutput }
+        return spoken
+    }
+
+    private struct Extraction: Decodable {
+        let answer: String
+    }
+}

--- a/Sources/TapQContracts/WorkQuestion.swift
+++ b/Sources/TapQContracts/WorkQuestion.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// What came back when TapQ was asked a question about an agent's work.
+///
+/// It lives in contracts because the two halves of the answer path are in different
+/// baselines and must not depend on each other: the interaction layer owns the tool call
+/// and the speaking, the context layer owns the transcript and the model call, and this is
+/// the only vocabulary they share.
+///
+/// The three cases are the whole failure posture of `ask_about_work`, ratified
+/// 2026-08-28 (`docs/TRANSCRIPT_CONTEXT_PLAN.md`), and the line between the last two is
+/// the load-bearing part:
+///
+/// - ``answered(_:)`` — spoken verbatim on the scripted channel, like every other TapQ
+///   sentence.
+/// - ``unavailable(_:)`` — the transcript could not be read: a missing path, a parse
+///   failure, permissions. **Not** a voice break. The voice pipe is intact and killing a
+///   session over a rotated file would be disproportionate, so TapQ says out loud that it
+///   cannot see the session's history and the session stays alive.
+/// - ``failed(_:)`` — the cloud call failed: HTTP error, timeout, refusal, a response that
+///   did not decode. Same model family and endpoint as narration, so the same posture —
+///   the run's voice breaks. There is deliberately no half-answer: a summary assembled
+///   locally out of slices would be TapQ inventing an answer about the wearer's work.
+public enum WorkQuestionOutcome: Sendable, Equatable {
+    /// The answer, in the words the model wrote. Spoken word for word.
+    case answered(String)
+    /// Session history is not visible, and this is the sentence saying so.
+    case unavailable(String)
+    /// The cloud call failed. Carries an operator-facing reason — never wearer speech,
+    /// never agent output, never the key — for the diagnostic and the break notice.
+    case failed(String)
+}

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -67,6 +67,16 @@ public enum SessionPolicy: Sendable, Equatable {
     /// Where this provider takes the wearer's intent from. See `VoiceIntentSource`.
     private let intentSource: VoiceIntentSource
     private let idleSleep: @MainActor (TimeInterval) async -> Void
+    /// Answers a wearer's question about an agent's work, or `nil` where there is no
+    /// transcript to answer from.
+    ///
+    /// Its presence is the whole gate on `ask_about_work`: with it, the tool is declared to
+    /// every session this provider opens; without it, the tool does not exist on the wire
+    /// and a call for it is a protocol failure like any other undeclared name. That is why
+    /// it is an initializer parameter and not a settable property — the declaration goes out
+    /// on the first frame of the first session, so "is there a transcript?" has to be
+    /// answered before this object exists rather than after.
+    private let answerWorkQuestion: (@MainActor (String, String?) async -> WorkQuestionOutcome)?
     /// Reports whether TapQ's own wearer turn signal is live. `nil` — the default, and every
     /// composition that predates the degrade path — means "assume it is", which keeps turn
     /// arbitration on TapQ's side exactly as it has always been.
@@ -192,6 +202,20 @@ public enum SessionPolicy: Sendable, Equatable {
     /// no longer have.
     public var onIntentPipelineFailed: (@MainActor (String) -> Void)?
 
+    /// Fired when the cloud call behind `ask_about_work` failed — an HTTP error, a timeout,
+    /// a refusal, a response that did not decode.
+    ///
+    /// A third sibling of the two hooks above, wired by composition to the same latch, and
+    /// separate from them for the same reason narration's is: the failure originates in a
+    /// side call rather than in this provider's own traffic, and an operator reading the log
+    /// needs to know which of the three broke. The posture is identical — the model family
+    /// and endpoint are narration's, so the answer is narration's answer: break, and do not
+    /// assemble a half-answer locally out of the slices TapQ selected.
+    ///
+    /// A transcript that cannot be *read* never reaches here. That is not a broken pipe, and
+    /// the wearer is told about it out loud instead.
+    public var onWorkAnswerFailed: (@MainActor (String) -> Void)?
+
     /// Observer fired after match evaluation for every final transcript in the current turn.
     /// The callback receives the transcript text and whether it matched a command.
     /// Needed by WP8 (free-form answers); inert until assigned.
@@ -217,6 +241,9 @@ public enum SessionPolicy: Sendable, Equatable {
                 responseAudio: (any VoiceResponseAudioPlaying)? = nil,
                 freeformEnabled: Bool = false,
                 isWearerTurnSignalLive: (@MainActor () -> Bool)? = nil,
+                answerWorkQuestion: (
+                    @MainActor (String, String?) async -> WorkQuestionOutcome
+                )? = nil,
                 monotonicNow: @escaping @MainActor () -> TimeInterval = {
                     ProcessInfo.processInfo.systemUptime
                 },
@@ -232,6 +259,7 @@ public enum SessionPolicy: Sendable, Equatable {
         self.responseAudio = responseAudio
         self.freeformEnabled = freeformEnabled
         self.isWearerTurnSignalLive = isWearerTurnSignalLive
+        self.answerWorkQuestion = answerWorkQuestion
         self.monotonicNow = monotonicNow
         self.idleSleep = idleSleep
         self.diagnostics = TapQDiagnosticEmitter(category: "VoiceBackend", sink: diagnosticSink)
@@ -241,7 +269,13 @@ public enum SessionPolicy: Sendable, Equatable {
         // coming up and its tools landing, and a window that opened inside that gap would
         // hear the wearer and have nothing to do about it.
         if intentSource == .modelToolCalls {
-            backend.declareTools(VoiceIntentTools.declarations)
+            backend.declareTools(VoiceIntentTools.declarations(
+                // Six tools where this run can read an agent's session, five where it
+                // cannot. Decided here, once, for the same reason the set is declared here:
+                // a session that came up before the answer is known would either be missing
+                // the tool or offering one nothing can carry out.
+                includingAskAboutWork: answerWorkQuestion != nil
+            ))
         }
     }
 
@@ -1334,7 +1368,11 @@ public enum SessionPolicy: Sendable, Equatable {
             return failIntentPipeline(
                 "the backend called a tool on a session with no tools declared")
         }
-        let resolution = VoiceIntentTools.resolve(call, windowOpen: handler != nil)
+        let resolution = VoiceIntentTools.resolve(
+            call,
+            windowOpen: handler != nil,
+            askAboutWorkDeclared: answerWorkQuestion != nil
+        )
         switch resolution {
         case .malformed(let detail):
             // Answered first so the peer is not left parked on a call whose session is about
@@ -1361,6 +1399,76 @@ public enum SessionPolicy: Sendable, Equatable {
             diagnostics.record("tool.executed",
                                fields: ["name": call.name, "command": "\(command)"])
             deliver(command)
+        case .answerWorkQuestion(let question, let agent):
+            guard let answerWorkQuestion else {
+                // Unreachable: `resolve` produces this case only when the tool was declared,
+                // and it is declared only when this closure exists. Answered and reported
+                // rather than trapped, because a crash in a voice provider is the one
+                // failure mode with no diagnostic at all.
+                backend.sendToolResult(callID: call.callID,
+                                       output: "That tool call could not be carried out.")
+                return failIntentPipeline("ask_about_work with no answerer composed")
+            }
+            // Named for the tool rather than for the lookup: the answerer records the
+            // `ask.requested`/`ask.answered` pair with the slice counts and the latency, and
+            // one question producing two identically named lines in two categories is a log
+            // an operator has to disambiguate rather than read.
+            diagnostics.record("tool.ask_requested",
+                               fields: ["length": "\(question.count)",
+                                        "agent_named": "\(agent != nil)"])
+            // The one tool whose result waits. Reading the transcript and asking the answer
+            // model takes seconds, and the peer holds the call for those seconds — which is
+            // the honest ordering, because the result says what TapQ *did*, and until the
+            // answer exists TapQ has not done it. It is bounded by the answerer's own
+            // timeout, the same bound narration runs under.
+            //
+            // No window is resolved, before or after: a question leaves whatever the wearer
+            // was asked exactly where it was.
+            Task { @MainActor [weak self] in
+                let outcome = await answerWorkQuestion(question, agent)
+                self?.deliverWorkAnswer(outcome, callID: call.callID)
+            }
+        }
+    }
+
+    /// Speaks the answer, or says why there isn't one, or breaks the run.
+    ///
+    /// The three-way split is the failure posture from `docs/TRANSCRIPT_CONTEXT_PLAN.md`,
+    /// and the middle case is the one worth stating: a transcript that cannot be read is
+    /// *not* a voice break. The pipe is intact, the wearer can still be spoken to, and
+    /// ending their session over a file that rotated would be the disproportionate answer.
+    /// So TapQ says out loud that it cannot see the session's history and carries on.
+    private func deliverWorkAnswer(_ outcome: WorkQuestionOutcome, callID: String) {
+        switch outcome {
+        case .answered(let text):
+            // The result first, then the sentence — the same order every other tool uses, so
+            // the peer is never parked while TapQ is talking.
+            backend.sendToolResult(
+                callID: callID,
+                output: "TapQ read the session history and has spoken the answer to the "
+                    + "wearer. Say nothing further about it."
+            )
+            diagnostics.record("ask.spoken", fields: ["length": "\(text.count)"])
+            // Verbatim on the scripted channel, like every other TapQ sentence: the answer
+            // model already wrote speech, and a second model rewriting it would be a
+            // paraphrase of the wearer's own transcript read back to them.
+            speakScripted(text)
+        case .unavailable(let notice):
+            backend.sendToolResult(
+                callID: callID,
+                output: "TapQ cannot see that session's history, and has told the wearer so "
+                    + "out loud. Nothing was looked up."
+            )
+            diagnostics.record("ask.unavailable", level: .error)
+            speakScripted(notice)
+        case .failed(let reason):
+            backend.sendToolResult(callID: callID,
+                                   output: "That question could not be answered.")
+            // Deliberately silent here: the latch this reaches speaks its own notice, and a
+            // sentence from TapQ saying "I couldn't answer" would be a degraded answer on a
+            // path whose whole posture is that there is no such thing.
+            diagnostics.record("ask.failed", level: .error, fields: ["reason": reason])
+            onWorkAnswerFailed?(reason)
         }
     }
 

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -148,6 +148,28 @@ public enum SessionPolicy: Sendable, Equatable {
     /// turn is cheap; one per turn that changes nothing is noise in the frame log.
     private var lastGroundingSent: String?
 
+    /// TapQ's own durable memory of this conversation, as a block to join the per-turn
+    /// grounding, or `nil` when there is nothing to state.
+    ///
+    /// A closure returning a rendered string rather than a store, because the store lives
+    /// in the context layer and this one deliberately does not depend on it — and because
+    /// what a provider is allowed to know about the wearer's history is "a paragraph
+    /// somebody else composed", not a reader it could query for more.
+    ///
+    /// `nil` — the Apple path, and every composition without a cloud backend — grounds
+    /// exactly what it grounded before: there is no memory to read and no line to omit.
+    /// Pillar A of docs/TAPQ_AGENT_PLAN.md, milestone M1.
+    public var wearerMemoryGrounding: (@MainActor () -> String?)?
+
+    /// Fired with each sentence TapQ has just handed the backend to read aloud, so a host
+    /// can keep a durable record of what the wearer heard.
+    ///
+    /// It sits inside `noteSpoken`, which already exists for the grounding and already
+    /// returns early on the grammar path — so this observer is structurally unreachable
+    /// off a model-backed session rather than disabled on one. What it reports is the
+    /// backend's own copy: the same string, at the same moment, that the wearer hears.
+    public var onSpokenToWearer: (@MainActor (String) -> Void)?
+
     /// The agents this run can currently address, for `queue_instruction`'s optional name.
     ///
     /// A closure because which sessions are live is the runtime's business and changes inside
@@ -534,12 +556,22 @@ public enum SessionPolicy: Sendable, Equatable {
         } else {
             lines.append("Agents the wearer may address by name: \(names.joined(separator: ", ")).")
         }
+        // Last, and only when there is something to say. It goes after the window brief
+        // rather than before it because the brief is what the wearer is answering *now*:
+        // a model that read a fortnight of history first would have the open question at
+        // the bottom of its prompt. Everything in the block was said or heard on this
+        // voice channel, so the redaction rule holds here for the same reason it holds
+        // for `spokenSinceWindowEnded`.
+        if let memory = wearerMemoryGrounding?(), !memory.isEmpty {
+            lines.append(memory)
+        }
         return lines.joined(separator: "\n")
     }
 
     /// Records a sentence the wearer is about to hear, for the next turn's grounding.
     private func noteSpoken(_ text: String) {
         guard intentSource == .modelToolCalls else { return }
+        onSpokenToWearer?(text)
         spokenSinceWindowEnded.append(text)
         // Bounded here as well as at read time: a window that spoke a hundred sentences
         // without opening a turn would otherwise grow this forever.

--- a/Sources/TapQInteractionBaseline/VoiceIntentTools.swift
+++ b/Sources/TapQInteractionBaseline/VoiceIntentTools.swift
@@ -51,6 +51,9 @@ public enum VoiceIntentTools {
     public static let selectItem = "select_item"
     public static let queueInstruction = "queue_instruction"
     public static let queryStatus = "query_status"
+    /// The sixth, and the only conditional one: declared only where a `TranscriptStore`
+    /// exists to answer from. See ``declarations(includingAskAboutWork:)``.
+    public static let askAboutWork = "ask_about_work"
 
     /// The two questions `query_status` can be asked, matching the two informational intents
     /// the windows already answer. A closed set on the wire, so a third kind is refused by
@@ -137,7 +140,9 @@ public enum VoiceIntentTools {
             description: """
                 The wearer is asking about state rather than answering anything: which agents \
                 are waiting, or what has already been decided in this session. This resolves \
-                nothing — whatever they were asked is still on the table afterwards.
+                nothing — whatever they were asked is still on the table afterwards. It \
+                answers from what TapQ itself has done, not from the agent's work, so a \
+                question about what an agent did, said, ran, or found is not this tool.
                 """,
             parameters: [
                 VoiceToolParameter(
@@ -152,6 +157,57 @@ public enum VoiceIntentTools {
             ]
         ),
     ]
+
+    /// The transcript tool (`docs/TRANSCRIPT_CONTEXT_PLAN.md`), declared only where there is
+    /// a transcript to read.
+    ///
+    /// Its description carries the whole of the routing decision between it and
+    /// `query_status`, because a description is the only place that distinction can be
+    /// drawn: both are questions, both resolve nothing, and the difference is whose history
+    /// answers them — TapQ's own record of what it has been asked and told, or the agent's
+    /// session.
+    public static let askAboutWorkDeclaration = VoiceToolDeclaration(
+        name: askAboutWork,
+        description: """
+            The wearer is asking about the work an agent has been doing: what it ran, what \
+            a command printed, what it changed, what it found, what it decided, or what it \
+            said earlier. TapQ reads that agent's session history and answers out loud. Use \
+            this for anything whose answer is inside the agent's own session, and use \
+            query_status instead for what is waiting on the wearer right now or what TapQ \
+            has already decided. This resolves nothing: whatever the wearer was asked is \
+            still on the table afterwards, and asking never approves anything.
+            """,
+        parameters: [
+            VoiceToolParameter(
+                name: "question",
+                kind: .string,
+                description: """
+                    The wearer's question, in their own words. Pass it through as they asked \
+                    it — do not narrow it to keywords and do not answer it yourself.
+                    """
+            ),
+            VoiceToolParameter(
+                name: "agent",
+                kind: .string,
+                description: """
+                    The agent's name exactly as the wearer said it, when they named one. \
+                    Omit this when they did not; never guess.
+                    """,
+                required: false
+            ),
+        ]
+    )
+
+    /// The tool set for one composition.
+    ///
+    /// `ask_about_work` is present only when a `TranscriptStore` exists — that is, only on a
+    /// cloud-backend run where an agent has a transcript TapQ may read. The Apple path
+    /// declares five tools and has no sixth to disable, which is the same structural absence
+    /// every other cloud-only pillar has: there is no flag, and a call for a tool that was
+    /// never declared is a protocol failure rather than a feature that quietly worked.
+    public static func declarations(includingAskAboutWork: Bool) -> [VoiceToolDeclaration] {
+        includingAskAboutWork ? declarations + [askAboutWorkDeclaration] : declarations
+    }
 
     /// What a provider should do about one tool call.
     public enum Resolution: Equatable {
@@ -175,6 +231,16 @@ public enum VoiceIntentTools {
         /// no response: nothing follows `sendToolResult`, so a refusal that lived only in
         /// `output` would be a refusal nobody ever hears.
         case refused(output: String, speak: String)
+        /// The wearer asked about an agent's work. Nothing is resolved and no window is
+        /// touched; the caller reads the transcript, asks the answer model, and speaks what
+        /// comes back on the scripted channel.
+        ///
+        /// It is its own case rather than a `command` because there is no window intent it
+        /// could carry: the five above all end in something a window consumes, and this one
+        /// ends in a sentence. Keeping it separate is also what keeps a question from
+        /// resolving an approval by accident — the window this call arrived inside is left
+        /// exactly as it was found.
+        case answerWorkQuestion(question: String, agent: String?)
         /// The call names a tool TapQ never declared, or its arguments cannot be read.
         ///
         /// Not a refusal: a refusal is a legal call that could not run, and this is the tool
@@ -214,6 +280,13 @@ public enum VoiceIntentTools {
     /// again.
     public static let emptyInstructionNotice = "I didn't catch that — say it again."
 
+    /// Spoken when `ask_about_work` arrives with nothing to answer.
+    ///
+    /// The same sentence a dictation that captured silence gets, and for the same reason:
+    /// from the wearer's side one situation happened — they spoke and nothing was heard —
+    /// and the remedy is to say it again.
+    public static let emptyQuestionNotice = emptyInstructionNotice
+
     /// Spoken when the model asks for a status TapQ does not keep.
     ///
     /// Names the two that exist, because unlike the entry above the remedy is a closed
@@ -228,11 +301,19 @@ public enum VoiceIntentTools {
     /// tested exhaustively against strings a model might actually produce.
     ///
     /// - Parameter windowOpen: whether a window is armed to receive a command. Every tool
-    ///   here delivers through one — including `queue_instruction`, whose read-back and
-    ///   fail-closed attribution check *are* the window's dictation flow. Executing one
-    ///   without a window would not be a shortcut, it would be the instruction path with its
-    ///   confirmation removed.
-    public static func resolve(_ call: VoiceToolCall, windowOpen: Bool) -> Resolution {
+    ///   that resolves *something* delivers through one — including `queue_instruction`,
+    ///   whose read-back and fail-closed attribution check *are* the window's dictation
+    ///   flow. Executing one without a window would not be a shortcut, it would be the
+    ///   instruction path with its confirmation removed. `ask_about_work` is the exception,
+    ///   and deliberately: it resolves nothing, so there is nothing for a window to receive,
+    ///   and an answer TapQ can speak on its own channel is not made safer by refusing it
+    ///   because a prompt happened to have closed a beat earlier.
+    /// - Parameter askAboutWorkDeclared: whether this composition declared the transcript
+    ///   tool. `false` — every Apple-path composition, and every cloud run with no
+    ///   transcript attached — makes a call for it a protocol failure, exactly as any other
+    ///   undeclared name is. That is the gate: not a disabled feature, an undeclared one.
+    public static func resolve(_ call: VoiceToolCall, windowOpen: Bool,
+                               askAboutWorkDeclared: Bool = false) -> Resolution {
         switch call.name {
         case approve:
             return windowed(.yes, output: "Approved.", windowOpen: windowOpen,
@@ -303,6 +384,26 @@ public enum VoiceIntentTools {
             }
             return windowed(command, output: "TapQ is answering the wearer out loud.",
                             windowOpen: windowOpen, speak: notListeningNotice)
+        case askAboutWork:
+            // Undeclared here means undeclared on the wire: this composition never sent the
+            // tool, so a call for it is the protocol not being the one TapQ configured.
+            guard askAboutWorkDeclared else {
+                return .malformed("the backend called an undeclared tool \"\(call.name)\"")
+            }
+            guard let arguments = decode(AskAboutWorkArguments.self, from: call) else {
+                return .malformed("ask_about_work arguments could not be read")
+            }
+            let question = arguments.question.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !question.isEmpty else {
+                return .refused(
+                    output: "No question was supplied, so nothing was looked up.",
+                    speak: emptyQuestionNotice
+                )
+            }
+            let agent = arguments.agent
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .flatMap { $0.isEmpty ? nil : $0 }
+            return .answerWorkQuestion(question: question, agent: agent)
         default:
             // A name TapQ never declared. The service refuses unknown tools before they are
             // sent, so reaching here means the tool protocol is not the one TapQ configured.
@@ -343,5 +444,10 @@ public enum VoiceIntentTools {
 
     private struct QueryStatusArguments: Decodable {
         let kind: String
+    }
+
+    private struct AskAboutWorkArguments: Decodable {
+        let question: String
+        let agent: String?
     }
 }

--- a/Sources/TapQWireProtocol/WireMessages.swift
+++ b/Sources/TapQWireProtocol/WireMessages.swift
@@ -31,6 +31,14 @@ public enum WireType {
 /// gained a `wait: "renew"` value, which an older shim can never provoke (it sends no
 /// lease) and would read as "nothing arrived" if it somehow did. Neither direction can
 /// misread the other, so there is nothing for a version gate to protect.
+///
+/// Transcript paths (2026-08-29, `docs/TRANSCRIPT_CONTEXT_PLAN.md`) did not move it either,
+/// on exactly the `lease_id` reasoning. `approval.request`, `notification.event`, and
+/// `stop.question` gained an optional `transcript_path`; a broker that does not know the
+/// field ignores it and behaves identically, and a shim that does not send one leaves a
+/// runtime that *does* know it with no transcript attached — which is the same state as
+/// every run before this existed. The field influences no decision: it says where a file
+/// is, and nothing on the deciding side of the broker reads it.
 public enum WireProtocol {
     public static let version = 6
     /// The immediately preceding protocol remains wire-compatible for messages that do
@@ -116,6 +124,14 @@ public struct ApprovalRequestMessage: Codable, Sendable, Equatable {
     public let agent: AgentIdentity?
     public let summary: String?
     public let detail: String?
+    /// Where this session's transcript lives on local disk, when the adapter's hook was
+    /// given a path (Claude Code's hooks all carry one).
+    ///
+    /// Optional and additive — see ``WireProtocol`` for why it moved no version. It is a
+    /// location and not content: nothing on the broker's deciding side reads it, and the
+    /// only thing that does is a runtime composed with a transcript store, which is only
+    /// ever the cloud-backend arm.
+    public let transcriptPath: String?
     public let protocolVersion: Int?
 
     enum CodingKeys: String, CodingKey {
@@ -128,6 +144,7 @@ public struct ApprovalRequestMessage: Codable, Sendable, Equatable {
         case approvalSource = "approval_source"
         case requestID = "request_id"
         case agent, summary, detail
+        case transcriptPath = "transcript_path"
         case protocolVersion = "protocol_version"
     }
 
@@ -135,6 +152,7 @@ public struct ApprovalRequestMessage: Codable, Sendable, Equatable {
                 toolInput: [String: JSONValue], permissionMode: String?, requestID: String,
                 approvalSource: ApprovalSource? = nil,
                 agent: AgentIdentity? = nil, summary: String? = nil, detail: String? = nil,
+                transcriptPath: String? = nil,
                 protocolVersion: Int? = nil) {
         self.token = token
         self.sessionID = sessionID
@@ -147,6 +165,7 @@ public struct ApprovalRequestMessage: Codable, Sendable, Equatable {
         self.agent = agent
         self.summary = summary
         self.detail = detail
+        self.transcriptPath = transcriptPath
         self.protocolVersion = protocolVersion
     }
 }
@@ -158,6 +177,10 @@ public struct NotificationMessage: Codable, Sendable, Equatable {
     public let event: Event
     public let summary: String?
     public let agent: AgentIdentity?
+    /// See ``ApprovalRequestMessage/transcriptPath``. Carried here as well because a Stop is
+    /// the one event every session produces whether or not it ever asks for anything, so a
+    /// session that only ever finishes turns is still one TapQ knows the transcript of.
+    public let transcriptPath: String?
     public let protocolVersion: Int?
 
     public enum Event: String, Codable, Sendable {
@@ -172,17 +195,20 @@ public struct NotificationMessage: Codable, Sendable, Equatable {
         case event
         case summary
         case agent
+        case transcriptPath = "transcript_path"
         case protocolVersion = "protocol_version"
     }
 
     public init(token: String, sessionID: String, event: Event, summary: String?,
                 agent: AgentIdentity? = nil,
+                transcriptPath: String? = nil,
                 protocolVersion: Int? = nil) {
         self.token = token
         self.sessionID = sessionID
         self.event = event
         self.summary = summary
         self.agent = agent
+        self.transcriptPath = transcriptPath
         self.protocolVersion = protocolVersion
     }
 }
@@ -235,23 +261,29 @@ public struct StopQuestionMessage: Codable, Sendable, Equatable {
     public let requestID: String
     public let text: String
     public let agent: AgentIdentity?
+    /// See ``ApprovalRequestMessage/transcriptPath``. The shim already had the path open to
+    /// read this very message's text out of it, so forwarding it costs nothing.
+    public let transcriptPath: String?
     public let protocolVersion: Int?
 
     enum CodingKeys: String, CodingKey {
         case token, text, agent
         case sessionID = "session_id"
         case requestID = "request_id"
+        case transcriptPath = "transcript_path"
         case protocolVersion = "protocol_version"
     }
 
     public init(token: String, sessionID: String, requestID: String, text: String,
                 agent: AgentIdentity? = nil,
+                transcriptPath: String? = nil,
                 protocolVersion: Int? = nil) {
         self.token = token
         self.sessionID = sessionID
         self.requestID = requestID
         self.text = text
         self.agent = agent
+        self.transcriptPath = transcriptPath
         self.protocolVersion = protocolVersion
     }
 }

--- a/Tests/TapQBrokerRuntimeTests/TranscriptAttachmentTests.swift
+++ b/Tests/TapQBrokerRuntimeTests/TranscriptAttachmentTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import TapQBrokerRuntime
+import TapQContracts
+import TapQWireProtocol
+
+/// The broker's transcript seam: a path forwarded on a message it already handles, handed
+/// to a host that has somewhere to put it — and, on the Apple path, to nobody.
+@MainActor
+final class TranscriptAttachmentTests: XCTestCase {
+    /// The socket is not what is under test here; `handle` is the whole dispatcher.
+    private final class StubTransport: BrokerTransport {
+        func start(handler: @escaping @Sendable (Data) async -> Data) throws {}
+        func stop() {}
+    }
+
+    private final class Attachments {
+        var received: [BrokerTranscriptAttachment] = []
+    }
+
+    private func makeServer(
+        attachments: Attachments?,
+        onApproval: @escaping @MainActor (ApprovalRequest) async -> Decision = { _ in .allow },
+        onNotification: @escaping @MainActor (AgentNotification) -> Void = { _ in },
+        onStopQuestion: @escaping @MainActor (StopQuestion) async -> String? = { _ in nil }
+    ) -> BrokerServer {
+        BrokerServer(
+            transport: StubTransport(),
+            token: "tok",
+            onApproval: onApproval,
+            onNotification: onNotification,
+            onStopQuestion: onStopQuestion,
+            onTranscriptPath: attachments.map { box in
+                { attachment in box.received.append(attachment) }
+            }
+        )
+    }
+
+    private func approval(transcriptPath: String? = nil) -> Data {
+        var fields = [
+            #""type":"approval.request""#, #""token":"tok""#, #""session_id":"s1""#,
+            #""tool_name":"Bash""#, #""tool_input":{}"#, #""request_id":"r1""#,
+            #""approval_source":"pre_tool_use""#, #""protocol_version":6"#,
+            #""agent":{"id":"claude-code","display_name":"Claude Code"}"#,
+        ]
+        if let transcriptPath { fields.append(#""transcript_path":"\#(transcriptPath)""#) }
+        return Data(("{" + fields.joined(separator: ",") + "}").utf8)
+    }
+
+    private func notification(transcriptPath: String?) -> Data {
+        var fields = [
+            #""type":"notification.event""#, #""token":"tok""#, #""session_id":"s2""#,
+            #""event":"stop""#, #""protocol_version":6"#,
+            #""agent":{"id":"claude-code","display_name":"Claude Code"}"#,
+        ]
+        if let transcriptPath { fields.append(#""transcript_path":"\#(transcriptPath)""#) }
+        return Data(("{" + fields.joined(separator: ",") + "}").utf8)
+    }
+
+    private func stopQuestion(transcriptPath: String?) -> Data {
+        var fields = [
+            #""type":"stop.question""#, #""token":"tok""#, #""session_id":"s3""#,
+            #""request_id":"r2""#, #""text":"Shall I continue?""#, #""protocol_version":6"#,
+            #""agent":{"id":"claude-code","display_name":"Claude Code"}"#,
+        ]
+        if let transcriptPath { fields.append(#""transcript_path":"\#(transcriptPath)""#) }
+        return Data(("{" + fields.joined(separator: ",") + "}").utf8)
+    }
+
+    // MARK: - Forwarded to a host that wants it
+
+    func testEveryCarryingMessageReachesTheHost() async {
+        let attachments = Attachments()
+        let server = makeServer(attachments: attachments)
+
+        _ = await server.handle(approval(transcriptPath: "/tmp/a.jsonl"))
+        _ = await server.handle(notification(transcriptPath: "/tmp/b.jsonl"))
+        _ = await server.handle(stopQuestion(transcriptPath: "/tmp/c.jsonl"))
+
+        XCTAssertEqual(attachments.received.map(\.sessionID), ["s1", "s2", "s3"])
+        XCTAssertEqual(attachments.received.map(\.path),
+                       ["/tmp/a.jsonl", "/tmp/b.jsonl", "/tmp/c.jsonl"])
+        XCTAssertEqual(attachments.received.first?.agent, .claudeCode)
+    }
+
+    /// The path is a fact about the session, not a decision: the approval still resolves
+    /// exactly as the host said, and the reply on the wire is unchanged.
+    func testAnAttachmentChangesNoDecision() async {
+        let attachments = Attachments()
+        let server = makeServer(attachments: attachments, onApproval: { _ in .deny })
+
+        let withPath = await server.handle(approval(transcriptPath: "/tmp/a.jsonl"))
+        let without = await server.handle(approval())
+
+        XCTAssertEqual(withPath, without)
+        let decoded = try? JSONDecoder().decode(BrokerResponse.self, from: withPath)
+        XCTAssertEqual(decoded, .decision(.deny, reason: "Denied via TapQ"))
+    }
+
+    // MARK: - Nothing to attach, or nobody to attach it to
+
+    /// The Apple path. The field still arrives and still decodes; there is simply no
+    /// callback, so nothing is ever read from disk. Structurally absent, not disabled.
+    func testWithoutAHostCallbackAPathGoesNowhere() async {
+        let server = makeServer(attachments: nil)
+
+        let response = await server.handle(approval(transcriptPath: "/tmp/a.jsonl"))
+
+        let decoded = try? JSONDecoder().decode(BrokerResponse.self, from: response)
+        XCTAssertEqual(decoded, .decision(.allow, reason: nil))
+    }
+
+    /// `acceptEdits` and `bypassPermissions` answer every tool call at the broker without
+    /// asking the wearer. The path still has to land, or a run in one of those modes would
+    /// not know where its transcript is until its first turn boundary.
+    func testAnAutoAnsweredApprovalStillAttachesItsTranscript() async {
+        let attachments = Attachments()
+        let server = makeServer(attachments: attachments)
+        let json = #"{"type":"approval.request","token":"tok","session_id":"s1","#
+            + #""tool_name":"Edit","tool_input":{},"request_id":"r1","#
+            + #""approval_source":"pre_tool_use","permission_mode":"acceptEdits","#
+            + #""transcript_path":"/tmp/a.jsonl","protocol_version":6}"#
+
+        let response = await server.handle(Data(json.utf8))
+
+        let decoded = try? JSONDecoder().decode(BrokerResponse.self, from: response)
+        XCTAssertEqual(decoded, .decision(.allow, reason: nil), "the auto-pass is unchanged")
+        XCTAssertEqual(attachments.received.map(\.path), ["/tmp/a.jsonl"])
+    }
+
+    /// A shim too old to send one, and a shim that sent a blank, are the same thing: no
+    /// attachment.
+    func testAMissingOrBlankPathIsNotAnAttachment() async {
+        let attachments = Attachments()
+        let server = makeServer(attachments: attachments)
+
+        _ = await server.handle(approval())
+        _ = await server.handle(notification(transcriptPath: nil))
+        _ = await server.handle(approval(transcriptPath: "   "))
+
+        XCTAssertTrue(attachments.received.isEmpty)
+    }
+}

--- a/Tests/TapQClaudeAdapterTests/HookShimTranscriptPathTests.swift
+++ b/Tests/TapQClaudeAdapterTests/HookShimTranscriptPathTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import TapQClaudeAdapter
+import TapQContracts
+import TapQWireProtocol
+
+/// The shim forwarding `transcript_path` on the messages it already sends.
+///
+/// Every Claude Code hook invocation carries the path and the shim already opens the file
+/// for the final assistant message. What is added is only the forwarding: a location, on
+/// messages that already existed, under the version they already used.
+final class HookShimTranscriptPathTests: XCTestCase {
+    /// Captures what the shim would have put on the socket.
+    private final class Sent: @unchecked Sendable {
+        private let lock = NSLock()
+        private var messages: [[String: JSONValue]] = []
+
+        func record(_ message: [String: JSONValue]) {
+            lock.lock()
+            messages.append(message)
+            lock.unlock()
+        }
+
+        var all: [[String: JSONValue]] {
+            lock.lock()
+            defer { lock.unlock() }
+            return messages
+        }
+
+        func first(ofType type: String) -> [String: JSONValue]? {
+            all.first { $0["type"]?.stringValue == type }
+        }
+    }
+
+    private func run(_ json: String, reply: String = #"{"ok":true}"#) -> Sent {
+        let sent = Sent()
+        _ = HookShim.handle(stdinData: Data(json.utf8)) { message, _ in
+            sent.record(message)
+            return Data(reply.utf8)
+        }
+        return sent
+    }
+
+    // MARK: - Forwarded
+
+    func testAnApprovalCarriesTheHooksTranscriptPath() throws {
+        let sent = run(#"{"hook_event_name":"PreToolUse","session_id":"s1","tool_name":"Bash","#
+            + #""tool_input":{"command":"swift test"},"request_id":"r1","#
+            + #""transcript_path":"/tmp/claude/session.jsonl"}"#)
+
+        let message = try XCTUnwrap(sent.first(ofType: WireType.approval))
+        XCTAssertEqual(message["transcript_path"]?.stringValue, "/tmp/claude/session.jsonl")
+    }
+
+    func testANotificationCarriesTheHooksTranscriptPath() throws {
+        let sent = run(#"{"hook_event_name":"Notification","session_id":"s1","#
+            + #""message":"Claude needs your permission","#
+            + #""transcript_path":"/tmp/claude/session.jsonl"}"#)
+
+        let message = try XCTUnwrap(sent.first(ofType: WireType.notification))
+        XCTAssertEqual(message["transcript_path"]?.stringValue, "/tmp/claude/session.jsonl")
+    }
+
+    /// The Stop notification is the one every session produces whether or not it ever asks
+    /// for anything, so it is how a session that only finishes turns becomes one TapQ knows
+    /// the transcript of.
+    func testTheStopNotificationCarriesTheHooksTranscriptPath() throws {
+        let sent = run(#"{"hook_event_name":"Stop","session_id":"s1","#
+            + #""transcript_path":"/tmp/claude/session.jsonl"}"#)
+
+        let message = try XCTUnwrap(sent.first(ofType: WireType.notification))
+        XCTAssertEqual(message["event"]?.stringValue, "stop")
+        XCTAssertEqual(message["transcript_path"]?.stringValue, "/tmp/claude/session.jsonl")
+    }
+
+    /// The shim does not check the path, stat it, or read it for this: a location is all it
+    /// forwards, and whether the file is readable is the runtime store's question.
+    func testAPathIsForwardedWithoutBeingRead() throws {
+        let sent = run(#"{"hook_event_name":"PreToolUse","session_id":"s1","tool_name":"Bash","#
+            + #""tool_input":{},"request_id":"r1","#
+            + #""transcript_path":"/definitely/not/here.jsonl"}"#)
+
+        let message = try XCTUnwrap(sent.first(ofType: WireType.approval))
+        XCTAssertEqual(message["transcript_path"]?.stringValue, "/definitely/not/here.jsonl")
+    }
+
+    // MARK: - Absent
+
+    /// A hook payload with no path — or a blank one — sends null, which a broker reads as no
+    /// transcript and an older broker ignores entirely.
+    func testAMissingOrBlankPathIsSentAsNull() throws {
+        for json in [
+            #"{"hook_event_name":"PreToolUse","session_id":"s1","tool_name":"Bash","tool_input":{},"request_id":"r1"}"#,
+            #"{"hook_event_name":"PreToolUse","session_id":"s1","tool_name":"Bash","tool_input":{},"request_id":"r1","transcript_path":"   "}"#,
+        ] {
+            let sent = run(json)
+            let message = try XCTUnwrap(sent.first(ofType: WireType.approval))
+            XCTAssertEqual(message["transcript_path"], .null)
+        }
+    }
+
+    // MARK: - Nothing else moved
+
+    /// The version the shim stamps is untouched, which is the whole additive claim.
+    func testTheForwardedMessagesStillCarryTheCurrentVersion() throws {
+        let sent = run(#"{"hook_event_name":"PreToolUse","session_id":"s1","tool_name":"Bash","#
+            + #""tool_input":{},"request_id":"r1","transcript_path":"/tmp/s.jsonl"}"#)
+
+        let message = try XCTUnwrap(sent.first(ofType: WireType.approval))
+        XCTAssertEqual(message["protocol_version"], .number(Double(WireProtocol.version)))
+    }
+
+    /// And the whole message still decodes into the shape the broker reads, with the path on
+    /// it — the shim's output and the broker's input agreeing is the actual contract.
+    func testTheForwardedApprovalDecodesAsTheBrokerWouldReadIt() throws {
+        let sent = run(#"{"hook_event_name":"PreToolUse","session_id":"s1","tool_name":"Bash","#
+            + #""tool_input":{"command":"swift test"},"request_id":"r1","#
+            + #""transcript_path":"/tmp/claude/session.jsonl"}"#)
+
+        // The token is added by the executable's socket client rather than by the shim, so
+        // it is supplied here to make the bytes the ones the broker actually reads.
+        var message = try XCTUnwrap(sent.first(ofType: WireType.approval))
+        message["token"] = .string("tok")
+        let data = try JSONEncoder().encode(message)
+        guard case .approval(let decoded) = try BrokerRequest(from: data) else {
+            return XCTFail("the shim's own message did not decode as an approval")
+        }
+        XCTAssertEqual(decoded.transcriptPath, "/tmp/claude/session.jsonl")
+        XCTAssertEqual(decoded.sessionID, "s1")
+    }
+}

--- a/Tests/TapQContextBaselineTests/TranscriptQuestionAnswererTests.swift
+++ b/Tests/TapQContextBaselineTests/TranscriptQuestionAnswererTests.swift
@@ -1,0 +1,374 @@
+import Foundation
+import XCTest
+@testable import TapQContextBaseline
+import TapQContracts
+
+/// The question path end to end, minus the network: transcript on disk → slices → one model
+/// call → the sentence TapQ speaks, and the two failure classes that must not be confused
+/// with each other.
+@MainActor
+final class TranscriptQuestionAnswererTests: XCTestCase {
+    /// Captures what crossed the boundary to the model, and answers with whatever the test
+    /// scripted.
+    private final class StubModel: WorkQuestionAnswering, @unchecked Sendable {
+        private let lock = NSLock()
+        private var requests: [WorkQuestionRequest] = []
+        private let outcome: Result<String, NarrationFailure>
+
+        init(_ outcome: Result<String, NarrationFailure>) { self.outcome = outcome }
+
+        var seen: [WorkQuestionRequest] {
+            lock.lock()
+            defer { lock.unlock() }
+            return requests
+        }
+
+        func answer(_ request: WorkQuestionRequest) async throws -> String {
+            lock.lock()
+            requests.append(request)
+            lock.unlock()
+            return try outcome.get()
+        }
+    }
+
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        var names: [String] { events.map(\.name) }
+    }
+
+    private var directory: URL!
+    private var path: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("tapq-answer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        path = directory.appendingPathComponent("session.jsonl").path
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        try await super.tearDown()
+    }
+
+    private func writeTranscript() throws {
+        let lines = [
+            #"{"type":"user","message":{"role":"user","content":"run the test suite"}}"#,
+            #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"swift test"}}]}}"#,
+            #"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"Executed 12 tests, with 1 failure"}]}}"#,
+            #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"One test failed: WireProtocolTests"}]}}"#,
+        ]
+        try Data((lines.joined(separator: "\n") + "\n").utf8)
+            .write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
+    private func makeStore(attached: Bool = true) throws -> TranscriptStore {
+        let store = TranscriptStore()
+        if attached {
+            try writeTranscript()
+            store.attach(session: "s1", path: path)
+        }
+        return store
+    }
+
+    // MARK: - The answer
+
+    /// The model's words are the wearer's answer, unedited. Nothing here summarizes a
+    /// summary: the model was asked for speech and this is the speech.
+    func testTheAnswerIsTheModelsOwnWords() async throws {
+        let model = StubModel(.success("One test failed, WireProtocolTests."))
+        let answerer = TranscriptQuestionAnswerer(store: try makeStore(), model: model)
+
+        let outcome = await answerer.answer(question: "what did the tests say?",
+                                            agentDisplayName: "Claude Code")
+
+        XCTAssertEqual(outcome, .answered("One test failed, WireProtocolTests."))
+    }
+
+    /// What crosses to the provider: the wearer's question as they asked it, the agent by
+    /// display name only, and the history. No session identifier — the wearer never hears
+    /// one and the model has no use for one.
+    func testTheModelIsGivenTheQuestionTheSlicesAndNothingElse() async throws {
+        let model = StubModel(.success("ok"))
+        let answerer = TranscriptQuestionAnswerer(store: try makeStore(), model: model)
+
+        _ = await answerer.answer(question: "did the tests pass?",
+                                  agentDisplayName: "Claude Code")
+
+        let request = try XCTUnwrap(model.seen.first)
+        XCTAssertEqual(request.question, "did the tests pass?")
+        XCTAssertEqual(request.agentDisplayName, "Claude Code")
+        XCTAssertEqual(request.slices.count, 4)
+        let rendered = WorkAnswerContract.input(for: request)
+        XCTAssertTrue(rendered.contains("Executed 12 tests, with 1 failure"), rendered)
+        XCTAssertTrue(rendered.contains("did the tests pass?"), rendered)
+        XCTAssertFalse(rendered.contains("s1"), "a session identifier reached the model")
+    }
+
+    /// Tool input and tool output are exactly what a question about the work is answered
+    /// from, and under a cloud backend TapQ may read them. This is the scoped exemption
+    /// stated as a test, so a later "tighten the redaction" edit has to face it directly.
+    func testToolInputAndOutputReachTheAnswerModel() async throws {
+        let model = StubModel(.success("ok"))
+        let answerer = TranscriptQuestionAnswerer(store: try makeStore(), model: model)
+
+        _ = await answerer.answer(question: "what command did you run?", agentDisplayName: nil)
+
+        let rendered = WorkAnswerContract.input(for: try XCTUnwrap(model.seen.first))
+        XCTAssertTrue(rendered.contains("swift test"), rendered)
+        XCTAssertTrue(rendered.contains("tool: Bash"), rendered)
+    }
+
+    /// The in-memory tail is bounded, so a question about something older than it would
+    /// otherwise be unanswerable. When the tail comes back saturated the store is asked to
+    /// go back to the file — which it can, because the agent's own transcript is the store
+    /// and TapQ kept no copy of it.
+    func testHistoryOlderThanTheTailIsRereadFromDisk() async throws {
+        let lines = (1...40).map {
+            #"{"type":"user","message":{"role":"user","content":"line \#($0)"}}"#
+        }
+        try Data((lines.joined(separator: "\n") + "\n").utf8)
+            .write(to: URL(fileURLWithPath: path), options: .atomic)
+        let store = TranscriptStore(tailEntryLimit: 5)
+        store.attach(session: "s1", path: path)
+        let model = StubModel(.success("ok"))
+        let answerer = TranscriptQuestionAnswerer(store: store, model: model)
+
+        _ = await answerer.answer(question: "what happened at line 1?", agentDisplayName: nil)
+
+        let request = try XCTUnwrap(model.seen.first)
+        XCTAssertEqual(request.slices.count, 40,
+                       "the answer was composed from the bounded tail alone")
+    }
+
+    // MARK: - Unreadable transcript: loud, but alive
+
+    /// No transcript is not a broken voice pipe. The wearer is told out loud, the model is
+    /// never called, and the session lives.
+    func testAnUnattachedSessionIsSpokenRatherThanBroken() async throws {
+        let model = StubModel(.success("should not be reached"))
+        let answerer = TranscriptQuestionAnswerer(store: try makeStore(attached: false),
+                                                  model: model)
+
+        let outcome = await answerer.answer(question: "what did you do?",
+                                            agentDisplayName: nil)
+
+        XCTAssertEqual(outcome, .unavailable(TranscriptQuestionAnswerer.notAttachedNotice))
+        XCTAssertTrue(model.seen.isEmpty, "no cloud call may be made with nothing to send")
+    }
+
+    func testAMissingTranscriptFileIsSpokenRatherThanBroken() async throws {
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: directory.appendingPathComponent("gone.jsonl").path)
+        let model = StubModel(.success("should not be reached"))
+        let answerer = TranscriptQuestionAnswerer(store: store, model: model)
+
+        let outcome = await answerer.answer(question: "what did you do?",
+                                            agentDisplayName: nil)
+
+        XCTAssertEqual(outcome, .unavailable(TranscriptQuestionAnswerer.unreadableNotice))
+        XCTAssertTrue(model.seen.isEmpty)
+    }
+
+    /// The three notices are different sentences, because "I don't know where your session
+    /// is", "I can't open it", and "there's nothing in it yet" are three different things
+    /// for someone who cannot look at a screen.
+    func testTheUnavailableNoticesAreDistinct() async throws {
+        let notices = Set([
+            TranscriptQuestionAnswerer.notAttachedNotice,
+            TranscriptQuestionAnswerer.unreadableNotice,
+            TranscriptQuestionAnswerer.emptyNotice,
+        ])
+        XCTAssertEqual(notices.count, 3)
+    }
+
+    // MARK: - Cloud failure: break, never a half-answer
+
+    /// The same model family and endpoint as narration, so the same posture. Notably there
+    /// is no fallback that assembles something out of the slices TapQ already had in hand:
+    /// that would be TapQ answering a question about the wearer's work by itself.
+    func testACloudFailureIsReportedAsAFailure() async throws {
+        for failure in [NarrationFailure.timedOut, .http(status: 500),
+                        .malformedResponse, .transport("send failed")] {
+            let model = StubModel(.failure(failure))
+            let answerer = TranscriptQuestionAnswerer(store: try makeStore(), model: model)
+
+            let outcome = await answerer.answer(question: "what did the tests say?",
+                                                agentDisplayName: nil)
+
+            guard case .failed(let reason) = outcome else {
+                XCTFail("\(failure) did not produce a failure outcome")
+                continue
+            }
+            XCTAssertEqual(reason, failure.reason)
+        }
+    }
+
+    // MARK: - Diagnostics
+
+    /// Lengths and counts, never content, never the key. The rule is checked by looking at
+    /// every field of every event rather than at the ones this test expects.
+    func testDiagnosticsCarryNoQuestionAndNoTranscriptContent() async throws {
+        let sink = RecordingSink()
+        let model = StubModel(.success("One test failed."))
+        let answerer = TranscriptQuestionAnswerer(
+            store: try makeStore(), model: model, diagnosticSink: sink
+        )
+
+        _ = await answerer.answer(question: "what did the tests say?",
+                                  agentDisplayName: "Claude Code")
+
+        XCTAssertTrue(sink.names.contains("ask.requested"), "\(sink.names)")
+        XCTAssertTrue(sink.names.contains("ask.answered"), "\(sink.names)")
+        let answered = try XCTUnwrap(sink.events.last { $0.name == "ask.answered" })
+        XCTAssertEqual(answered.fields["slices"], "4")
+        XCTAssertNotNil(answered.fields["latency_ms"])
+        for event in sink.events {
+            for value in event.fields.values {
+                XCTAssertFalse(value.contains("what did the tests"), "a question was logged")
+                XCTAssertFalse(value.contains("Executed 12 tests"), "transcript content logged")
+                XCTAssertFalse(value.contains("swift test"), "transcript content was logged")
+            }
+        }
+    }
+
+    /// A question that arrives empty is answered as "nothing legible", not sent to the
+    /// model. The provider refuses an empty one before this, so this is the second guard.
+    func testAnEmptyQuestionIsNeverSentToTheModel() async throws {
+        let model = StubModel(.success("should not be reached"))
+        let answerer = TranscriptQuestionAnswerer(store: try makeStore(), model: model)
+
+        let outcome = await answerer.answer(question: "   ", agentDisplayName: nil)
+
+        XCTAssertEqual(outcome, .unavailable(TranscriptQuestionAnswerer.emptyNotice))
+        XCTAssertTrue(model.seen.isEmpty)
+    }
+
+    // MARK: - The contract
+
+    /// The prompt is the only thing standing between "read me the output" and reading a key
+    /// out loud, so its four rules are pinned. Best effort, and documented as such.
+    func testTheAnswerPromptStatesItsFourRules() async throws {
+        let instructions = WorkAnswerContract.instructions.lowercased()
+        XCTAssertTrue(instructions.contains("only from the history"))
+        XCTAssertTrue(instructions.contains("credential"))
+        XCTAssertTrue(instructions.contains("quote technical tokens exactly"))
+        XCTAssertTrue(instructions.contains("say so plainly"))
+    }
+
+    /// Strict structured output: TapQ speaks the field verbatim, so a free-text completion
+    /// that drifted into prose would be read out as prose.
+    func testTheAnswerSchemaIsStrictAndSingleFielded() async throws {
+        XCTAssertEqual(WorkAnswerContract.outputSchema["required"] as? [String], ["answer"])
+        XCTAssertEqual(WorkAnswerContract.outputSchema["additionalProperties"] as? Bool, false)
+        XCTAssertEqual(try WorkAnswerContract.decode(#"{"answer":"Twelve tests passed."}"#),
+                       "Twelve tests passed.")
+    }
+
+    /// A spoken line has no use for newlines, and an answer that normalized to nothing is a
+    /// failure rather than a sentence of silence.
+    func testAnEmptyOrUnreadableAnswerIsRejected() async throws {
+        XCTAssertThrowsError(try WorkAnswerContract.decode(#"{"answer":"   "}"#))
+        XCTAssertThrowsError(try WorkAnswerContract.decode("not json"))
+        XCTAssertEqual(try WorkAnswerContract.decode(#"{"answer":"one\ntwo"}"#), "one two")
+    }
+}
+
+/// Which parts of a long session are handed to the model, and what is reported about the
+/// parts that are not.
+final class TranscriptSliceSelectionTests: XCTestCase {
+    private func entry(_ text: String) -> TranscriptEntry {
+        TranscriptEntry(role: .assistant, text: text)
+    }
+
+    /// The newest entries are always taken, whatever the question is about: almost every
+    /// question a wearer asks is about what just happened.
+    func testTheNewestEntriesAreAlwaysSelected() {
+        let entries = (1...100).map { entry("line \($0)") }
+        let result = TranscriptSliceSelection.select(
+            entries: entries, question: "nothing matches this at all", recencyFloor: 5
+        )
+
+        XCTAssertEqual(result.slices.map(\.index), [96, 97, 98, 99, 100])
+        XCTAssertEqual(result.droppedEntries, 95)
+        XCTAssertGreaterThan(result.droppedCharacters, 0)
+    }
+
+    /// And then relevance reaches back past them, which is what makes "what did you decide
+    /// about the migration?" answerable after twenty lines of something else.
+    func testRelevantOlderEntriesAreReachedAfterTheRecentOnes() {
+        var entries = [entry("we decided to postpone the migration")]
+        entries.append(contentsOf: (1...10).map { entry("unrelated line \($0)") })
+        let result = TranscriptSliceSelection.select(
+            entries: entries, question: "what did you decide about the migration?",
+            recencyFloor: 3
+        )
+
+        XCTAssertTrue(result.slices.contains { $0.index == 1 },
+                      "the relevant older entry was not reached")
+        XCTAssertEqual(result.slices.map(\.index), result.slices.map(\.index).sorted(),
+                       "slices are handed over in the order they happened")
+    }
+
+    /// The budget is a cap on the answer prompt, not a suggestion.
+    func testTheCharacterBudgetIsRespected() {
+        let entries = (1...50).map { _ in entry(String(repeating: "z", count: 1_000)) }
+        let result = TranscriptSliceSelection.select(
+            entries: entries, question: "anything", budget: 5_000, recencyFloor: 50
+        )
+
+        let total = result.slices.reduce(0) { $0 + $1.text.count }
+        XCTAssertLessThanOrEqual(total, 5_000)
+        XCTAssertGreaterThan(result.droppedEntries, 0)
+    }
+
+    /// One enormous tool output must not evict everything around it: it is capped, the cut
+    /// is reported inside the text so the model does not mistake it for the end, and the
+    /// characters removed are counted as dropped.
+    func testOneHugeEntryIsCappedRatherThanAllowedToEvictTheRest() {
+        let entries = [entry(String(repeating: "q", count: 50_000))] + (1...5).map {
+            entry("later line \($0)")
+        }
+        let result = TranscriptSliceSelection.select(
+            entries: entries, question: "q", recencyFloor: 6, entryCap: 1_000
+        )
+
+        XCTAssertEqual(result.slices.count, 6, "every entry still made it in")
+        let first = try? XCTUnwrap(result.slices.first)
+        XCTAssertTrue(first?.text.contains("characters not shown") ?? false)
+        XCTAssertGreaterThan(result.droppedCharacters, 40_000)
+    }
+
+    /// Nothing to answer from is not a crash and not an empty prompt: the caller turns it
+    /// into the spoken "there is nothing there yet".
+    func testNoEntriesSelectsNothing() {
+        let result = TranscriptSliceSelection.select(entries: [], question: "anything")
+        XCTAssertTrue(result.slices.isEmpty)
+        XCTAssertEqual(result.droppedEntries, 0)
+    }
+
+    /// Short technical words are exactly what a question hangs on, so the filter is a length
+    /// floor rather than a dictionary of "important" words.
+    func testShortTechnicalWordsSurviveKeywordExtraction() {
+        let keywords = TranscriptSliceSelection.keywords(in: "did npm ci pass for the CLI?")
+        XCTAssertTrue(keywords.contains("npm"))
+        XCTAssertTrue(keywords.contains("cli"))
+        XCTAssertFalse(keywords.contains("the"))
+        XCTAssertFalse(keywords.contains("did"))
+    }
+}

--- a/Tests/TapQContextBaselineTests/TranscriptStoreTests.swift
+++ b/Tests/TapQContextBaselineTests/TranscriptStoreTests.swift
@@ -1,0 +1,383 @@
+import Foundation
+import XCTest
+@testable import TapQContextBaseline
+import TapQContracts
+
+/// The transcript tail: what TapQ reads out of a file it does not own and cannot stop from
+/// rewriting itself under it.
+///
+/// The fixtures are written here rather than checked in, deliberately: a `.jsonl` file in
+/// the tree is refused by `scripts/check-public-boundary.sh`, and the interesting cases —
+/// growth, truncation, a compaction that leaves the file *longer*, a half-written line —
+/// are about a file changing between two reads, which a static fixture cannot express.
+@MainActor
+final class TranscriptStoreTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        var names: [String] { events.map(\.name) }
+
+        func fields(of name: String) -> [String: String]? {
+            events.last { $0.name == name }?.fields
+        }
+    }
+
+    private var directory: URL!
+    private var path: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("tapq-transcript-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        path = directory.appendingPathComponent("session.jsonl").path
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private func user(_ text: String) -> String {
+        #"{"type":"user","message":{"role":"user","content":"\#(text)"},"#
+            + #""timestamp":"2026-08-29T10:00:00.000Z"}"#
+    }
+
+    private func assistant(_ text: String) -> String {
+        #"{"type":"assistant","message":{"role":"assistant","content":"#
+            + #"[{"type":"text","text":"\#(text)"}]},"#
+            + #""timestamp":"2026-08-29T10:00:01.000Z"}"#
+    }
+
+    private func toolUse(_ name: String, _ command: String) -> String {
+        #"{"type":"assistant","message":{"role":"assistant","content":"#
+            + #"[{"type":"tool_use","name":"\#(name)","input":{"command":"\#(command)"}}]}}"#
+    }
+
+    private func toolResult(_ output: String) -> String {
+        #"{"type":"user","message":{"role":"user","content":"#
+            + #"[{"type":"tool_result","content":"\#(output)"}]}}"#
+    }
+
+    private func write(_ lines: [String], newlineAtEnd: Bool = true) throws {
+        var body = lines.joined(separator: "\n")
+        if newlineAtEnd, !lines.isEmpty { body += "\n" }
+        try Data(body.utf8).write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
+    private func appendLine(_ line: String) throws {
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data((line + "\n").utf8))
+    }
+
+    private func texts(
+        _ store: TranscriptStore,
+        session: String = "s1",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> [String] {
+        switch store.entries(session: session) {
+        case .success(let entries):
+            return entries.map(\.text)
+        case .failure(let reason):
+            XCTFail("transcript unavailable: \(reason.rawValue)", file: file, line: line)
+            return []
+        }
+    }
+
+    // MARK: - Growth
+
+    /// The ordinary case: a file the agent keeps appending to, read from the byte after the
+    /// last line TapQ already has.
+    func testTailingReadsOnlyWhatIsNew() async throws {
+        try write([user("start the migration"), assistant("running it now")])
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: path)
+        XCTAssertEqual(texts(store), ["start the migration", "running it now"])
+
+        try appendLine(assistant("the migration finished"))
+        XCTAssertEqual(texts(store),
+                       ["start the migration", "running it now", "the migration finished"])
+    }
+
+    /// Attaching is called on every hook event. It must not re-read the file into a doubled
+    /// tail, or the model would be shown the same turn several times over.
+    func testAttachingTheSamePathAgainDoesNotDuplicateEntries() async throws {
+        try write([user("hello")])
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: path)
+        store.attach(session: "s1", path: path)
+        store.attach(session: "s1", path: path)
+
+        XCTAssertEqual(texts(store), ["hello"])
+    }
+
+    /// A read can land in the middle of a line the agent is still writing. Those bytes are
+    /// left unconsumed so the line is parsed once, whole, on the next read — rather than
+    /// counted as a permanent parse failure.
+    func testAHalfWrittenLineIsParsedOnlyOnceItIsWhole() async throws {
+        try write([user("first")], newlineAtEnd: true)
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: path)
+        XCTAssertEqual(texts(store), ["first"])
+
+        // The agent starts writing a second line and stops mid-flight.
+        let partial = String(assistant("second").prefix(30))
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(partial.utf8))
+        try handle.close()
+        XCTAssertEqual(texts(store), ["first"], "a partial line must not be parsed")
+
+        // …and then finishes it.
+        let rest = String(assistant("second").dropFirst(30))
+        let second = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        try second.seekToEnd()
+        try second.write(contentsOf: Data((rest + "\n").utf8))
+        try second.close()
+        XCTAssertEqual(texts(store), ["first", "second"])
+    }
+
+    // MARK: - The file rewriting itself
+
+    /// Compaction that leaves the file *shorter*. The offset now points past the end, so
+    /// everything held is about a conversation that no longer exists.
+    func testTruncationResyncsFromTheTop() async throws {
+        try write([user("one"), assistant("two"), assistant("three")])
+        let sink = RecordingSink()
+        let store = TranscriptStore(diagnosticSink: sink)
+        store.attach(session: "s1", path: path)
+        XCTAssertEqual(texts(store).count, 3)
+
+        try write([user("compacted summary")])
+
+        XCTAssertEqual(texts(store), ["compacted summary"])
+        XCTAssertTrue(sink.names.contains("transcript.resynced"), "\(sink.names)")
+        XCTAssertEqual(sink.fields(of: "transcript.resynced")?["reason"], "truncated")
+    }
+
+    /// The harder rewrite: the new file is *longer* than the old offset, so a size check
+    /// alone says "nothing to do but read from here" — and reading from there would splice
+    /// the middle of one line onto the tail of a conversation that is gone. The offset is
+    /// therefore also checked for sitting immediately after a newline.
+    func testARewriteThatLeavesTheFileLongerAlsoResyncs() async throws {
+        try write([user("one"), user("two")])
+        let sink = RecordingSink()
+        let store = TranscriptStore(diagnosticSink: sink)
+        store.attach(session: "s1", path: path)
+        XCTAssertEqual(texts(store).count, 2)
+
+        // One line, no newlines inside it, longer than the two it replaces — so the old
+        // offset lands in the middle of it.
+        try write([user(String(repeating: "x", count: 4_000))])
+
+        let entries = texts(store)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.count, 4_000)
+        XCTAssertEqual(sink.fields(of: "transcript.resynced")?["reason"], "offset_invalid")
+    }
+
+    /// A session TapQ meets for the first time with megabytes already in it: the read starts
+    /// at the last window rather than parsing the whole history at a turn boundary.
+    func testAFileFarLargerThanTheWindowIsReadFromItsTail() async throws {
+        let filler = (0..<200).map { user("line \($0) " + String(repeating: "y", count: 200)) }
+        try write(filler + [assistant("the last thing that happened")])
+        let sink = RecordingSink()
+        let store = TranscriptStore(readWindowBytes: 4_096, diagnosticSink: sink)
+        store.attach(session: "s1", path: path)
+
+        let entries = texts(store)
+        XCTAssertEqual(entries.last, "the last thing that happened")
+        XCTAssertLessThan(entries.count, 200, "the whole history must not be parsed")
+        XCTAssertEqual(sink.fields(of: "transcript.resynced")?["reason"], "window_clamped")
+    }
+
+    /// A session that moved to a different file is a different conversation: the offset and
+    /// the tail from the old one mean nothing.
+    func testReattachingADifferentPathResetsTheTail() async throws {
+        try write([user("old conversation")])
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: path)
+        XCTAssertEqual(texts(store), ["old conversation"])
+
+        let other = directory.appendingPathComponent("other.jsonl")
+        try Data((user("new conversation") + "\n").utf8).write(to: other)
+        store.attach(session: "s1", path: other.path)
+
+        XCTAssertEqual(texts(store), ["new conversation"])
+    }
+
+    // MARK: - Malformed input
+
+    /// Junk between good lines costs those lines and nothing else. The count is reported;
+    /// the content never is.
+    func testMalformedLinesAreSkippedAndCountedWithoutTheirContent() async throws {
+        let sink = RecordingSink()
+        try write([
+            user("good one"),
+            "{ not json at all",
+            "",
+            #"{"type":"assistant"}"#,          // no content anywhere: carries no history
+            assistant("good two"),
+        ])
+        let store = TranscriptStore(diagnosticSink: sink)
+        store.attach(session: "s1", path: path)
+
+        XCTAssertEqual(texts(store), ["good one", "good two"])
+        let tailed = try XCTUnwrap(sink.fields(of: "transcript.tailed"))
+        // Two lines produced no entry: the one that is not JSON, and the one that is JSON
+        // but carries no prose, no tool, and no output. An empty line is not counted — it
+        // is not a line anything was lost from.
+        XCTAssertEqual(tailed["malformed"], "2")
+        for event in sink.events {
+            for value in event.fields.values {
+                XCTAssertFalse(value.contains("good one"),
+                               "a diagnostic carried transcript content")
+            }
+        }
+    }
+
+    // MARK: - Unavailability
+
+    /// Three different ways to have no transcript, kept apart because the wearer hears a
+    /// different sentence for the first and the operator reads a different reason for all
+    /// three.
+    func testTheThreeUnavailableReasonsAreDistinct() async throws {
+        let store = TranscriptStore()
+        guard case .failure(.notAttached) = store.entries(session: "unknown") else {
+            return XCTFail("an unknown session must report notAttached")
+        }
+
+        store.attach(session: "gone", path: directory.appendingPathComponent("no.jsonl").path)
+        guard case .failure(.unreadable) = store.entries(session: "gone") else {
+            return XCTFail("a missing file must report unreadable")
+        }
+
+        try write(["{ junk", "also junk"])
+        store.attach(session: "s1", path: path)
+        guard case .failure(.empty) = store.entries(session: "s1") else {
+            return XCTFail("a file with nothing legible must report empty")
+        }
+    }
+
+    /// An unreadable transcript is an *error*-level fact, because the wearer is about to be
+    /// told out loud that TapQ cannot see the session — but it is not a break, and nothing
+    /// here throws.
+    func testAnUnreadableTranscriptIsRecordedAtErrorLevel() async throws {
+        let sink = RecordingSink()
+        let store = TranscriptStore(diagnosticSink: sink)
+        store.attach(session: "s1", path: directory.appendingPathComponent("no.jsonl").path)
+        _ = store.entries(session: "s1")
+
+        let event = try XCTUnwrap(sink.events.last { $0.name == "transcript.unavailable" })
+        XCTAssertEqual(event.level, .error)
+        XCTAssertEqual(event.fields["reason"], "unreadable")
+    }
+
+    // MARK: - Parsing
+
+    /// A tool call and its result are the two halves a question like "what did the tests
+    /// say?" is answered from, so both are parsed into their own fields rather than flattened
+    /// into prose.
+    func testToolUseAndToolResultKeepTheirParts() async throws {
+        try write([toolUse("Bash", "swift test"), toolResult("Executed 12 tests, 0 failures")])
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: path)
+        guard case .success(let entries) = store.entries(session: "s1") else {
+            return XCTFail("expected entries")
+        }
+
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].role, .assistant)
+        XCTAssertEqual(entries[0].toolName, "Bash")
+        XCTAssertEqual(entries[0].toolInput, #"{"command":"swift test"}"#)
+        XCTAssertEqual(entries[1].role, .toolResult)
+        XCTAssertEqual(entries[1].toolOutput, "Executed 12 tests, 0 failures")
+        XCTAssertTrue(entries[1].rendered.contains("Executed 12 tests, 0 failures"))
+    }
+
+    func testTimestampsAreParsedWhenPresent() async throws {
+        try write([user("hello")])
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: path)
+        guard case .success(let entries) = store.entries(session: "s1") else {
+            return XCTFail("expected entries")
+        }
+        XCTAssertNotNil(entries.first?.timestamp)
+    }
+
+    /// The tail is bounded. A session that runs all day must not turn into a heap the
+    /// runtime carries around.
+    func testTheInMemoryTailIsBounded() async throws {
+        try write((0..<50).map { user("line \($0)") })
+        let store = TranscriptStore(tailEntryLimit: 10)
+        store.attach(session: "s1", path: path)
+
+        let entries = texts(store)
+        XCTAssertEqual(entries.count, 10)
+        XCTAssertEqual(entries.last, "line 49", "the newest entries are the ones kept")
+    }
+
+    /// The other half of the bounded tail: history older than it is still reachable, because
+    /// the agent's own file is the store and TapQ kept no copy to lose.
+    func testRereadingReachesPastTheBoundedTailWithoutDisturbingIt() async throws {
+        try write((0..<50).map { user("line \($0)") })
+        let store = TranscriptStore(tailEntryLimit: 10)
+        store.attach(session: "s1", path: path)
+        XCTAssertEqual(texts(store).count, 10)
+
+        guard case .success(let all) = store.reread(session: "s1") else {
+            return XCTFail("a re-read of a readable file must succeed")
+        }
+        XCTAssertEqual(all.count, 50)
+        XCTAssertEqual(all.first?.text, "line 0")
+        XCTAssertEqual(texts(store).count, 10,
+                       "a re-read must leave the checkpoint and the tail alone")
+        XCTAssertEqual(store.tailLimit, 10)
+    }
+
+    /// Nothing about a transcript is written down: the store holds an offset and a tail, and
+    /// the only file involved is the agent's own.
+    func testTheStoreWritesNothingToDisk() async throws {
+        try write([user("hello")])
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: path)
+        _ = texts(store)
+
+        let contents = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        XCTAssertEqual(contents, ["session.jsonl"])
+    }
+
+    /// With one agent connected there is no ambiguity about which session a question is
+    /// about, and that is the resolution M1 ships.
+    func testTheMostRecentlyActiveSessionIsTheOneAnswered() async throws {
+        try write([user("first session")])
+        let other = directory.appendingPathComponent("other.jsonl")
+        try Data((user("second session") + "\n").utf8).write(to: other)
+
+        let store = TranscriptStore()
+        store.attach(session: "s1", path: path)
+        store.attach(session: "s2", path: other.path)
+        _ = store.entries(session: "s2")
+
+        XCTAssertEqual(store.mostRecentlyActiveSession(), "s2")
+        XCTAssertEqual(store.attachedSessions, ["s1", "s2"])
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/AskAboutWorkTests.swift
+++ b/Tests/TapQInteractionBaselineTests/AskAboutWorkTests.swift
@@ -1,0 +1,400 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+/// `ask_about_work`: the sixth tool, the one that exists only where there is a transcript to
+/// read.
+///
+/// Three properties are load-bearing here and each has its own test below. The tool is
+/// *declared* only when an answerer exists, so on the Apple path it is not a disabled
+/// feature but an undeclared one. A question resolves nothing, so the request the wearer was
+/// asked is still on the table after they ask about the work. And the two failure classes
+/// stay apart: a transcript TapQ cannot read is spoken out loud and the session lives, while
+/// a cloud call that fails breaks the run's voice with nothing said.
+@MainActor
+final class AskAboutWorkTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        var names: [String] { events.map(\.name) }
+    }
+
+    /// The same duplex fake the tool-intent suite uses, restated here so the two suites can
+    /// drift independently.
+    @MainActor
+    private final class ToolBackend: VoiceBackend {
+        let capabilities = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                    duplex: true,
+                                                    supportsNativeTurnDetection: true,
+                                                    supportsToolCalling: true)
+
+        private(set) var declaredTools: [[String]] = []
+        private(set) var toolResults: [(callID: String, output: String)] = []
+        private(set) var scriptedSpeech: [String] = []
+        private(set) var isOpen = false
+        private var handler: (@MainActor (VoiceBackendEvent) -> Void)?
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            isOpen = true
+            handler = onEvent
+        }
+
+        func close() { isOpen = false }
+        func beginUserTurn() {}
+
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool { expectingResponse }
+
+        func sendAudio(_ chunk: VoiceAudioChunk) {}
+        func requestResponse(text: String) {}
+        func requestScriptedSpeech(text: String) { scriptedSpeech.append(text) }
+        func cancelResponse() {}
+        func setNativeTurnDetection(_ enabled: Bool) {}
+
+        @discardableResult
+        func requestModelTurn() -> Bool { true }
+
+        func declareTools(_ tools: [VoiceToolDeclaration]) {
+            declaredTools.append(tools.map(\.name))
+        }
+
+        func updateInstructions(_ instructions: String) {}
+
+        func sendToolResult(callID: String, output: String) {
+            toolResults.append((callID, output))
+        }
+
+        func emit(_ event: VoiceBackendEvent) {
+            guard let handler else { return XCTFail("no session is listening") }
+            handler(event)
+        }
+    }
+
+    /// Records the questions asked and answers with whatever the test scripted.
+    @MainActor
+    private final class Answerer {
+        var outcome: WorkQuestionOutcome
+        private(set) var asked: [(question: String, agent: String?)] = []
+
+        init(_ outcome: WorkQuestionOutcome) { self.outcome = outcome }
+
+        func answer(_ question: String, _ agent: String?) async -> WorkQuestionOutcome {
+            asked.append((question, agent))
+            return outcome
+        }
+    }
+
+    private func makeProvider(
+        _ backend: ToolBackend,
+        answerer: Answerer?,
+        sink: RecordingSink = RecordingSink(),
+        policy: SessionPolicy = .conversation(idleClose: 60)
+    ) -> VoiceBackendCommandProvider {
+        VoiceBackendCommandProvider(
+            backend: backend,
+            intentSource: .modelToolCalls,
+            sessionPolicy: policy,
+            supportsBargeIn: true,
+            answerWorkQuestion: answerer.map { answerer in
+                { question, agent in await answerer.answer(question, agent) }
+            },
+            // Bounded rather than the shipped sixty seconds: an unbounded sleep left running
+            // in-process stalls whichever test runs next.
+            idleSleep: { _ in try? await Task.sleep(for: .seconds(1)) },
+            diagnosticSink: sink
+        )
+    }
+
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    private func call(_ arguments: String, id: String = "call_1") -> VoiceBackendEvent {
+        .toolCall(VoiceToolCall(callID: id, name: "ask_about_work", argumentsJSON: arguments))
+    }
+
+    // MARK: - Declaration
+
+    /// The gate, and it is a declaration rather than a flag: with a transcript to read the
+    /// model is offered six tools, and without one it is offered five and cannot ask for a
+    /// sixth that does not exist.
+    func testTheToolIsDeclaredOnlyWhenThereIsSomethingToAnswerFrom() async {
+        let withTranscript = ToolBackend()
+        _ = makeProvider(withTranscript, answerer: Answerer(.answered("x")))
+        XCTAssertEqual(withTranscript.declaredTools, [[
+            "approve", "deny", "select_item", "queue_instruction", "query_status",
+            "ask_about_work",
+        ]])
+
+        let without = ToolBackend()
+        _ = makeProvider(without, answerer: nil)
+        XCTAssertEqual(without.declaredTools, [[
+            "approve", "deny", "select_item", "queue_instruction", "query_status",
+        ]])
+    }
+
+    /// The Apple path declares nothing at all — there is no model to declare to — so there
+    /// is no composition in which the transcript tool exists beside a keyword grammar.
+    func testTheGrammarPathDeclaresNoToolsAtAll() async {
+        let backend = ToolBackend()
+        _ = VoiceBackendCommandProvider(backend: backend, match: { _ in nil })
+        XCTAssertEqual(backend.declaredTools, [])
+    }
+
+    /// A call for the tool on a composition that never declared it is the tool protocol
+    /// being wrong, not a feature to switch on. Same treatment as any other undeclared name:
+    /// the peer is answered so it is not parked, and the voice channel breaks.
+    func testAskingWhereTheToolWasNeverDeclaredIsAProtocolFailure() async {
+        let backend = ToolBackend()
+        let sink = RecordingSink()
+        let provider = makeProvider(backend, answerer: nil, sink: sink)
+        var failures: [String] = []
+        provider.onIntentPipelineFailed = { failures.append($0) }
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(call(#"{"question":"what did you run?"}"#))
+        await settle()
+
+        XCTAssertEqual(failures.count, 1)
+        XCTAssertEqual(backend.toolResults.count, 1, "the peer must not be left parked")
+        XCTAssertTrue(backend.scriptedSpeech.isEmpty)
+        XCTAssertTrue(sink.names.contains("tool.protocol_failed"))
+    }
+
+    // MARK: - The round trip
+
+    /// Question in, answer out, spoken word for word on the channel every other TapQ
+    /// sentence uses. The ordering is the real one: the wearer's turn is committed, the tool
+    /// call arrives inside the response, and the answer goes out when that response is done.
+    func testAQuestionIsAnsweredAndSpokenVerbatim() async {
+        let backend = ToolBackend()
+        let answerer = Answerer(.answered("One test failed, WireProtocolTests."))
+        let sink = RecordingSink()
+        let provider = makeProvider(backend, answerer: answerer, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.endActiveTurn()
+        backend.emit(call(#"{"question":"what did the tests say?","agent":"Claude Code"}"#))
+        await settle()
+        backend.emit(.responseCompleted)
+        await settle()
+
+        XCTAssertEqual(answerer.asked.count, 1)
+        XCTAssertEqual(answerer.asked.first?.question, "what did the tests say?")
+        XCTAssertEqual(answerer.asked.first?.agent, "Claude Code")
+        XCTAssertEqual(backend.scriptedSpeech, ["One test failed, WireProtocolTests."])
+        XCTAssertEqual(backend.toolResults.count, 1)
+        XCTAssertEqual(backend.toolResults.first?.callID, "call_1")
+        XCTAssertTrue(sink.names.contains("tool.ask_requested"), "\(sink.names)")
+        XCTAssertTrue(sink.names.contains("ask.spoken"), "\(sink.names)")
+    }
+
+    /// A question resolves nothing. The approval the wearer was read is still open
+    /// afterwards, and nothing was delivered to the window.
+    func testAQuestionLeavesTheOpenWindowExactlyAsItFoundIt() async {
+        let backend = ToolBackend()
+        let provider = makeProvider(backend, answerer: Answerer(.answered("It ran the tests.")))
+        var delivered: [VoiceCommand] = []
+
+        provider.start { delivered.append($0) }
+        await settle()
+        provider.endActiveTurn()
+        backend.emit(call(#"{"question":"what did you run?"}"#))
+        await settle()
+
+        XCTAssertEqual(delivered, [], "a question must resolve nothing")
+        XCTAssertTrue(provider.isWindowOpenForTesting, "the window was closed by a question")
+    }
+
+    /// Unlike the other five, this one needs no window: it delivers no command, so there is
+    /// nothing for a window to receive, and refusing an answer because a prompt closed a beat
+    /// earlier would only leave the wearer's question unanswered.
+    func testAQuestionIsAnsweredWithNoWindowOpen() async {
+        let backend = ToolBackend()
+        let answerer = Answerer(.answered("It finished the migration."))
+        let provider = makeProvider(backend, answerer: answerer)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"question":"what happened?"}"#))
+        await settle()
+
+        XCTAssertEqual(backend.scriptedSpeech, ["It finished the migration."])
+        XCTAssertEqual(answerer.asked.count, 1)
+    }
+
+    /// The agent argument is optional, and an omitted one arrives as nothing rather than as
+    /// a guess.
+    func testTheAgentIsOptionalAndNeverInvented() async {
+        let backend = ToolBackend()
+        let answerer = Answerer(.answered("ok"))
+        let provider = makeProvider(backend, answerer: answerer)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"question":"what happened?"}"#))
+        await settle()
+        backend.emit(call(#"{"question":"and before that?","agent":"   "}"#, id: "call_2"))
+        await settle()
+
+        XCTAssertEqual(answerer.asked.map(\.agent), [nil, nil])
+    }
+
+    // MARK: - Unreadable transcript: loud, but alive
+
+    /// The wearer hears why, the model is told the same fact in its own words, and nothing
+    /// breaks. Killing a voice session over a file that rotated is the disproportionate
+    /// answer this case exists to avoid.
+    func testAnUnreadableTranscriptIsSpokenAndTheSessionSurvives() async {
+        let backend = ToolBackend()
+        let notice = "I can't see that session's history, so I can't answer that."
+        let provider = makeProvider(backend, answerer: Answerer(.unavailable(notice)))
+        var failures: [String] = []
+        var intentFailures: [String] = []
+        provider.onWorkAnswerFailed = { failures.append($0) }
+        provider.onIntentPipelineFailed = { intentFailures.append($0) }
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"question":"what did you run?"}"#))
+        await settle()
+
+        XCTAssertEqual(backend.scriptedSpeech, [notice])
+        XCTAssertEqual(backend.toolResults.count, 1)
+        XCTAssertTrue(failures.isEmpty, "an unreadable transcript is not a voice break")
+        XCTAssertTrue(intentFailures.isEmpty)
+    }
+
+    // MARK: - Cloud failure: break, and say nothing
+
+    /// The model family and endpoint are narration's, so the posture is narration's. TapQ
+    /// says nothing — the latch speaks its own notice, and a sentence saying "I couldn't
+    /// answer" would be the degraded half-answer this path does not have.
+    func testACloudFailureBreaksTheRunAndSpeaksNothing() async {
+        let backend = ToolBackend()
+        let sink = RecordingSink()
+        let provider = makeProvider(backend, answerer: Answerer(.failed("timeout")), sink: sink)
+        var failures: [String] = []
+        provider.onWorkAnswerFailed = { failures.append($0) }
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"question":"what did you run?"}"#))
+        await settle()
+
+        XCTAssertEqual(failures, ["timeout"])
+        XCTAssertTrue(backend.scriptedSpeech.isEmpty, "no half-answer may be spoken")
+        XCTAssertEqual(backend.toolResults.count, 1, "the peer is still answered")
+        let failed = sink.events.last { $0.name == "ask.failed" }
+        XCTAssertEqual(failed?.level, .error)
+    }
+
+    /// The three hooks are separate on purpose: an operator reading the log has to know
+    /// whether TapQ could not be heard, could not understand the wearer, or could not answer
+    /// a question. They reach the same latch and mean different things.
+    func testTheAnswerFailureHookIsNotTheIntentFailureHook() async {
+        let backend = ToolBackend()
+        let provider = makeProvider(backend, answerer: Answerer(.failed("http 500")))
+        var intentFailures: [String] = []
+        var speechFailures: [String] = []
+        provider.onIntentPipelineFailed = { intentFailures.append($0) }
+        provider.onScriptedSpeechUndeliverable = { speechFailures.append($0) }
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"question":"what did you run?"}"#))
+        await settle()
+
+        XCTAssertTrue(intentFailures.isEmpty)
+        XCTAssertTrue(speechFailures.isEmpty)
+    }
+
+    // MARK: - Bad arguments
+
+    /// Nothing to look up is a legal call that could not run — refused out loud, and the
+    /// session survives it. The model is never asked a question TapQ did not hear.
+    func testAnEmptyQuestionIsRefusedOutLoudAndNeverReachesTheAnswerer() async {
+        let backend = ToolBackend()
+        let answerer = Answerer(.answered("should not be reached"))
+        let provider = makeProvider(backend, answerer: answerer)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"question":"   "}"#))
+        await settle()
+
+        XCTAssertEqual(backend.scriptedSpeech, [VoiceIntentTools.emptyQuestionNotice])
+        XCTAssertTrue(answerer.asked.isEmpty)
+    }
+
+    /// Arguments that cannot be read are the protocol being wrong, exactly as for the other
+    /// five tools.
+    func testUnreadableArgumentsAreAProtocolFailure() async {
+        let backend = ToolBackend()
+        let provider = makeProvider(backend, answerer: Answerer(.answered("x")))
+        var failures: [String] = []
+        provider.onIntentPipelineFailed = { failures.append($0) }
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(call("{not json"))
+        await settle()
+
+        XCTAssertEqual(failures.count, 1)
+        XCTAssertEqual(backend.toolResults.count, 1)
+    }
+
+    // MARK: - The declaration's own words
+
+    /// The description is the only place the boundary between this tool and `query_status`
+    /// can be drawn, so both halves of it are pinned.
+    func testTheDescriptionsSteerWorkQuestionsHereAndStatusQuestionsAway() async {
+        let ask = VoiceIntentTools.askAboutWorkDeclaration
+        XCTAssertEqual(ask.name, "ask_about_work")
+        XCTAssertTrue(ask.description.contains("query_status"),
+                      "the transcript tool must name the tool it is not")
+        XCTAssertTrue(ask.description.lowercased().contains("session history"))
+
+        let status = VoiceIntentTools.declarations.first { $0.name == "query_status" }
+        XCTAssertEqual(status?.description.contains("not this tool"), true,
+                       "query_status must point work questions away from itself")
+
+        let byName = Dictionary(uniqueKeysWithValues: ask.parameters.map { ($0.name, $0) })
+        XCTAssertEqual(byName["question"]?.required, true)
+        XCTAssertEqual(byName["agent"]?.required, false)
+    }
+
+    /// The five ratified actions are unchanged by the sixth: nothing was renamed, nothing
+    /// was reordered, and the tool that can end a session still does not exist.
+    func testTheFiveRatifiedToolsAreUntouched() async {
+        XCTAssertEqual(VoiceIntentTools.declarations.map(\.name),
+                       ["approve", "deny", "select_item", "queue_instruction", "query_status"])
+        for declaration in VoiceIntentTools.declarations(includingAskAboutWork: true) {
+            for word in ["end", "quit", "exit", "shutdown", "kill", "sleep"] {
+                XCTAssertFalse(declaration.name.contains(word),
+                               "\(declaration.name) reads like a way out of the session")
+            }
+        }
+    }
+}

--- a/Tests/TapQWearerMemoryTests/MemoryCommandTests.swift
+++ b/Tests/TapQWearerMemoryTests/MemoryCommandTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import XCTest
+@testable import TapQCLI
+import TapQContextBaseline
+
+/// `tapq memory clear` — the on-demand wipe of TapQ's own conversation memory.
+///
+/// The command exists because the record is a private log of what its wearer said out
+/// loud, and a person must be able to end it without editing a path by hand or knowing
+/// where the runtime keeps its state.
+final class MemoryCommandTests: XCTestCase {
+    private final class Buffer {
+        var output = ""
+        var error = ""
+        /// What the confirmation prompt is answered with. `nil` is an EOF stdin, which is
+        /// what the packaged runtime's launcher gives a prompt — and which must therefore
+        /// keep the file rather than remove it.
+        var answer: String?
+
+        var io: TapQCLIIO {
+            TapQCLIIO(
+                writeOutput: { self.output += $0 },
+                writeError: { self.error += $0 },
+                readInput: { self.answer }
+            )
+        }
+    }
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("tapq-memory-cmd-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    // MARK: - Parsing
+
+    func testClearIsTheOnlyMemoryAction() throws {
+        XCTAssertEqual(
+            try CLICommandParser.parse(["memory", "clear"]),
+            .memory(.clear(MemoryClearOptions()))
+        )
+        XCTAssertEqual(
+            try CLICommandParser.parse(["memory", "clear", "--yes"]),
+            .memory(.clear(MemoryClearOptions(confirmed: true)))
+        )
+        XCTAssertEqual(
+            try CLICommandParser.parse(["memory", "clear", "--broker-dir", "/tmp/x"]),
+            .memory(.clear(MemoryClearOptions(brokerDirectoryPath: "/tmp/x")))
+        )
+        XCTAssertEqual(try CLICommandParser.parse(["memory"]), .help(.memory))
+        XCTAssertEqual(try CLICommandParser.parse(["help", "memory"]), .help(.memory))
+    }
+
+    /// Refused by name rather than falling through to help: a verb whose whole job is to
+    /// destroy something must not read as a command that quietly did nothing.
+    func testAnUnknownMemoryActionIsRefused() {
+        XCTAssertThrowsError(try CLICommandParser.parse(["memory", "show"])) { error in
+            XCTAssertEqual(
+                (error as? CLIUsageError)?.message,
+                "Unknown memory action 'show'. Available actions: 'clear'."
+            )
+        }
+        XCTAssertThrowsError(try CLICommandParser.parse(["memory", "clear", "--all"]))
+    }
+
+    // MARK: - Clearing
+
+    @MainActor
+    func testClearRemovesTheRecordTheRuntimeWrites() async {
+        let store = WearerConversationStore(directory: directory)
+        store.recordWearerUtterance("something I would rather not keep")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.fileURL.path))
+
+        let buffer = Buffer()
+        let status = await application(io: buffer.io)
+            .run(arguments: ["memory", "clear", "--yes"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("Conversation memory cleared"), buffer.output)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    /// The prompt is answered, not assumed. An EOF stdin — which is what the packaged
+    /// runtime's `open -n -W` launcher gives an interactive prompt — keeps the file.
+    @MainActor
+    func testTheConfirmationPromptMustBeAnswered() async {
+        let store = WearerConversationStore(directory: directory)
+        store.recordWearerUtterance("keep me")
+
+        let buffer = Buffer()
+        buffer.answer = nil
+        let status = await application(io: buffer.io).run(arguments: ["memory", "clear"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("Conversation memory kept."), buffer.output)
+        XCTAssertTrue(buffer.error.contains("remembered exchange(s)"), buffer.error)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    @MainActor
+    func testAYesAtThePromptClearsTheRecord() async {
+        let store = WearerConversationStore(directory: directory)
+        store.recordWearerUtterance("go ahead")
+
+        let buffer = Buffer()
+        buffer.answer = "y"
+        let status = await application(io: buffer.io).run(arguments: ["memory", "clear"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    /// Nothing to clear is not a failure; it is a different sentence, and it names the
+    /// path so an operator who cleared the wrong directory can see that they did.
+    @MainActor
+    func testClearSaysWhenThereWasNothingThere() async {
+        let buffer = Buffer()
+        let status = await application(io: buffer.io)
+            .run(arguments: ["memory", "clear", "--yes"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(buffer.output.contains("No conversation memory found"), buffer.output)
+        XCTAssertTrue(
+            buffer.output.contains(WearerConversationStore.fileName),
+            buffer.output
+        )
+    }
+
+    /// `--broker-dir` clears the record a runtime served with the same override wrote,
+    /// rather than the default one it never touched.
+    @MainActor
+    func testBrokerDirSelectsTheRecordToClear() async throws {
+        let other = directory.appendingPathComponent("other", isDirectory: true)
+        try FileManager.default.createDirectory(at: other, withIntermediateDirectories: true)
+        let defaultStore = WearerConversationStore(directory: directory)
+        defaultStore.recordWearerUtterance("in the default directory")
+        let overrideStore = WearerConversationStore(directory: other)
+        overrideStore.recordWearerUtterance("in the override")
+
+        let buffer = Buffer()
+        let status = await application(io: buffer.io)
+            .run(arguments: ["memory", "clear", "--broker-dir", other.path, "--yes"])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: overrideStore.fileURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: defaultStore.fileURL.path))
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func application(io: TapQCLIIO) -> TapQCLIApplication {
+        TapQCLIApplication(
+            io: io,
+            environment: ["TAPQ_BROKER_DIR": directory.path],
+            homeDirectory: directory,
+            executableURL: directory.appendingPathComponent("tapq"),
+            currentDirectory: directory
+        )
+    }
+}

--- a/Tests/TapQWearerMemoryTests/WearerConversationStoreTests.swift
+++ b/Tests/TapQWearerMemoryTests/WearerConversationStoreTests.swift
@@ -1,0 +1,375 @@
+import Foundation
+import XCTest
+import TapQContracts
+@testable import TapQContextBaseline
+
+/// A clock a test can move.
+///
+/// A class with a lock rather than a captured `var`, because the store takes a
+/// `@Sendable` closure and a mutable capture would be a data race the compiler is right
+/// to complain about — and because a rotation test has to be able to jump a month
+/// forward between two appends.
+final class SteppableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var now: Date
+
+    init(_ start: Date) {
+        now = start
+    }
+
+    var date: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return now
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        now = now.addingTimeInterval(interval)
+        lock.unlock()
+    }
+
+    var read: @Sendable () -> Date {
+        { self.date }
+    }
+}
+
+/// TapQ's own durable memory of what it and the wearer have said to each other
+/// (`WearerConversationStore`, Pillar A of docs/TAPQ_AGENT_PLAN.md, milestone M1).
+///
+/// The properties under test are the ones the plan makes promises about: it survives a
+/// restart, it bounds itself by age and by size without losing the newest thing said, a
+/// torn line does not cost the wearer their month, and `tapq memory clear` empties it.
+final class WearerConversationStoreTests: XCTestCase {
+    private var directory: URL!
+    /// A fixed, far-from-epoch instant so a 30-day subtraction stays a real date.
+    private let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+    override func setUpWithError() throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("tapq-wearer-memory-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    // MARK: - Append and read back
+
+    @MainActor
+    func testEveryRecordedKindReadsBackWithItsFields() async {
+        let store = makeStore()
+        store.recordWearerUtterance("run the tests when you're done")
+        store.recordSpokenSentence("Claude Code wants to run npm test.")
+        store.recordDecision(
+            agentDisplayName: "Claude Code",
+            summary: "swift test",
+            outcome: "approved",
+            toolName: "Bash"
+        )
+        store.recordInstruction(agentDisplayName: "Codex", text: "rerun the failing suite")
+
+        let entries = store.entries()
+        XCTAssertEqual(entries.map(\.kind), [
+            .wearerSaid, .tapqSaid, .decision, .instruction,
+        ])
+        XCTAssertEqual(entries[0].text, "run the tests when you're done")
+        XCTAssertEqual(entries[1].text, "Claude Code wants to run npm test.")
+        XCTAssertEqual(entries[2].outcome, "approved")
+        XCTAssertEqual(entries[2].toolName, "Bash")
+        XCTAssertEqual(entries[2].agentDisplayName, "Claude Code")
+        XCTAssertEqual(entries[3].text, "rerun the failing suite")
+        XCTAssertEqual(entries[3].agentDisplayName, "Codex")
+    }
+
+    /// Nothing goes in with no words in it. A recognizer that finalized silence would
+    /// otherwise fill the window with blank turns and push the real history out of it.
+    @MainActor
+    func testEmptyUtterancesAreNotRecorded() async {
+        let store = makeStore()
+        store.recordWearerUtterance("   ")
+        store.recordSpokenSentence("")
+        XCTAssertTrue(store.entries().isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    /// Whitespace is collapsed and a runaway recognizer is capped. Verbatim means "not
+    /// summarized", not "unbounded": the cap exists so a microphone that ran away with a
+    /// nearby conversation cannot turn one utterance into a page of prompt.
+    @MainActor
+    func testTextIsNormalizedAndCapped() async {
+        let store = makeStore()
+        store.recordWearerUtterance("run   the\n tests")
+        store.recordWearerUtterance(String(repeating: "a", count: 900))
+
+        let entries = store.entries()
+        XCTAssertEqual(entries[0].text, "run the tests")
+        XCTAssertEqual(entries[1].text.count, WearerDialogueEntry.textCharacterLimit)
+    }
+
+    // MARK: - Durability
+
+    /// The restart. A second store over the same directory is a new process reading the
+    /// file the old one left, which is what "survives realtime-session recycling and
+    /// runtime restarts" has to mean in a test.
+    @MainActor
+    func testTheRecordSurvivesAStoreReopen() async {
+        let first = makeStore()
+        first.recordWearerUtterance("remind me what Codex was doing")
+        first.recordSpokenSentence("Codex is waiting on the migration.")
+
+        let second = makeStore()
+        XCTAssertEqual(second.entries().map(\.text), [
+            "remind me what Codex was doing",
+            "Codex is waiting on the migration.",
+        ])
+        XCTAssertEqual(second.entries().map(\.kind), [.wearerSaid, .tapqSaid])
+        XCTAssertEqual(second.entries()[0].timestamp, start)
+    }
+
+    /// The file is `0600`, like every other artifact in the runtime's `0700` directory.
+    @MainActor
+    func testTheFileIsPrivateToTheUser() async throws {
+        let store = makeStore()
+        store.recordWearerUtterance("anything")
+        let attributes = try FileManager.default.attributesOfItem(atPath: store.fileURL.path)
+        XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+    }
+
+    /// A kind this build has never heard of — an M3 standing directive read by an M1
+    /// binary — round-trips instead of failing the line. This is the whole of the
+    /// "no migration for M3" claim, and the reason `WearerDialogueKind` is an open
+    /// rawValue rather than an `enum`.
+    @MainActor
+    func testAnUnknownEntryKindSurvivesAReopen() async throws {
+        let line = #"{"agent":"","kind":"directive","outcome":"","tool":"","ts":"2027-01-01T00:00:00.000Z","text":"watch the build and tell me if it fails"}"#
+        try Data((line + "\n").utf8).write(
+            to: directory.appendingPathComponent(WearerConversationStore.fileName))
+
+        let store = makeStore()
+        let entries = store.entries()
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].kind.rawValue, "directive")
+        XCTAssertEqual(entries[0].text, "watch the build and tell me if it fails")
+
+        // And it is still there after this build appends to the same file.
+        store.recordWearerUtterance("what are you watching?")
+        XCTAssertEqual(makeStore().entries().count, 2)
+    }
+
+    /// One unreadable line — a torn tail after a crash — costs that line and nothing else.
+    @MainActor
+    func testATornLineIsSkippedRatherThanLosingTheRecord() async throws {
+        let good = #"{"agent":"","kind":"wearer_said","outcome":"","tool":"","ts":"2027-01-01T00:00:00.000Z","text":"the first thing"}"#
+        let torn = #"{"agent":"","kind":"wearer_sa"#
+        try Data((good + "\n" + torn).utf8).write(
+            to: directory.appendingPathComponent(WearerConversationStore.fileName))
+
+        let store = makeStore()
+        XCTAssertEqual(store.entries().map(\.text), ["the first thing"])
+        // The rewrite that drops it is the only way a bad line ever leaves the file.
+        XCTAssertEqual(makeStore().entries().map(\.text), ["the first thing"])
+    }
+
+    // MARK: - Rotation
+
+    /// 30 days, ratified 2026-08-29. The append that crosses the boundary is what prunes.
+    @MainActor
+    func testEntriesOlderThanRetentionAreDroppedOnAppend() async {
+        let clock = SteppableClock(start)
+        let store = makeStore(clock: clock)
+        store.recordWearerUtterance("a month ago")
+
+        clock.advance(by: WearerConversationStore.defaultRetention + 60)
+        store.recordWearerUtterance("just now")
+
+        XCTAssertEqual(store.entries().map(\.text), ["just now"])
+        // And the file agrees: rotation rewrites rather than only forgetting in memory.
+        XCTAssertEqual(makeStore(clock: clock).entries().map(\.text), ["just now"])
+    }
+
+    /// A runtime coming back after a fortnight away starts with the file already pruned,
+    /// rather than pruning it at the first thing the wearer says.
+    @MainActor
+    func testExpiredEntriesAreDroppedWhenTheStoreReopens() async {
+        let clock = SteppableClock(start)
+        let first = makeStore(clock: clock)
+        first.recordWearerUtterance("long ago")
+        clock.advance(by: 10)
+        first.recordWearerUtterance("also long ago")
+
+        clock.advance(by: WearerConversationStore.defaultRetention + 60)
+        XCTAssertTrue(makeStore(clock: clock).entries().isEmpty)
+    }
+
+    /// The boundary is not a rounding error: an entry exactly at the cutoff is inside the
+    /// window, and only what is strictly older goes.
+    @MainActor
+    func testAnEntryOnTheRetentionBoundaryIsKept() async {
+        let clock = SteppableClock(start)
+        let store = makeStore(clock: clock)
+        store.recordWearerUtterance("oldest")
+        clock.advance(by: 10)
+        store.recordWearerUtterance("ten seconds later")
+
+        // Now is exactly one retention period past the second entry.
+        clock.advance(by: WearerConversationStore.defaultRetention)
+        XCTAssertEqual(
+            makeStore(clock: clock).entries().map(\.text),
+            ["ten seconds later"]
+        )
+    }
+
+    /// The size cap binds when it binds first, and it binds by dropping the *oldest*: a
+    /// rotation that emptied the live file would erase the wearer's recent history at the
+    /// exact moment it got interesting, which is why this compacts in place rather than
+    /// moving a generation aside the way the review logs do.
+    @MainActor
+    func testTheSizeCapDropsTheOldestAndKeepsTheNewest() async {
+        let cap = 1_200
+        let store = makeStore(maximumBytes: cap)
+        for index in 1...40 {
+            store.recordWearerUtterance("utterance number \(index)")
+        }
+
+        XCTAssertLessThanOrEqual(store.storedByteCount, cap)
+        let texts = store.entries().map(\.text)
+        XCTAssertEqual(texts.last, "utterance number 40")
+        XCTAssertFalse(texts.contains("utterance number 1"))
+        XCTAssertGreaterThan(texts.count, 1)
+
+        // The bytes on disk are the bytes the store thinks it has.
+        let attributes = try? FileManager.default
+            .attributesOfItem(atPath: store.fileURL.path)
+        XCTAssertEqual((attributes?[.size] as? NSNumber)?.intValue, store.storedByteCount)
+        XCTAssertEqual(makeStore(maximumBytes: cap).entries().map(\.text), texts)
+    }
+
+    /// Compaction goes *past* the cap, not to it, so the append right after a rotation
+    /// does not rotate again. Asserted at the moment the first rotation lands, because
+    /// that is the only moment the property is about: after it, ordinary appends climb
+    /// back towards the cap, which is what the headroom is for.
+    @MainActor
+    func testCompactionLeavesHeadroomBelowTheCap() async {
+        let cap = 1_200
+        let target = Int(Double(cap) * WearerConversationStore.compactionFraction)
+        let sink = RotationCounter()
+        let store = makeStore(maximumBytes: cap, sink: sink)
+
+        var rotated = false
+        for index in 1...200 where !rotated {
+            store.recordWearerUtterance("utterance number \(index)")
+            guard sink.rotations > 0 else { continue }
+            rotated = true
+            XCTAssertLessThanOrEqual(store.storedByteCount, target)
+        }
+        XCTAssertTrue(rotated, "the cap was never reached")
+    }
+
+    // MARK: - Clearing
+
+    @MainActor
+    func testClearRemovesTheFileAndEverythingHeld() async {
+        let store = makeStore()
+        store.recordWearerUtterance("something private")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.fileURL.path))
+
+        XCTAssertTrue(store.clear())
+        XCTAssertTrue(store.entries().isEmpty)
+        XCTAssertEqual(store.storedByteCount, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.fileURL.path))
+        XCTAssertTrue(makeStore().entries().isEmpty)
+    }
+
+    /// Clearing what is not there is not an error; it is a different sentence.
+    @MainActor
+    func testClearReportsThatThereWasNothingToRemove() async {
+        XCTAssertFalse(makeStore().clear())
+    }
+
+    /// A cleared store is a working store: the next thing said starts the file again.
+    @MainActor
+    func testTheStoreKeepsRecordingAfterAClear() async {
+        let store = makeStore()
+        store.recordWearerUtterance("before")
+        store.clear()
+        store.recordWearerUtterance("after")
+        XCTAssertEqual(makeStore().entries().map(\.text), ["after"])
+    }
+
+    // MARK: - The recent window
+
+    @MainActor
+    func testTheRecentWindowIsBoundedByCount() async {
+        let store = makeStore()
+        for index in 1...(WearerConversationRecall.windowEntryLimit + 6) {
+            store.recordWearerUtterance("line \(index)")
+        }
+        let window = store.recentWindow()
+        XCTAssertEqual(window.count, WearerConversationRecall.windowEntryLimit)
+        XCTAssertEqual(window.last?.text, "line \(WearerConversationRecall.windowEntryLimit + 6)")
+        XCTAssertEqual(window.first?.text, "line 7")
+    }
+
+    /// The character budget is spent from the newest end backwards, so what survives a
+    /// tight budget is always the most recent thing said — the entries the wearer is most
+    /// likely to mean by "earlier".
+    @MainActor
+    func testTheRecentWindowSpendsItsCharacterBudgetOnTheNewest() async {
+        let store = makeStore()
+        for index in 1...8 {
+            store.recordWearerUtterance("line \(index)")
+        }
+        let window = store.recentWindow(characterBudget: 30)
+        XCTAssertFalse(window.isEmpty)
+        XCTAssertEqual(window.last?.text, "line 8")
+        XCTAssertFalse(window.map(\.text).contains("line 1"))
+    }
+
+    @MainActor
+    func testTheRecentWindowIsOldestFirst() async {
+        let store = makeStore()
+        store.recordWearerUtterance("first")
+        store.recordWearerUtterance("second")
+        XCTAssertEqual(store.recentWindow().map(\.text), ["first", "second"])
+    }
+
+    // MARK: - Helpers
+
+    /// Counts the store's own `rotated` diagnostic, which is the only way to observe the
+    /// moment a rotation lands rather than guessing at it from the byte count.
+    private final class RotationCounter: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        func record(_ event: TapQDiagnosticEvent) {
+            guard event.name == "rotated" else { return }
+            lock.lock()
+            count += 1
+            lock.unlock()
+        }
+
+        var rotations: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return count
+        }
+    }
+
+    @MainActor
+    private func makeStore(
+        clock: SteppableClock? = nil,
+        maximumBytes: Int = WearerConversationStore.defaultMaximumBytes,
+        sink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) -> WearerConversationStore {
+        let start = start
+        return WearerConversationStore(
+            directory: directory,
+            clock: clock?.read ?? { start },
+            maximumBytes: maximumBytes,
+            diagnosticSink: sink
+        )
+    }
+}

--- a/Tests/TapQWearerMemoryTests/WearerMemoryGroundingTests.swift
+++ b/Tests/TapQWearerMemoryTests/WearerMemoryGroundingTests.swift
@@ -1,0 +1,266 @@
+import Foundation
+import XCTest
+import TapQContracts
+@testable import TapQContextBaseline
+@testable import TapQInteractionBaseline
+
+/// The consumption half of milestone M1: a bounded recent window from TapQ's own memory
+/// joins the realtime model's per-turn grounding, so "the thing I asked you earlier"
+/// resolves even after the realtime session has been recycled out from under the
+/// conversation.
+///
+/// Two things are pinned here. What the window *reads like* — deterministic, verbatim for
+/// the wearer's own words (ratified 2026-08-29) — and where it *lands*: appended to the
+/// window brief the provider already sends, and structurally absent on the path with no
+/// model to ground.
+@MainActor
+final class WearerMemoryGroundingTests: XCTestCase {
+    /// The smallest duplex backend that can hold a session open and record what it was
+    /// told. Everything the grounding path touches, and nothing else.
+    private final class RecordingBackend: VoiceBackend {
+        let capabilities = VoiceBackendCapabilities(
+            supportsBargeIn: true,
+            producesAudio: true,
+            duplex: true,
+            supportsNativeTurnDetection: true,
+            supportsToolCalling: true
+        )
+
+        private(set) var instructions: [String] = []
+        private(set) var scriptedSpeech: [String] = []
+        private var handler: (@MainActor (VoiceBackendEvent) -> Void)?
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            handler = onEvent
+        }
+
+        func close() {}
+        func beginUserTurn() {}
+
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool { expectingResponse }
+
+        func sendAudio(_ chunk: VoiceAudioChunk) {}
+        func requestResponse(text: String) {}
+
+        func requestScriptedSpeech(text: String) {
+            scriptedSpeech.append(text)
+        }
+
+        func cancelResponse() {}
+        func setNativeTurnDetection(_ enabled: Bool) {}
+        func declareTools(_ tools: [VoiceToolDeclaration]) {}
+
+        func updateInstructions(_ instructions: String) {
+            self.instructions.append(instructions)
+        }
+
+        @discardableResult
+        func requestModelTurn() -> Bool { true }
+
+        func sendToolResult(callID: String, output: String) {}
+
+        func emit(_ event: VoiceBackendEvent) {
+            handler?(event)
+        }
+    }
+
+    private var directory: URL!
+    private let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("tapq-grounding-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+        try await super.tearDown()
+    }
+
+    // MARK: - Rendering
+
+    /// The wearer's own words are quoted and unaltered. The quotation marks are not
+    /// decoration: they are what tells the model that the words inside are the wearer's
+    /// and not TapQ describing them.
+    func testWearerUtterancesAreQuotedVerbatim() async {
+        let store = makeStore()
+        store.recordWearerUtterance("tell Codex to rebase onto main, not merge")
+
+        guard let grounding = WearerConversationRecall.grounding(
+            for: store.recentWindow()
+        ) else {
+            return XCTFail("no grounding for a non-empty memory")
+        }
+        XCTAssertTrue(
+            grounding.contains("Wearer: \"tell Codex to rebase onto main, not merge\""),
+            grounding
+        )
+        XCTAssertTrue(grounding.hasPrefix(WearerConversationRecall.heading), grounding)
+    }
+
+    /// Every kind reads as the thing it was, numbered in the order it happened.
+    func testTheWindowRendersEachKindInOrder() async {
+        let store = makeStore()
+        store.recordWearerUtterance("run the tests")
+        store.recordSpokenSentence("Claude Code wants to run swift test.")
+        store.recordDecision(
+            agentDisplayName: "Claude Code",
+            summary: "swift test",
+            outcome: "approved",
+            toolName: "Bash"
+        )
+        store.recordInstruction(agentDisplayName: "Codex", text: "rerun the failing suite")
+
+        let lines = WearerConversationRecall
+            .grounding(for: store.recentWindow())?
+            .split(separator: "\n")
+            .map(String.init) ?? []
+        XCTAssertEqual(Array(lines.suffix(4)), [
+            "  1. Wearer: \"run the tests\"",
+            "  2. TapQ: Claude Code wants to run swift test.",
+            "  3. Decision: approved Bash for Claude Code: swift test",
+            "  4. TapQ told Codex: rerun the failing suite",
+        ])
+    }
+
+    /// An M3 standing directive read by an M1 binary renders as itself rather than being
+    /// dropped: a line the model can read beats a hole in the history, and dropping it
+    /// would make the numbering lie about what is in the file.
+    func testAnUnknownKindStillRenders() async {
+        let entry = WearerDialogueEntry(
+            kind: WearerDialogueKind(rawValue: "directive"),
+            timestamp: start,
+            text: "watch the build and tell me if it fails"
+        )
+        XCTAssertEqual(
+            WearerConversationRecall.line(for: entry),
+            "directive: watch the build and tell me if it fails"
+        )
+    }
+
+    /// No history, no line. The per-turn grounding already says what TapQ has said since
+    /// the last window; a sentence announcing an empty memory would spend prompt on the
+    /// absence of a fact.
+    func testAnEmptyMemoryContributesNothing() async {
+        XCTAssertNil(WearerConversationRecall.grounding(for: []))
+        XCTAssertNil(WearerConversationRecall.grounding(for: makeStore().recentWindow()))
+    }
+
+    // MARK: - The join
+
+    /// The window lands in the brief the provider sends immediately before the microphone
+    /// opens, after the open-window line and the agent names — the open question stays the
+    /// last thing the model reads about *now*, with the history behind it.
+    func testTheRecentWindowJoinsThePerTurnGrounding() async {
+        let store = makeStore()
+        store.recordWearerUtterance("remind me what I asked Codex for")
+
+        let backend = RecordingBackend()
+        let provider = makeProvider(backend, intentSource: .modelToolCalls)
+        provider.wearerMemoryGrounding = {
+            WearerConversationRecall.grounding(for: store.recentWindow())
+        }
+
+        provider.start { _ in }
+        await settle()
+
+        guard let grounding = backend.instructions.last else {
+            return XCTFail("no grounding was sent")
+        }
+        XCTAssertTrue(grounding.contains("A TapQ window is open"), grounding)
+        XCTAssertTrue(
+            grounding.contains("Wearer: \"remind me what I asked Codex for\""),
+            grounding
+        )
+        // Order: the window brief first, TapQ's own history last.
+        let brief = grounding.range(of: "A TapQ window is open")
+        let memory = grounding.range(of: WearerConversationRecall.heading)
+        XCTAssertNotNil(brief)
+        XCTAssertNotNil(memory)
+        if let brief, let memory {
+            XCTAssertTrue(brief.lowerBound < memory.lowerBound, grounding)
+        }
+    }
+
+    /// Every sentence TapQ hands the backend is recorded at the moment it goes out, so the
+    /// memory is in the order the wearer heard it.
+    func testSpokenSentencesReachTheStoreAsTheyGoOut() async {
+        let store = makeStore()
+        let backend = RecordingBackend()
+        let provider = makeProvider(backend, intentSource: .modelToolCalls)
+        provider.onSpokenToWearer = { store.recordSpokenSentence($0) }
+
+        provider.speakScripted("Run the migration? Nod or say yes.")
+        await settle()
+
+        XCTAssertEqual(backend.scriptedSpeech, ["Run the migration? Nod or say yes."])
+        XCTAssertEqual(store.entries().map(\.text), ["Run the migration? Nod or say yes."])
+        XCTAssertEqual(store.entries().map(\.kind), [.tapqSaid])
+    }
+
+    // MARK: - Scoping
+
+    /// The Apple path neither records nor reads.
+    ///
+    /// This is the portable half of the guarantee. The composition half — the store is
+    /// built only on the `.openaiRealtime` arm of `AppleTapQRuntimeService`, so on the
+    /// Apple path there is no object to wire — lives in the host-only runtime target and
+    /// is not reachable from a portable test. What *is* provable here is the seam it
+    /// leans on: on a transcript-grammar session the recording hook and the memory
+    /// grounding are unreachable even when a host wires them, because both sit behind the
+    /// provider's existing `.modelToolCalls` guard. A miswiring cannot leak.
+    func testTheGrammarPathNeitherRecordsNorGrounds() async {
+        let store = makeStore()
+        store.recordWearerUtterance("something from an earlier run")
+        let recorded = store.entries().count
+
+        let backend = RecordingBackend()
+        let provider = makeProvider(backend, intentSource: .transcriptGrammar)
+        provider.onSpokenToWearer = { store.recordSpokenSentence($0) }
+        provider.wearerMemoryGrounding = {
+            WearerConversationRecall.grounding(for: store.recentWindow())
+        }
+
+        provider.speakScripted("Run the migration? Nod or say yes.")
+        await settle()
+        provider.start { _ in }
+        await settle()
+
+        XCTAssertEqual(backend.scriptedSpeech, ["Run the migration? Nod or say yes."],
+                       "the sentence is still spoken")
+        XCTAssertTrue(backend.instructions.isEmpty,
+                      "a grammar session is never grounded: \(backend.instructions)")
+        XCTAssertEqual(store.entries().count, recorded,
+                       "nothing on the grammar path may reach the durable record")
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore() -> WearerConversationStore {
+        let start = start
+        return WearerConversationStore(directory: directory, clock: { start })
+    }
+
+    private func makeProvider(
+        _ backend: RecordingBackend,
+        intentSource: VoiceIntentSource
+    ) -> VoiceBackendCommandProvider {
+        VoiceBackendCommandProvider(
+            backend: backend,
+            intentSource: intentSource,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            // Bounded rather than the shipped sixty seconds: an unbounded sleep left
+            // running in-process stalls whichever test runs next.
+            idleSleep: { _ in try? await Task.sleep(for: .seconds(1)) }
+        )
+    }
+
+    private func settle() async {
+        for _ in 0..<4 { await Task.yield() }
+    }
+}

--- a/Tests/TapQWireProtocolTests/TranscriptWireFieldTests.swift
+++ b/Tests/TapQWireProtocolTests/TranscriptWireFieldTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import TapQContracts
+@testable import TapQWireProtocol
+
+/// `transcript_path`: one optional field on three messages that already existed, added
+/// without moving the wire version.
+///
+/// The claim being tested is the `lease_id` claim, restated for this field: both directions
+/// are inert to a peer that does not know it. A message carrying it decodes in a build that
+/// does, a message without it decodes as nothing in the same build, and nothing about the
+/// version negotiation moves — so an installed shim and a running runtime that disagree
+/// about this field still talk.
+final class TranscriptWireFieldTests: XCTestCase {
+    // MARK: - Carried
+
+    func testAnApprovalCarriesTheTranscriptPath() throws {
+        let json = #"{"type":"approval.request","token":"t","session_id":"s1","tool_name":"Bash","#
+            + #""tool_input":{},"approval_source":"pre_tool_use","request_id":"r1","#
+            + #""transcript_path":"/tmp/session.jsonl","protocol_version":6}"#
+        guard case .approval(let message) = try BrokerRequest(from: Data(json.utf8)) else {
+            return XCTFail("expected an approval")
+        }
+        XCTAssertEqual(message.transcriptPath, "/tmp/session.jsonl")
+    }
+
+    func testANotificationCarriesTheTranscriptPath() throws {
+        let json = #"{"type":"notification.event","token":"t","session_id":"s1","event":"stop","#
+            + #""transcript_path":"/tmp/session.jsonl","protocol_version":6}"#
+        guard case .notification(let message) = try BrokerRequest(from: Data(json.utf8)) else {
+            return XCTFail("expected a notification")
+        }
+        XCTAssertEqual(message.transcriptPath, "/tmp/session.jsonl")
+    }
+
+    func testAStopQuestionCarriesTheTranscriptPath() throws {
+        let json = #"{"type":"stop.question","token":"t","session_id":"s1","request_id":"r1","#
+            + #""text":"Shall I continue?","transcript_path":"/tmp/session.jsonl","#
+            + #""protocol_version":6}"#
+        guard case .stopQuestion(let message) = try BrokerRequest(from: Data(json.utf8)) else {
+            return XCTFail("expected a stop question")
+        }
+        XCTAssertEqual(message.transcriptPath, "/tmp/session.jsonl")
+    }
+
+    // MARK: - Absent
+
+    /// The other direction, and the reason no version gate was needed: a shim that predates
+    /// the field sends none, and a runtime that knows about it reads that as "no transcript"
+    /// — which is the state every run was in before this existed.
+    func testAMessageWithoutTheFieldDecodesAsNoTranscript() throws {
+        let approval = #"{"type":"approval.request","token":"t","session_id":"s1","#
+            + #""tool_name":"Bash","tool_input":{},"approval_source":"pre_tool_use","#
+            + #""request_id":"r1","protocol_version":6}"#
+        guard case .approval(let message) = try BrokerRequest(from: Data(approval.utf8)) else {
+            return XCTFail("expected an approval")
+        }
+        XCTAssertNil(message.transcriptPath)
+
+        let notification = #"{"type":"notification.event","token":"t","session_id":"s1","#
+            + #""event":"stop","protocol_version":6}"#
+        guard case .notification(let note) = try BrokerRequest(from: Data(notification.utf8))
+        else {
+            return XCTFail("expected a notification")
+        }
+        XCTAssertNil(note.transcriptPath)
+    }
+
+    /// An explicit `null` is the same as an absent key. The shim encodes null rather than
+    /// omitting the key so the message shape stays fixed.
+    func testAnExplicitNullReadsAsNoTranscript() throws {
+        let json = #"{"type":"notification.event","token":"t","session_id":"s1","event":"stop","#
+            + #""transcript_path":null,"protocol_version":6}"#
+        guard case .notification(let message) = try BrokerRequest(from: Data(json.utf8)) else {
+            return XCTFail("expected a notification")
+        }
+        XCTAssertNil(message.transcriptPath)
+    }
+
+    /// An older broker's `Codable` ignores a key it does not model. Stated here by decoding
+    /// the same bytes into a shape that has no such field — the same proof shape the
+    /// lease-id tests use for the other direction.
+    func testAPeerThatDoesNotModelTheFieldIgnoresIt() throws {
+        struct OlderNotification: Decodable {
+            let sessionID: String
+            let event: String
+
+            enum CodingKeys: String, CodingKey {
+                case sessionID = "session_id"
+                case event
+            }
+        }
+        let json = #"{"type":"notification.event","token":"t","session_id":"s1","event":"stop","#
+            + #""transcript_path":"/tmp/session.jsonl","protocol_version":6}"#
+        let older = try JSONDecoder().decode(OlderNotification.self, from: Data(json.utf8))
+        XCTAssertEqual(older.sessionID, "s1")
+        XCTAssertEqual(older.event, "stop")
+    }
+
+    // MARK: - The version did not move
+
+    /// The whole point of the additive shape: nothing about negotiation changed, so a v5 or
+    /// v4 peer keeps talking exactly as it did.
+    func testTheWireVersionAndNegotiationAreUnchanged() {
+        XCTAssertEqual(WireProtocol.version, 6)
+        XCTAssertEqual(WireProtocol.minimumVersion(for: WireType.approval), 1)
+        XCTAssertEqual(WireProtocol.minimumVersion(for: WireType.notification), 1)
+        XCTAssertEqual(WireProtocol.minimumVersion(for: WireType.stopQuestion), 1)
+        XCTAssertTrue(WireProtocol.isCompatible(5))
+        XCTAssertTrue(WireProtocol.isCompatible(4))
+    }
+
+    /// A path sent to an older broker under that broker's own version is still just a field
+    /// it ignores, so the negotiated outbound version is unaffected by carrying one.
+    func testCarryingAPathDoesNotChangeTheOutboundVersion() {
+        XCTAssertEqual(
+            WireProtocol.outboundVersion(for: 5, approvalSource: .preToolUse,
+                                         messageType: WireType.approval),
+            5
+        )
+        XCTAssertEqual(
+            WireProtocol.outboundVersion(for: 6, approvalSource: nil,
+                                         messageType: WireType.notification),
+            6
+        )
+    }
+
+    // MARK: - Round trip
+
+    func testAPathSurvivesAnEncodeDecodeRoundTrip() throws {
+        let message = StopQuestionMessage(
+            token: "t", sessionID: "s1", requestID: "r1", text: "Shall I continue?",
+            agent: .claudeCode, transcriptPath: "/tmp/session.jsonl", protocolVersion: 6
+        )
+        let data = try JSONEncoder().encode(message)
+        let object = try JSONDecoder().decode([String: JSONValue].self, from: data)
+        XCTAssertEqual(object["transcript_path"]?.stringValue, "/tmp/session.jsonl")
+
+        let decoded = try JSONDecoder().decode(StopQuestionMessage.self, from: data)
+        XCTAssertEqual(decoded, message)
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,6 +22,7 @@ tapq bench         Score a stage-2 reasoner against a labeled scenario corpus
 tapq serve         Run the local agent-neutral broker
 tapq instruct      Queue an instruction for a session on a running broker (debug)
 tapq integration   Manage agent integrations
+tapq memory        Clear what TapQ remembers of its conversation with you
 tapq policy        Show the auto-answer policy serving would use
 tapq version       Print version information
 ```
@@ -1133,6 +1134,31 @@ Options and errors:
 The broker validates the token and the wire version, requires non-empty text, and answers
 `ok` only when the instruction was queued. It records the submission's length and request
 id — never its text.
+
+## Conversation memory
+
+```bash
+tapq memory clear [--broker-dir PATH] [--yes]
+```
+
+On `--voice-backend openai-realtime`, TapQ keeps its own record of the dialogue it has
+with you — `wearer-conversation.jsonl` in the runtime directory. It holds what you said
+(verbatim), what TapQ said back, how each request was resolved, and which instructions
+reached which agent, each with a timestamp and an agent name. A bounded recent slice of it
+joins the model's per-turn context, which is what lets "the thing I asked you earlier"
+survive a dropped voice session or a restarted runtime.
+
+Nothing else is in it, and that is structural rather than filtered: the file records only
+what was spoken or heard on the voice channel, and a tool's input, a working directory,
+and a permission mode are never spoken. The Apple voice backend composes no store at all
+and writes no such file.
+
+It bounds itself: entries older than 30 days are dropped, and the file is held under a
+couple of megabytes — whichever comes first — by dropping the oldest and keeping the
+newest. `0600` inside the `0700` runtime directory, never leaves the machine, and safe to
+delete by hand at any time. This command is the on-demand wipe; it names the file, says
+how many exchanges are about to go, and asks unless given `--yes`. There is no
+`memory show`.
 
 ## Auto-answer policy
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -264,12 +264,12 @@ somewhere. TapQ keeps the table statically (`AgentCapabilities`) rather than ask
 wire: every shim is TapQ's own, shipped and versioned in this repository, so what an
 adapter can carry is known at build time and a handshake would only re-learn it.
 
-| Agent | Approvals | Questions | Notifications | Instructions |
-|---|:--:|:--:|:--:|:--:|
-| Claude Code | yes | yes | yes | yes |
-| Codex | yes | yes | yes | yes |
-| Cursor | yes | no | yes | no |
-| OpenCode | yes | no | yes | no |
+| Agent | Approvals | Questions | Notifications | Instructions | Session transcript |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Claude Code | yes | yes | yes | yes | yes |
+| Codex | yes | yes | yes | yes | not yet |
+| Cursor | yes | no | yes | no | no |
+| OpenCode | yes | no | yes | no | no |
 
 - **Approvals** — the agent asks before it acts, and a nod can answer.
 - **Questions** — the agent's own questions reach TapQ as something answerable out loud:
@@ -283,6 +283,16 @@ adapter can carry is known at build time and a handshake would only re-learn it.
   plugin is strictly event → relay → reply, spawned per event, and OpenCode exposes no
   documented way to continue a finished turn — so an instruction has nowhere to land.
   Cursor has no text-bearing channel at all.
+- **Session transcript** — whether TapQ can read the agent's full session and answer
+  spoken questions about the work from it (`ask_about_work`). This needs the adapter to
+  hand its hook a file TapQ can tail; Claude Code's hooks all carry `transcript_path`,
+  which the shim now forwards. Codex writes rollout files under `$CODEX_HOME/sessions`
+  and is phase 2 — the same tail-and-index approach once the shim can name the file.
+  Cursor and OpenCode are given no transcript surface at all and stay at event-level
+  visibility. Reading a transcript happens **only** under a cloud voice backend
+  (`--voice-backend openai-realtime`): selecting one is the consent, and on the Apple
+  path nothing is read and the tool is never declared. See
+  [TRANSCRIPT_CONTEXT_PLAN.md](TRANSCRIPT_CONTEXT_PLAN.md).
 
 Where a capability is missing, TapQ says so rather than dropping the request silently: a
 dictation aimed at an agent that cannot receive one is refused out loud by name

--- a/docs/TAPQ_AGENT_PLAN.md
+++ b/docs/TAPQ_AGENT_PLAN.md
@@ -2,8 +2,10 @@
 
 Status: direction ratified by the maintainer 2026-08-28 ("TapQ itself will
 become a small agent with its own agent loop, and this agent will be
-controlling other agents such as Claude Code"). Plan under review; not
-implemented. Everything here is **cloud-backend-only** — composed on the
+controlling other agents such as Claude Code"). **Milestone M1 implemented
+2026-08-29** (both pillars; see the "As built" sections and the answered
+open questions below); M2–M4 not started. Everything here is
+**cloud-backend-only** — composed on the
 `.openaiRealtime` branch (and future model-backed backends); the Apple path
 keeps today's reactive, event-level behavior, structurally absent not
 disabled.
@@ -205,11 +207,9 @@ Guardrails, non-negotiable:
 ## Milestones
 
 - **M1 — perception + memory:** WearerConversationStore (record, persist,
-  recent-window grounding, `tapq memory clear`) — **built 2026-08-29** —
-  + Pillar B phase 1
+  recent-window grounding, `tapq memory clear`) + Pillar B phase 1
   (TranscriptStore, wire field, direct `ask_about_work`). Independently
-  shippable and useful with zero loop. *Pillar B phase 1 implemented
-  2026-08-29.*
+  shippable and useful with zero loop. **Both pillars built 2026-08-29.**
 - **M2 — the loop, wearer-initiated only:** `start_task`, internal tools,
   `ask_about_work` folded in as a loop task, pause/resume on `ask_wearer`.
 - **M3 — initiative:** standing directives, boundary-review invocation,

--- a/docs/TAPQ_AGENT_PLAN.md
+++ b/docs/TAPQ_AGENT_PLAN.md
@@ -30,6 +30,11 @@ initiative (Pillar C).
 
 ## Pillar A — TapQ's own memory
 
+**Implemented 2026-08-29 for milestone M1** — record, persist, recent-window
+grounding, `tapq memory clear`. See "As built (Pillar A, M1)" below for what
+the code does that this section did not say. Per-question retrieval of older
+history stays M2; standing directives stay M3.
+
 `WearerConversationStore` (portable): an append-only local JSONL under the
 runtime's application-support dir, recording the dialogue TapQ itself has
 with the wearer:
@@ -54,6 +59,60 @@ Properties:
   loop, same slicing approach as transcripts.
 - Composed only on the cloud branch: on the Apple path nothing records and
   nothing reads — symmetry with every other pillar.
+
+### As built (Pillar A, M1, 2026-08-29)
+
+Where the implementation is more specific than the plan above, or differs.
+
+- **Two files, one target.** `WearerConversationStore` (entries, durability,
+  rotation) and `WearerConversationRecall` (the deterministic rendering of a
+  window) live in `Sources/TapQContextBaseline`, split the way
+  `SessionContextStore` and `SessionRecall` are and for the same reason: what
+  is remembered and what is said about it are different things to test.
+- **It is not the conversation-memory rung, and the doc comments say so.**
+  `SessionContextStore` / `SessionRecall` / `ConversationMemory` remember the
+  *agents' requests* — bounded, in memory, per agent session, gone at exit.
+  This remembers *the conversation* — what the wearer said and what TapQ said
+  back, on disk, across sessions and restarts. They overlap on decisions and
+  instructions by design; neither is a cache of the other, and nothing reads
+  one to answer the other's question.
+- **The entry schema is open at two seams, which is what "no migration for M3"
+  means.** `WearerDialogueKind` is a string newtype rather than an `enum`, so a
+  `directive` entry written by an M3 build round-trips through an M1 one and
+  renders as itself; and every field but the kind and the timestamp decodes
+  with a default, so a line gains fields without breaking older readers. One
+  unreadable line is skipped and dropped at the next rewrite rather than
+  costing the wearer their month.
+- **Rotation compacts in place.** `AutoAnswerLog` and `ReasonerShadowLog` move
+  a generation aside to `.1.jsonl`, which is right for a file a person reads
+  after the fact. This one is read by TapQ *on the next turn*, so a rotation
+  that emptied the live file would erase the wearer's recent history at the
+  moment it got interesting. The oldest entries are dropped and the survivors
+  rewritten atomically, past the cap rather than to it (75%) so the next append
+  does not rotate again. Bounds: 30 days and 2 MB, whichever binds first.
+- **The file is mirrored in memory**, because the recent window is read on the
+  per-turn grounding path immediately before the microphone opens and must not
+  touch the disk. The whole file is loaded once at construction; writes are
+  appends, and a full rewrite happens only at a rotation.
+- **The recording surface is three hooks and two call sites**, all of them
+  speech-cleared by construction. `VoiceBackendCommandProvider.onSpokenToWearer`
+  fires from the provider's existing `noteSpoken` — which already returns early
+  off a model-backed session — so every sentence TapQ speaks is recorded and
+  nothing on the grammar path can reach the store even if a host wires it.
+  `onTranscriptFinal` carries the wearer's finals, which on this path decide
+  nothing. Decisions are recorded where `resolveApproval` already records the
+  session event, and instructions where the stop coordinator already reports a
+  delivery. No request object reaches the store; the API takes strings TapQ has
+  already said.
+- **The window joins the grounding last.** `wearerMemoryGrounding` is a closure
+  returning a rendered block, read inside `currentGrounding()` after the window
+  brief and the agent names, so the open question stays the most prominent
+  thing about *now* with the history behind it. Its heading says the tail may
+  repeat the sentences the brief lists separately, because it does.
+- **`tapq memory clear` is the only memory verb.** No `show`: the file is the
+  wearer's own spoken history, and a supported way to print it is not something
+  this feature should add. It confirms like `calibration reset` (and `--yes`
+  skips), names the path, and says how many exchanges are about to go.
 
 ## Pillar B — transcript context (absorbed from TRANSCRIPT_CONTEXT_PLAN.md)
 
@@ -141,7 +200,8 @@ Guardrails, non-negotiable:
 ## Milestones
 
 - **M1 — perception + memory:** WearerConversationStore (record, persist,
-  recent-window grounding, `tapq memory clear`) + Pillar B phase 1
+  recent-window grounding, `tapq memory clear`) — **built 2026-08-29** —
+  + Pillar B phase 1
   (TranscriptStore, wire field, direct `ask_about_work`). Independently
   shippable and useful with zero loop.
 - **M2 — the loop, wearer-initiated only:** `start_task`, internal tools,
@@ -154,9 +214,12 @@ Guardrails, non-negotiable:
 
 ## Open questions for the maintainer
 
-1. Memory retention default (proposed: 30 days rotating; `tapq memory
-   clear` for on-demand wipe) — acceptable?
+1. ~~Memory retention default~~ — **answered 2026-08-29: 30 days rotating,
+   plus `tapq memory clear` for the on-demand wipe.** Built as asked; the
+   size cap (2 MB) is a second bound and whichever binds first, binds.
 2. M3 initiative budgets (proposed: one autonomous instruction per
    boundary, re-confirm after 5 unattended firings) — tune?
-3. Should M1's recent-window grounding include wearer utterances verbatim
-   or TapQ's summaries of them? (Proposed: verbatim, they are short.)
+3. ~~Verbatim wearer utterances in the recent window, or summaries?~~ —
+   **answered 2026-08-29: verbatim, they are short.** Built as asked. The
+   window quotes them, and the only bound on one is a 480-character cap
+   against a recognizer that ran away with a nearby conversation.

--- a/docs/TAPQ_AGENT_PLAN.md
+++ b/docs/TAPQ_AGENT_PLAN.md
@@ -57,6 +57,11 @@ Properties:
 
 ## Pillar B — transcript context (absorbed from TRANSCRIPT_CONTEXT_PLAN.md)
 
+**Phase 1 implemented 2026-08-29** (TranscriptStore, the optional
+`transcript_path` wire field, `ask_about_work` answered by `gpt-5.6-luna`);
+see that doc's "As built" for where the code is more specific than the plan.
+Hardware smoke pending.
+
 Unchanged in substance; see that doc for full detail. Summary: cloud-backend
 selection is consent for TapQ to read connected agents' full transcripts.
 Claude Code phase 1 via the hook-supplied `transcript_path`, forwarded as an
@@ -143,7 +148,8 @@ Guardrails, non-negotiable:
 - **M1 — perception + memory:** WearerConversationStore (record, persist,
   recent-window grounding, `tapq memory clear`) + Pillar B phase 1
   (TranscriptStore, wire field, direct `ask_about_work`). Independently
-  shippable and useful with zero loop.
+  shippable and useful with zero loop. *Pillar B phase 1 implemented
+  2026-08-29.*
 - **M2 — the loop, wearer-initiated only:** `start_task`, internal tools,
   `ask_about_work` folded in as a loop task, pause/resume on `ask_wearer`.
 - **M3 — initiative:** standing directives, boundary-review invocation,

--- a/docs/TRANSCRIPT_CONTEXT_PLAN.md
+++ b/docs/TRANSCRIPT_CONTEXT_PLAN.md
@@ -1,9 +1,12 @@
 # Transcript context: full session history for cloud backends
 
-Status: ratified by the maintainer 2026-08-28. Not yet implemented — plan
-under review. Absorbed 2026-08-28 as Pillar B / milestone M1 of
-TAPQ_AGENT_PLAN.md (TapQ as an agent); this doc remains the detailed spec
-for the transcript pillar.
+Status: ratified by the maintainer 2026-08-28. **Phase 1 implemented
+2026-08-29** — see "As built" at the end for what the code does that this
+plan did not say. Hardware smoke still pending: everything below is verified
+against fixture transcripts, the scripted realtime peer, and a fake HTTP
+transport, not against a live session. Absorbed 2026-08-28 as Pillar B /
+milestone M1 of TAPQ_AGENT_PLAN.md (TapQ as an agent); this doc remains the
+detailed spec for the transcript pillar.
 Companions: REALTIME_INTENT_PLAN.md (how the wearer's intent reaches TapQ),
 NARRATION_MODEL_PLAN.md (how TapQ speaks). This plan is what TapQ *knows*.
 
@@ -127,6 +130,65 @@ Two distinct failure classes, one clean line between them:
 ## Phasing
 
 1. **Phase 1 (this plan):** Claude Code transcripts, `ask_about_work`,
-   TranscriptStore, wire field, docs.
+   TranscriptStore, wire field, docs. **Implemented 2026-08-29.**
 2. **Phase 2 (deferred):** Codex rollout files; narration enrichment;
    retrieval quality (embeddings) if plain slicing proves insufficient.
+
+## As built (2026-08-29)
+
+Where the implementation is more specific than the plan, or differs from it.
+
+- **The wire field rides three messages, not all of them.** `approval.request`,
+  `notification.event`, and `stop.question` carry an optional
+  `transcript_path`; `selection.request` and `instruction.wait` do not. The
+  three that do cover every session that ever asks for anything and every
+  session that merely finishes a turn (a Stop is a notification), so a fourth
+  carrier would add a code path and no coverage. No version bump, on the
+  `lease_id` reasoning, pinned by `TranscriptWireFieldTests`.
+- **The broker's seam is a callback, not a contract field.** Adding
+  `transcriptPath` to `ApprovalRequest`/`AgentNotification` would have put a
+  filesystem path on the types the whole interaction layer passes around, for
+  one reader. `BrokerServer` takes an optional
+  `onTranscriptPath(BrokerTranscriptAttachment)` instead — session id, agent,
+  path — and the Apple composition passes `nil`, so the field arrives, decodes,
+  and reaches nothing.
+- **`ask_about_work` needs no open window.** The plan grouped it with the five,
+  and the five all refuse when nothing is listening because delivering them
+  *is* a window's flow. A question delivers no command: there is nothing for a
+  window to receive, and refusing an answer because a prompt closed a beat
+  earlier would only leave the wearer's question unanswered. It also resolves
+  nothing — the window it arrived inside is left exactly as it was found, which
+  is what keeps a question from resolving an approval by accident.
+- **The peer waits for the answer.** Every other tool result goes back before
+  anything happens; this one goes back after, because the result says what TapQ
+  *did*, and until the answer exists TapQ has not done it. The call is bounded
+  by the answer model's own 15 s timeout, the same bound narration runs under.
+- **One client, two prompts.** `OpenAINarrationModel` gained a second method
+  and conforms to `WorkQuestionAnswering`. Same endpoint, same key, same
+  strict-schema decoding, same timeout race — and, the part that matters, the
+  same failure posture, rather than a second client that could learn to degrade
+  on its own. Diagnostics are prefixed `narration.` or `ask.` so an operator can
+  tell which call failed.
+- **Slice selection is recency-first, then relevance.** Always take the newest
+  ~20 entries, then rank the rest by how many of the question's own words they
+  contain, all under a 100k-character budget with a per-entry cap of 8k so one
+  enormous tool output cannot evict the twenty lines around it. Everything
+  dropped is reported as counts and lengths (`ask.dropped entries=… chars=…`).
+- **Which session a question is about.** M1 answers about the session TapQ has
+  most recently read from, which is exact with one agent connected and is the
+  seam rung F's roster plugs into. A wearer who names an agent TapQ cannot route
+  to is therefore answered about the active session rather than refused; the
+  name is still passed to the answer model, which sees it in the prompt.
+- **Failure hooks are three, not two.** `onWorkAnswerFailed` joins
+  `onScriptedSpeechUndeliverable` and `onIntentPipelineFailed` on the same
+  latch. Separate because an operator reading the log has to know whether TapQ
+  could not be heard, could not understand the wearer, or could not answer a
+  question.
+- **Verification.** `TranscriptStoreTests` (growth, a half-written line,
+  truncation, a rewrite that leaves the file *longer*, window clamping,
+  malformed lines, the three unavailable reasons, tail bound),
+  `TranscriptQuestionAnswererTests` + `TranscriptSliceSelectionTests`,
+  `AskAboutWorkTests` (declaration scoping, round trip, window untouched,
+  unavailable spoken, cloud failure breaks and says nothing),
+  `TranscriptWireFieldTests`, `HookShimTranscriptPathTests`,
+  `TranscriptAttachmentTests` (the Apple path's `nil` callback).


### PR DESCRIPTION
Milestone M1 of [`docs/TAPQ_AGENT_PLAN.md`](../blob/main/docs/TAPQ_AGENT_PLAN.md): the agent's perception and memory, both pillars, no loop yet. Cloud-backend-only throughout — everything below composes on the `.openaiRealtime` arm; the Apple path neither records, reads, nor declares any of it.

## Pillar A — TapQ's own memory

`WearerConversationStore`: an append-only JSONL under application support recording the dialogue TapQ has with the wearer — wearer finals, TapQ's spoken sentences, decisions, delivered instructions, narrated boundaries. Speech-safe by construction: the API accepts only speech-cleared strings, so tool inputs, working directories, and permission modes have no path in. A verbatim recent window (12 entries / 1200 chars) joins per-turn grounding, so "the thing I asked you earlier" survives a session recycle and a runtime restart. Retention 30 days / 2 MB (whichever binds first), compacting in place so rotation can never empty the file TapQ re-reads on the next turn. Entry kinds are open strings with defaulted fields — M3's directive entries will need no migration. `tapq memory clear` wipes on demand; deliberately no `memory show`.

## Pillar B — transcript context, phase 1

Selecting a cloud voice backend is consent for TapQ to read connected agents' transcripts ([`docs/TRANSCRIPT_CONTEXT_PLAN.md`](../blob/main/docs/TRANSCRIPT_CONTEXT_PLAN.md), ratified 2026-08-28). The Claude Code shim forwards the hook's `transcript_path` as an optional wire field on `approval.request`, `notification.event`, and `stop.question` — no version bump, inert to old peers. The runtime tails the file into a `TranscriptStore` (byte-offset checkpoints, resync on truncation or torn offset, bounded tail, nothing persisted). A sixth realtime tool, `ask_about_work(question, agent?)`, declared only when a store exists, selects recency-weighted slices under a 100k budget and answers with one `gpt-5.6-luna` call through the existing narration client; the answer is spoken verbatim in the run's voice. Failure keeps the ratified two-class line: cloud-call failure breaks the run's voice on the same latch as narration; an unreadable transcript is said out loud and the session carries on.

## Ratified along the way

- Retention default: 30 days rotating + `tapq memory clear` (plan open question 1).
- Recent-window grounding quotes wearer utterances verbatim (plan open question 3).

## Known limits (documented in the plans)

- Named-agent routing in `ask_about_work` is a single-session stub until the rung-F roster.
- Credential redaction in spoken answers is prompt-only, best-effort, pinned by a test.
- Codex transcript acquisition is phase 2; Cursor/OpenCode stay event-level (capability table updated).
- Hardware smoke of both pillars is pending.

## Verification

102 new tests across 10 suites (store durability/rotation/clear, grounding windows, transcript tailing fixtures incl. truncation and torn offsets, tool round-trips, spoken refusal, break latch, wire-field optionality, apple-path scoping). Slim check green from the main tree with all new suites plus every touched suite appended; host `swift build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
