### PR TITLE
TapQ agent M2: the deliberation loop, wearer-initiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Added
 
+- **Hand TapQ a goal, out loud** (`--voice-backend openai-realtime` only). "Run the tests
+  and let me know if anything fails", "tell Codex to do what Claude just did" — a new
+  `start_task` tool hands the sentence to TapQ's own deliberation loop: up to six steps of
+  searching its memory, reading agents' transcripts, checking status, queueing
+  instructions, or asking you a question, reasoned by the narration model. One task at a
+  time, acknowledged when it starts, and every ending is audible — a finished summary, an
+  honest "I couldn't finish", or your unanswered question timing the task out. The loop
+  has no authority you didn't already have: instructions it queues go through the same
+  no-authority channel as dictation and are announced as they go, and nothing it does can
+  approve anything. Asking TapQ *about* the work now runs through the same loop, so
+  answers can combine session history with what you and TapQ said to each other. The
+  Apple path composes none of it. See [`docs/TAPQ_AGENT_PLAN.md`](docs/TAPQ_AGENT_PLAN.md)
+  (Pillar C, milestone M2).
 - **TapQ remembers its own conversation with you** (`--voice-backend openai-realtime`
   only). What you said, what TapQ said back, what was approved or denied, and which
   instructions reached which agent are appended to `wearer-conversation.jsonl` in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ Container facts, all hard-won — do not rediscover them by hanging:
   target's siblings. Never anchor it: `--filter '^(A|B)$'` matches nothing,
   runs 0 tests and exits 0 — a silent false green.
 - macOS has no `timeout`; any watchdog must live INSIDE the container.
+- On Linux, the Swift 6 test-discovery shim cannot register SYNCHRONOUS test
+  methods on a `@MainActor` XCTestCase — hard errors in the container,
+  invisible on macOS. Every test method in a `@MainActor` suite must be
+  `async`, even pure assertions.
 - The build dir is the shared volume `tapq-linux-build` via `--scratch-path
   /build`. Never run two containers against it at once — they starve each other.
 - Only the host `swift build` covers the Apple adapters and runtime app; they

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -114,6 +114,12 @@ import Darwin
     /// Whether a listening loop is running. For diagnostics and tests.
     var isListening: Bool { isRunning }
 
+    /// The wearer ended the voice session. Set by the composition to cancel a deliberation
+    /// task that is still thinking: "end voice session" is about the mode the wearer is in,
+    /// and a task that went on speaking after they stepped out of it would be TapQ talking
+    /// to a room. `nil` on every path that composes no loop.
+    var onEndedByWearer: (@MainActor () -> Void)?
+
     /// Starts listening for the boundary just held, if nothing is listening already.
     ///
     /// Called immediately before the caller suspends on the registry, so the loop's first
@@ -163,9 +169,43 @@ import Darwin
                 // Everything, not just this session: "end voice session" is about the mode
                 // the wearer is in, not about one agent they cannot see the names of.
                 waits.releaseAll()
+                onEndedByWearer?()
                 return
             }
         }
+    }
+}
+
+/// Where an `ask_about_work` question is answered from, once the pieces exist.
+///
+/// A one-field box, and it exists because of an ordering the composition cannot avoid. The
+/// voice provider is built at the top of `serve`, and its `answerWorkQuestion` closure is an
+/// init parameter; the deliberation loop is built two hundred lines later, because its
+/// surfaces need the conversation memory, the durable store, and the interaction gate, none
+/// of which exist yet up there. So the provider is handed a closure that asks *this* where
+/// to go, and this learns the answer before any voice traffic can arrive — the provider
+/// opens no session until a window arms, which is after `onReady`.
+///
+/// The direct answerer stays behind it rather than being discarded. It is M1's one-call
+/// shape of the same question, it owns the three unavailability sentences the loop reuses,
+/// and if a future edit ever leaves the loop unbuilt this composition answers questions
+/// instead of failing them.
+@MainActor private final class WorkQuestionRoute {
+    private let direct: TranscriptQuestionAnswerer
+    /// Set once, by the M2 hookup below.
+    var loop: WearerTaskLoop?
+
+    init(direct: TranscriptQuestionAnswerer) {
+        self.direct = direct
+    }
+
+    func answer(question: String, agentDisplayName: String?) async -> WorkQuestionOutcome {
+        guard let loop else {
+            return await direct.answer(question: question, agentDisplayName: agentDisplayName)
+        }
+        return await loop.answerWorkQuestion(
+            question: question, agentDisplayName: agentDisplayName
+        )
     }
 }
 
@@ -384,6 +424,11 @@ import Darwin
         /// this is non-nil, so with no cloud to call there is nothing to disable and no flag
         /// to read — the classifier and the spoken summarizer keep every boundary they had.
         var boundaryNarrator: (any BoundaryNarrating)?
+        /// The deliberation loop's reasoner, on the model-backed path only — the same
+        /// ``OpenAINarrationModel`` value the narrator is, because one client family is what
+        /// keeps the failure posture from diverging. `nil` on the Apple path, and that nil is
+        /// what makes the loop structurally absent there rather than disabled.
+        var taskReasoner: (any WearerTaskReasoning)?
         /// The connected agents' session transcripts, on the model-backed path only.
         ///
         /// nil on the Apple path, and that nil is load-bearing twice over: the broker gets
@@ -393,6 +438,13 @@ import Darwin
         /// quietly worked. TapQ persists nothing here — offsets and a bounded tail, both of
         /// which die with this object.
         var transcriptStore: TranscriptStore?
+        /// Pillar B retrieval, on the model-backed path only. Held out here because the
+        /// deliberation loop's `read_transcript` reaches the store through it — the same
+        /// session resolution, the same on-demand re-read, the same three unavailability
+        /// sentences — and the loop is built much further down.
+        var transcriptAnswerer: TranscriptQuestionAnswerer?
+        /// Where `ask_about_work` goes. See ``WorkQuestionRoute``.
+        var workQuestionRoute: WorkQuestionRoute?
         switch configuration.voiceBackend {
         case .apple:
             rawVoice = VoiceListener(
@@ -497,6 +549,9 @@ import Darwin
                 ),
                 diagnosticSink: diagnostics
             )
+            transcriptAnswerer = answerer
+            let route = WorkQuestionRoute(direct: answerer)
+            workQuestionRoute = route
             let provider = VoiceBackendCommandProvider(
                 backend: broken,
                 // No matcher, and the absence is the feature. Ratified 2026-08-28: for the
@@ -523,8 +578,13 @@ import Darwin
                 // opens. The provider knows nothing about transcripts beyond this closure:
                 // it asks a question and gets back a sentence, a spoken refusal, or a
                 // failure to break on.
-                answerWorkQuestion: { [answerer] question, agent in
-                    await answerer.answer(question: question, agentDisplayName: agent)
+                //
+                // Since M2 it goes through the deliberation loop (Pillar B's one revision:
+                // an answer may now combine transcript slices with TapQ's own memory). The
+                // three outcomes the provider handles are unchanged, and so is what the
+                // wearer hears in each; only where the evidence comes from moved.
+                answerWorkQuestion: { [route] question, agent in
+                    await route.answer(question: question, agentDisplayName: agent)
                 },
                 diagnosticSink: diagnostics
             )
@@ -573,11 +633,17 @@ import Darwin
                 throw VoiceBackendConfigurationError.missingOpenAIAPIKey
             }
             let narrationModel = OpenAINarrationModel.resolvedModel()
-            boundaryNarrator = OpenAINarrationModel(
+            let narrator = OpenAINarrationModel(
                 apiKey: narrationKey,
                 model: narrationModel,
                 diagnosticSink: diagnostics
             )
+            boundaryNarrator = narrator
+            // The same value, in its third role. `OpenAINarrationModel` narrates boundaries,
+            // answers questions, and now drives the deliberation loop's turns — one client,
+            // one key, one timeout race, one way to fail. A separate reasoner here would be
+            // a second place for a cloud call to learn how to degrade.
+            taskReasoner = narrator
             diagnostics.record(.init(
                 category: "Context",
                 name: "narration.selected",
@@ -1446,6 +1512,249 @@ import Darwin
             return decision
         }
 
+        // -- The deliberation loop (docs/TAPQ_AGENT_PLAN.md, Pillar C, milestone M2) --
+        //
+        // Composed here and nowhere else, on the same branch every other pillar hangs off:
+        // with no reasoner there is no loop, no `start_task` to declare, and no second
+        // route for `ask_about_work`. The Apple path builds nothing — structurally absent,
+        // not disabled, and there is no flag.
+        //
+        // Built this far down because its seven tool surfaces are seven things the runtime
+        // already has: the durable memory, the transcript store, conversation memory's
+        // roster and recall, the mailbox behind rung E's resolver, the run's one voice, and
+        // the prompt path. The engine knows none of those types; it knows seven closures.
+        //
+        // It has no authority the wearer does not already have. Every surface below is one
+        // a wearer can reach by speaking, `queue_instruction` goes through the same
+        // fail-closed name resolution a dictation does, and nothing here can approve
+        // anything — `ask_wearer` *asks* the wearer, which is the opposite.
+        let wearerTaskLoop: WearerTaskLoop? = taskReasoner.map { reasoner in
+            WearerTaskLoop(
+                model: reasoner,
+                surfaces: WearerTaskSurfaces(
+                    // Pillar A retrieval, the half M1 deferred to the loop: the whole
+                    // retained record, ranked against the query, rather than the unranked
+                    // recent window the realtime session already carries per turn.
+                    searchMemory: { [wearerMemory] query in
+                        guard let wearerMemory else {
+                            return .ok(WearerMemorySearch.emptyMemoryText)
+                        }
+                        let found = WearerMemorySearch.search(
+                            entries: wearerMemory.entries(),
+                            query: query,
+                            now: Date()
+                        )
+                        diagnostics.record(.init(
+                            category: "WearerTask",
+                            name: "memory.searched",
+                            fields: [
+                                "matches": "\(found.matches.count)",
+                                "dropped": "\(found.droppedEntries)",
+                            ]
+                        ))
+                        return .ok(found.text)
+                    },
+                    // Pillar B retrieval. Excerpts, not an answer: the loop writes the
+                    // answer itself, which is the whole of what folding `ask_about_work`
+                    // into the loop buys — one sentence composed from the agent's history
+                    // *and* TapQ's own memory of what the wearer asked for.
+                    readTranscript: { [transcriptAnswerer] agent, query in
+                        guard let transcriptAnswerer else {
+                            return .localFailure(
+                                "no transcript store",
+                                tellingModel: "TapQ has no session history to read.",
+                                saying: TranscriptQuestionAnswerer.notAttachedNotice
+                            )
+                        }
+                        switch transcriptAnswerer.excerpts(
+                            question: query, agentDisplayName: agent
+                        ) {
+                        case let .selected(slices, droppedEntries, droppedCharacters):
+                            diagnostics.record(.init(
+                                category: "WearerTask",
+                                name: "transcript.read",
+                                fields: [
+                                    "slices": "\(slices.count)",
+                                    "dropped_entries": "\(droppedEntries)",
+                                    "dropped_chars": "\(droppedCharacters)",
+                                ]
+                            ))
+                            return .ok(TranscriptExcerpts.rendered(
+                                slices: slices, agentDisplayName: agent
+                            ))
+                        case let .unavailable(reason, notice):
+                            // The other failure class, and it stays the other one: loud in
+                            // the log, honest to the model, and the session lives. Only a
+                            // cloud call breaks the voice.
+                            return .localFailure(
+                                reason.rawValue,
+                                tellingModel: "TapQ cannot read that session's history "
+                                    + "(\(reason.rawValue)), so there are no excerpts. Say "
+                                    + "so plainly rather than guessing what it contained.",
+                                saying: notice
+                            )
+                        }
+                    },
+                    // The surfaces `query_status` already answers out of, plus the roster —
+                    // because the names it lists are the only names `queue_instruction`
+                    // below will accept, and a loop told to guess would guess.
+                    status: { [memory] in
+                        var lines: [String] = []
+                        let names = memory.liveAgentDisplayNames
+                        lines.append(names.isEmpty
+                            ? "No agent can be addressed by name right now."
+                            : "Agents addressable by name right now: "
+                                + names.joined(separator: ", ") + ".")
+                        if let waiting = memory.standingRecallResponder(.status) {
+                            lines.append("Waiting on the wearer: \(waiting)")
+                        }
+                        if let changed = memory.standingRecallResponder(.whatChanged) {
+                            lines.append("Already done in this session: \(changed)")
+                        }
+                        return .ok(lines.joined(separator: "\n"))
+                    },
+                    // The existing instruction path, rung E resolution and all. Two
+                    // differences from the dictation flow, both deliberate: a name is
+                    // *required* here, because the loop is not standing in a window and
+                    // "the agent that just asked me something" does not exist off one; and
+                    // what was sent is announced, because a sentence delivered in the
+                    // wearer's name while they are not listening has to be audible.
+                    queueInstruction: { [memory] agent, text in
+                        let sentence = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !sentence.isEmpty else {
+                            return .ok("No instruction text was supplied, so nothing was "
+                                + "queued.")
+                        }
+                        guard let resolve = memory.instructionAddressResolver else {
+                            return .ok("This run has no instruction queue, so nothing can "
+                                + "be sent to an agent. Tell the wearer.")
+                        }
+                        guard let name = agent, !name.isEmpty else {
+                            return .ok("An agent name is required. Call get_status for the "
+                                + "names that are addressable right now; never guess one.")
+                        }
+                        switch resolve(name) {
+                        case .none:
+                            return .ok("Nothing live answers to \"\(name)\", so nothing was "
+                                + "queued.")
+                        case let .ambiguous(agentDisplayName):
+                            return .ok("\(agentDisplayName) has more than one live session, "
+                                + "so that name does not identify one of them. Nothing was "
+                                + "queued.")
+                        case let .resolved(addressee):
+                            guard addressee.acceptsInstructions else {
+                                return .ok("\(addressee.agentDisplayName) cannot be sent "
+                                    + "instructions, so nothing was queued.")
+                            }
+                            switch addressee.enqueue(sentence) {
+                            case .notQueued:
+                                return .ok("\(addressee.agentDisplayName) would not take "
+                                    + "it, so nothing was queued.")
+                            case .queued, .queuedDroppingOldest:
+                                return .announcing(
+                                    "Queued for \(addressee.agentDisplayName); it is "
+                                        + "delivered at that agent's next turn boundary. It "
+                                        + "authorizes nothing on its own.",
+                                    say: "I've told \(addressee.agentDisplayName): "
+                                        + WearerTaskLoop.spokenGoal(sentence)
+                                )
+                            }
+                        }
+                    },
+                    // The run's one voice, at notification priority like every other
+                    // sentence TapQ says that is not a prompt. Not routed through the quiet
+                    // decorator: `--quiet` trades prompts and notifications for cues and
+                    // says so on the status line — "answers still spoken" — and everything
+                    // the loop says is an answer to something the wearer asked for.
+                    speak: { [routedSpeech] text in
+                        routedSpeech.speak(text, priority: .notification, onFinish: nil)
+                    },
+                    // The existing question machinery: the same `ApprovalRequest(kind:
+                    // .question)` the narrated boundary path builds, through the same gate,
+                    // answered the same three ways by nod, tap, or voice.
+                    //
+                    // Deliberately *not* through `resolveApproval`. That wrapper opens a
+                    // session window, which would put "TapQ" in the roster as an agent the
+                    // loop could then address, and it runs the stage-2 assessment and the
+                    // delegation filter — which could auto-answer TapQ's own question
+                    // without the wearer. Both are right for an agent's request and wrong
+                    // for TapQ asking one. The durable record is kept here instead.
+                    askWearer: { [wearerMemory] question in
+                        let request = ApprovalRequest(
+                            id: UUID().uuidString,
+                            sessionID: "tapq-task",
+                            agent: AgentIdentity(id: "tapq", displayName: "TapQ"),
+                            toolName: "TapQTask",
+                            summary: question,
+                            detail: "",
+                            kind: .question,
+                            spokenPreamble: nil
+                        )
+                        // The question machinery's own bound is the bound: a window that
+                        // nobody answers inside `InteractionBudget.total` resolves `.ask`,
+                        // and the loop ends audibly on it rather than waiting forever.
+                        let deadline = ContinuousClock.now
+                            + .seconds(InteractionBudget.total)
+                        let decision = await interactionGate.run {
+                            armPrompt()
+                            return await interaction.resolve(request, deadline: deadline)
+                        }
+                        wearerMemory?.recordDecision(
+                            agentDisplayName: "TapQ",
+                            summary: question,
+                            outcome: Self.spokenOutcome(of: decision)
+                        )
+                        switch decision {
+                        case .allow: return .yes
+                        case .deny: return .no
+                        case .ask: return .unanswered
+                        }
+                    },
+                    // Pillar A, twice per task: the goal when it starts and the outcome when
+                    // it ends. Only speech-cleared text — the goal is the sentence TapQ read
+                    // back out loud when it accepted, and the outcome is one word.
+                    recordTask: { [wearerMemory] goal, outcome in
+                        wearerMemory?.recordTask(goal: goal, outcome: outcome)
+                    }
+                ),
+                diagnosticSink: diagnostics
+            )
+        }
+        if let wearerTaskLoop {
+            // The fourth sibling on the same latch. A cloud call that fails inside the loop
+            // is the narration model on the narration endpoint with the narration key, so it
+            // gets narration's answer: break, loudly, once. Its own hook rather than a reuse
+            // of `onWorkAnswerFailed`, because an operator reading the log has to know
+            // whether TapQ could not be heard, could not understand the wearer, could not
+            // answer a question, or could not think.
+            wearerTaskLoop.onLoopBroken = { [weak voiceBrokenState] reason in
+                voiceBrokenState?.noteBackendFailed(reason: "task loop: \(reason)")
+            }
+            // `ask_about_work` now answers through the loop, so a question can draw on the
+            // transcript and on TapQ's own memory in one sentence.
+            workQuestionRoute?.loop = wearerTaskLoop
+            // The wearer stepping out of the voice session is an ending, and a task ends
+            // with it. Silently, like the shutdown case: they just told TapQ to stop.
+            voiceSessionListening?.onEndedByWearer = { [weak wearerTaskLoop] in
+                wearerTaskLoop?.cancel(reason: "voice session ended by wearer")
+            }
+            // And so is the pipe dying. `releaseHolds` is the one hook the latch fires, and
+            // it is already carrying the boundary release, so this chains rather than
+            // replaces. A loop that kept thinking past a break would be exactly the
+            // degraded half-agent the posture forbids — its HTTP calls would keep working
+            // while the channel the answer was for is gone.
+            let releaseHoldsBeforeLoop = voiceBrokenState?.releaseHolds
+            voiceBrokenState?.releaseHolds = { [weak wearerTaskLoop] in
+                releaseHoldsBeforeLoop?()
+                wearerTaskLoop?.cancel(reason: "voice channel broken")
+            }
+            // M2 hookup: pass `wearerTaskLoop` as the provider's `startWearerTask:`
+            // argument (it sits after `answerWorkQuestion:` in the init above); the loop
+            // conforms to `WearerTaskStarting` with a `nonisolated` async `startTask` that
+            // hops to the main actor internally, so the provider's `await` is safe from any
+            // isolation.
+        }
+
         let stopQuestions = StopQuestionCoordinator(
             // Both of these are dead weight on the model-backed path and are passed anyway,
             // so the two compositions keep one shape: with a narrator present the
@@ -1798,6 +2107,12 @@ import Darwin
             // it. Releasing first means every waiter is answered "carry on" by a broker
             // that is still listening.
             instructionWaits?.releaseAll()
+            // Before the voice pipe goes: a task still thinking has a `speak` surface
+            // pointing at a `BackendSpeechSink` this block is about to tear down, and one
+            // more model turn would spend seconds resolving into a sentence nobody can
+            // hear. It ends silently and on purpose — the record still gets `canceled`, so
+            // a wearer who asks tomorrow finds out what happened to what they asked for.
+            wearerTaskLoop?.cancel(reason: "runtime shutdown")
             voiceSessionListening = nil
             turnCoordinator?.stop()
             // Prevent ARC from releasing the wearer-speech source at the

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -209,6 +209,24 @@ import Darwin
     }
 }
 
+/// The `start_task` seam, boxed for construction order: the provider is built before the
+/// loop's seven tool surfaces exist, so it holds this handle and the M2 hookup fills it —
+/// the same shape ``WorkQuestionRoute`` is, for the same reason. On the arm that builds
+/// the provider the loop is always built too (its reasoner is the narrator, and the
+/// narrator is mandatory there), so a call through an unfilled handle means composition
+/// itself broke — it answers audibly rather than pretending a task is running.
+@MainActor private final class WearerTaskHandle: WearerTaskStarting {
+    /// Set once, by the M2 hookup below.
+    var loop: WearerTaskLoop?
+
+    nonisolated func startTask(goal: String) async -> WearerTaskStart {
+        guard let loop = await MainActor.run(body: { self.loop }) else {
+            return .busy(spoken: "I can't take tasks right now.")
+        }
+        return await loop.startTask(goal: goal)
+    }
+}
+
 /// Headless macOS host composed from TapQ's broker, interaction, and hardware adapters.
 /// The broker and interaction layers remain agent-neutral; installed adapters normalize
 /// Claude Code, Codex, or future agent events before they reach this process.
@@ -445,6 +463,8 @@ import Darwin
         var transcriptAnswerer: TranscriptQuestionAnswerer?
         /// Where `ask_about_work` goes. See ``WorkQuestionRoute``.
         var workQuestionRoute: WorkQuestionRoute?
+        /// Where `start_task` goes. See ``WearerTaskHandle``.
+        var wearerTaskHandle: WearerTaskHandle?
         switch configuration.voiceBackend {
         case .apple:
             rawVoice = VoiceListener(
@@ -552,6 +572,8 @@ import Darwin
             transcriptAnswerer = answerer
             let route = WorkQuestionRoute(direct: answerer)
             workQuestionRoute = route
+            let taskHandle = WearerTaskHandle()
+            wearerTaskHandle = taskHandle
             let provider = VoiceBackendCommandProvider(
                 backend: broken,
                 // No matcher, and the absence is the feature. Ratified 2026-08-28: for the
@@ -586,6 +608,10 @@ import Darwin
                 answerWorkQuestion: { [route] question, agent in
                     await route.answer(question: question, agentDisplayName: agent)
                 },
+                // Present, so `start_task` is declared to every session this provider
+                // opens — the loop itself is built much further down, once its seven tool
+                // surfaces exist, and the M2 hookup fills this handle then.
+                startWearerTask: taskHandle,
                 diagnosticSink: diagnostics
             )
             // A sentence the specified backend cannot say is not a cue to say it in a
@@ -1748,11 +1774,10 @@ import Darwin
                 releaseHoldsBeforeLoop?()
                 wearerTaskLoop?.cancel(reason: "voice channel broken")
             }
-            // M2 hookup: pass `wearerTaskLoop` as the provider's `startWearerTask:`
-            // argument (it sits after `answerWorkQuestion:` in the init above); the loop
-            // conforms to `WearerTaskStarting` with a `nonisolated` async `startTask` that
-            // hops to the main actor internally, so the provider's `await` is safe from any
-            // isolation.
+            // The M2 hookup: the provider has held the handle since its init, and the
+            // loop exists now. The loop's `startTask` is `nonisolated` and hops to the
+            // main actor internally, so the provider's `await` is safe from any isolation.
+            wearerTaskHandle?.loop = wearerTaskLoop
         }
 
         let stopQuestions = StopQuestionCoordinator(

--- a/Sources/TapQContextBaseline/OpenAINarrationModel.swift
+++ b/Sources/TapQContextBaseline/OpenAINarrationModel.swift
@@ -29,7 +29,7 @@ import TapQContracts
 ///
 /// The API key is never logged, and neither is the request body or the agent's output:
 /// diagnostics carry counts, lengths, statuses, and timings only.
-public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering {
+public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering, WearerTaskReasoning {
     /// The maintainer-specified narration model (ratified 2026-08-28).
     public static let defaultModel = "gpt-5.6-luna"
     /// The single override seam. No CLI flag: the model id is an operational detail of a
@@ -48,6 +48,11 @@ public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering {
     /// failures, and because a cap that clips is a cap that lies about what the history
     /// contained.
     static let answerOutputTokens = 1_024
+    /// One turn of the deliberation loop. Sized like an answer rather than an utterance,
+    /// because the turn that ends a task *is* an answer — `finish` carries the whole spoken
+    /// summary — and a cap that clipped the last turn would clip exactly the sentence the
+    /// wearer was waiting for.
+    static let taskOutputTokens = 1_024
 
     /// The model id for this run: the environment override when set and non-blank,
     /// otherwise ``defaultModel``.
@@ -170,6 +175,65 @@ public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering {
         }
     }
 
+    /// One turn of the deliberation loop (`docs/TAPQ_AGENT_PLAN.md`, Pillar C).
+    ///
+    /// The third method on this client and not a fourth client, for the reason ``answer(_:)``
+    /// gave when it was the second: same model family, same key, same endpoint, same timeout
+    /// race — and, the part that matters, the same failure posture. A loop that reasoned
+    /// through its own transport would be a second place for a cloud call to learn how to
+    /// degrade, and the plan's posture has exactly one answer for all of them.
+    ///
+    /// The one shape that differs is the output. Narration and answers use strict
+    /// `text.format.json_schema` because they produce one string; a loop turn produces a
+    /// *choice among tools*, so it sends `tools` with `tool_choice: "required"` and reads a
+    /// `function_call` item back. `reasoning.effort` stays `none` like its siblings: the
+    /// wearer is waiting either way, and the loop's thinking is the sequence of turns, not
+    /// the depth of one.
+    public func decide(_ request: WearerTaskTurnRequest) async throws -> WearerTaskDecision {
+        diagnostics.record("task.turn_requested", fields: [
+            "mode": request.mode.rawValue,
+            "model": model,
+            "steps": "\(request.steps.count)",
+        ])
+        let (data, latency) = try await transport(
+            body: [
+                "model": model,
+                "instructions": WearerTaskContract.instructions(for: request.mode),
+                "input": WearerTaskContract.input(for: request),
+                "max_output_tokens": Self.taskOutputTokens,
+                "reasoning": ["effort": "none"],
+                "store": false,
+                "tools": WearerTaskContract.tools(for: request.mode),
+                // Required, not auto: every turn of this loop is a tool call by
+                // construction, `finish` included. A turn that came back as prose would be
+                // a turn TapQ could neither execute nor speak.
+                "tool_choice": "required",
+            ],
+            label: "task"
+        )
+        do {
+            let call = try Self.decodeFunctionCall(data)
+            let decision = try WearerTaskContract.decode(
+                name: call.name,
+                argumentsJSON: call.arguments,
+                mode: request.mode
+            )
+            diagnostics.record("task.turn_decided", fields: [
+                "latency_ms": latency,
+                "model": model,
+                "tool": decision.toolName,
+            ])
+            return decision
+        } catch let failure as NarrationFailure {
+            diagnostics.record("task.response_rejected", level: .warning, fields: [
+                "latency_ms": latency,
+                "model": model,
+                "reason": failure.reason,
+            ])
+            throw failure
+        }
+    }
+
     /// One request against the Responses API, with the timeout race, the status check, and
     /// the `output_text` extraction every caller of this endpoint needs.
     ///
@@ -183,6 +247,30 @@ public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering {
     ///   transport logging.
     /// - Returns: the response's text payload and the call's latency in milliseconds.
     private func perform(body: [String: Any], label: String) async throws -> (String, String) {
+        let (data, latency) = try await transport(body: body, label: label)
+        do {
+            return (try Self.decodeResponse(data), latency)
+        } catch let failure as NarrationFailure {
+            diagnostics.record("\(label).response_rejected", level: .warning, fields: [
+                "latency_ms": latency,
+                "model": model,
+                "reason": failure.reason,
+            ])
+            throw failure
+        }
+    }
+
+    /// The wire, and nothing above it: encode, race the timeout, check the status, hand back
+    /// the bytes.
+    ///
+    /// Split out of ``perform(body:label:)`` when the loop arrived, because the loop reads a
+    /// `function_call` item where the other two read `output_text` — a different decode over
+    /// the identical transport. Splitting here rather than giving the loop its own client is
+    /// what keeps "one client family, one failure posture" literally true: every unhappy
+    /// answer in this file still comes out of these thirty lines.
+    ///
+    /// - Returns: the raw response body and the call's latency in milliseconds.
+    private func transport(body: [String: Any], label: String) async throws -> (Data, String) {
         let httpRequest: URLRequest
         do {
             httpRequest = try makeRequest(body: body)
@@ -236,16 +324,7 @@ public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering {
                 ])
                 throw NarrationFailure.http(status: response.statusCode)
             }
-            do {
-                return (try Self.decodeResponse(data), latency)
-            } catch let failure as NarrationFailure {
-                diagnostics.record("\(label).response_rejected", level: .warning, fields: [
-                    "latency_ms": latency,
-                    "model": model,
-                    "reason": failure.reason,
-                ])
-                throw failure
-            }
+            return (data, latency)
         }
     }
 
@@ -305,6 +384,37 @@ public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering {
         return text
     }
 
+    /// The same triad, then the first `function_call` item.
+    ///
+    /// The *first*, deliberately: the loop executes one tool per turn, and a response
+    /// carrying two calls is a model proposing an ordering TapQ never agreed to run. Taking
+    /// the first and ignoring the rest would silently drop an action the model believed it
+    /// had taken, so a second call is a protocol failure and the run's voice breaks on it —
+    /// the same answer an undeclared tool name gets.
+    private static func decodeFunctionCall(
+        _ data: Data
+    ) throws -> (name: String, arguments: String) {
+        guard let response = try? JSONDecoder().decode(ResponseBody.self, from: data),
+              response.status == "completed",
+              response.error == nil,
+              response.incompleteDetails == nil else {
+            throw NarrationFailure.malformedResponse
+        }
+        let refusals = response.output.compactMap(\.content).flatMap { $0 }
+        guard !refusals.contains(where: { $0.type == "refusal" }) else {
+            throw NarrationFailure.malformedResponse
+        }
+        let calls = response.output.filter { $0.type == "function_call" }
+        guard calls.count == 1, let call = calls.first, let name = call.name else {
+            throw NarrationFailure.transport(
+                calls.isEmpty
+                    ? "the turn came back with no tool call"
+                    : "the turn came back with \(calls.count) tool calls"
+            )
+        }
+        return (name, call.arguments ?? "")
+    }
+
     private static func liveSend(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else {
@@ -345,6 +455,14 @@ public struct OpenAINarrationModel: BoundaryNarrating, WorkQuestionAnswering {
             }
 
             let content: [Content]?
+            /// `"message"` for the two text callers, `"function_call"` for a loop turn.
+            /// Optional so a payload from before the loop existed still decodes.
+            let type: String?
+            /// The Responses API puts a function call's name and its JSON arguments on the
+            /// output item itself, not inside `content` — the flat shape, matching the flat
+            /// tool declaration this client sends.
+            let name: String?
+            let arguments: String?
         }
 
         let status: String

--- a/Sources/TapQContextBaseline/TranscriptQuestionAnswerer.swift
+++ b/Sources/TapQContextBaseline/TranscriptQuestionAnswerer.swift
@@ -1,6 +1,48 @@
 import Foundation
 import TapQContracts
 
+/// The evidence half of an answer: which parts of a session's history were selected, or why
+/// none could be.
+///
+/// It exists because milestone M2 split the one thing `ask_about_work` used to do into two.
+/// The retrieval — resolve the session, read the tail, re-read the file if the tail was
+/// saturated, select slices, map every way that can fail onto the sentence TapQ says — is
+/// Pillar B's, and the deliberation loop needs exactly that and nothing else: it writes the
+/// answer itself, out of these slices *and* whatever `search_memory` returned, which is the
+/// whole point of the fold-in. The model call that used to follow immediately is now one
+/// caller of this rather than the only path to it.
+public enum TranscriptExcerpts: Sendable, Equatable {
+    /// Slices in the order they happened, with what did not fit reported by count.
+    case selected(slices: [WorkQuestionSlice], droppedEntries: Int, droppedCharacters: Int)
+    /// No history to answer from, and the sentence saying so. Never a voice break.
+    case unavailable(reason: TranscriptUnavailability, notice: String)
+
+    /// Selected slices as a tool result the loop's model reads.
+    ///
+    /// The same excerpt framing ``WorkAnswerContract/input(for:)`` uses — numbered, oldest
+    /// first, fenced, and explicit that the excerpts may not be contiguous — because a model
+    /// reading history it did not fetch has to be able to tell a gap from an ending. What is
+    /// left out is the question: the loop already has it, and repeating it inside a tool
+    /// result would tell the model it had been asked twice.
+    public static func rendered(
+        slices: [WorkQuestionSlice],
+        agentDisplayName: String?
+    ) -> String {
+        var lines: [String] = []
+        if let agent = agentDisplayName, !agent.isEmpty {
+            lines.append("Agent: \(agent)")
+        }
+        lines.append("Session history, oldest first (\(slices.count) excerpts, not "
+            + "necessarily contiguous):")
+        for slice in slices {
+            lines.append("--- excerpt \(slice.index)")
+            lines.append(slice.text)
+        }
+        lines.append("--- end of history")
+        return lines.joined(separator: "\n")
+    }
+}
+
 /// Answers `ask_about_work`: reads the session's transcript, selects slices, asks the
 /// narration-family model, and hands back the sentence TapQ will speak.
 ///
@@ -57,19 +99,21 @@ import TapQContracts
         self.diagnostics = TapQDiagnosticEmitter(category: "Transcript", sink: diagnosticSink)
     }
 
-    /// The seam the voice provider calls. Never throws: every failure is one of the two
-    /// outcomes above, because a thrown error at a tool call is a peer left parked.
-    public func answer(question: String, agentDisplayName: String?) async -> WorkQuestionOutcome {
+    /// Pillar B retrieval on its own: session resolution, the tail, the on-demand re-read,
+    /// slice selection, and the three unavailability sentences — everything except the model
+    /// call.
+    ///
+    /// Its own method because M2's deliberation loop needs exactly this and writes the answer
+    /// itself. Extracted rather than reimplemented, so the loop's `read_transcript` and the
+    /// direct path below cannot drift on which session a question is about or on what a
+    /// rotated file sounds like.
+    public func excerpts(question: String, agentDisplayName: String?) -> TranscriptExcerpts {
         let question = question.trimmingCharacters(in: .whitespacesAndNewlines)
-        diagnostics.record("ask.requested", fields: [
-            "question_length": "\(question.count)",
-            "agent_named": "\(agentDisplayName?.isEmpty == false)",
-        ])
         guard !question.isEmpty else {
-            return unavailable(.empty, notice: Self.emptyNotice)
+            return .unavailable(reason: .empty, notice: Self.emptyNotice)
         }
         guard let session = resolveSession(agentDisplayName) else {
-            return unavailable(.notAttached, notice: Self.notAttachedNotice)
+            return .unavailable(reason: .notAttached, notice: Self.notAttachedNotice)
         }
 
         var entries: [TranscriptEntry]
@@ -77,7 +121,7 @@ import TapQContracts
         case .success(let read):
             entries = read
         case .failure(let reason):
-            return unavailable(reason, notice: Self.notice(for: reason))
+            return .unavailable(reason: reason, notice: Self.notice(for: reason))
         }
         // A saturated tail means there is older history on disk, and the wearer may be
         // asking about it. This is the on-demand re-read: one bounded pass over the file,
@@ -93,7 +137,42 @@ import TapQContracts
             entries: entries, question: question, budget: characterBudget
         )
         guard !selection.slices.isEmpty else {
-            return unavailable(.empty, notice: Self.emptyNotice)
+            return .unavailable(reason: .empty, notice: Self.emptyNotice)
+        }
+        return .selected(
+            slices: selection.slices,
+            droppedEntries: selection.droppedEntries,
+            droppedCharacters: selection.droppedCharacters
+        )
+    }
+
+    /// The direct M1 answer path: retrieve, ask the model, hand back a sentence.
+    ///
+    /// Never throws: every failure is one of the two outcomes above, because a thrown error
+    /// at a tool call is a peer left parked.
+    ///
+    /// Composed on the `.openaiRealtime` branch through M1; from M2 the composition routes
+    /// `ask_about_work` through ``WearerTaskLoop/answerWorkQuestion(question:agentDisplayName:)``
+    /// instead, which reaches the same store through ``excerpts(question:agentDisplayName:)``.
+    /// Kept, not deleted: it is the one-call shape of this question, it is what the
+    /// composition falls back to if the loop is ever unwired, and its tests are the
+    /// specification of the three outcomes.
+    public func answer(question: String, agentDisplayName: String?) async -> WorkQuestionOutcome {
+        let question = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        diagnostics.record("ask.requested", fields: [
+            "question_length": "\(question.count)",
+            "agent_named": "\(agentDisplayName?.isEmpty == false)",
+        ])
+        let selection: TranscriptSliceSelection.Result
+        switch excerpts(question: question, agentDisplayName: agentDisplayName) {
+        case let .unavailable(reason, notice):
+            return unavailable(reason, notice: notice)
+        case let .selected(slices, droppedEntries, droppedCharacters):
+            selection = TranscriptSliceSelection.Result(
+                slices: slices,
+                droppedEntries: droppedEntries,
+                droppedCharacters: droppedCharacters
+            )
         }
         if selection.droppedEntries > 0 || selection.droppedCharacters > 0 {
             diagnostics.record("ask.dropped", fields: [

--- a/Sources/TapQContextBaseline/WearerConversationRecall.swift
+++ b/Sources/TapQContextBaseline/WearerConversationRecall.swift
@@ -67,6 +67,13 @@ public enum WearerConversationRecall {
             return entry.agentDisplayName.isEmpty
                 ? "TapQ delivered an instruction: \(entry.text)"
                 : "TapQ told \(entry.agentDisplayName): \(entry.text)"
+        case .task:
+            // Two entries per task read as two lines, and they should: the wearer asked for
+            // something at one moment and heard how it went at another. A `started` with no
+            // ending after it is a task a restart interrupted, and reads as exactly that.
+            return entry.outcome == WearerTaskLoop.startedOutcome
+                ? "The wearer asked TapQ to: \(entry.text)"
+                : "TapQ's task (\(entry.outcome)): \(entry.text)"
         default:
             // A kind this build does not know — an M3 directive read by an M1 binary. It
             // is rendered as itself rather than dropped: a line the model can read is

--- a/Sources/TapQContextBaseline/WearerConversationStore.swift
+++ b/Sources/TapQContextBaseline/WearerConversationStore.swift
@@ -28,6 +28,11 @@ public struct WearerDialogueKind: RawRepresentable, Codable, Hashable, Sendable 
     public static let decision = WearerDialogueKind(rawValue: "decision")
     /// An instruction that actually reached an agent, in full.
     public static let instruction = WearerDialogueKind(rawValue: "instruction")
+    /// A deliberation-loop task (Pillar C, M2): the goal the wearer handed over and how it
+    /// ended. Added exactly as this type's doc comment predicted a kind would be — one
+    /// `static let` and one recorder — so a file written by this build reads on an M1 binary
+    /// and vice versa.
+    public static let task = WearerDialogueKind(rawValue: "task")
 }
 
 /// One line of the durable record of TapQ's own dialogue with the wearer.
@@ -322,6 +327,28 @@ enum WearerConversationTimestamp {
             text: text,
             agentDisplayName: agentDisplayName,
             outcome: "delivered"
+        ))
+    }
+
+    /// Records a deliberation-loop task: what was asked, and how it ended
+    /// (`docs/TAPQ_AGENT_PLAN.md`, Pillar C).
+    ///
+    /// Called twice per task — once at the start with `outcome` `"started"`, once at the end
+    /// with the ending — and the pair is the point. A runtime that dies mid-task leaves a
+    /// `started` with no ending, which is exactly the honest record: the loop is gone, the
+    /// wearer's request is not. "A restart mid-task loses the loop but not the record of
+    /// what was asked" is this method and its ordering.
+    ///
+    /// `goal` is the wearer's own sentence as the realtime model reported it — the same
+    /// provenance as ``recordInstruction(agentDisplayName:text:)``'s text, and read back to
+    /// them out loud when the task was accepted. There is nothing here a wearer did not say
+    /// or hear; internal tool payloads, excerpts, and agent output never reach this store.
+    public func recordTask(goal: String, outcome: String) {
+        append(.init(
+            kind: .task,
+            timestamp: clock(),
+            text: goal,
+            outcome: outcome
         ))
     }
 

--- a/Sources/TapQContextBaseline/WearerMemorySearch.swift
+++ b/Sources/TapQContextBaseline/WearerMemorySearch.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+/// Per-question retrieval over TapQ's own memory — the half of Pillar A that M1 deferred to
+/// the loop (`docs/TAPQ_AGENT_PLAN.md`: "older history is retrieved per-question inside the
+/// loop, same slicing approach as transcripts").
+///
+/// **Why it is not the recent window.** ``WearerConversationRecall`` renders the last dozen
+/// entries into the realtime model's per-turn grounding, unranked, so that "the thing I
+/// asked you earlier" resolves. That window is deliberately blind to the question — it is
+/// built before anyone has asked one. This is the other direction: a query exists, and what
+/// matters is the entry from three days ago, not the twelve from three minutes ago.
+///
+/// **Same slicing approach as transcripts, with the priorities reversed.**
+/// ``TranscriptSliceSelection`` takes the newest entries *first* because a wearer asking
+/// about an agent's work almost always means what just happened. Here relevance goes first
+/// and recency only breaks ties, because the loop is being asked about the past — the
+/// present is already in the grounding the realtime session carries. The keyword extraction
+/// is literally shared, so "what did I tell Codex about the migration?" hangs on the same
+/// words in both pillars.
+///
+/// No embeddings, for the reason phase 1 of the transcript plan gives: the answer model
+/// reads generous excerpts happily, and an index would be a second thing to keep in sync
+/// with a file that rewrites itself at every rotation.
+///
+/// Deterministic — same entries and same query in, same characters out. Nothing here calls a
+/// model, so what the loop is told about the wearer's history is reproducible and cannot be
+/// confused with something a model invented.
+public enum WearerMemorySearch {
+    /// The most entries one search may return. Twenty is a couple of screens of dialogue
+    /// read aloud — far more than any answer needs, and small enough that a query matching
+    /// half the file does not spend the loop's whole turn.
+    public static let matchLimit = 20
+    /// The whole result's character budget. Generous next to the recent window's 1,200,
+    /// because this text is read once by a model rather than carried on every turn of a live
+    /// conversation.
+    public static let characterBudget = 6_000
+    /// What comes back when nothing matched. A sentence rather than an empty string: the
+    /// model has to be able to tell "TapQ has no record of that" from "the tool returned
+    /// nothing", and only the first of those is an answer it can honestly speak.
+    public static let noMatchesText =
+        "Nothing in TapQ's memory of its conversation with the wearer matches that."
+    /// What comes back when the record itself is empty — a first run, or a wearer who has
+    /// just cleared it.
+    public static let emptyMemoryText =
+        "TapQ has no recorded conversation with the wearer yet."
+
+    /// One retrieved entry and why it was picked, for tests and diagnostics. The loop only
+    /// ever sends ``Result/text``.
+    public struct Match: Sendable, Equatable {
+        /// The entry's position in the record, 1-based and oldest-first, so a diagnostic can
+        /// say *which* entries were used without quoting one.
+        public let index: Int
+        /// How many of the query's words this entry contains. Zero for a recency fallback.
+        public let score: Int
+        public let line: String
+
+        public init(index: Int, score: Int, line: String) {
+            self.index = index
+            self.score = score
+            self.line = line
+        }
+    }
+
+    public struct Result: Sendable, Equatable {
+        public let matches: [Match]
+        /// The rendered block the loop hands the model.
+        public let text: String
+        /// How many retained entries were not returned. Counts only — the diagnostics rule
+        /// is that what was left out is reported by number, never by content.
+        public let droppedEntries: Int
+
+        public init(matches: [Match], text: String, droppedEntries: Int) {
+            self.matches = matches
+            self.text = text
+            self.droppedEntries = droppedEntries
+        }
+    }
+
+    /// Searches `entries` (oldest first, as the store hands them over) for `query`.
+    ///
+    /// - Parameters:
+    ///   - now: the clock, so each line can say how long ago it was. Injected because a
+    ///     relative timestamp is the one part of this that is not a pure function of the
+    ///     file, and a test that could not fix it would be a test of the calendar.
+    public static func search(
+        entries: [WearerDialogueEntry],
+        query: String,
+        now: Date,
+        limit: Int = WearerMemorySearch.matchLimit,
+        budget: Int = WearerMemorySearch.characterBudget
+    ) -> Result {
+        guard !entries.isEmpty else {
+            return Result(matches: [], text: emptyMemoryText, droppedEntries: 0)
+        }
+        guard limit > 0, budget > 0 else {
+            return Result(matches: [], text: noMatchesText, droppedEntries: entries.count)
+        }
+
+        let keywords = TranscriptSliceSelection.keywords(in: query)
+        let numbered = entries.enumerated().map { (index: $0.offset + 1, entry: $0.element) }
+
+        // A query with nothing to match *on* — "what was I doing?", or a question whose
+        // every word is a stop word — is not a miss. It is a request for the recent past,
+        // and answering it with "nothing matches" would be TapQ pretending not to remember a
+        // conversation it has on disk.
+        //
+        // A query with real words that matched nothing is the opposite, and the line between
+        // them is load-bearing: handing back the most recent entries for "kubernetes
+        // ingress" would give the model a page of unrelated dialogue to answer from, which
+        // is exactly how a loop invents a memory. Nothing matched, and that is the answer.
+        let usedRecencyFallback = keywords.isEmpty
+        let ranked: [(index: Int, entry: WearerDialogueEntry, score: Int)]
+        if usedRecencyFallback {
+            ranked = numbered.suffix(limit).reversed().map {
+                (index: $0.index, entry: $0.entry, score: 0)
+            }
+        } else {
+            // Relevance first, newest breaking ties — the mirror image of the transcript
+            // selector, and the reason is in this type's doc comment.
+            ranked = numbered
+                .map { (index: $0.index, entry: $0.entry, score: score($0.entry, keywords)) }
+                .filter { $0.score > 0 }
+                .sorted { ($0.score, $0.index) > ($1.score, $1.index) }
+        }
+
+        var matches: [Match] = []
+        var spent = 0
+        for candidate in ranked {
+            guard matches.count < limit else { break }
+            let line = self.line(for: candidate.entry, index: candidate.index, now: now)
+            guard spent + line.count <= budget else { continue }
+            spent += line.count
+            matches.append(Match(index: candidate.index, score: candidate.score, line: line))
+        }
+
+        guard !matches.isEmpty else {
+            return Result(matches: [], text: noMatchesText, droppedEntries: entries.count)
+        }
+        // Rendered oldest first, whatever order they ranked in: the model is reading a
+        // conversation, and a conversation read backwards says different things.
+        let ordered = matches.sorted { $0.index < $1.index }
+        var rendered = [heading(usedRecencyFallback: usedRecencyFallback, count: ordered.count)]
+        rendered.append(contentsOf: ordered.map(\.line))
+        return Result(
+            matches: ordered,
+            text: rendered.joined(separator: "\n"),
+            droppedEntries: entries.count - ordered.count
+        )
+    }
+
+    static func heading(usedRecencyFallback: Bool, count: Int) -> String {
+        usedRecencyFallback
+            ? "No word in the query matched, so here are the \(count) most recent entries "
+                + "from TapQ's conversation with the wearer, oldest first:"
+            : "\(count) matching entries from TapQ's conversation with the wearer, oldest "
+                + "first. This is TapQ's own memory, not any agent's session:"
+    }
+
+    /// One entry as the model reads it: when, then what.
+    ///
+    /// The rendering itself is ``WearerConversationRecall/line(for:)`` — the same one the
+    /// grounding window uses, deliberately, so an entry does not read as two different facts
+    /// depending on which pillar surfaced it. What is added is the age, because a retrieved
+    /// entry has been pulled out of its order in time and "you approved that" means something
+    /// different at ten minutes and at ten days.
+    static func line(for entry: WearerDialogueEntry, index: Int, now: Date) -> String {
+        "  \(index). [\(age(of: entry.timestamp, now: now))] "
+            + WearerConversationRecall.line(for: entry)
+    }
+
+    /// A spoken-shaped relative age. Coarse on purpose: the loop may read this out, and
+    /// "yesterday" is what a person says where a timestamp would say 19 hours.
+    static func age(of timestamp: Date, now: Date) -> String {
+        let seconds = now.timeIntervalSince(timestamp)
+        guard seconds >= 0 else { return "just now" }
+        let minutes = Int(seconds / 60)
+        if minutes < 1 { return "just now" }
+        if minutes < 60 { return "\(minutes) minute\(minutes == 1 ? "" : "s") ago" }
+        let hours = minutes / 60
+        if hours < 24 { return "\(hours) hour\(hours == 1 ? "" : "s") ago" }
+        let days = hours / 24
+        return "\(days) day\(days == 1 ? "" : "s") ago"
+    }
+
+    /// How many of the query's words this entry carries, over every field that holds
+    /// language: the utterance, the decision's outcome, the agent's name, the tool's.
+    ///
+    /// All four, because a wearer's question routinely hangs on the one that is not the
+    /// text — "what did I tell Codex?" matches on the agent, "did I approve the Bash one?"
+    /// on the tool.
+    static func score(_ entry: WearerDialogueEntry, _ keywords: Set<String>) -> Int {
+        guard !keywords.isEmpty else { return 0 }
+        let haystack = [entry.text, entry.outcome, entry.agentDisplayName, entry.toolName]
+            .joined(separator: " ")
+            .lowercased()
+        return keywords.reduce(0) { $0 + (haystack.contains($1) ? 1 : 0) }
+    }
+}

--- a/Sources/TapQContextBaseline/WearerTaskContract.swift
+++ b/Sources/TapQContextBaseline/WearerTaskContract.swift
@@ -1,0 +1,536 @@
+import Foundation
+import TapQContracts
+
+/// Which of the two loops a turn belongs to.
+///
+/// One engine, two lanes, and the split is latency (`docs/TAPQ_AGENT_PLAN.md`, Pillar C).
+/// A goal the wearer handed over runs off the voice turn and may take six steps; a question
+/// folded in from `ask_about_work` is answered while the realtime peer holds its tool call,
+/// so it gets fewer steps, fewer tools, and a wall clock. See ``WearerTaskLoop`` for the
+/// bounds and the reasoning behind them.
+public enum WearerTaskMode: String, Sendable, Equatable {
+    /// `start_task`: a goal, spoken progress, up to ``WearerTaskLoop/taskStepCap`` steps.
+    case task
+    /// `ask_about_work`, folded in (Pillar B's one revision). Answers only; it may not
+    /// speak, ask, or queue.
+    case question
+}
+
+/// The seven internal tools, by wire name.
+///
+/// Exactly the seven the plan names, and the set is closed at both ends: the loop declares
+/// only these, and a call for anything else is a malformed turn rather than a tool that
+/// quietly did nothing. Nothing here is new authority — every one of them is a surface the
+/// runtime already exposes to the wearer, reached through a closure the composition wires.
+public enum WearerTaskToolName {
+    public static let searchMemory = "search_memory"
+    public static let readTranscript = "read_transcript"
+    public static let getStatus = "get_status"
+    public static let queueInstruction = "queue_instruction"
+    public static let speak = "speak"
+    public static let askWearer = "ask_wearer"
+    public static let finish = "finish"
+}
+
+/// What the model asked for on one turn.
+///
+/// A closed enum rather than a name plus a bag of arguments: the loop branches on this, and
+/// every branch reaches a surface that does something in the world. A string switch with a
+/// `default` would be a place for an eighth tool to appear without anyone deciding to add
+/// one.
+public enum WearerTaskDecision: Sendable, Equatable {
+    case searchMemory(query: String)
+    case readTranscript(agent: String?, query: String)
+    case getStatus
+    case queueInstruction(agent: String?, text: String)
+    case speak(String)
+    case askWearer(question: String)
+    case finish(summary: String)
+
+    /// The wire name, for diagnostics and for the rendered history. Counts and names only —
+    /// never the arguments.
+    public var toolName: String {
+        switch self {
+        case .searchMemory: return WearerTaskToolName.searchMemory
+        case .readTranscript: return WearerTaskToolName.readTranscript
+        case .getStatus: return WearerTaskToolName.getStatus
+        case .queueInstruction: return WearerTaskToolName.queueInstruction
+        case .speak: return WearerTaskToolName.speak
+        case .askWearer: return WearerTaskToolName.askWearer
+        case .finish: return WearerTaskToolName.finish
+        }
+    }
+}
+
+/// One completed step, as the next turn reads it back.
+///
+/// The rendered history is the loop's whole memory of itself: the Responses API is called
+/// with `store: false`, so nothing is kept at the provider and every turn carries what
+/// happened so far as text. That is deliberate — it is the same shape
+/// ``WorkAnswerContract/input(for:)`` uses, it is a string a test can assert on, and it
+/// means there is no second, invisible copy of the task at a vendor.
+public struct WearerTaskStep: Sendable, Equatable {
+    /// The tool the model called, by wire name.
+    public let tool: String
+    /// The arguments as they were rendered back — the wearer's own words in a query, a
+    /// sentence queued for an agent. Never a payload the wearer could not have heard.
+    public let arguments: String
+    /// What the tool answered, verbatim, as the model reads it.
+    public let result: String
+
+    public init(tool: String, arguments: String, result: String) {
+        self.tool = tool
+        self.arguments = arguments
+        self.result = result
+    }
+}
+
+/// One turn of the loop: the goal, what has happened, and how much room is left.
+public struct WearerTaskTurnRequest: Sendable, Equatable {
+    public let goal: String
+    public let mode: WearerTaskMode
+    /// The agent the question named, when the wearer named one. `question` lane only;
+    /// `nil` everywhere else.
+    public let agentDisplayName: String?
+    public let steps: [WearerTaskStep]
+    /// Tool calls left, this one included. Never zero — the loop stops rather than asking
+    /// for a turn it would not honor.
+    public let stepsRemaining: Int
+
+    public init(
+        goal: String,
+        mode: WearerTaskMode,
+        agentDisplayName: String? = nil,
+        steps: [WearerTaskStep],
+        stepsRemaining: Int
+    ) {
+        self.goal = goal
+        self.mode = mode
+        self.agentDisplayName = agentDisplayName
+        self.steps = steps
+        self.stepsRemaining = stepsRemaining
+    }
+}
+
+/// The model that drives the loop.
+///
+/// It throws for the reason ``BoundaryNarrating`` and ``WorkQuestionAnswering`` do: there is
+/// no local heuristic behind it, and a turn that cannot be decided must be loud enough for
+/// the caller to break the run's voice pipe. Same model family, same key, same endpoint,
+/// same timeout — one client family, so the failure posture cannot diverge.
+public protocol WearerTaskReasoning: Sendable {
+    func decide(_ request: WearerTaskTurnRequest) async throws -> WearerTaskDecision
+}
+
+/// What the loop sends and how it reads what comes back.
+///
+/// Separated from ``WearerTaskLoop`` so the bytes that cross the boundary have one place a
+/// test can read them from, and from ``OpenAINarrationModel`` so a second provider would
+/// send the same tools rather than its own dialect of them.
+public enum WearerTaskContract {
+    /// The rules the loop reasons under, in the task lane.
+    ///
+    /// Written for a model that has the goal and its own tool results and nothing else. Each
+    /// paragraph exists because of a specific way this can go wrong: talking the wearer
+    /// through steps they did not ask to hear, inventing an agent to instruct, treating a
+    /// question as permission to act, and running out of steps without saying so.
+    public static let taskInstructions = """
+        You are TapQ, a hands-free assistant a person wears while coding agents work for \
+        them. Their hands and eyes are busy and they cannot see a screen. They have handed \
+        you one goal out loud. You work on it by calling tools, one per turn, and you finish \
+        by calling finish.
+
+        Rules:
+
+        - Every turn is exactly one tool call. You have a small, fixed number of turns; the \
+        input tells you how many are left. Spend them on the goal.
+        - speak is for progress the wearer needs *while* you work — something changed, \
+        something is going to take a while. It is not narration of your own steps. Most \
+        tasks need none: say nothing and finish.
+        - finish ends the task and its summary is spoken aloud. Write speech, not prose: no \
+        markdown, no bullet points, no headings, no emoji, no stage directions. Lead with \
+        the answer or the outcome.
+        - If you run out of turns without calling finish, the wearer hears that you could \
+        not finish. Prefer finishing honestly one turn early over being cut off.
+        - Answer only from what your tools returned. Never infer what an agent probably did, \
+        never fill a gap from general knowledge, never describe work you did not see.
+        - Quote technical tokens exactly: file paths, command lines, flags, identifiers, \
+        error codes, test counts, version numbers. Never round a number and never abbreviate \
+        a path.
+        - Never read out anything that looks like a credential — an API key, a token, a \
+        password, a bearer string, a private key — even when the wearer asked for output \
+        word for word. Say the output contains a key and carry on with the rest.
+        - queue_instruction sends a sentence to a coding agent. It needs the agent's name, \
+        and the name must be one get_status listed as addressable right now. Never guess a \
+        name, never substitute an agent that happens to be live, and never send an \
+        instruction the wearer's goal did not ask for. Queuing authorizes nothing: whatever \
+        the agent then tries still asks the wearer for approval.
+        - ask_wearer asks the wearer a yes-or-no question and waits for them. Use it only \
+        when the goal genuinely cannot be carried out without their answer. If they do not \
+        answer, the task ends.
+        """
+
+    /// The rules for the question lane.
+    ///
+    /// Deliberately the four rules ``WorkAnswerContract/instructions`` already ratified for
+    /// `ask_about_work`, restated for a model that fetches its own evidence. Preserving them
+    /// word-for-word in substance is what keeps the M1 answer the wearer hears the same
+    /// answer after the fold-in: only *where the slices come from* changed.
+    public static let questionInstructions = """
+        You are the voice of TapQ, a hands-free assistant a person wears while a coding \
+        agent works for them. Their hands and eyes are busy; they cannot see a screen. They \
+        have asked you one question out loud. You gather what you need with read_transcript \
+        (the agent's own session history) and search_memory (TapQ's record of its \
+        conversation with the wearer), then you call finish with the single answer TapQ will \
+        speak.
+
+        Rules:
+
+        - Every turn is exactly one tool call, and you have very few turns. In most cases \
+        one lookup is enough; then finish.
+        - Your finish summary is spoken aloud word for word, so write speech, not prose: no \
+        markdown, no bullet points, no headings, no emoji, no stage directions.
+        - Answer only from what your tools returned. Never infer what the agent probably \
+        did, never fill a gap from general knowledge about the tools involved, and never \
+        describe work that is not in what you read.
+        - If what you read does not answer the question, say so plainly and briefly — "that \
+        isn't in what I can see of the session" — and stop. A short honest miss is worth \
+        more to someone who cannot look at a screen than a confident guess.
+        - Quote technical tokens exactly: file paths, command lines, flags, identifiers, \
+        error codes, test counts, version numbers. Never round a number, never abbreviate a \
+        path, never "fix" a spelling inside one. If a command is long, it is still better to \
+        say it than to describe it.
+        - Never read out anything that looks like a credential — an API key, a token, a \
+        password, a bearer string, a private key — even when asked to read output word for \
+        word. Say that the output contains a key and carry on with the rest of it.
+        - Keep it to what was asked. Lead with the answer, add only the detail that makes it \
+        usable, and do not offer to do anything further.
+        """
+
+    /// The instructions for one lane.
+    public static func instructions(for mode: WearerTaskMode) -> String {
+        switch mode {
+        case .task: return taskInstructions
+        case .question: return questionInstructions
+        }
+    }
+
+    /// The tools declared for one lane, in the order they are sent.
+    ///
+    /// The question lane declares three. That is the gate, and it is the same structural one
+    /// `ask_about_work` itself uses: a lane that cannot speak, cannot ask, and cannot queue
+    /// has no tool to disable — the authority is undeclared, not switched off. A question
+    /// resolves nothing, and a lane that could queue an instruction while answering one
+    /// would be exactly the authority the wearer did not hand over.
+    public static func tools(for mode: WearerTaskMode) -> [[String: Any]] {
+        switch mode {
+        case .question:
+            return [searchMemoryTool, readTranscriptTool, finishTool]
+        case .task:
+            return [
+                searchMemoryTool,
+                readTranscriptTool,
+                getStatusTool,
+                queueInstructionTool,
+                speakTool,
+                askWearerTool,
+                finishTool,
+            ]
+        }
+    }
+
+    /// One turn's input: the goal, the history, and the budget.
+    ///
+    /// Rendered rather than replayed as structured items so the whole of what crosses the
+    /// boundary is one string a test can assert on, and so the two lanes read the same way.
+    public static func input(for request: WearerTaskTurnRequest) -> String {
+        var lines: [String] = []
+        switch request.mode {
+        case .task:
+            lines.append("The wearer's goal, in their own words: \(request.goal)")
+        case .question:
+            if let agent = request.agentDisplayName, !agent.isEmpty {
+                lines.append("Agent: \(agent)")
+            }
+            lines.append("The wearer asked: \(request.goal)")
+        }
+        if request.steps.isEmpty {
+            lines.append("You have not called any tools yet.")
+        } else {
+            lines.append("What you have done so far, oldest first:")
+            for (offset, step) in request.steps.enumerated() {
+                lines.append("--- step \(offset + 1): \(step.tool)(\(step.arguments))")
+                lines.append(step.result)
+            }
+            lines.append("--- end of steps")
+        }
+        lines.append(budgetLine(remaining: request.stepsRemaining))
+        return lines.joined(separator: "\n")
+    }
+
+    /// How the budget is stated. Its own function because the last-turn wording is the one
+    /// sentence standing between a model that finishes and a wearer who hears "I couldn't
+    /// finish".
+    static func budgetLine(remaining: Int) -> String {
+        remaining <= 1
+            ? "This is your last turn. Call finish now — the wearer hears its summary."
+            : "You have \(remaining) turns left, this one included. Call finish before they "
+                + "run out."
+    }
+
+    /// Reads one function call into a decision, or throws.
+    ///
+    /// Throwing is the point. A name this lane never declared, or arguments that will not
+    /// parse, is the tool protocol being wrong — the same class of failure
+    /// `onIntentPipelineFailed` latches on, and the loop treats it exactly as it treats a
+    /// dropped connection: the run's voice breaks rather than continuing with a loop that is
+    /// inventing actions.
+    public static func decode(
+        name: String,
+        argumentsJSON: String,
+        mode: WearerTaskMode
+    ) throws -> WearerTaskDecision {
+        let decision = try decodeAnyDeclared(name: name, argumentsJSON: argumentsJSON)
+        guard tools(for: mode).contains(where: { ($0["name"] as? String) == name }) else {
+            throw NarrationFailure.transport(
+                "the model called \"\(name)\", which this lane does not declare"
+            )
+        }
+        return decision
+    }
+
+    private static func decodeAnyDeclared(
+        name: String,
+        argumentsJSON: String
+    ) throws -> WearerTaskDecision {
+        switch name {
+        case WearerTaskToolName.searchMemory:
+            let arguments: QueryArguments = try decodeArguments(argumentsJSON, tool: name)
+            return .searchMemory(query: try required(arguments.query, tool: name, field: "query"))
+        case WearerTaskToolName.readTranscript:
+            let arguments: ReadTranscriptArguments = try decodeArguments(argumentsJSON, tool: name)
+            return .readTranscript(
+                agent: cleaned(arguments.agent),
+                query: try required(arguments.query, tool: name, field: "query")
+            )
+        case WearerTaskToolName.getStatus:
+            return .getStatus
+        case WearerTaskToolName.queueInstruction:
+            let arguments: QueueArguments = try decodeArguments(argumentsJSON, tool: name)
+            return .queueInstruction(
+                agent: cleaned(arguments.agent),
+                text: try required(arguments.text, tool: name, field: "text")
+            )
+        case WearerTaskToolName.speak:
+            let arguments: TextArguments = try decodeArguments(argumentsJSON, tool: name)
+            return .speak(try required(arguments.text, tool: name, field: "text"))
+        case WearerTaskToolName.askWearer:
+            let arguments: QuestionArguments = try decodeArguments(argumentsJSON, tool: name)
+            return .askWearer(
+                question: try required(arguments.question, tool: name, field: "question")
+            )
+        case WearerTaskToolName.finish:
+            let arguments: SummaryArguments = try decodeArguments(argumentsJSON, tool: name)
+            return .finish(
+                summary: try required(arguments.summary, tool: name, field: "summary")
+            )
+        default:
+            throw NarrationFailure.transport(
+                "the model called an undeclared tool \"\(name)\""
+            )
+        }
+    }
+
+    private static func decodeArguments<T: Decodable>(
+        _ json: String,
+        tool: String
+    ) throws -> T {
+        let payload = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        let source = payload.isEmpty ? "{}" : payload
+        guard let data = source.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(T.self, from: data) else {
+            throw NarrationFailure.transport("\(tool) arguments could not be read")
+        }
+        return decoded
+    }
+
+    /// A required string argument, normalized, or a thrown protocol failure.
+    ///
+    /// Blank is a failure and not an empty call: every required argument here carries the
+    /// wearer's own words or the model's sentence, and a tool that fired with nothing in it
+    /// is a turn spent saying nothing — which, six of them in a row, is a task that ends in
+    /// "I couldn't finish" for no reason the wearer could act on.
+    private static func required(_ value: String?, tool: String, field: String) throws -> String {
+        let text = SpokenSummaryText.normalized(value ?? "")
+        guard !text.isEmpty else {
+            throw NarrationFailure.transport("\(tool) was called with an empty \(field)")
+        }
+        return text
+    }
+
+    private static func cleaned(_ value: String?) -> String? {
+        let text = SpokenSummaryText.normalized(value ?? "")
+        return text.isEmpty ? nil : text
+    }
+
+    // MARK: - Declarations
+
+    /// The Responses API's flat function shape: `type`/`name`/`description`/`parameters`.
+    /// Not the nested chat-completions one — the same endpoint choice the rest of this
+    /// client family already made.
+    private static func function(
+        _ name: String,
+        _ description: String,
+        properties: [String: Any] = [:],
+        required: [String] = []
+    ) -> [String: Any] {
+        [
+            "type": "function",
+            "name": name,
+            "description": description,
+            "parameters": [
+                "type": "object",
+                "properties": properties,
+                "required": required,
+                "additionalProperties": false,
+            ],
+        ]
+    }
+
+    private static let searchMemoryTool = function(
+        WearerTaskToolName.searchMemory,
+        """
+        Search TapQ's own memory: what the wearer has said to TapQ, what TapQ said back, \
+        what was decided, and which instructions went to which agent — across earlier voice \
+        sessions and restarts. Use it for "what did I ask you to do?", "did I approve that?", \
+        or anything about the conversation the two of you have had. It does not know what an \
+        agent did; that is read_transcript.
+        """,
+        properties: [
+            "query": [
+                "type": "string",
+                "description": "What to look for, in the wearer's own words where you have "
+                    + "them.",
+            ],
+        ],
+        required: ["query"]
+    )
+
+    private static let readTranscriptTool = function(
+        WearerTaskToolName.readTranscript,
+        """
+        Read a coding agent's own session history: what it ran, what a command printed, what \
+        it changed, what it found, what it said. Returns excerpts, not an answer — you write \
+        the answer. Use it for anything whose answer is inside the agent's session.
+        """,
+        properties: [
+            "agent": [
+                "type": "string",
+                "description": "The agent's name as the wearer said it, when they named one. "
+                    + "Omit it when they did not; never guess.",
+            ],
+            "query": [
+                "type": "string",
+                "description": "What to look for. The wearer's own words work best — the "
+                    + "excerpts are selected by matching them.",
+            ],
+        ],
+        required: ["query"]
+    )
+
+    private static let getStatusTool = function(
+        WearerTaskToolName.getStatus,
+        """
+        What TapQ itself knows right now: which agents are addressable by name, what is \
+        waiting on the wearer, and what this session has already decided or queued. Call it \
+        before queue_instruction to learn the names you may use. It answers from TapQ's own \
+        record, never from an agent's work.
+        """
+    )
+
+    private static let queueInstructionTool = function(
+        WearerTaskToolName.queueInstruction,
+        """
+        Send one sentence to a named coding agent, delivered at its next turn boundary. The \
+        name must be one get_status listed as addressable right now; an unknown or \
+        ambiguous name is refused. TapQ says out loud what it sent. This authorizes nothing \
+        — whatever the agent then tries still goes to the wearer for approval.
+        """,
+        properties: [
+            "agent": [
+                "type": "string",
+                "description": "The agent's display name, exactly as get_status listed it.",
+            ],
+            "text": [
+                "type": "string",
+                "description": "The instruction, in the wearer's own words where you have "
+                    + "them. Do not summarize or tidy a sentence they dictated.",
+            ],
+        ],
+        required: ["agent", "text"]
+    )
+
+    private static let speakTool = function(
+        WearerTaskToolName.speak,
+        """
+        Say one sentence to the wearer now, spoken word for word, and carry on working. For \
+        progress they need while you work — not for narrating your own steps, and not for \
+        the answer, which belongs in finish.
+        """,
+        properties: [
+            "text": [
+                "type": "string",
+                "description": "The exact words TapQ will speak. Plain spoken text.",
+            ],
+        ],
+        required: ["text"]
+    )
+
+    private static let askWearerTool = function(
+        WearerTaskToolName.askWearer,
+        """
+        Ask the wearer one yes-or-no question and wait for their answer. It goes out through \
+        the same prompt they answer every other question with, so they can nod, tap, or \
+        speak. Use it only when the goal cannot be carried out without their answer; if they \
+        do not answer, the task ends.
+        """,
+        properties: [
+            "question": [
+                "type": "string",
+                "description": "The question, phrased so that yes and no are both sensible "
+                    + "answers. Spoken word for word.",
+            ],
+        ],
+        required: ["question"]
+    )
+
+    private static let finishTool = function(
+        WearerTaskToolName.finish,
+        """
+        End the task. The summary is spoken to the wearer word for word — the answer, the \
+        outcome, or an honest account of what you could not find out. Always end this way.
+        """,
+        properties: [
+            "summary": [
+                "type": "string",
+                "description": "The exact words TapQ will speak. Plain spoken text.",
+            ],
+        ],
+        required: ["summary"]
+    )
+
+    // MARK: - Argument shapes
+
+    private struct QueryArguments: Decodable { let query: String? }
+    private struct ReadTranscriptArguments: Decodable {
+        let agent: String?
+        let query: String?
+    }
+    private struct QueueArguments: Decodable {
+        let agent: String?
+        let text: String?
+    }
+    private struct TextArguments: Decodable { let text: String? }
+    private struct QuestionArguments: Decodable { let question: String? }
+    private struct SummaryArguments: Decodable { let summary: String? }
+}

--- a/Sources/TapQContextBaseline/WearerTaskLoop.swift
+++ b/Sources/TapQContextBaseline/WearerTaskLoop.swift
@@ -1,0 +1,529 @@
+import Foundation
+import TapQContracts
+
+/// How one task ended, in the word the record keeps.
+///
+/// Five, and every one of them is audible except the two that cannot be: a run whose voice
+/// pipe just broke has nothing left to speak with, and a run being shut down has nobody left
+/// to speak to. Everything else the wearer hears.
+public enum WearerTaskOutcome: String, Sendable, Equatable {
+    /// The model called `finish`; its summary was spoken.
+    case finished
+    /// The step cap was reached without a `finish`. TapQ said so out loud.
+    case couldNotFinish = "could not finish"
+    /// `ask_wearer` got no answer inside the question machinery's own deadline. TapQ said so
+    /// out loud and stopped.
+    case unanswered
+    /// A cloud call failed. Nothing is spoken here — the voice latch speaks its own notice,
+    /// and a second sentence from TapQ would be a degraded answer on a path whose whole
+    /// posture is that there is no such thing.
+    case broken
+    /// The voice session or the runtime ended under the task. Silent by design: see
+    /// ``WearerTaskLoop/cancel(reason:)``.
+    case canceled
+}
+
+/// TapQ's deliberation tier: a bounded tool-executing loop that works on one goal the wearer
+/// handed over (`docs/TAPQ_AGENT_PLAN.md`, Pillar C, milestone M2).
+///
+/// ## Two lanes, split by who is waiting
+///
+/// - **The task lane** (``startTask(goal:)``, the `start_task` seam) runs *off* the voice
+///   turn. The call returns an acknowledgment immediately and the loop works in the
+///   background for up to ``taskStepCap`` steps, speaking only when it has something to say.
+///   One at a time: a goal offered while one is running is refused out loud, per
+///   ``TapQContracts/WearerTaskStart/busy(spoken:)``, rather than queued behind a task the
+///   wearer has probably stopped caring about.
+/// - **The question lane** (``answerWorkQuestion(question:agentDisplayName:)``) is
+///   `ask_about_work` folded in, which is Pillar B's one revision now that the loop exists:
+///   an answer can combine transcript slices with TapQ's own memory. It runs *inside* the
+///   realtime peer's tool call, which is the whole reason it is a separate lane — see the
+///   bounds on ``questionStepCap`` and ``questionWallClock``.
+///
+/// The question lane does not take the task slot and is not refused by one. It resolves
+/// nothing, declares three read-only tools, and cannot speak, ask, or queue; refusing to
+/// answer a question because a background task happened to be running would be a regression
+/// against the M1 behavior it replaces, for no safety gained.
+///
+/// ## Initiative is not here
+///
+/// M2 is wearer-initiated only. There is no timer, no event subscription, and no path by
+/// which this object starts a task nobody asked for — the two entry points above are both
+/// calls from the voice surface. Standing directives and boundary-review invocation are M3.
+///
+/// ## Failure posture, which is not negotiable
+///
+/// A cloud call that fails anywhere in either lane is a voice-pipeline failure: the task lane
+/// reports it through ``onLoopBroken`` (the composition latches it exactly as it latches
+/// narration and `ask_about_work`) and says nothing; the question lane returns
+/// ``TapQContracts/WorkQuestionOutcome/failed(_:)`` and the provider does the same. A local
+/// file that will not open is the other class entirely: error-level diagnostics, the model
+/// told plainly so it can be honest, and the session alive.
+///
+/// Diagnostics carry counts, names, and lengths. Never a goal, never an excerpt, never a
+/// sentence, never the key.
+@MainActor public final class WearerTaskLoop {
+    /// `nonisolated` throughout the constants below, for the reason
+    /// ``WearerConversationStore/fileName`` is: they are read at call sites that are not on
+    /// the main actor — a default argument, the recall renderer — and an isolated constant
+    /// would make a plain string into a hop.
+    ///
+    /// Six, from the plan. It is a cap on *model turns*, so the worst case is six times the
+    /// client's own per-call timeout — acceptable because nobody is parked: the wearer heard
+    /// an acknowledgment and went back to what they were doing.
+    public nonisolated static let taskStepCap = 6
+
+    /// Three. Enough to read the agent's transcript, search TapQ's memory, and answer from
+    /// both — which is exactly the capability the fold-in exists to add — and no more,
+    /// because the realtime peer is holding its tool call for every one of them.
+    public nonisolated static let questionStepCap = 3
+
+    /// The question lane's wall clock: past this, the loop stops asking for another turn.
+    ///
+    /// M1's direct path held the peer for one model call under a 15 s timeout. Three calls
+    /// cannot honor that, so this is the honest replacement rather than a pretence: after
+    /// 20 s no further turn is requested, which bounds the hold at 20 s plus one in-flight
+    /// call — about 35 s worst case, against a typical two calls of a few seconds each. The
+    /// alternative considered and rejected was answering the peer immediately and speaking
+    /// later: it would have left the realtime model free to talk over TapQ's own answer.
+    public nonisolated static let questionWallClock: TimeInterval = 20
+
+    /// Spoken when a goal arrives while one is already running.
+    public nonisolated static let busyNotice =
+        "I'm still on the last thing you asked — I'll tell you when it's done."
+
+    /// Spoken when `start_task` arrives with no goal in it. The same sentence a dictation
+    /// that captured silence gets, because from the wearer's side it is the same event.
+    public nonisolated static let emptyGoalNotice = "I didn't catch that — say it again."
+
+    /// What the wearer hears when the step cap runs out, per the plan's "never silent
+    /// abandonment". The goal is read back so they know *which* thing stalled.
+    public nonisolated static func couldNotFinishNotice(goal: String) -> String {
+        "I couldn't finish: " + spokenGoal(goal)
+    }
+
+    /// What the wearer hears when they never answered an `ask_wearer`.
+    public nonisolated static func unansweredNotice(goal: String) -> String {
+        "I asked you something and didn't hear back, so I've stopped: " + spokenGoal(goal)
+    }
+
+    /// The question lane's own last resort: no `finish`, and nothing local to blame.
+    public nonisolated static let couldNotAnswerNotice =
+        "I couldn't work that out in time — ask me again."
+
+    /// The acknowledgment. It reads the goal back, shortened, for the reason the dictation
+    /// read-back does: a wearer who cannot see a screen has no other way to find out that
+    /// TapQ heard something different from what they said. The *recorded* goal is the full
+    /// one; only the spoken copy is condensed.
+    public nonisolated static func acceptedNotice(goal: String) -> String {
+        "On it — " + spokenGoal(goal)
+    }
+
+    /// A wearer sentence in the length a spoken read-back can carry.
+    ///
+    /// Shortening a read-back is the established rule and this is the established cap:
+    /// NARRATION_MODEL_PLAN's rule 1 governs what reaches the *agent* — which is never
+    /// shortened, here or anywhere — and this reaches nobody but the wearer's ear. Public
+    /// because the composition's `queue_instruction` announcement reads a sentence back the
+    /// same way, and two read-backs at two lengths would be two behaviors.
+    public nonisolated static func spokenGoal(_ goal: String) -> String {
+        SpokenSummaryText.truncated(
+            SpokenSummaryText.normalized(goal),
+            limit: SpokenSummary.sentenceCharacterLimit
+        )
+    }
+
+    private let model: any WearerTaskReasoning
+    private let surfaces: WearerTaskSurfaces
+    private let stepCap: Int
+    private let questionCap: Int
+    private let wallClock: TimeInterval
+    private let diagnostics: TapQDiagnosticEmitter
+
+    /// A cloud call inside the loop failed. Wired by the composition to the same
+    /// `VoiceBrokenState` latch `onNarrationFailed`, `onScriptedSpeechUndeliverable`, and
+    /// `onWorkAnswerFailed` reach.
+    ///
+    /// Its own hook rather than a reuse of `onWorkAnswerFailed`, for the reason that one is
+    /// separate from the other two: an operator reading the log has to know whether TapQ
+    /// could not be heard, could not understand the wearer, could not answer a question, or
+    /// could not think.
+    public var onLoopBroken: (@MainActor (String) -> Void)?
+
+    private var running: Task<Void, Never>?
+    private var runningGoal: String?
+
+    public init(
+        model: any WearerTaskReasoning,
+        surfaces: WearerTaskSurfaces,
+        stepCap: Int = WearerTaskLoop.taskStepCap,
+        questionStepCap: Int = WearerTaskLoop.questionStepCap,
+        questionWallClock: TimeInterval = WearerTaskLoop.questionWallClock,
+        diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
+    ) {
+        self.model = model
+        self.surfaces = surfaces
+        self.stepCap = max(1, stepCap)
+        self.questionCap = max(1, questionStepCap)
+        self.wallClock = questionWallClock
+        self.diagnostics = TapQDiagnosticEmitter(category: "WearerTask", sink: diagnosticSink)
+    }
+
+    /// Whether a task is running right now. For tests and for the composition's teardown.
+    public var isBusy: Bool { running != nil }
+
+    // MARK: - The task lane
+
+    /// Takes a goal, or says why it did not.
+    ///
+    /// Returns as soon as the task is *started*, never when it is done: the wearer is at the
+    /// end of a voice turn and the realtime session must not be parked while TapQ thinks.
+    public func begin(goal: String) -> WearerTaskStart {
+        let goal = SpokenSummaryText.normalized(goal)
+        guard !goal.isEmpty else {
+            // The contract has two cases and this is neither's name, but it is the right
+            // behavior for both halves of what `busy` promises: nothing was started, and the
+            // wearer hears one sentence saying so. Flagged in the M2 report.
+            diagnostics.record("task.rejected", fields: ["reason": "empty_goal"])
+            return .busy(spoken: Self.emptyGoalNotice)
+        }
+        guard running == nil else {
+            diagnostics.record("task.busy", fields: ["goal_length": "\(goal.count)"])
+            return .busy(spoken: Self.busyNotice)
+        }
+
+        // Recorded before the first turn, and that ordering is the whole of "a restart
+        // mid-task loses the loop but not the record of what was asked". A goal recorded at
+        // the end would be a goal a crash erases.
+        surfaces.recordTask(goal, Self.startedOutcome)
+        diagnostics.record("task.started", fields: [
+            "goal_length": "\(goal.count)",
+            "steps": "\(stepCap)",
+        ])
+        runningGoal = goal
+        // Assigned before any suspension point, so `isBusy` is true the instant this
+        // returns and a second goal in the same turn is refused rather than raced.
+        running = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.runTask(goal: goal)
+            self.running = nil
+            self.runningGoal = nil
+        }
+        return .accepted(spoken: Self.acceptedNotice(goal: goal))
+    }
+
+    /// Ends the running task without speaking.
+    ///
+    /// Silent by design, and the design is that both callers are endings. The voice session
+    /// closing and the runtime shutting down both take away the channel a sentence would go
+    /// out on — `BackendSpeechSink` is being torn down in the same `defer` — so a spoken
+    /// "I've stopped" would at best be dropped and at worst be half-said over a closing
+    /// pipe. The record still gets the outcome, so a wearer who asks tomorrow finds out.
+    public func cancel(reason: String = "session ended") {
+        guard let task = running else { return }
+        diagnostics.record("task.canceled", fields: ["reason": reason])
+        task.cancel()
+        running = nil
+        runningGoal = nil
+    }
+
+    private func runTask(goal: String) async {
+        let started = ContinuousClock.now
+        var steps: [WearerTaskStep] = []
+
+        for step in 1...stepCap {
+            guard !Task.isCancelled else {
+                return end(goal: goal, outcome: .canceled, steps: steps.count, started: started)
+            }
+            let decision: WearerTaskDecision
+            do {
+                decision = try await model.decide(WearerTaskTurnRequest(
+                    goal: goal,
+                    mode: .task,
+                    steps: steps,
+                    stepsRemaining: stepCap - step + 1
+                ))
+            } catch {
+                return breakVoice(goal: goal, error: error, step: step,
+                                  steps: steps.count, started: started)
+            }
+            guard !Task.isCancelled else {
+                return end(goal: goal, outcome: .canceled, steps: steps.count, started: started)
+            }
+            diagnostics.record("task.step", fields: [
+                "n": "\(step)",
+                "tool": decision.toolName,
+            ])
+
+            switch decision {
+            case .finish(let summary):
+                surfaces.speak(summary)
+                return end(goal: goal, outcome: .finished, steps: step, started: started)
+
+            case .askWearer(let question):
+                let answer = await surfaces.askWearer(question)
+                guard !Task.isCancelled else {
+                    return end(goal: goal, outcome: .canceled, steps: step, started: started)
+                }
+                guard answer != .unanswered else {
+                    // The bound on a pause. The question machinery has its own deadline
+                    // (`InteractionBudget.total`), and a wearer who let it pass has moved on;
+                    // resuming into a seventh turn they are not listening to would be the
+                    // loop talking to itself. Audible, because "never silent abandonment"
+                    // covers this ending too.
+                    diagnostics.record("task.ask_unanswered", fields: ["n": "\(step)"])
+                    surfaces.speak(Self.unansweredNotice(goal: goal))
+                    return end(goal: goal, outcome: .unanswered, steps: step, started: started)
+                }
+                steps.append(WearerTaskStep(
+                    tool: decision.toolName,
+                    arguments: question,
+                    result: answer == .yes
+                        ? "The wearer answered yes."
+                        : "The wearer answered no."
+                ))
+
+            case .speak(let text):
+                surfaces.speak(text)
+                steps.append(WearerTaskStep(
+                    tool: decision.toolName,
+                    arguments: text,
+                    result: "Spoken to the wearer."
+                ))
+
+            default:
+                steps.append(perform(decision, speaking: true).step)
+            }
+        }
+
+        // The cap, spoken. Reached only when the model spent every turn on something other
+        // than `finish`, having been told on each of them how many were left.
+        surfaces.speak(Self.couldNotFinishNotice(goal: goal))
+        end(goal: goal, outcome: .couldNotFinish, steps: stepCap, started: started)
+    }
+
+    // MARK: - The question lane
+
+    /// Answers one `ask_about_work` question through the loop, so the answer can draw on the
+    /// agent's transcript *and* TapQ's own memory (`docs/TAPQ_AGENT_PLAN.md`, Pillar B's one
+    /// revision).
+    ///
+    /// The three outcomes are M1's, unchanged, and so is what the wearer hears in each:
+    /// ``TapQContracts/WorkQuestionOutcome/answered(_:)`` is spoken verbatim,
+    /// ``TapQContracts/WorkQuestionOutcome/unavailable(_:)`` is spoken and the session lives,
+    /// ``TapQContracts/WorkQuestionOutcome/failed(_:)`` says nothing and breaks the run's
+    /// voice. What changed is where the slices come from and how many model calls it takes.
+    ///
+    /// One widening, recorded honestly: `unavailable` now also carries "I couldn't work that
+    /// out in time", which is not a transcript that could not be read. It is the right
+    /// *handling* — spoken, error-logged, session alive — and the alternative, `failed`,
+    /// would break the wearer's voice channel over a slow think, which the ratified
+    /// two-class posture reserves for cloud calls that actually failed.
+    public func answerWorkQuestion(
+        question: String,
+        agentDisplayName: String?
+    ) async -> WorkQuestionOutcome {
+        let question = SpokenSummaryText.normalized(question)
+        diagnostics.record("task.question", fields: [
+            "question_length": "\(question.count)",
+            "agent_named": "\(agentDisplayName?.isEmpty == false)",
+            "steps": "\(questionCap)",
+        ])
+        guard !question.isEmpty else {
+            diagnostics.record("task.question_unavailable", level: .error,
+                               fields: ["reason": "empty"])
+            return .unavailable(TranscriptQuestionAnswerer.emptyNotice)
+        }
+
+        let started = ContinuousClock.now
+        var steps: [WearerTaskStep] = []
+        /// The last local problem a read reported, kept so a lane that runs out of room can
+        /// say the true thing rather than the generic one.
+        var lastLocalNotice: String?
+
+        for step in 1...questionCap {
+            if step > 1, started.seconds(elapsedTo: .now) >= wallClock {
+                diagnostics.record("task.question_deadline", level: .warning, fields: [
+                    "n": "\(step - 1)",
+                    "budget_s": "\(Int(wallClock))",
+                ])
+                break
+            }
+            let decision: WearerTaskDecision
+            do {
+                decision = try await model.decide(WearerTaskTurnRequest(
+                    goal: question,
+                    mode: .question,
+                    agentDisplayName: agentDisplayName,
+                    steps: steps,
+                    stepsRemaining: questionCap - step + 1
+                ))
+            } catch {
+                let reason = (error as? NarrationFailure)?.reason ?? "unknown"
+                diagnostics.record("task.question_failed", level: .error, fields: [
+                    "n": "\(step)",
+                    "reason": reason,
+                ])
+                // Deliberately not `onLoopBroken`: the provider breaks on a `failed`
+                // outcome through `onWorkAnswerFailed`, which is the seam an operator
+                // already reads for this question. Latching here as well would report one
+                // failure twice.
+                return .failed(reason)
+            }
+            diagnostics.record("task.step", fields: [
+                "n": "\(step)",
+                "tool": decision.toolName,
+            ])
+
+            if case .finish(let summary) = decision {
+                diagnostics.record("task.question_answered", fields: [
+                    "steps": "\(step)",
+                    "length": "\(summary.count)",
+                ])
+                return .answered(summary)
+            }
+            // Nothing else in this lane can speak: `speak`, `ask_wearer`, and
+            // `queue_instruction` are not declared for it, and a call for one of them was
+            // already rejected as a protocol failure by the decoder.
+            let run = perform(decision, speaking: false)
+            if let failure = run.output.localFailure {
+                lastLocalNotice = failure.wearerNotice
+            }
+            steps.append(run.step)
+        }
+
+        let notice = lastLocalNotice ?? Self.couldNotAnswerNotice
+        diagnostics.record("task.question_unavailable", level: .error, fields: [
+            "reason": lastLocalNotice == nil ? "no_finish" : "local",
+            "steps": "\(steps.count)",
+        ])
+        return .unavailable(notice)
+    }
+
+    // MARK: - Tool execution
+
+    /// Runs one non-terminal, non-speaking tool and renders the step the next turn reads.
+    ///
+    /// Both halves come back: the task lane uses the step, and the question lane also needs
+    /// the raw output, because a local failure's sentence is the one it will speak if it
+    /// runs out of room to say anything better.
+    ///
+    /// - Parameter speaking: whether an ``WearerTaskToolOutput/announce`` may go out. False
+    ///   in the question lane, which speaks nothing itself — its one sentence is the answer
+    ///   the provider speaks.
+    private func perform(
+        _ decision: WearerTaskDecision,
+        speaking: Bool
+    ) -> (step: WearerTaskStep, output: WearerTaskToolOutput) {
+        let arguments: String
+        let output: WearerTaskToolOutput
+        switch decision {
+        case .searchMemory(let query):
+            arguments = query
+            output = surfaces.searchMemory(query)
+        case .readTranscript(let agent, let query):
+            arguments = agent.map { "\($0), \(query)" } ?? query
+            output = surfaces.readTranscript(agent, query)
+        case .getStatus:
+            arguments = ""
+            output = surfaces.status()
+        case .queueInstruction(let agent, let text):
+            arguments = agent.map { "\($0), \(text)" } ?? text
+            output = surfaces.queueInstruction(agent, text)
+        case .speak, .askWearer, .finish:
+            // Unreachable: the three are handled by the task lane's own switch and are
+            // undeclared in the question lane. Rendered rather than trapped, because a trap
+            // inside a voice path is the one failure with no diagnostic at all.
+            arguments = ""
+            output = .ok("That tool is not available here.")
+        }
+
+        if let failure = output.localFailure {
+            // Error, not warning: the wearer asked for something and is going to get a
+            // thinner answer than they wanted because a file on this machine would not open.
+            diagnostics.record("task.tool_unavailable", level: .error, fields: [
+                "tool": decision.toolName,
+                "reason": failure.reason,
+            ])
+        }
+        if speaking, let announce = output.announce {
+            surfaces.speak(announce)
+        }
+        return (
+            WearerTaskStep(
+                tool: decision.toolName,
+                arguments: arguments,
+                result: output.text
+            ),
+            output
+        )
+    }
+
+    // MARK: - Endings
+
+    private func end(
+        goal: String,
+        outcome: WearerTaskOutcome,
+        steps: Int,
+        started: ContinuousClock.Instant
+    ) {
+        surfaces.recordTask(goal, outcome.rawValue)
+        diagnostics.record("task.finished", fields: [
+            "steps": "\(steps)",
+            "outcome": outcome.rawValue,
+            "duration_ms": Self.milliseconds(from: started),
+        ])
+    }
+
+    private func breakVoice(
+        goal: String,
+        error: any Error,
+        step: Int,
+        steps: Int,
+        started: ContinuousClock.Instant
+    ) {
+        let reason = (error as? NarrationFailure)?.reason ?? "unknown"
+        diagnostics.record("task.model_failed", level: .error, fields: [
+            "n": "\(step)",
+            "reason": reason,
+        ])
+        // Nothing is spoken. The latch this reaches speaks its own notice, and a sentence
+        // from TapQ saying "I couldn't think" would be the degraded half-agent the posture
+        // forbids.
+        onLoopBroken?(reason)
+        end(goal: goal, outcome: .broken, steps: steps, started: started)
+    }
+
+    /// The word the record keeps for a task that has begun but not ended. Its own constant
+    /// because a restart looking at the file has to be able to tell a task that was
+    /// interrupted from one that finished, and the difference is this string.
+    public nonisolated static let startedOutcome = "started"
+
+    private nonisolated static func milliseconds(from start: ContinuousClock.Instant) -> String {
+        let components = start.duration(to: .now).components
+        let milliseconds = Double(components.seconds) * 1_000
+            + Double(components.attoseconds) / 1e15
+        return String(format: "%.0f", milliseconds)
+    }
+}
+
+extension WearerTaskLoop: WearerTaskStarting {
+    /// The committed seam (``TapQContracts/WearerTaskStarting``).
+    ///
+    /// `nonisolated` and `async` so a caller on any actor can reach it: the body does nothing
+    /// but hop to the main actor, where every surface behind the loop already lives. Written
+    /// this way rather than as a bare `@MainActor` witness so the isolation of the
+    /// conformance is stated here rather than inferred.
+    public nonisolated func startTask(goal: String) async -> WearerTaskStart {
+        await MainActor.run { self.begin(goal: goal) }
+    }
+}
+
+extension ContinuousClock.Instant {
+    /// Seconds from this instant to `other`. The loop's own wall clock; the interaction
+    /// layer's `seconds(after:)` reads the other way round and lives in another target.
+    func seconds(elapsedTo other: ContinuousClock.Instant) -> TimeInterval {
+        let parts = duration(to: other).components
+        return Double(parts.seconds) + Double(parts.attoseconds) / 1e18
+    }
+}

--- a/Sources/TapQContextBaseline/WearerTaskSurfaces.swift
+++ b/Sources/TapQContextBaseline/WearerTaskSurfaces.swift
@@ -1,0 +1,152 @@
+import Foundation
+import TapQContracts
+
+/// A local file that would not answer, in the two vocabularies it needs.
+///
+/// A memory file that will not open or a transcript that rotated is a *local* problem:
+/// loud in the log at error level, honest in what the model is told, and emphatically not a
+/// reason to end the wearer's session (`docs/TAPQ_AGENT_PLAN.md`, failure posture). Only
+/// cloud calls break the voice.
+public struct WearerTaskLocalFailure: Sendable, Equatable {
+    /// Operator-facing, for the error-level diagnostic. Never wearer speech, never agent
+    /// output, never the key.
+    public let reason: String
+    /// The sentence TapQ would say about it. Carried rather than spoken on the spot: the
+    /// model has already been told, and in most cases it says something better in its own
+    /// summary. It becomes the spoken sentence only where nothing else will be said — see
+    /// ``WearerTaskLoop/answerWorkQuestion(question:agentDisplayName:)``.
+    public let wearerNotice: String
+
+    public init(reason: String, wearerNotice: String) {
+        self.reason = reason
+        self.wearerNotice = wearerNotice
+    }
+}
+
+/// What one internal tool answered.
+///
+/// Three fields rather than a string, because the loop has to do three different things
+/// with what a tool returns and only one of them is "hand it to the model":
+///
+/// - ``text`` is the model's, and only the model's. It is never spoken.
+/// - ``announce`` is the wearer's, spoken verbatim the moment the tool returns. It exists
+///   for one rule: an instruction the loop sent to an agent is audible, always. The wearer
+///   handed over a goal, not the right to have sentences delivered in their name without
+///   hearing about it.
+/// - ``localFailure`` is the operator's, and the fallback sentence if the task ends with
+///   nothing better to say.
+public struct WearerTaskToolOutput: Sendable, Equatable {
+    /// What the model reads. Always present — a tool that answered nothing still says so.
+    public let text: String
+    /// Spoken verbatim before the next turn, or `nil` when the tool has nothing the wearer
+    /// needs to hear.
+    public let announce: String?
+    /// Set when a local file could not be read.
+    public let localFailure: WearerTaskLocalFailure?
+
+    public init(
+        text: String,
+        announce: String? = nil,
+        localFailure: WearerTaskLocalFailure? = nil
+    ) {
+        self.text = text
+        self.announce = announce
+        self.localFailure = localFailure
+    }
+
+    /// A tool that worked.
+    public static func ok(_ text: String) -> WearerTaskToolOutput {
+        .init(text: text)
+    }
+
+    /// A tool that worked and did something the wearer must hear about.
+    public static func announcing(_ text: String, say notice: String) -> WearerTaskToolOutput {
+        .init(text: text, announce: notice)
+    }
+
+    /// A local file that would not answer. Loud, honest, and survivable.
+    ///
+    /// - Parameters:
+    ///   - reason: the operator's short reason, for the error-level diagnostic.
+    ///   - text: what the model is told, so it can be honest in its own words.
+    ///   - notice: the sentence TapQ says if nothing better gets said.
+    public static func localFailure(
+        _ reason: String, tellingModel text: String, saying notice: String
+    ) -> WearerTaskToolOutput {
+        .init(
+            text: text,
+            localFailure: WearerTaskLocalFailure(reason: reason, wearerNotice: notice)
+        )
+    }
+}
+
+/// How an `ask_wearer` ended.
+///
+/// The three cases are the three a ``TapQContracts/Decision`` already has, and that is not a
+/// coincidence: `ask_wearer` goes out through the runtime's existing question machinery, so
+/// its answers are that machinery's answers. ``unanswered`` covers every way the wearer did
+/// not say yes or no — the window timed out, they deferred to the screen, the prompt could
+/// not be delivered — because from the loop's side those are one fact.
+public enum WearerTaskWearerAnswer: Sendable, Equatable {
+    case yes
+    case no
+    /// No answer inside the question machinery's own deadline
+    /// (``TapQContracts/InteractionBudget/total``). The loop ends the task audibly on this;
+    /// see ``WearerTaskLoop``.
+    case unanswered
+}
+
+/// The tools, as closures the composition wires.
+///
+/// Closures rather than a protocol with seven methods for the reason every other seam on
+/// this path is one: the real implementations live in three different targets and one
+/// executable — the transcript store here, the roster and the mailbox in the CLI's
+/// conversation memory, the approval machinery in the interaction baseline — and an engine
+/// that named those types would drag the whole runtime into a portable target. The engine
+/// knows seven verbs; it does not know what is behind any of them.
+///
+/// Every closure is `@MainActor` because every surface behind it already is. None of them
+/// throws: a tool that failed says so in its ``WearerTaskToolOutput``, because a thrown
+/// error inside the loop would be indistinguishable from the one thing that *must* break the
+/// voice, which is a failed cloud call.
+public struct WearerTaskSurfaces {
+    /// Pillar A retrieval: TapQ's own dialogue with the wearer, older than the recent window.
+    public var searchMemory: @MainActor (_ query: String) -> WearerTaskToolOutput
+    /// Pillar B retrieval: excerpts from an agent's session history. Excerpts, not an answer
+    /// — the loop's own model writes the answer, which is what lets one turn combine a
+    /// transcript slice with something out of memory.
+    public var readTranscript:
+        @MainActor (_ agent: String?, _ query: String) -> WearerTaskToolOutput
+    /// Roster, waits, and queues, from the surfaces `query_status` already answers out of.
+    public var status: @MainActor () -> WearerTaskToolOutput
+    /// The existing instruction path, rung E name resolution and fail-closed refusal
+    /// included. The loop gets no authority the dictation flow does not have.
+    public var queueInstruction:
+        @MainActor (_ agent: String?, _ text: String) -> WearerTaskToolOutput
+    /// The scripted-speech channel, verbatim.
+    public var speak: @MainActor (_ text: String) -> Void
+    /// The existing question machinery. It suspends until the wearer answers or the window's
+    /// own deadline passes, which is what makes `ask_wearer` a pause the loop resumes from.
+    public var askWearer: @MainActor (_ question: String) async -> WearerTaskWearerAnswer
+    /// Records the task in Pillar A: the goal when it starts, the outcome when it ends. Only
+    /// speech-cleared text — never a tool payload, never an excerpt.
+    public var recordTask: @MainActor (_ goal: String, _ outcome: String) -> Void
+
+    public init(
+        searchMemory: @escaping @MainActor (String) -> WearerTaskToolOutput,
+        readTranscript: @escaping @MainActor (String?, String) -> WearerTaskToolOutput,
+        status: @escaping @MainActor () -> WearerTaskToolOutput,
+        queueInstruction: @escaping @MainActor (String?, String) -> WearerTaskToolOutput,
+        speak: @escaping @MainActor (String) -> Void,
+        askWearer: @escaping @MainActor (String) async -> WearerTaskWearerAnswer,
+        recordTask: @escaping @MainActor (String, String) -> Void
+    ) {
+        self.searchMemory = searchMemory
+        self.readTranscript = readTranscript
+        self.status = status
+        self.queueInstruction = queueInstruction
+        self.speak = speak
+        self.askWearer = askWearer
+        self.recordTask = recordTask
+    }
+}

--- a/Sources/TapQContracts/WearerTask.swift
+++ b/Sources/TapQContracts/WearerTask.swift
@@ -1,0 +1,26 @@
+/// The seam between the realtime voice surface and TapQ's deliberation loop
+/// (agent-plan Pillar C, milestone M2).
+///
+/// The realtime intent model keeps handling latency-critical, single-step
+/// intents directly — the reflex tier. Anything that needs knowledge or
+/// multiple steps is handed across this seam as a goal. The call returns
+/// immediately with a sentence for the wearer; the loop itself runs off the
+/// voice turn and speaks again on the scripted channel only when it has
+/// something to say.
+///
+/// One task runs at a time. A goal offered while one is running is not
+/// queued — the wearer hears that TapQ is busy and decides what to do.
+/// The caller speaks whichever sentence comes back, verbatim.
+public enum WearerTaskStart: Sendable, Equatable {
+    /// The loop took the task. The sentence acknowledges the goal out loud.
+    case accepted(spoken: String)
+    /// A task is already running; the goal was not queued. Spoken as-is.
+    case busy(spoken: String)
+}
+
+/// Implemented by the deliberation loop; consumed by the voice surface.
+/// The `start_task` realtime tool is declared only when an implementation
+/// is composed — on the Apple path none is, and the tool does not exist.
+public protocol WearerTaskStarting: Sendable {
+    func startTask(goal: String) async -> WearerTaskStart
+}

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -77,6 +77,22 @@ public enum SessionPolicy: Sendable, Equatable {
     /// on the first frame of the first session, so "is there a transcript?" has to be
     /// answered before this object exists rather than after.
     private let answerWorkQuestion: (@MainActor (String, String?) async -> WorkQuestionOutcome)?
+    /// TapQ's deliberation loop, or `nil` where none is composed.
+    ///
+    /// The seam of `docs/TAPQ_AGENT_PLAN.md` Pillar C, and it gates `start_task` on exactly
+    /// the terms `answerWorkQuestion` gates `ask_about_work`: with a loop the tool is declared
+    /// to every session this provider opens, and without one it does not exist on the wire.
+    /// An initializer parameter rather than a settable property for the same reason as well —
+    /// the declaration rides the first frame of the first session, so the question has to be
+    /// answered before this object exists.
+    ///
+    /// It is the protocol rather than a closure, unlike its neighbor, because the contract is
+    /// the protocol: `WearerTaskStarting` is what the other half of M2 implements and what
+    /// pins "one task at a time, the caller speaks what comes back". Nothing about a loop is
+    /// visible here beyond that one method — this provider hands over a sentence the wearer
+    /// said and gets back a sentence to say, and every later thing the loop speaks arrives on
+    /// the same scripted channel through composition, not through this reference.
+    private let startWearerTask: (any WearerTaskStarting)?
     /// Reports whether TapQ's own wearer turn signal is live. `nil` — the default, and every
     /// composition that predates the degrade path — means "assume it is", which keeps turn
     /// arbitration on TapQ's side exactly as it has always been.
@@ -266,6 +282,7 @@ public enum SessionPolicy: Sendable, Equatable {
                 answerWorkQuestion: (
                     @MainActor (String, String?) async -> WorkQuestionOutcome
                 )? = nil,
+                startWearerTask: (any WearerTaskStarting)? = nil,
                 monotonicNow: @escaping @MainActor () -> TimeInterval = {
                     ProcessInfo.processInfo.systemUptime
                 },
@@ -282,6 +299,7 @@ public enum SessionPolicy: Sendable, Equatable {
         self.freeformEnabled = freeformEnabled
         self.isWearerTurnSignalLive = isWearerTurnSignalLive
         self.answerWorkQuestion = answerWorkQuestion
+        self.startWearerTask = startWearerTask
         self.monotonicNow = monotonicNow
         self.idleSleep = idleSleep
         self.diagnostics = TapQDiagnosticEmitter(category: "VoiceBackend", sink: diagnosticSink)
@@ -296,7 +314,12 @@ public enum SessionPolicy: Sendable, Equatable {
                 // cannot. Decided here, once, for the same reason the set is declared here:
                 // a session that came up before the answer is known would either be missing
                 // the tool or offering one nothing can carry out.
-                includingAskAboutWork: answerWorkQuestion != nil
+                includingAskAboutWork: answerWorkQuestion != nil,
+                // And a seventh where a deliberation loop exists to hand a goal to. Its own
+                // gate, read at the same instant and for the same reason: a run with no loop
+                // has no seventh tool to disable, and the reflex six are untouched by whether
+                // it is there.
+                includingStartTask: startWearerTask != nil
             ))
         }
     }
@@ -1403,7 +1426,8 @@ public enum SessionPolicy: Sendable, Equatable {
         let resolution = VoiceIntentTools.resolve(
             call,
             windowOpen: handler != nil,
-            askAboutWorkDeclared: answerWorkQuestion != nil
+            askAboutWorkDeclared: answerWorkQuestion != nil,
+            startTaskDeclared: startWearerTask != nil
         )
         switch resolution {
         case .malformed(let detail):
@@ -1460,6 +1484,68 @@ public enum SessionPolicy: Sendable, Equatable {
                 let outcome = await answerWorkQuestion(question, agent)
                 self?.deliverWorkAnswer(outcome, callID: call.callID)
             }
+        case .startTask(let goal):
+            guard let startWearerTask else {
+                // Unreachable on the same terms as its neighbor above: `resolve` produces
+                // this case only when the tool was declared, and it is declared only when
+                // this seam exists. Answered and reported rather than trapped — a crash in a
+                // voice provider is the one failure mode that leaves no diagnostic at all.
+                backend.sendToolResult(callID: call.callID,
+                                       output: "That tool call could not be carried out.")
+                return failIntentPipeline("start_task with no deliberation loop composed")
+            }
+            // Length only, never the goal itself. The goal is the wearer's own sentence, and
+            // the log this provider writes has never held one.
+            diagnostics.record("tool.start_task_requested",
+                               fields: ["length": "\(goal.count)"])
+            // Fast by contract: the loop takes the goal or says it is busy, and either way
+            // hands back one sentence. Everything it does afterwards it does off this turn
+            // and speaks on the same scripted channel through composition, so nothing here
+            // waits for a task to finish. It is still a `Task`, because the seam is `async`
+            // and a provider that blocked the main actor on a loop's first step would stall
+            // the window it was called from.
+            //
+            // No window is resolved, before or after — see `deliverTaskStart`.
+            Task { @MainActor [weak self] in
+                let start = await startWearerTask.startTask(goal: goal)
+                self?.deliverTaskStart(start, callID: call.callID)
+            }
+        }
+    }
+
+    /// Speaks the loop's acknowledgment, whichever of the two it is.
+    ///
+    /// Both cases speak, and that is the whole of this method: `accepted` and `busy` are the
+    /// same event from the wearer's side — they said something and TapQ has to answer — and
+    /// the contract in `WearerTask.swift` is that the caller speaks the sentence it is given,
+    /// verbatim. There is no third case and no failure branch: a loop that cannot take a task
+    /// says so in the sentence, so nothing here can turn a busy loop into a broken run.
+    ///
+    /// Verbatim on the scripted channel, like every other TapQ sentence, and for the reason
+    /// `sendToolResult` makes unavoidable: no response follows a tool result, so a sentence
+    /// that lived only in the output would be one the wearer never hears.
+    private func deliverTaskStart(_ start: WearerTaskStart, callID: String) {
+        // The result first, then the sentence — the same order every other tool uses, so the
+        // peer is never parked while TapQ is talking.
+        switch start {
+        case .accepted(let spoken):
+            backend.sendToolResult(
+                callID: callID,
+                output: "TapQ has taken the task and told the wearer out loud. It is working "
+                    + "on it now and will speak again when it has something to say. Say "
+                    + "nothing further about it."
+            )
+            diagnostics.record("task.accepted", fields: ["length": "\(spoken.count)"])
+            speakScripted(spoken)
+        case .busy(let spoken):
+            backend.sendToolResult(
+                callID: callID,
+                output: "TapQ is already working on a task, so this goal was not started and "
+                    + "was not queued. The wearer has been told out loud. Say nothing "
+                    + "further about it."
+            )
+            diagnostics.record("task.busy", fields: ["length": "\(spoken.count)"])
+            speakScripted(spoken)
         }
     }
 

--- a/Sources/TapQInteractionBaseline/VoiceIntentTools.swift
+++ b/Sources/TapQInteractionBaseline/VoiceIntentTools.swift
@@ -52,8 +52,12 @@ public enum VoiceIntentTools {
     public static let queueInstruction = "queue_instruction"
     public static let queryStatus = "query_status"
     /// The sixth, and the only conditional one: declared only where a `TranscriptStore`
-    /// exists to answer from. See ``declarations(includingAskAboutWork:)``.
+    /// exists to answer from. See ``declarations(includingAskAboutWork:includingStartTask:)``.
     public static let askAboutWork = "ask_about_work"
+    /// The seventh, and the deliberation tier's only door. Declared only where a
+    /// `WearerTaskStarting` is composed — see
+    /// ``declarations(includingAskAboutWork:includingStartTask:)``.
+    public static let startTask = "start_task"
 
     /// The two questions `query_status` can be asked, matching the two informational intents
     /// the windows already answer. A closed set on the wire, so a third kind is refused by
@@ -112,7 +116,9 @@ public enum VoiceIntentTools {
                 answering a question. Pass their sentence through as they said it — do not \
                 summarize, translate, or tidy it. TapQ reads it back to them for confirmation \
                 before anything is sent, so a slightly wrong capture is recoverable and a \
-                rewritten one is not.
+                rewritten one is not. This sends one sentence and does nothing else, so a \
+                request TapQ would first have to find something out to carry out — what \
+                another agent just did, what a run produced — is not this tool.
                 """,
             parameters: [
                 VoiceToolParameter(
@@ -175,7 +181,10 @@ public enum VoiceIntentTools {
             this for anything whose answer is inside the agent's own session, and use \
             query_status instead for what is waiting on the wearer right now or what TapQ \
             has already decided. This resolves nothing: whatever the wearer was asked is \
-            still on the table afterwards, and asking never approves anything.
+            still on the table afterwards, and asking never approves anything. It only \
+            reads and answers, so a request to go and *do* something with what is found — \
+            run it, pass it on, watch for it — is not this tool, however much history TapQ \
+            would have to read to carry it out.
             """,
         parameters: [
             VoiceToolParameter(
@@ -198,6 +207,57 @@ public enum VoiceIntentTools {
         ]
     )
 
+    /// The deliberation tier's entry point (`docs/TAPQ_AGENT_PLAN.md`, Pillar C, milestone
+    /// M2), declared only where a loop exists to hand a goal to.
+    ///
+    /// Everything above it is the reflex tier and stays exactly as fast as it was: a spoken
+    /// "approve" resolves a window in the time one tool call takes, and nothing about this
+    /// seventh tool may put a loop in that path. What this one buys is the other half — a
+    /// request that takes several steps, or that TapQ has to go and find something out
+    /// before it can act on, which the six above can only refuse a piece at a time.
+    ///
+    /// Its description does the same job `ask_about_work`'s does, in the other direction,
+    /// and against a harder boundary: `queue_instruction` is also "the wearer said a
+    /// sentence to be acted on", and the difference is entirely whether one sentence sent
+    /// verbatim is the whole of it. So the description names the reflex tools it is not,
+    /// and says what the wearer gets back — an acknowledgment now, the work afterwards —
+    /// because a model that expected an answer here would sit waiting for one.
+    ///
+    /// It names no conditional tool, deliberately. `ask_about_work` is composed on its own
+    /// gate and may be absent from a run that has this one; a description that pointed at a
+    /// tool the session never declared would be an invitation to call it, and a call for an
+    /// undeclared name breaks the voice channel. The question boundary is therefore drawn by
+    /// behavior, exactly as `query_status` draws its half.
+    public static let startTaskDeclaration = VoiceToolDeclaration(
+        name: startTask,
+        description: """
+            The wearer wants something done that takes more than one step, or that TapQ has \
+            to look something up before it can do: "run the tests and let me know if \
+            anything fails", "tell Codex to do what Claude just did", "find out why the \
+            build broke and fix it". TapQ says out loud that it has taken the goal and \
+            works on it after this call returns, so no answer or result comes back here — \
+            do not wait for one and do not narrate what you think will happen. Use the \
+            direct tools instead for anything that is one step and immediate: approve, \
+            deny, select_item, one dictated sentence passed straight to an agent \
+            (queue_instruction), or what is waiting and what has changed (query_status). A \
+            question whose whole answer is already sitting in an agent's session history is \
+            a question, not a task. Starting a task authorizes nothing: anything it leads \
+            to still comes back to the wearer for approval.
+            """,
+        parameters: [
+            VoiceToolParameter(
+                name: "goal",
+                kind: .string,
+                description: """
+                    What the wearer wants done, in their own words, including any agent \
+                    names they said. Pass the whole request through — do not narrow it to \
+                    keywords, do not break it into steps, and do not answer any part of it \
+                    yourself.
+                    """
+            ),
+        ]
+    )
+
     /// The tool set for one composition.
     ///
     /// `ask_about_work` is present only when a `TranscriptStore` exists — that is, only on a
@@ -205,8 +265,17 @@ public enum VoiceIntentTools {
     /// declares five tools and has no sixth to disable, which is the same structural absence
     /// every other cloud-only pillar has: there is no flag, and a call for a tool that was
     /// never declared is a protocol failure rather than a feature that quietly worked.
-    public static func declarations(includingAskAboutWork: Bool) -> [VoiceToolDeclaration] {
-        includingAskAboutWork ? declarations + [askAboutWorkDeclaration] : declarations
+    ///
+    /// `start_task` is present on exactly the same terms and on its own gate: a composition
+    /// with a deliberation loop declares it, and one without does not have a seventh tool to
+    /// disable. The two gates are independent because the seams are — a run may be able to
+    /// read a transcript and have no loop, or the reverse — and neither implies the other.
+    public static func declarations(includingAskAboutWork: Bool,
+                                    includingStartTask: Bool = false) -> [VoiceToolDeclaration] {
+        var all = declarations
+        if includingAskAboutWork { all.append(askAboutWorkDeclaration) }
+        if includingStartTask { all.append(startTaskDeclaration) }
+        return all
     }
 
     /// What a provider should do about one tool call.
@@ -241,6 +310,16 @@ public enum VoiceIntentTools {
         /// resolving an approval by accident — the window this call arrived inside is left
         /// exactly as it was found.
         case answerWorkQuestion(question: String, agent: String?)
+        /// The wearer asked for something that takes deliberation. Nothing is resolved and no
+        /// window is touched; the caller hands the goal to the loop and speaks the sentence
+        /// the loop hands back.
+        ///
+        /// It is a sibling of `answerWorkQuestion` for the same reason that one is not a
+        /// `command`: there is no window intent it could carry. The five above all end in
+        /// something a window consumes, and these two end in a sentence. The difference
+        /// between the two of them is what happens after the sentence — a question is over,
+        /// and a task has only just started.
+        case startTask(goal: String)
         /// The call names a tool TapQ never declared, or its arguments cannot be read.
         ///
         /// Not a refusal: a refusal is a legal call that could not run, and this is the tool
@@ -287,6 +366,15 @@ public enum VoiceIntentTools {
     /// and the remedy is to say it again.
     public static let emptyQuestionNotice = emptyInstructionNotice
 
+    /// Spoken when `start_task` arrives carrying no goal.
+    ///
+    /// The third of the same sentence, and it stays the same sentence on purpose. The wearer
+    /// does not know which of the seven tools the model reached for; what happened to them is
+    /// that they spoke and nothing was heard, and the remedy has been "say it again" since the
+    /// Apple path. A distinct sentence here would be TapQ describing its own tool routing to
+    /// somebody who has no screen to see it on.
+    public static let emptyGoalNotice = emptyInstructionNotice
+
     /// Spoken when the model asks for a status TapQ does not keep.
     ///
     /// Names the two that exist, because unlike the entry above the remedy is a closed
@@ -304,16 +392,23 @@ public enum VoiceIntentTools {
     ///   that resolves *something* delivers through one — including `queue_instruction`,
     ///   whose read-back and fail-closed attribution check *are* the window's dictation
     ///   flow. Executing one without a window would not be a shortcut, it would be the
-    ///   instruction path with its confirmation removed. `ask_about_work` is the exception,
-    ///   and deliberately: it resolves nothing, so there is nothing for a window to receive,
-    ///   and an answer TapQ can speak on its own channel is not made safer by refusing it
-    ///   because a prompt happened to have closed a beat earlier.
+    ///   instruction path with its confirmation removed. `ask_about_work` and `start_task`
+    ///   are the exceptions, and deliberately: neither resolves anything, so there is nothing
+    ///   for a window to receive, and a sentence TapQ can speak on its own channel is not
+    ///   made safer by refusing it because a prompt happened to have closed a beat earlier.
     /// - Parameter askAboutWorkDeclared: whether this composition declared the transcript
     ///   tool. `false` — every Apple-path composition, and every cloud run with no
     ///   transcript attached — makes a call for it a protocol failure, exactly as any other
     ///   undeclared name is. That is the gate: not a disabled feature, an undeclared one.
+    /// - Parameter startTaskDeclared: whether this composition declared the deliberation
+    ///   tool. Its own gate, read exactly as the one above: `false` is every Apple-path
+    ///   composition and every cloud run with no loop, and a call for it there is the tool
+    ///   protocol being wrong rather than a loop that quietly did not run. `start_task` needs
+    ///   no window for the same reason `ask_about_work` does not — it resolves nothing, it
+    ///   delivers no command, and the sentence it produces goes out on TapQ's own channel.
     public static func resolve(_ call: VoiceToolCall, windowOpen: Bool,
-                               askAboutWorkDeclared: Bool = false) -> Resolution {
+                               askAboutWorkDeclared: Bool = false,
+                               startTaskDeclared: Bool = false) -> Resolution {
         switch call.name {
         case approve:
             return windowed(.yes, output: "Approved.", windowOpen: windowOpen,
@@ -404,6 +499,28 @@ public enum VoiceIntentTools {
                 .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .flatMap { $0.isEmpty ? nil : $0 }
             return .answerWorkQuestion(question: question, agent: agent)
+        case startTask:
+            // Same gate, same reading as above: undeclared here means this composition never
+            // put the tool on the wire, so a call for it is the protocol not being the one
+            // TapQ configured. A run with no loop has no deliberation tier to route into and
+            // must not pretend otherwise.
+            guard startTaskDeclared else {
+                return .malformed("the backend called an undeclared tool \"\(call.name)\"")
+            }
+            guard let arguments = decode(StartTaskArguments.self, from: call) else {
+                return .malformed("start_task arguments could not be read")
+            }
+            let goal = arguments.goal.trimmingCharacters(in: .whitespacesAndNewlines)
+            // A legal call that could not run, exactly like an empty dictation: refused out
+            // loud, and the session survives it. Nothing reaches the loop — a task with no
+            // goal is a loop spending its step budget on silence.
+            guard !goal.isEmpty else {
+                return .refused(
+                    output: "No goal was supplied, so no task was started.",
+                    speak: emptyGoalNotice
+                )
+            }
+            return .startTask(goal: goal)
         default:
             // A name TapQ never declared. The service refuses unknown tools before they are
             // sent, so reaching here means the tool protocol is not the one TapQ configured.
@@ -449,5 +566,9 @@ public enum VoiceIntentTools {
     private struct AskAboutWorkArguments: Decodable {
         let question: String
         let agent: String?
+    }
+
+    private struct StartTaskArguments: Decodable {
+        let goal: String
     }
 }

--- a/Tests/TapQBrokerRuntimeTests/TranscriptAttachmentTests.swift
+++ b/Tests/TapQBrokerRuntimeTests/TranscriptAttachmentTests.swift
@@ -91,9 +91,12 @@ final class TranscriptAttachmentTests: XCTestCase {
         let withPath = await server.handle(approval(transcriptPath: "/tmp/a.jsonl"))
         let without = await server.handle(approval())
 
-        XCTAssertEqual(withPath, without)
+        // Compare decoded, not bytes: macOS's JSONEncoder orders keys
+        // nondeterministically per encode, so two equal responses need not be
+        // byte-identical. The claim under test is about the decision.
         let decoded = try? JSONDecoder().decode(BrokerResponse.self, from: withPath)
         XCTAssertEqual(decoded, .decision(.deny, reason: "Denied via TapQ"))
+        XCTAssertEqual(decoded, try? JSONDecoder().decode(BrokerResponse.self, from: without))
     }
 
     // MARK: - Nothing to attach, or nobody to attach it to

--- a/Tests/TapQContextBaselineTests/OpenAITaskTurnTests.swift
+++ b/Tests/TapQContextBaselineTests/OpenAITaskTurnTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+import TapQContracts
+@testable import TapQContextBaseline
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// The loop's turn, over the wire: the third method on the narration client.
+///
+/// Two things are being defended. The request shape — Responses API function tools, the same
+/// endpoint, key, and timeout race as narration and `ask_about_work` — because "one client
+/// family" is what keeps the failure posture from diverging. And the decode, because a turn
+/// that came back as prose, as a refusal, or as two calls at once is the tool protocol being
+/// wrong, and this path answers that the way every other one does: loudly, so the run's voice
+/// breaks rather than continuing with a loop inventing actions.
+final class OpenAITaskTurnTests: XCTestCase {
+    private static let request = WearerTaskTurnRequest(
+        goal: "check whether the tests passed",
+        mode: .task,
+        steps: [],
+        stepsRemaining: 6
+    )
+
+    // MARK: - Wire shape
+
+    func testATurnSendsFunctionToolsOnTheNarrationEndpoint() async throws {
+        let model = makeModel { request in
+            XCTAssertEqual(request.url, OpenAINarrationModel.defaultEndpoint)
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Authorization"), "Bearer test-key"
+            )
+
+            let body = try XCTUnwrap(request.httpBody)
+            let json = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: body) as? [String: Any]
+            )
+            XCTAssertEqual(json["model"] as? String, OpenAINarrationModel.defaultModel)
+            XCTAssertEqual(json["store"] as? Bool, false)
+            XCTAssertEqual(json["tool_choice"] as? String, "required")
+            let reasoning = try XCTUnwrap(json["reasoning"] as? [String: Any])
+            XCTAssertEqual(reasoning["effort"] as? String, "none")
+            // Tools, not a strict text schema: a turn produces a choice among tools.
+            XCTAssertNil(json["text"])
+            let tools = try XCTUnwrap(json["tools"] as? [[String: Any]])
+            XCTAssertEqual(tools.compactMap { $0["name"] as? String }, [
+                "search_memory", "read_transcript", "get_status", "queue_instruction",
+                "speak", "ask_wearer", "finish",
+            ])
+            let input = try XCTUnwrap(json["input"] as? String)
+            XCTAssertTrue(input.contains("check whether the tests passed"), input)
+
+            return try self.functionCall(
+                name: "read_transcript", arguments: #"{"query":"tests"}"#
+            )
+        }
+
+        let decision = try await model.decide(Self.request)
+        XCTAssertEqual(decision, .readTranscript(agent: nil, query: "tests"))
+    }
+
+    func testTheQuestionLaneSendsOnlyItsThreeTools() async throws {
+        let model = makeModel { request in
+            let body = try XCTUnwrap(request.httpBody)
+            let json = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: body) as? [String: Any]
+            )
+            let tools = try XCTUnwrap(json["tools"] as? [[String: Any]])
+            XCTAssertEqual(tools.compactMap { $0["name"] as? String },
+                           ["search_memory", "read_transcript", "finish"])
+            return try self.functionCall(
+                name: "finish", arguments: #"{"summary":"All green."}"#
+            )
+        }
+
+        let decision = try await model.decide(WearerTaskTurnRequest(
+            goal: "what did the tests say?",
+            mode: .question,
+            agentDisplayName: "Claude Code",
+            steps: [],
+            stepsRemaining: 3
+        ))
+        XCTAssertEqual(decision, .finish(summary: "All green."))
+    }
+
+    // MARK: - Decode failures
+
+    func testATurnThatCameBackAsProseIsAProtocolFailure() async throws {
+        let model = makeModel { _ in try self.textResponse("I would read the transcript.") }
+        await assertThrows(model, containing: "no tool call")
+    }
+
+    func testATurnCarryingTwoToolCallsIsAProtocolFailure() async throws {
+        // Taking the first and dropping the second would silently discard an action the
+        // model believed it had taken.
+        let model = makeModel { _ in
+            try self.response(output: [
+                self.callItem(name: "get_status", arguments: "{}"),
+                self.callItem(name: "finish", arguments: #"{"summary":"done"}"#),
+            ])
+        }
+        await assertThrows(model, containing: "2 tool calls")
+    }
+
+    func testARefusalIsAProtocolFailure() async throws {
+        let model = makeModel { _ in
+            try self.response(output: [[
+                "type": "message",
+                "content": [["type": "refusal", "text": "no"]],
+            ]])
+        }
+        await assertThrows(model, containing: "malformed")
+    }
+
+    func testAnIncompleteResponseIsAProtocolFailure() async throws {
+        let model = makeModel { _ in
+            let body: [String: Any] = [
+                "status": "incomplete",
+                "error": NSNull(),
+                "incomplete_details": ["reason": "max_output_tokens"],
+                "output": [],
+            ]
+            return (
+                try JSONSerialization.data(withJSONObject: body),
+                HTTPURLResponse(
+                    url: OpenAINarrationModel.defaultEndpoint,
+                    statusCode: 200, httpVersion: nil, headerFields: nil
+                )!
+            )
+        }
+        await assertThrows(model, containing: "malformed")
+    }
+
+    func testAnHTTPErrorThrowsTheSameFailureNarrationThrows() async throws {
+        let model = makeModel { _ in
+            (
+                Data(),
+                HTTPURLResponse(
+                    url: OpenAINarrationModel.defaultEndpoint,
+                    statusCode: 503, httpVersion: nil, headerFields: nil
+                )!
+            )
+        }
+        do {
+            _ = try await model.decide(Self.request)
+            XCTFail("expected a thrown failure")
+        } catch let failure as NarrationFailure {
+            XCTAssertEqual(failure, .http(status: 503))
+        }
+    }
+
+    func testATurnNamingATheUndeclaredToolIsAProtocolFailure() async throws {
+        let model = makeModel { _ in
+            try self.functionCall(name: "approve", arguments: "{}")
+        }
+        await assertThrows(model, containing: "undeclared")
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrows(
+        _ model: OpenAINarrationModel,
+        containing fragment: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await model.decide(Self.request)
+            XCTFail("expected a thrown failure", file: file, line: line)
+        } catch let failure as NarrationFailure {
+            XCTAssertTrue(failure.reason.contains(fragment),
+                          failure.reason, file: file, line: line)
+        } catch {
+            XCTFail("unexpected error \(error)", file: file, line: line)
+        }
+    }
+
+    private func makeModel(
+        send: @escaping OpenAINarrationModel.HTTPSender
+    ) -> OpenAINarrationModel {
+        OpenAINarrationModel(
+            apiKey: "test-key",
+            model: OpenAINarrationModel.defaultModel,
+            endpoint: OpenAINarrationModel.defaultEndpoint,
+            timeout: 1,
+            diagnosticSink: NoOpTapQDiagnosticSink(),
+            send: send
+        )
+    }
+
+    private func callItem(name: String, arguments: String) -> [String: Any] {
+        [
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": name,
+            "arguments": arguments,
+        ]
+    }
+
+    private func functionCall(
+        name: String, arguments: String
+    ) throws -> (Data, HTTPURLResponse) {
+        try response(output: [callItem(name: name, arguments: arguments)])
+    }
+
+    private func textResponse(_ text: String) throws -> (Data, HTTPURLResponse) {
+        try response(output: [[
+            "type": "message",
+            "content": [["type": "output_text", "text": text]],
+        ]])
+    }
+
+    private func response(output: [[String: Any]]) throws -> (Data, HTTPURLResponse) {
+        let body: [String: Any] = [
+            "status": "completed",
+            "error": NSNull(),
+            "incomplete_details": NSNull(),
+            "output": output,
+        ]
+        return (
+            try JSONSerialization.data(withJSONObject: body),
+            HTTPURLResponse(
+                url: OpenAINarrationModel.defaultEndpoint,
+                statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+        )
+    }
+}

--- a/Tests/TapQContextBaselineTests/WearerMemorySearchTests.swift
+++ b/Tests/TapQContextBaselineTests/WearerMemorySearchTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import TapQContextBaseline
+import TapQContracts
+
+/// Pillar A's per-question retrieval — the half M1 deferred to the loop.
+///
+/// The property worth defending is that this reaches *past* the recent window. M1's grounding
+/// carries the last dozen entries unranked; if this suite ever ends up proving that the newest
+/// entries come back first, the retrieval has become a second copy of the window and the loop
+/// has lost the only thing it could look up that the realtime session could not.
+@MainActor
+final class WearerMemorySearchTests: XCTestCase {
+    private func entry(
+        _ kind: WearerDialogueKind,
+        _ text: String,
+        minutesAgo: Int,
+        agent: String = "",
+        outcome: String = "",
+        tool: String = ""
+    ) -> WearerDialogueEntry {
+        WearerDialogueEntry(
+            kind: kind,
+            timestamp: Date(timeIntervalSince1970: 1_000_000)
+                .addingTimeInterval(TimeInterval(-minutesAgo * 60)),
+            text: text,
+            agentDisplayName: agent,
+            outcome: outcome,
+            toolName: tool
+        )
+    }
+
+    private var now: Date { Date(timeIntervalSince1970: 1_000_000) }
+
+    func testRelevanceReachesPastTheRecentWindow() async {
+        var entries = [
+            entry(.wearerSaid, "should we do the database migration this week?",
+                  minutesAgo: 4_000),
+        ]
+        // Twenty newer entries about something else, which is more than the recent window
+        // holds — so a recency-first selector would bury the one that answers.
+        for index in 0..<20 {
+            entries.append(entry(.tapqSaid, "Claude Code finished a turn number \(index)",
+                                 minutesAgo: 20 - index))
+        }
+
+        let found = WearerMemorySearch.search(
+            entries: entries, query: "what did I say about the migration?", now: now
+        )
+
+        XCTAssertEqual(found.matches.count, 1)
+        XCTAssertEqual(found.matches.first?.index, 1)
+        XCTAssertTrue(found.text.contains("should we do the database migration"), found.text)
+        XCTAssertTrue(found.text.contains("2 days ago"), found.text)
+        XCTAssertEqual(found.droppedEntries, 20)
+    }
+
+    func testAnEntryMatchesOnItsAgentAndToolAsWellAsItsText() async {
+        let entries = [
+            entry(.decision, "run the tests", minutesAgo: 90,
+                  agent: "Codex", outcome: "approved", tool: "Bash"),
+            entry(.wearerSaid, "unrelated chatter", minutesAgo: 5),
+        ]
+
+        let byAgent = WearerMemorySearch.search(
+            entries: entries, query: "what did I tell Codex?", now: now
+        )
+        XCTAssertEqual(byAgent.matches.map(\.index), [1])
+
+        let byTool = WearerMemorySearch.search(
+            entries: entries, query: "did I approve the Bash one?", now: now
+        )
+        XCTAssertEqual(byTool.matches.map(\.index), [1])
+        XCTAssertTrue(byTool.text.contains("approved Bash for Codex: run the tests"),
+                      byTool.text)
+    }
+
+    func testMatchesAreRenderedOldestFirstWhateverOrderTheyRankedIn() async {
+        let entries = [
+            entry(.wearerSaid, "start the migration", minutesAgo: 300),
+            entry(.tapqSaid, "unrelated", minutesAgo: 200),
+            entry(.wearerSaid, "is the migration done?", minutesAgo: 100),
+        ]
+
+        let found = WearerMemorySearch.search(
+            entries: entries, query: "migration", now: now
+        )
+
+        XCTAssertEqual(found.matches.map(\.index), [1, 3])
+        let first = found.text.range(of: "start the migration")
+        let second = found.text.range(of: "is the migration done?")
+        XCTAssertNotNil(first)
+        XCTAssertNotNil(second)
+        XCTAssertTrue(first!.lowerBound < second!.lowerBound, found.text)
+    }
+
+    func testAQueryWithNothingToMatchOnFallsBackToTheRecentPast() async {
+        let entries = (0..<5).map { entry(.wearerSaid, "line \($0)", minutesAgo: 50 - $0) }
+
+        // Every word is a stop word: this is not a miss, it is a request for the recent past,
+        // and answering "nothing matches" would be TapQ pretending not to remember a
+        // conversation it has on disk.
+        let found = WearerMemorySearch.search(
+            entries: entries, query: "what did you just say?", now: now
+        )
+
+        XCTAssertEqual(found.matches.count, 5)
+        XCTAssertTrue(found.text.contains("No word in the query matched"), found.text)
+    }
+
+    func testNoMatchAndNoMemoryAreDifferentSentences() async {
+        XCTAssertEqual(
+            WearerMemorySearch.search(entries: [], query: "anything", now: now).text,
+            WearerMemorySearch.emptyMemoryText
+        )
+        let entries = [entry(.wearerSaid, "run the tests", minutesAgo: 10)]
+        XCTAssertEqual(
+            WearerMemorySearch.search(
+                entries: entries, query: "kubernetes ingress", now: now
+            ).text,
+            WearerMemorySearch.noMatchesText
+        )
+    }
+
+    func testTheResultIsBoundedByCountAndByCharacters() async {
+        let entries = (0..<60).map {
+            entry(.wearerSaid, "migration note \($0)", minutesAgo: 500 - $0)
+        }
+
+        let capped = WearerMemorySearch.search(
+            entries: entries, query: "migration", now: now, limit: 5
+        )
+        XCTAssertEqual(capped.matches.count, 5)
+        XCTAssertEqual(capped.droppedEntries, 55)
+
+        let squeezed = WearerMemorySearch.search(
+            entries: entries, query: "migration", now: now, budget: 120
+        )
+        XCTAssertLessThanOrEqual(squeezed.matches.count, 3)
+        XCTAssertGreaterThan(squeezed.matches.count, 0)
+    }
+
+    func testAgesAreSpokenShaped() async {
+        XCTAssertEqual(WearerMemorySearch.age(of: now, now: now), "just now")
+        XCTAssertEqual(
+            WearerMemorySearch.age(of: now.addingTimeInterval(-60), now: now), "1 minute ago"
+        )
+        XCTAssertEqual(
+            WearerMemorySearch.age(of: now.addingTimeInterval(-3_600), now: now), "1 hour ago"
+        )
+        XCTAssertEqual(
+            WearerMemorySearch.age(of: now.addingTimeInterval(-172_800), now: now),
+            "2 days ago"
+        )
+        // A clock that went backwards is not a reason to say "-3 minutes ago".
+        XCTAssertEqual(
+            WearerMemorySearch.age(of: now.addingTimeInterval(180), now: now), "just now"
+        )
+    }
+
+    func testATaskEntryReadsAsItselfRatherThanAsAnUnknownKind() async {
+        let entries = [
+            entry(.task, "check whether the tests passed", minutesAgo: 30,
+                  outcome: WearerTaskLoop.startedOutcome),
+            entry(.task, "check whether the tests passed", minutesAgo: 29,
+                  outcome: WearerTaskOutcome.finished.rawValue),
+        ]
+
+        let found = WearerMemorySearch.search(entries: entries, query: "tests", now: now)
+
+        XCTAssertTrue(
+            found.text.contains("The wearer asked TapQ to: check whether the tests passed"),
+            found.text
+        )
+        XCTAssertTrue(
+            found.text.contains("TapQ's task (finished): check whether the tests passed"),
+            found.text
+        )
+    }
+}

--- a/Tests/TapQContextBaselineTests/WearerTaskContractTests.swift
+++ b/Tests/TapQContextBaselineTests/WearerTaskContractTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+@testable import TapQContextBaseline
+import TapQContracts
+
+/// What the loop sends and how it reads what comes back.
+///
+/// The decoding half is where the loop's authority is actually enforced — a tool the lane
+/// never declared has to be a protocol failure, not a call that quietly does nothing — so
+/// most of this suite is about what is refused.
+@MainActor
+final class WearerTaskContractTests: XCTestCase {
+    func testTheTaskLaneDeclaresExactlyTheSevenToolsThePlanNames() async {
+        let names = WearerTaskContract.tools(for: .task).compactMap { $0["name"] as? String }
+        XCTAssertEqual(names, [
+            "search_memory", "read_transcript", "get_status", "queue_instruction",
+            "speak", "ask_wearer", "finish",
+        ])
+        // The Responses API's flat function shape, not the nested chat-completions one.
+        for tool in WearerTaskContract.tools(for: .task) {
+            XCTAssertEqual(tool["type"] as? String, "function")
+            XCTAssertNotNil(tool["description"] as? String)
+            XCTAssertNotNil(tool["parameters"] as? [String: Any])
+        }
+    }
+
+    func testEveryDeclaredToolDecodesFromTheArgumentsAModelWouldSend() async throws {
+        XCTAssertEqual(
+            try WearerTaskContract.decode(
+                name: "search_memory", argumentsJSON: #"{"query":"the migration"}"#, mode: .task
+            ),
+            .searchMemory(query: "the migration")
+        )
+        XCTAssertEqual(
+            try WearerTaskContract.decode(
+                name: "read_transcript",
+                argumentsJSON: #"{"agent":"Codex","query":"tests"}"#,
+                mode: .task
+            ),
+            .readTranscript(agent: "Codex", query: "tests")
+        )
+        // A parameterless tool decodes whichever way the service spells "no arguments".
+        XCTAssertEqual(
+            try WearerTaskContract.decode(name: "get_status", argumentsJSON: "", mode: .task),
+            .getStatus
+        )
+        XCTAssertEqual(
+            try WearerTaskContract.decode(name: "get_status", argumentsJSON: "{}", mode: .task),
+            .getStatus
+        )
+        XCTAssertEqual(
+            try WearerTaskContract.decode(
+                name: "queue_instruction",
+                argumentsJSON: #"{"agent":"Codex","text":"rerun it"}"#,
+                mode: .task
+            ),
+            .queueInstruction(agent: "Codex", text: "rerun it")
+        )
+        XCTAssertEqual(
+            try WearerTaskContract.decode(
+                name: "finish", argumentsJSON: #"{"summary":"All green."}"#, mode: .task
+            ),
+            .finish(summary: "All green.")
+        )
+    }
+
+    func testAnOmittedAgentIsNilRatherThanAnEmptyName() async throws {
+        XCTAssertEqual(
+            try WearerTaskContract.decode(
+                name: "read_transcript", argumentsJSON: #"{"query":"tests"}"#, mode: .task
+            ),
+            .readTranscript(agent: nil, query: "tests")
+        )
+        // A blank one is the same fact and must not reach the resolver as a name.
+        XCTAssertEqual(
+            try WearerTaskContract.decode(
+                name: "queue_instruction",
+                argumentsJSON: #"{"agent":"   ","text":"rerun it"}"#,
+                mode: .task
+            ),
+            .queueInstruction(agent: nil, text: "rerun it")
+        )
+    }
+
+    func testAnUndeclaredToolIsAProtocolFailure() async {
+        XCTAssertThrowsError(try WearerTaskContract.decode(
+            name: "approve", argumentsJSON: "{}", mode: .task
+        )) { error in
+            // Same class as an undeclared realtime tool: the run's voice breaks rather than
+            // continuing with a loop that is inventing actions.
+            XCTAssertTrue("\(error)".contains("undeclared"), "\(error)")
+        }
+    }
+
+    func testArgumentsThatWillNotParseAreAProtocolFailure() async {
+        XCTAssertThrowsError(try WearerTaskContract.decode(
+            name: "finish", argumentsJSON: "not json", mode: .task
+        ))
+        // A required field that arrived blank is a turn spent saying nothing.
+        XCTAssertThrowsError(try WearerTaskContract.decode(
+            name: "speak", argumentsJSON: #"{"text":"   "}"#, mode: .task
+        ))
+        XCTAssertThrowsError(try WearerTaskContract.decode(
+            name: "search_memory", argumentsJSON: "{}", mode: .task
+        ))
+    }
+
+    func testTheRenderedTurnCarriesTheGoalTheHistoryAndTheBudget() async {
+        let request = WearerTaskTurnRequest(
+            goal: "check whether the tests passed",
+            mode: .task,
+            steps: [
+                WearerTaskStep(tool: "read_transcript", arguments: "Codex, tests",
+                               result: "Session history: 385 tests."),
+            ],
+            stepsRemaining: 4
+        )
+        let input = WearerTaskContract.input(for: request)
+        XCTAssertTrue(input.contains("The wearer's goal, in their own words: check whether "
+            + "the tests passed"), input)
+        XCTAssertTrue(input.contains("--- step 1: read_transcript(Codex, tests)"), input)
+        XCTAssertTrue(input.contains("Session history: 385 tests."), input)
+        XCTAssertTrue(input.contains("You have 4 turns left"), input)
+    }
+
+    func testAFirstTurnSaysSoRatherThanRenderingAnEmptyHistory() async {
+        let input = WearerTaskContract.input(for: WearerTaskTurnRequest(
+            goal: "watch the build", mode: .task, steps: [], stepsRemaining: 6
+        ))
+        XCTAssertTrue(input.contains("You have not called any tools yet."), input)
+    }
+
+    func testTheQuestionLaneRendersLikeTheM1AnswerPrompt() async {
+        let input = WearerTaskContract.input(for: WearerTaskTurnRequest(
+            goal: "what did the tests say?",
+            mode: .question,
+            agentDisplayName: "Claude Code",
+            steps: [],
+            stepsRemaining: 3
+        ))
+        XCTAssertTrue(input.contains("Agent: Claude Code"), input)
+        XCTAssertTrue(input.contains("The wearer asked: what did the tests say?"), input)
+    }
+
+    func testTheQuestionLaneKeepsTheM1AnswerRules() async {
+        // Not the same string as `WorkAnswerContract.instructions` — the lane fetches its own
+        // evidence — but the four rules that made an M1 answer trustworthy are all still
+        // stated, and a future edit that drops one should fail here.
+        let rules = WearerTaskContract.questionInstructions
+        XCTAssertTrue(rules.contains("Answer only from what your tools returned"), rules)
+        XCTAssertTrue(rules.contains("isn't in what I can see of the session"), rules)
+        XCTAssertTrue(rules.contains("Quote technical tokens exactly"), rules)
+        XCTAssertTrue(rules.contains("looks like a credential"), rules)
+        XCTAssertTrue(rules.contains("spoken aloud word for word"), rules)
+    }
+
+    func testExcerptsRenderLikeTheAnswerPromptsHistoryBlock() async {
+        let rendered = TranscriptExcerpts.rendered(
+            slices: [
+                WorkQuestionSlice(index: 3, text: "assistant: ran swift build"),
+                WorkQuestionSlice(index: 7, text: "tool: 0 errors"),
+            ],
+            agentDisplayName: "Claude Code"
+        )
+        XCTAssertTrue(rendered.contains("Agent: Claude Code"), rendered)
+        XCTAssertTrue(rendered.contains("2 excerpts, not necessarily contiguous"), rendered)
+        XCTAssertTrue(rendered.contains("--- excerpt 3"), rendered)
+        XCTAssertTrue(rendered.contains("--- excerpt 7"), rendered)
+        XCTAssertTrue(rendered.hasSuffix("--- end of history"), rendered)
+    }
+}

--- a/Tests/TapQContextBaselineTests/WearerTaskLoopSupport.swift
+++ b/Tests/TapQContextBaselineTests/WearerTaskLoopSupport.swift
@@ -1,0 +1,164 @@
+import Foundation
+import XCTest
+@testable import TapQContextBaseline
+import TapQContracts
+
+/// A reasoner that answers from a script.
+///
+/// The whole loop is a conversation with a model, so every property worth pinning is a
+/// property of "given these turns, what did TapQ do?" — which means the model has to be a
+/// list. Each element is either the decision to return or the failure to throw, and the
+/// requests it was given are kept so a test can assert on what crossed the boundary.
+final class ScriptedTaskReasoner: WearerTaskReasoning, @unchecked Sendable {
+    enum Turn {
+        case decide(WearerTaskDecision)
+        case fail(NarrationFailure)
+    }
+
+    private let lock = NSLock()
+    private var script: [Turn]
+    private var seen: [WearerTaskTurnRequest] = []
+    /// What to do once the script runs dry. `finish` by default so a test that under-scripts
+    /// ends with a clean sentence instead of an opaque hang.
+    private let exhausted: Turn
+
+    init(_ script: [Turn], whenExhausted: Turn = .decide(.finish(summary: "Done."))) {
+        self.script = script
+        self.exhausted = whenExhausted
+    }
+
+    var requests: [WearerTaskTurnRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return seen
+    }
+
+    var remaining: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return script.count
+    }
+
+    func decide(_ request: WearerTaskTurnRequest) async throws -> WearerTaskDecision {
+        lock.lock()
+        seen.append(request)
+        let turn = script.isEmpty ? exhausted : script.removeFirst()
+        lock.unlock()
+        switch turn {
+        case .decide(let decision): return decision
+        case .fail(let failure): throw failure
+        }
+    }
+}
+
+/// A reasoner that never answers, so a test can watch a task being cancelled mid-think.
+final class HangingTaskReasoner: WearerTaskReasoning, @unchecked Sendable {
+    func decide(_ request: WearerTaskTurnRequest) async throws -> WearerTaskDecision {
+        // An hour, which is forever next to any test's patience. Cancellation unblocks it.
+        try? await Task.sleep(for: .seconds(3_600))
+        throw NarrationFailure.timedOut
+    }
+}
+
+/// Everything the loop reached for, and everything it was told.
+///
+/// One object rather than seven closures at each call site: what a test asserts is usually a
+/// *pair* — TapQ said this and queued that — and a recorder that holds both makes the
+/// assertion read like the behavior.
+@MainActor final class RecordingTaskSurfaces {
+    var memoryAnswer: WearerTaskToolOutput = .ok("Nothing in memory.")
+    var transcriptAnswer: WearerTaskToolOutput = .ok("Session history: the tests passed.")
+    var statusAnswer: WearerTaskToolOutput = .ok("No agent can be addressed by name.")
+    var queueAnswer: WearerTaskToolOutput = .ok("Queued.")
+    var wearerAnswer: WearerTaskWearerAnswer = .yes
+
+    private(set) var spoken: [String] = []
+    private(set) var memoryQueries: [String] = []
+    private(set) var transcriptQueries: [(agent: String?, query: String)] = []
+    private(set) var statusCalls = 0
+    private(set) var queued: [(agent: String?, text: String)] = []
+    private(set) var asked: [String] = []
+    private(set) var recorded: [(goal: String, outcome: String)] = []
+
+    /// Fires as the last thing a task does, so an `async` test can await the background loop
+    /// without polling a flag.
+    var onRecorded: (@MainActor (String) -> Void)?
+
+    func make() -> WearerTaskSurfaces {
+        WearerTaskSurfaces(
+            searchMemory: { [self] query in
+                memoryQueries.append(query)
+                return memoryAnswer
+            },
+            readTranscript: { [self] agent, query in
+                transcriptQueries.append((agent, query))
+                return transcriptAnswer
+            },
+            status: { [self] in
+                statusCalls += 1
+                return statusAnswer
+            },
+            queueInstruction: { [self] agent, text in
+                queued.append((agent, text))
+                return queueAnswer
+            },
+            speak: { [self] text in spoken.append(text) },
+            askWearer: { [self] question in
+                asked.append(question)
+                return wearerAnswer
+            },
+            recordTask: { [self] goal, outcome in
+                recorded.append((goal, outcome))
+                onRecorded?(outcome)
+            }
+        )
+    }
+}
+
+/// Collects diagnostics for the assertions that are about the log rather than the voice.
+final class TaskDiagnosticSink: TapQDiagnosticSink, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [TapQDiagnosticEvent] = []
+
+    func record(_ event: TapQDiagnosticEvent) {
+        lock.lock()
+        storage.append(event)
+        lock.unlock()
+    }
+
+    var events: [TapQDiagnosticEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    var names: [String] { events.map(\.name) }
+
+    func first(_ name: String) -> TapQDiagnosticEvent? {
+        events.first { $0.name == name }
+    }
+
+    func all(_ name: String) -> [TapQDiagnosticEvent] {
+        events.filter { $0.name == name }
+    }
+}
+
+extension XCTestCase {
+    /// Waits for a background task lane to reach its ending.
+    ///
+    /// Polled rather than awaited on a continuation because the loop deliberately exposes no
+    /// handle: `begin` returns the acknowledgment and the task runs off the voice turn, which
+    /// is the behavior under test. One millisecond a turn, bounded, so a loop that never ends
+    /// fails the test instead of hanging the suite.
+    func awaitIdle(
+        _ loop: WearerTaskLoop,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0..<2_000 {
+            if await MainActor.run(body: { !loop.isBusy }) { return }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("the task never finished", file: file, line: line)
+    }
+}

--- a/Tests/TapQContextBaselineTests/WearerTaskLoopTests.swift
+++ b/Tests/TapQContextBaselineTests/WearerTaskLoopTests.swift
@@ -1,0 +1,397 @@
+import XCTest
+@testable import TapQContextBaseline
+import TapQContracts
+
+/// The task lane of TapQ's deliberation loop (`docs/TAPQ_AGENT_PLAN.md`, Pillar C, M2).
+///
+/// What is pinned here is the set of promises the plan makes out loud: one task at a time,
+/// bounded steps, progress spoken only when there is progress, a pause that resumes, and —
+/// the load-bearing one — that *every* way a task can end is audible except the two where
+/// there is nobody left to hear it.
+///
+/// Every test method is `async`, including the ones with nothing to await: the Swift 6
+/// test-discovery shim on Linux will not register a synchronous method on a `@MainActor`
+/// case, and a test that silently does not run is worse than one that fails.
+@MainActor
+final class WearerTaskLoopTests: XCTestCase {
+    private func makeLoop(
+        _ script: [ScriptedTaskReasoner.Turn],
+        surfaces: RecordingTaskSurfaces,
+        sink: TaskDiagnosticSink = TaskDiagnosticSink(),
+        stepCap: Int = WearerTaskLoop.taskStepCap
+    ) -> (WearerTaskLoop, ScriptedTaskReasoner) {
+        let reasoner = ScriptedTaskReasoner(script)
+        let loop = WearerTaskLoop(
+            model: reasoner,
+            surfaces: surfaces.make(),
+            stepCap: stepCap,
+            diagnosticSink: sink
+        )
+        return (loop, reasoner)
+    }
+
+    // MARK: - The happy path
+
+    func testMultiStepTaskGathersEvidenceThenSpeaksTheSummary() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.memoryAnswer = .ok("The wearer asked TapQ to watch the build.")
+        surfaces.transcriptAnswer = .ok("Session history: 385 tests, 0 failures.")
+        let sink = TaskDiagnosticSink()
+        let (loop, reasoner) = makeLoop([
+            .decide(.searchMemory(query: "build")),
+            .decide(.readTranscript(agent: "Claude Code", query: "tests")),
+            .decide(.finish(summary: "385 tests, no failures.")),
+        ], surfaces: surfaces, sink: sink)
+
+        let start = loop.begin(goal: "check whether the tests passed")
+        XCTAssertEqual(start, .accepted(spoken: "On it — check whether the tests passed"))
+        await awaitIdle(loop)
+
+        XCTAssertEqual(surfaces.memoryQueries, ["build"])
+        XCTAssertEqual(surfaces.transcriptQueries.map(\.agent), ["Claude Code"])
+        // Only the summary is spoken. The two lookups said nothing, which is the plan's
+        // "speaks progress only when it has something to say".
+        XCTAssertEqual(surfaces.spoken, ["385 tests, no failures."])
+
+        // Each turn carries what the previous ones found, because the Responses API is
+        // called with `store: false` and the rendered history is the loop's whole memory.
+        XCTAssertEqual(reasoner.requests.count, 3)
+        XCTAssertEqual(reasoner.requests[0].steps.count, 0)
+        XCTAssertEqual(reasoner.requests[2].steps.map(\.tool),
+                       ["search_memory", "read_transcript"])
+        XCTAssertTrue(reasoner.requests[2].steps[1].result.contains("385 tests"))
+        XCTAssertEqual(reasoner.requests[0].stepsRemaining, WearerTaskLoop.taskStepCap)
+
+        let finished = sink.first("task.finished")
+        XCTAssertEqual(finished?.fields["outcome"], "finished")
+        XCTAssertEqual(finished?.fields["steps"], "3")
+        XCTAssertEqual(sink.all("task.step").map { $0.fields["tool"] },
+                       ["search_memory", "read_transcript", "finish"])
+        // Counts and names only: nothing in the log quotes the goal or an excerpt.
+        for event in sink.events where event.category == "WearerTask" {
+            for value in event.fields.values {
+                XCTAssertFalse(value.contains("385 tests"), "\(event.name) leaked a result")
+                XCTAssertFalse(value.contains("check whether"), "\(event.name) leaked the goal")
+            }
+        }
+    }
+
+    func testSpeakToolSaysProgressAndTheTaskCarriesOn() async {
+        let surfaces = RecordingTaskSurfaces()
+        let (loop, _) = makeLoop([
+            .decide(.speak("This will take a moment.")),
+            .decide(.getStatus),
+            .decide(.finish(summary: "Nothing is waiting.")),
+        ], surfaces: surfaces)
+
+        _ = loop.begin(goal: "see what is waiting")
+        await awaitIdle(loop)
+
+        XCTAssertEqual(surfaces.spoken, ["This will take a moment.", "Nothing is waiting."])
+        XCTAssertEqual(surfaces.statusCalls, 1)
+    }
+
+    // MARK: - One at a time
+
+    func testASecondGoalIsRefusedOutLoudRatherThanQueued() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        let loop = WearerTaskLoop(
+            model: HangingTaskReasoner(),
+            surfaces: surfaces.make(),
+            diagnosticSink: sink
+        )
+
+        let first = loop.begin(goal: "watch the build")
+        guard case .accepted = first else { return XCTFail("expected the first goal taken") }
+        XCTAssertTrue(loop.isBusy)
+
+        let second = loop.begin(goal: "rerun the failing suite")
+        XCTAssertEqual(second, .busy(spoken: WearerTaskLoop.busyNotice))
+        XCTAssertTrue(sink.names.contains("task.busy"))
+        // Not queued anywhere: the second goal left no trace but the refusal.
+        XCTAssertEqual(surfaces.recorded.map(\.goal), ["watch the build"])
+
+        loop.cancel()
+    }
+
+    func testAnEmptyGoalIsRefusedAndStartsNothing() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        let (loop, _) = makeLoop([], surfaces: surfaces, sink: sink)
+
+        XCTAssertEqual(loop.begin(goal: "   "),
+                       .busy(spoken: WearerTaskLoop.emptyGoalNotice))
+        XCTAssertFalse(loop.isBusy)
+        XCTAssertTrue(surfaces.recorded.isEmpty)
+        XCTAssertEqual(sink.first("task.rejected")?.fields["reason"], "empty_goal")
+    }
+
+    // MARK: - The step cap
+
+    func testHittingTheStepCapSaysSoRatherThanGoingQuiet() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        let (loop, _) = makeLoop([
+            .decide(.getStatus),
+            .decide(.getStatus),
+            .decide(.getStatus),
+        ], surfaces: surfaces, sink: sink, stepCap: 3)
+
+        _ = loop.begin(goal: "find out what Codex is doing")
+        await awaitIdle(loop)
+
+        XCTAssertEqual(surfaces.spoken, [
+            WearerTaskLoop.couldNotFinishNotice(goal: "find out what Codex is doing"),
+        ])
+        XCTAssertEqual(surfaces.spoken.first, "I couldn't finish: find out what Codex is doing")
+        XCTAssertEqual(sink.first("task.finished")?.fields["outcome"], "could not finish")
+        XCTAssertEqual(surfaces.recorded.last?.outcome, "could not finish")
+    }
+
+    func testTheLastTurnIsToldItIsTheLastTurn() async {
+        let surfaces = RecordingTaskSurfaces()
+        let (loop, reasoner) = makeLoop([
+            .decide(.getStatus),
+            .decide(.finish(summary: "Nothing is waiting.")),
+        ], surfaces: surfaces, stepCap: 2)
+
+        _ = loop.begin(goal: "check the queue")
+        await awaitIdle(loop)
+
+        XCTAssertEqual(reasoner.requests.map(\.stepsRemaining), [2, 1])
+        let lastInput = WearerTaskContract.input(for: reasoner.requests[1])
+        XCTAssertTrue(lastInput.contains("This is your last turn"), lastInput)
+    }
+
+    // MARK: - ask_wearer
+
+    func testAskWearerPausesTheLoopAndResumesWithTheAnswer() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.wearerAnswer = .no
+        let (loop, reasoner) = makeLoop([
+            .decide(.askWearer(question: "Should I have Codex rerun it?")),
+            .decide(.finish(summary: "Left it alone, then.")),
+        ], surfaces: surfaces)
+
+        _ = loop.begin(goal: "decide what to do about the failure")
+        await awaitIdle(loop)
+
+        XCTAssertEqual(surfaces.asked, ["Should I have Codex rerun it?"])
+        // The answer comes back as the tool's result, so the next turn reasons from it.
+        XCTAssertEqual(reasoner.requests[1].steps.first?.result, "The wearer answered no.")
+        XCTAssertEqual(surfaces.spoken, ["Left it alone, then."])
+    }
+
+    func testAskWearerWithNoAnswerEndsTheTaskAudibly() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.wearerAnswer = .unanswered
+        let sink = TaskDiagnosticSink()
+        let (loop, reasoner) = makeLoop([
+            .decide(.askWearer(question: "Should I have Codex rerun it?")),
+            // Never reached: an unanswered question ends the task where it stands.
+            .decide(.finish(summary: "unreachable")),
+        ], surfaces: surfaces, sink: sink)
+
+        _ = loop.begin(goal: "decide what to do about the failure")
+        await awaitIdle(loop)
+
+        XCTAssertEqual(reasoner.requests.count, 1)
+        XCTAssertEqual(surfaces.spoken, [
+            WearerTaskLoop.unansweredNotice(goal: "decide what to do about the failure"),
+        ])
+        XCTAssertTrue(sink.names.contains("task.ask_unanswered"))
+        XCTAssertEqual(surfaces.recorded.last?.outcome, "unanswered")
+    }
+
+    // MARK: - Failure posture
+
+    func testACloudFailureBreaksTheVoiceAndSaysNothing() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        let (loop, _) = makeLoop([
+            .decide(.getStatus),
+            .fail(.http(status: 503)),
+        ], surfaces: surfaces, sink: sink)
+
+        var broken: [String] = []
+        loop.onLoopBroken = { broken.append($0) }
+
+        _ = loop.begin(goal: "check the build")
+        await awaitIdle(loop)
+
+        XCTAssertEqual(broken, ["http 503"])
+        // Deliberately silent: the latch speaks its own notice, and a second sentence from
+        // TapQ would be the degraded half-agent the posture forbids.
+        XCTAssertTrue(surfaces.spoken.isEmpty, "\(surfaces.spoken)")
+        let failed = sink.first("task.model_failed")
+        XCTAssertEqual(failed?.level, .error)
+        XCTAssertEqual(failed?.fields["reason"], "http 503")
+        XCTAssertEqual(sink.first("task.finished")?.fields["outcome"], "broken")
+        XCTAssertEqual(surfaces.recorded.last?.outcome, "broken")
+    }
+
+    func testALocalFileProblemIsLoudAndTheTaskCarriesOn() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.transcriptAnswer = .localFailure(
+            "unreadable",
+            tellingModel: "TapQ cannot read that session's history.",
+            saying: TranscriptQuestionAnswerer.unreadableNotice
+        )
+        let sink = TaskDiagnosticSink()
+        var broken: [String] = []
+        let (loop, reasoner) = makeLoop([
+            .decide(.readTranscript(agent: nil, query: "tests")),
+            .decide(.finish(summary: "I can't see the session history right now.")),
+        ], surfaces: surfaces, sink: sink)
+        loop.onLoopBroken = { broken.append($0) }
+
+        _ = loop.begin(goal: "say what the tests did")
+        await awaitIdle(loop)
+
+        // Loud.
+        let unavailable = sink.first("task.tool_unavailable")
+        XCTAssertEqual(unavailable?.level, .error)
+        XCTAssertEqual(unavailable?.fields["reason"], "unreadable")
+        XCTAssertEqual(unavailable?.fields["tool"], "read_transcript")
+        // Honest to the model, so it can be honest to the wearer.
+        XCTAssertEqual(reasoner.requests[1].steps.first?.result,
+                       "TapQ cannot read that session's history.")
+        // Alive: no break, and the wearer hears the model's own sentence.
+        XCTAssertTrue(broken.isEmpty)
+        XCTAssertEqual(surfaces.spoken, ["I can't see the session history right now."])
+        XCTAssertEqual(sink.first("task.finished")?.fields["outcome"], "finished")
+    }
+
+    // MARK: - Cancellation
+
+    func testCancellationEndsTheTaskSilentlyAndRecordsIt() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        let loop = WearerTaskLoop(
+            model: HangingTaskReasoner(),
+            surfaces: surfaces.make(),
+            diagnosticSink: sink
+        )
+
+        _ = loop.begin(goal: "watch the build")
+        XCTAssertTrue(loop.isBusy)
+        loop.cancel(reason: "runtime shutdown")
+
+        // The slot is free the instant cancel returns, so a runtime tearing down does not
+        // wait on a model call it is about to have no use for.
+        XCTAssertFalse(loop.isBusy)
+        XCTAssertEqual(sink.first("task.canceled")?.fields["reason"], "runtime shutdown")
+        // Silent by design: the channel a sentence would go out on is being torn down.
+        XCTAssertTrue(surfaces.spoken.isEmpty)
+        // The record still gets the start, which is what a wearer asking tomorrow reads.
+        XCTAssertEqual(surfaces.recorded.first?.outcome, WearerTaskLoop.startedOutcome)
+    }
+
+    func testCancellingBetweenTurnsStopsBeforeTheNextToolRuns() async {
+        let surfaces = RecordingTaskSurfaces()
+        let reasoner = ScriptedTaskReasoner(
+            [.decide(.getStatus)],
+            // The second turn hangs, so the test can cancel while it is in flight.
+            whenExhausted: .decide(.finish(summary: "never spoken"))
+        )
+        let loop = WearerTaskLoop(model: reasoner, surfaces: surfaces.make())
+
+        _ = loop.begin(goal: "check the queue")
+        // Let the first turn land, then cancel before the loop can speak a summary.
+        await Task.yield()
+        loop.cancel()
+        await awaitIdle(loop)
+
+        XCTAssertFalse(surfaces.spoken.contains("never spoken"))
+    }
+
+    // MARK: - The durable record
+
+    func testTheGoalAndItsEndingSurviveARestart() async throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tapq-task-record-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = WearerConversationStore(directory: directory)
+        let surfaces = RecordingTaskSurfaces()
+        let reasoner = ScriptedTaskReasoner([.decide(.finish(summary: "All green."))])
+        var wired = surfaces.make()
+        wired.recordTask = { goal, outcome in
+            store.recordTask(goal: goal, outcome: outcome)
+        }
+        let loop = WearerTaskLoop(model: reasoner, surfaces: wired)
+
+        _ = loop.begin(goal: "tell me whether the tests passed")
+        await awaitIdle(loop)
+
+        // A second store over the same file is the restart: nothing is held in memory
+        // between them.
+        let reopened = WearerConversationStore(directory: directory)
+        let tasks = reopened.entries().filter { $0.kind == .task }
+        XCTAssertEqual(tasks.map(\.outcome), [WearerTaskLoop.startedOutcome, "finished"])
+        XCTAssertEqual(tasks.map(\.text), [
+            "tell me whether the tests passed",
+            "tell me whether the tests passed",
+        ])
+        // And it reads as itself in the recall window, rather than as an unknown kind.
+        let lines = tasks.map { WearerConversationRecall.line(for: $0) }
+        XCTAssertEqual(lines.first, "The wearer asked TapQ to: tell me whether the tests passed")
+        XCTAssertEqual(lines.last, "TapQ's task (finished): tell me whether the tests passed")
+    }
+
+    func testAnInterruptedTaskLeavesAStartedEntryWithNoEnding() async throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tapq-task-record-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = WearerConversationStore(directory: directory)
+        let surfaces = RecordingTaskSurfaces()
+        var wired = surfaces.make()
+        wired.recordTask = { goal, outcome in
+            store.recordTask(goal: goal, outcome: outcome)
+        }
+        let loop = WearerTaskLoop(model: HangingTaskReasoner(), surfaces: wired)
+
+        _ = loop.begin(goal: "watch the build")
+        // No cancel and no ending: this is the runtime dying mid-task.
+
+        let reopened = WearerConversationStore(directory: directory)
+        let tasks = reopened.entries().filter { $0.kind == .task }
+        XCTAssertEqual(tasks.map(\.outcome), [WearerTaskLoop.startedOutcome])
+        XCTAssertEqual(tasks.first?.text, "watch the build")
+
+        loop.cancel()
+    }
+
+    // MARK: - queue_instruction
+
+    func testAQueuedInstructionIsAnnouncedOutLoud() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.queueAnswer = .announcing(
+            "Queued for Codex.",
+            say: "I've told Codex: rerun the failing suite"
+        )
+        let (loop, _) = makeLoop([
+            .decide(.queueInstruction(agent: "Codex", text: "rerun the failing suite")),
+            .decide(.finish(summary: "Codex is on it.")),
+        ], surfaces: surfaces)
+
+        _ = loop.begin(goal: "have Codex rerun the failing suite")
+        await awaitIdle(loop)
+
+        XCTAssertEqual(surfaces.queued.map(\.agent), ["Codex"])
+        // The announcement is spoken *before* the summary, so an instruction leaving in the
+        // wearer's name is never something they only find out about at the end.
+        XCTAssertEqual(surfaces.spoken, [
+            "I've told Codex: rerun the failing suite",
+            "Codex is on it.",
+        ])
+    }
+}

--- a/Tests/TapQContextBaselineTests/WearerTaskQuestionLaneTests.swift
+++ b/Tests/TapQContextBaselineTests/WearerTaskQuestionLaneTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+@testable import TapQContextBaseline
+import TapQContracts
+
+/// `ask_about_work`, folded into the loop (`docs/TAPQ_AGENT_PLAN.md`, Pillar B's one
+/// revision at M2).
+///
+/// The point of this suite is that the *wearer-facing* behavior did not move. M1's three
+/// outcomes still mean what they meant, the answer is still the model's words spoken
+/// verbatim, and the two failure classes are still apart: a file that will not open is
+/// spoken and survivable, a cloud call that fails says nothing and breaks the run's voice.
+/// What changed is underneath — the lane fetches its own evidence and may combine an agent's
+/// transcript with TapQ's own memory — plus one bound the fold-in cost, pinned below.
+@MainActor
+final class WearerTaskQuestionLaneTests: XCTestCase {
+    private func makeLoop(
+        _ script: [ScriptedTaskReasoner.Turn],
+        surfaces: RecordingTaskSurfaces,
+        sink: TaskDiagnosticSink = TaskDiagnosticSink(),
+        questionStepCap: Int = WearerTaskLoop.questionStepCap
+    ) -> (WearerTaskLoop, ScriptedTaskReasoner) {
+        // A tripwire rather than a polite default: every test below scripts exactly as many
+        // turns as its cap allows, so reaching this means the lane asked for a turn it had
+        // no budget for.
+        let reasoner = ScriptedTaskReasoner(script, whenExhausted: .fail(.malformedResponse))
+        let loop = WearerTaskLoop(
+            model: reasoner,
+            surfaces: surfaces.make(),
+            questionStepCap: questionStepCap,
+            diagnosticSink: sink
+        )
+        return (loop, reasoner)
+    }
+
+    // MARK: - Answered
+
+    func testAnAnswerCombinesTheTranscriptWithTapQsOwnMemory() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.transcriptAnswer = .ok("Session history: 3 tests failed in VoiceSuite.")
+        surfaces.memoryAnswer = .ok("The wearer asked TapQ to watch VoiceSuite.")
+        let sink = TaskDiagnosticSink()
+        let (loop, reasoner) = makeLoop([
+            .decide(.readTranscript(agent: "Claude Code", query: "tests")),
+            .decide(.searchMemory(query: "VoiceSuite")),
+            .decide(.finish(summary: "Three failed in VoiceSuite — the suite you asked me "
+                + "to watch.")),
+        ], surfaces: surfaces, sink: sink)
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "what did the tests say?", agentDisplayName: "Claude Code"
+        )
+
+        XCTAssertEqual(outcome, .answered(
+            "Three failed in VoiceSuite — the suite you asked me to watch."
+        ))
+        XCTAssertEqual(surfaces.transcriptQueries.map(\.query), ["tests"])
+        XCTAssertEqual(surfaces.memoryQueries, ["VoiceSuite"])
+        // The lane never speaks: the provider speaks the answer, exactly as it did in M1.
+        XCTAssertTrue(surfaces.spoken.isEmpty, "\(surfaces.spoken)")
+        // The named agent reaches the model in the prompt, as it did through
+        // `WorkAnswerContract.input`.
+        XCTAssertEqual(reasoner.requests.first?.agentDisplayName, "Claude Code")
+        XCTAssertTrue(
+            WearerTaskContract.input(for: reasoner.requests[0]).contains("Agent: Claude Code")
+        )
+        XCTAssertEqual(sink.first("task.question_answered")?.fields["steps"], "3")
+    }
+
+    func testTheQuestionLaneDeclaresOnlyItsThreeReadOnlyTools() async throws {
+        let names = WearerTaskContract.tools(for: .question)
+            .compactMap { $0["name"] as? String }
+        XCTAssertEqual(names, ["search_memory", "read_transcript", "finish"])
+
+        // Undeclared here means undeclared on the wire, exactly as `ask_about_work` itself
+        // is gated: a question that could queue an instruction would be authority the wearer
+        // did not hand over.
+        for forbidden in ["queue_instruction", "speak", "ask_wearer", "get_status"] {
+            XCTAssertThrowsError(try WearerTaskContract.decode(
+                name: forbidden, argumentsJSON: "{\"text\":\"x\"}", mode: .question
+            ), forbidden)
+        }
+    }
+
+    func testAnEmptyQuestionIsTheM1EmptyNotice() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        let (loop, reasoner) = makeLoop([], surfaces: surfaces, sink: sink)
+
+        let outcome = await loop.answerWorkQuestion(question: "  ", agentDisplayName: nil)
+
+        XCTAssertEqual(outcome, .unavailable(TranscriptQuestionAnswerer.emptyNotice))
+        XCTAssertEqual(reasoner.requests.count, 0, "no cloud call for an empty question")
+        XCTAssertEqual(sink.first("task.question_unavailable")?.level, .error)
+    }
+
+    // MARK: - The two failure classes stay apart
+
+    func testAnUnreadableTranscriptIsSpokenAndTheSessionLives() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.transcriptAnswer = .localFailure(
+            "unreadable",
+            tellingModel: "TapQ cannot read that session's history.",
+            saying: TranscriptQuestionAnswerer.unreadableNotice
+        )
+        let sink = TaskDiagnosticSink()
+        var broken: [String] = []
+        // The model keeps reaching for a transcript it cannot have and never finishes, which
+        // is the worst case: the lane runs out of room with a local problem to report.
+        let (loop, _) = makeLoop([
+            .decide(.readTranscript(agent: nil, query: "tests")),
+            .decide(.readTranscript(agent: nil, query: "tests")),
+            .decide(.readTranscript(agent: nil, query: "tests")),
+        ], surfaces: surfaces, sink: sink)
+        loop.onLoopBroken = { broken.append($0) }
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "what did the tests say?", agentDisplayName: nil
+        )
+
+        // The M1 sentence, unchanged, and the M1 class: unavailable, not failed.
+        XCTAssertEqual(outcome, .unavailable(TranscriptQuestionAnswerer.unreadableNotice))
+        XCTAssertTrue(broken.isEmpty, "an unreadable file must never break the voice")
+        XCTAssertEqual(sink.first("task.tool_unavailable")?.level, .error)
+        XCTAssertEqual(sink.first("task.question_unavailable")?.fields["reason"], "local")
+    }
+
+    func testACloudFailureFailsTheQuestionAndSaysNothing() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        var broken: [String] = []
+        let (loop, _) = makeLoop([.fail(.timedOut)], surfaces: surfaces, sink: sink)
+        loop.onLoopBroken = { broken.append($0) }
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "what did the tests say?", agentDisplayName: nil
+        )
+
+        XCTAssertEqual(outcome, .failed("timeout"))
+        XCTAssertTrue(surfaces.spoken.isEmpty)
+        // Not `onLoopBroken`: the provider latches a `failed` outcome through
+        // `onWorkAnswerFailed`, and reporting the same failure twice would give an operator
+        // two lines for one event.
+        XCTAssertTrue(broken.isEmpty)
+        XCTAssertEqual(sink.first("task.question_failed")?.level, .error)
+    }
+
+    // MARK: - The bound the fold-in cost
+
+    func testRunningOutOfStepsSaysSoRatherThanInventingAnAnswer() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        let (loop, reasoner) = makeLoop([
+            .decide(.searchMemory(query: "one")),
+            .decide(.searchMemory(query: "two")),
+        ], surfaces: surfaces, sink: sink, questionStepCap: 2)
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "what did the tests say?", agentDisplayName: nil
+        )
+
+        XCTAssertEqual(outcome, .unavailable(WearerTaskLoop.couldNotAnswerNotice))
+        XCTAssertEqual(reasoner.requests.count, 2, "the cap is a cap on model calls")
+        XCTAssertEqual(sink.first("task.question_unavailable")?.fields["reason"], "no_finish")
+    }
+
+    // MARK: - The lane does not take the task slot
+
+    /// Hangs a task turn forever and answers a question turn from a script, so one loop can
+    /// be busy and asked at the same time.
+    private final class ModeSplitReasoner: WearerTaskReasoning, @unchecked Sendable {
+        private let answer: String
+
+        init(answer: String) { self.answer = answer }
+
+        func decide(_ request: WearerTaskTurnRequest) async throws -> WearerTaskDecision {
+            switch request.mode {
+            case .task:
+                try? await Task.sleep(for: .seconds(3_600))
+                throw NarrationFailure.timedOut
+            case .question:
+                return .finish(summary: answer)
+            }
+        }
+    }
+
+    func testAQuestionIsAnsweredWhileATaskIsStillRunning() async {
+        // M1 answered every question; refusing one because a background task happened to be
+        // running would be a regression for no safety gained. The lane resolves nothing,
+        // declares three read-only tools, and holds no slot, so `busy` governs `start_task`
+        // and nothing else.
+        let surfaces = RecordingTaskSurfaces()
+        let loop = WearerTaskLoop(
+            model: ModeSplitReasoner(answer: "All green."),
+            surfaces: surfaces.make()
+        )
+
+        _ = loop.begin(goal: "watch the build")
+        XCTAssertTrue(loop.isBusy)
+        XCTAssertEqual(loop.begin(goal: "something else"),
+                       .busy(spoken: WearerTaskLoop.busyNotice))
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "how did it go?", agentDisplayName: nil
+        )
+        XCTAssertEqual(outcome, .answered("All green."))
+        XCTAssertTrue(loop.isBusy, "answering a question must not end the running task")
+
+        loop.cancel()
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/StartTaskToolTests.swift
+++ b/Tests/TapQInteractionBaselineTests/StartTaskToolTests.swift
@@ -1,0 +1,536 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+/// `start_task`: the seventh tool, and the only one that hands the wearer's words to
+/// something that thinks about them (`docs/TAPQ_AGENT_PLAN.md`, Pillar C, milestone M2).
+///
+/// Four properties are load-bearing and each has its own test below. The tool is *declared*
+/// only where a loop is composed, so on the Apple path and on every cloud run without one it
+/// is not a disabled feature but an undeclared name. Whatever sentence the loop hands back is
+/// spoken word for word — accepted and busy alike, because the contract in `WearerTask.swift`
+/// says the caller speaks what comes back and does not compose sentences of its own. Nothing
+/// is resolved, so the request the wearer was read is still open afterwards. And the reflex
+/// six are untouched: adding a deliberation tier may not put a loop in the path of "approve".
+@MainActor
+final class StartTaskToolTests: XCTestCase {
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        var names: [String] { events.map(\.name) }
+    }
+
+    /// The same duplex fake the tool-intent and transcript suites use, restated here so the
+    /// three can drift independently.
+    @MainActor
+    private final class ToolBackend: VoiceBackend {
+        let capabilities = VoiceBackendCapabilities(supportsBargeIn: true, producesAudio: true,
+                                                    duplex: true,
+                                                    supportsNativeTurnDetection: true,
+                                                    supportsToolCalling: true)
+
+        private(set) var declaredTools: [[String]] = []
+        private(set) var toolResults: [(callID: String, output: String)] = []
+        private(set) var scriptedSpeech: [String] = []
+        private(set) var isOpen = false
+        private var handler: (@MainActor (VoiceBackendEvent) -> Void)?
+
+        func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
+            isOpen = true
+            handler = onEvent
+        }
+
+        func close() { isOpen = false }
+        func beginUserTurn() {}
+
+        @discardableResult
+        func endUserTurn(expectingResponse: Bool) -> Bool { expectingResponse }
+
+        func sendAudio(_ chunk: VoiceAudioChunk) {}
+        func requestResponse(text: String) {}
+        func requestScriptedSpeech(text: String) { scriptedSpeech.append(text) }
+        func cancelResponse() {}
+        func setNativeTurnDetection(_ enabled: Bool) {}
+
+        @discardableResult
+        func requestModelTurn() -> Bool { true }
+
+        func declareTools(_ tools: [VoiceToolDeclaration]) {
+            declaredTools.append(tools.map(\.name))
+        }
+
+        func updateInstructions(_ instructions: String) {}
+
+        func sendToolResult(callID: String, output: String) {
+            toolResults.append((callID, output))
+        }
+
+        func emit(_ event: VoiceBackendEvent) {
+            guard let handler else { return XCTFail("no session is listening") }
+            handler(event)
+        }
+    }
+
+    /// A deliberation loop that records the goals it was offered and answers with whatever
+    /// the test scripted. Nothing here runs a loop — what is under test is the seam.
+    private final class Loop: WearerTaskStarting, @unchecked Sendable {
+        private let start: WearerTaskStart
+        /// Written inside `startTask` and read by the test after it has awaited the round
+        /// trip, so the `await` is the ordering and no lock is needed — which also keeps this
+        /// out of the "a lock taken across an await is an error in Swift 6" rule.
+        nonisolated(unsafe) private(set) var goals: [String] = []
+
+        init(_ start: WearerTaskStart) { self.start = start }
+
+        func startTask(goal: String) async -> WearerTaskStart {
+            goals.append(goal)
+            return start
+        }
+    }
+
+    private func makeProvider(
+        _ backend: ToolBackend,
+        loop: Loop?,
+        answerer: (@MainActor (String, String?) async -> WorkQuestionOutcome)? = nil,
+        sink: RecordingSink = RecordingSink(),
+        policy: SessionPolicy = .conversation(idleClose: 60)
+    ) -> VoiceBackendCommandProvider {
+        VoiceBackendCommandProvider(
+            backend: backend,
+            intentSource: .modelToolCalls,
+            sessionPolicy: policy,
+            supportsBargeIn: true,
+            answerWorkQuestion: answerer,
+            startWearerTask: loop,
+            // Bounded rather than the shipped sixty seconds: an unbounded sleep left running
+            // in-process stalls whichever test runs next.
+            idleSleep: { _ in try? await Task.sleep(for: .seconds(1)) },
+            diagnosticSink: sink
+        )
+    }
+
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    private func call(_ arguments: String, id: String = "call_1") -> VoiceBackendEvent {
+        .toolCall(VoiceToolCall(callID: id, name: "start_task", argumentsJSON: arguments))
+    }
+
+    // MARK: - Declaration
+
+    /// The gate, and it is a declaration rather than a flag: with a loop the model is offered
+    /// the tool, and without one it is offered six and cannot ask for a seventh that does not
+    /// exist.
+    func testTheToolIsDeclaredOnlyWhenALoopIsComposed() async {
+        let withLoop = ToolBackend()
+        _ = makeProvider(withLoop, loop: Loop(.accepted(spoken: "ok")))
+        XCTAssertEqual(withLoop.declaredTools, [[
+            "approve", "deny", "select_item", "queue_instruction", "query_status",
+            "start_task",
+        ]])
+
+        let without = ToolBackend()
+        _ = makeProvider(without, loop: nil)
+        XCTAssertEqual(without.declaredTools, [[
+            "approve", "deny", "select_item", "queue_instruction", "query_status",
+        ]])
+    }
+
+    /// The two conditional tools are on independent gates, because the seams are: a run may
+    /// be able to read a transcript and have no loop, or the reverse, and neither implies the
+    /// other. All seven only where both are composed.
+    func testTheTwoConditionalToolsAreGatedSeparately() async {
+        let both = ToolBackend()
+        _ = makeProvider(both, loop: Loop(.accepted(spoken: "ok")),
+                         answerer: { _, _ in .answered("x") })
+        XCTAssertEqual(both.declaredTools, [[
+            "approve", "deny", "select_item", "queue_instruction", "query_status",
+            "ask_about_work", "start_task",
+        ]])
+
+        let askOnly = ToolBackend()
+        _ = makeProvider(askOnly, loop: nil, answerer: { _, _ in .answered("x") })
+        XCTAssertEqual(askOnly.declaredTools.first?.contains("start_task"), false)
+        XCTAssertEqual(askOnly.declaredTools.first?.contains("ask_about_work"), true)
+    }
+
+    /// The Apple path declares nothing at all — there is no model to declare to — so there is
+    /// no composition in which a deliberation tier exists beside a keyword grammar.
+    func testTheGrammarPathDeclaresNoToolsAtAll() async {
+        let backend = ToolBackend()
+        _ = VoiceBackendCommandProvider(backend: backend, match: { _ in nil })
+        XCTAssertEqual(backend.declaredTools, [])
+    }
+
+    /// A call for the tool where it was never declared is the tool protocol being wrong, not a
+    /// loop that quietly did not run. Same treatment as any other undeclared name: the peer is
+    /// answered so it is not parked, and the voice channel breaks.
+    func testStartingATaskWhereTheToolWasNeverDeclaredIsAProtocolFailure() async {
+        let backend = ToolBackend()
+        let sink = RecordingSink()
+        let provider = makeProvider(backend, loop: nil, sink: sink)
+        var failures: [String] = []
+        provider.onIntentPipelineFailed = { failures.append($0) }
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(call(#"{"goal":"run the tests and tell me if anything fails"}"#))
+        await settle()
+
+        XCTAssertEqual(failures.count, 1)
+        XCTAssertEqual(backend.toolResults.count, 1, "the peer must not be left parked")
+        XCTAssertTrue(backend.scriptedSpeech.isEmpty)
+        XCTAssertTrue(sink.names.contains("tool.protocol_failed"))
+    }
+
+    // MARK: - The round trip
+
+    /// Goal in, acknowledgment out, spoken word for word on the channel every other TapQ
+    /// sentence uses. The ordering is the real one: the wearer's turn is committed, the tool
+    /// call arrives inside the response, and the sentence goes out when that response is done.
+    func testAGoalIsHandedToTheLoopAndTheAcknowledgmentIsSpokenVerbatim() async {
+        let backend = ToolBackend()
+        let loop = Loop(.accepted(spoken: "I'm on it — running the tests now."))
+        let sink = RecordingSink()
+        let provider = makeProvider(backend, loop: loop, sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.endActiveTurn()
+        backend.emit(call(#"{"goal":"run the tests and let me know if anything fails"}"#))
+        await settle()
+        backend.emit(.responseCompleted)
+        await settle()
+
+        XCTAssertEqual(loop.goals, ["run the tests and let me know if anything fails"])
+        XCTAssertEqual(backend.scriptedSpeech, ["I'm on it — running the tests now."])
+        XCTAssertEqual(backend.toolResults.count, 1)
+        XCTAssertEqual(backend.toolResults.first?.callID, "call_1")
+        XCTAssertTrue(sink.names.contains("tool.start_task_requested"), "\(sink.names)")
+        XCTAssertTrue(sink.names.contains("task.accepted"), "\(sink.names)")
+    }
+
+    /// One task at a time is the contract's rule, and a refused goal is not queued. What the
+    /// wearer hears is the loop's own sentence, verbatim — this provider composes nothing and
+    /// so cannot describe a state it does not model.
+    func testABusyLoopSaysSoAndTheSentenceIsSpokenVerbatim() async {
+        let backend = ToolBackend()
+        let busy = "I'm still on the last thing you asked — tell me again when I'm done."
+        let loop = Loop(.busy(spoken: busy))
+        let sink = RecordingSink()
+        let provider = makeProvider(backend, loop: loop, sink: sink)
+        var failures: [String] = []
+        provider.onIntentPipelineFailed = { failures.append($0) }
+        provider.onWorkAnswerFailed = { failures.append($0) }
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"goal":"tell Codex to do what Claude just did"}"#))
+        await settle()
+
+        XCTAssertEqual(backend.scriptedSpeech, [busy])
+        XCTAssertEqual(loop.goals, ["tell Codex to do what Claude just did"])
+        XCTAssertEqual(backend.toolResults.count, 1, "the peer is answered either way")
+        XCTAssertTrue(failures.isEmpty, "a busy loop is not a broken run")
+        XCTAssertTrue(sink.names.contains("task.busy"), "\(sink.names)")
+    }
+
+    /// The tool result is for the model and the sentence is for the wearer, and they are not
+    /// the same words. The output has to stop the model narrating a task it will not see the
+    /// end of — nothing follows `sendToolResult`, so anything it said about the work would be
+    /// said into a session with no response.
+    func testTheModelIsToldTheTaskIsRunningAndToldToSayNothingFurther() async {
+        let backend = ToolBackend()
+        let provider = makeProvider(backend, loop: Loop(.accepted(spoken: "On it.")))
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"goal":"watch the build"}"#))
+        await settle()
+
+        let output = backend.toolResults.first?.output ?? ""
+        XCTAssertTrue(output.contains("Say nothing further"), output)
+        XCTAssertNotEqual(output, "On it.", "the model's record is not the wearer's sentence")
+    }
+
+    /// Starting a task resolves nothing. The approval the wearer was read is still open
+    /// afterwards, and nothing was delivered to the window.
+    func testStartingATaskLeavesTheOpenWindowExactlyAsItFoundIt() async {
+        let backend = ToolBackend()
+        let provider = makeProvider(backend, loop: Loop(.accepted(spoken: "On it.")))
+        var delivered: [VoiceCommand] = []
+
+        provider.start { delivered.append($0) }
+        await settle()
+        provider.endActiveTurn()
+        backend.emit(call(#"{"goal":"run the tests"}"#))
+        await settle()
+
+        XCTAssertEqual(delivered, [], "starting a task must resolve nothing")
+        XCTAssertTrue(provider.isWindowOpenForTesting, "the window was closed by a task")
+    }
+
+    /// Like `ask_about_work` and unlike the other five, this one needs no window: it delivers
+    /// no command, so there is nothing for a window to receive, and refusing a goal because a
+    /// prompt closed a beat earlier would only lose the goal.
+    func testAGoalIsTakenWithNoWindowOpen() async {
+        let backend = ToolBackend()
+        let loop = Loop(.accepted(spoken: "I'll find out and tell you."))
+        let provider = makeProvider(backend, loop: loop)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"goal":"find out why the build broke"}"#))
+        await settle()
+
+        XCTAssertEqual(backend.scriptedSpeech, ["I'll find out and tell you."])
+        XCTAssertEqual(loop.goals.count, 1)
+        XCTAssertFalse(provider.isWindowOpenForTesting)
+    }
+
+    /// The goal is the wearer's sentence and it reaches the loop unaltered, agent names and
+    /// all. Nothing here parses it: which agent a goal is about is the loop's problem, and a
+    /// provider that pre-chewed it would be a second grammar on the path that exists to have
+    /// none.
+    func testTheGoalReachesTheLoopWhole() async {
+        let backend = ToolBackend()
+        let loop = Loop(.accepted(spoken: "ok"))
+        let provider = makeProvider(backend, loop: loop)
+        let goal = "tell Codex to review what Claude just wrote, then tell me what it said"
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"goal":"\#(goal)"}"#))
+        await settle()
+
+        XCTAssertEqual(loop.goals, [goal])
+    }
+
+    // MARK: - Bad arguments
+
+    /// Nothing to work on is a legal call that could not run — refused out loud, and the
+    /// session survives it. The loop is never handed a goal TapQ did not hear.
+    func testAnEmptyGoalIsRefusedOutLoudAndNeverReachesTheLoop() async {
+        let backend = ToolBackend()
+        let loop = Loop(.accepted(spoken: "should not be reached"))
+        let provider = makeProvider(backend, loop: loop)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"goal":"   "}"#))
+        await settle()
+
+        XCTAssertEqual(backend.scriptedSpeech, [VoiceIntentTools.emptyGoalNotice])
+        XCTAssertTrue(loop.goals.isEmpty)
+        XCTAssertEqual(backend.toolResults.count, 1, "the peer is still answered")
+    }
+
+    /// The refusal is the sentence a dictation that captured silence has always got. The
+    /// wearer does not know which of the seven tools the model reached for, and a sentence
+    /// that told them would be TapQ narrating its own routing.
+    func testTheEmptyGoalRefusalIsTheOrdinarySayItAgain() async {
+        XCTAssertEqual(VoiceIntentTools.emptyGoalNotice,
+                       VoiceIntentTools.emptyInstructionNotice)
+    }
+
+    /// Arguments that cannot be read are the protocol being wrong, exactly as for the other
+    /// six tools.
+    func testUnreadableArgumentsAreAProtocolFailure() async {
+        let backend = ToolBackend()
+        let provider = makeProvider(backend, loop: Loop(.accepted(spoken: "ok")))
+        var failures: [String] = []
+        provider.onIntentPipelineFailed = { failures.append($0) }
+
+        provider.start { _ in }
+        await settle()
+        backend.emit(call("{not json"))
+        await settle()
+        backend.emit(call("{}", id: "call_2"))
+        await settle()
+
+        XCTAssertEqual(failures.count, 2, "a missing goal field is not a goal")
+        XCTAssertEqual(backend.toolResults.count, 2)
+    }
+
+    // MARK: - Diagnostics
+
+    /// The goal is the wearer's own words. The log this provider writes has never held one,
+    /// and the deliberation tier does not get to be the first.
+    func testTheGoalIsLoggedByLengthAndNeverByContent() async {
+        let backend = ToolBackend()
+        let sink = RecordingSink()
+        let secret = "tell Claude to push the release key to the staging box"
+        let provider = makeProvider(backend, loop: Loop(.accepted(spoken: "On it.")), sink: sink)
+
+        provider.start { _ in }
+        await settle()
+        provider.stop()
+        backend.emit(call(#"{"goal":"\#(secret)"}"#))
+        await settle()
+
+        let requested = sink.events.first { $0.name == "tool.start_task_requested" }
+        XCTAssertEqual(requested?.fields["length"], "\(secret.count)")
+        for event in sink.events {
+            for value in event.fields.values {
+                XCTAssertFalse(value.contains("staging box"),
+                               "\(event.name) put the wearer's goal in the log")
+            }
+        }
+    }
+
+    // MARK: - The reflex tier is untouched
+
+    /// The point of the two tiers is latency, so the test is that nothing changed for the six
+    /// that were instant: a spoken "approve" still resolves its window in one call, with no
+    /// loop anywhere in the path, on a provider that has a loop composed.
+    func testApproveStillResolvesTheWindowDirectlyWithALoopComposed() async {
+        let backend = ToolBackend()
+        let loop = Loop(.accepted(spoken: "should not be reached"))
+        let provider = makeProvider(backend, loop: loop)
+        var delivered: [VoiceCommand] = []
+
+        provider.start { delivered.append($0) }
+        await settle()
+        backend.emit(.toolCall(VoiceToolCall(callID: "c1", name: "approve", argumentsJSON: "")))
+        await settle()
+
+        XCTAssertEqual(delivered, [.yes])
+        XCTAssertTrue(loop.goals.isEmpty, "the reflex tier must not go through the loop")
+    }
+
+    // MARK: - The declaration's own words
+
+    /// The description is the only place the boundary between a task and the reflex tools can
+    /// be drawn, so the load-bearing halves of it are pinned: it names the tools it is not,
+    /// it says the answer does not come back through the call, and it says that starting a
+    /// task authorizes nothing.
+    func testTheDescriptionSteersMultiStepGoalsHereAndSingleStepIntentsAway() async {
+        let task = VoiceIntentTools.startTaskDeclaration
+        XCTAssertEqual(task.name, "start_task")
+        for reflex in ["approve", "deny", "select_item", "queue_instruction", "query_status"] {
+            XCTAssertTrue(task.description.contains(reflex),
+                          "the task tool must name the reflex tool it is not: \(reflex)")
+        }
+        XCTAssertTrue(task.description.lowercased().contains("more than one step"))
+        XCTAssertTrue(task.description.lowercased().contains("authorizes nothing"),
+                      "starting a task must not read like an approval")
+
+        let byName = Dictionary(uniqueKeysWithValues: task.parameters.map { ($0.name, $0) })
+        XCTAssertEqual(byName["goal"]?.required, true)
+        XCTAssertEqual(task.parameters.count, 1, "a task takes a goal and nothing else")
+    }
+
+    /// It names no conditional tool. `ask_about_work` is composed on its own gate and may be
+    /// absent from a run that has this one, and a description pointing at a tool the session
+    /// never declared is an invitation to call it — which breaks the voice channel. The
+    /// question boundary is drawn by behavior instead, exactly as `query_status` draws its
+    /// half.
+    func testTheDescriptionNamesNoToolThatMightNotBeDeclared() async {
+        let task = VoiceIntentTools.startTaskDeclaration
+        XCTAssertFalse(task.description.contains("ask_about_work"),
+                       "a conditional tool must not be named by another conditional tool")
+        XCTAssertTrue(task.description.lowercased().contains("session history"),
+                      "the question boundary still has to be drawn, by behavior")
+    }
+
+    /// The steering added to the two neighbors points work *away* without naming a tool that
+    /// may not exist, which is the same rule `query_status` was written under in M1.
+    func testTheNeighborsSteerMultiStepRequestsAwayWithoutNamingTheTaskTool() async {
+        let queue = VoiceIntentTools.declarations.first { $0.name == "queue_instruction" }
+        XCTAssertEqual(queue?.description.contains("is not this tool"), true,
+                       "dictation must point a look-something-up request away from itself")
+        XCTAssertEqual(queue?.description.contains("start_task"), false)
+
+        let ask = VoiceIntentTools.askAboutWorkDeclaration
+        XCTAssertTrue(ask.description.contains("is not this tool"),
+                      "a question tool must point a go-and-do request away from itself")
+        XCTAssertFalse(ask.description.contains("start_task"))
+    }
+
+    /// The five ratified actions are unchanged by the seventh: nothing was renamed, nothing
+    /// was reordered, and the tool that can end a session still does not exist.
+    func testTheFiveRatifiedToolsAreUntouchedAndNothingEndsTheSession() async {
+        XCTAssertEqual(VoiceIntentTools.declarations.map(\.name),
+                       ["approve", "deny", "select_item", "queue_instruction", "query_status"])
+        let all = VoiceIntentTools.declarations(includingAskAboutWork: true,
+                                                includingStartTask: true)
+        XCTAssertEqual(all.map(\.name), [
+            "approve", "deny", "select_item", "queue_instruction", "query_status",
+            "ask_about_work", "start_task",
+        ])
+        for declaration in all {
+            for word in ["end", "quit", "exit", "shutdown", "kill", "sleep"] {
+                XCTAssertFalse(declaration.name.contains(word),
+                               "\(declaration.name) reads like a way out of the session")
+            }
+        }
+    }
+
+    // MARK: - Resolution, in isolation
+
+    /// The pure half, enumerated the way `VoiceIntentToolsTests` enumerates the other six:
+    /// undeclared is fatal, an unreadable or absent goal is fatal, a blank one is refused, and
+    /// a real one produces the goal trimmed and otherwise untouched.
+    func testResolutionEnumeratedWithoutAProvider() async {
+        func resolve(_ arguments: String, declared: Bool = true,
+                     windowOpen: Bool = true) -> VoiceIntentTools.Resolution {
+            VoiceIntentTools.resolve(
+                VoiceToolCall(callID: "c1", name: "start_task", argumentsJSON: arguments),
+                windowOpen: windowOpen, startTaskDeclared: declared)
+        }
+
+        guard case .malformed = resolve(#"{"goal":"x"}"#, declared: false) else {
+            return XCTFail("an undeclared start_task must be a protocol failure")
+        }
+        guard case .malformed = resolve("{not json") else {
+            return XCTFail("unreadable arguments must be a protocol failure")
+        }
+        guard case .malformed = resolve("{}") else {
+            return XCTFail("a missing goal must be a protocol failure")
+        }
+        guard case .refused(_, let speak) = resolve(#"{"goal":" \n "}"#) else {
+            return XCTFail("a blank goal must be refused, not fatal")
+        }
+        XCTAssertEqual(speak, VoiceIntentTools.emptyGoalNotice)
+        guard case .startTask(let goal) = resolve(#"{"goal":"  run the tests  "}"#) else {
+            return XCTFail("a real goal must start a task")
+        }
+        XCTAssertEqual(goal, "run the tests")
+
+        // And with nothing listening, which changes none of it.
+        guard case .startTask = resolve(#"{"goal":"run the tests"}"#, windowOpen: false) else {
+            return XCTFail("a task needs no open window")
+        }
+    }
+
+    /// The gate defaults to closed. A caller that forgot the argument gets the Apple path's
+    /// answer, not the loop's — the same fail direction every other gate on this path has.
+    func testTheGateIsClosedByDefault() async {
+        guard case .malformed = VoiceIntentTools.resolve(
+            VoiceToolCall(callID: "c1", name: "start_task", argumentsJSON: #"{"goal":"x"}"#),
+            windowOpen: true) else {
+            return XCTFail("start_task must be undeclared unless a composition asked for it")
+        }
+        XCTAssertEqual(VoiceIntentTools.declarations(includingAskAboutWork: false).map(\.name),
+                       ["approve", "deny", "select_item", "queue_instruction", "query_status"])
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/VoiceIntentToolsTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceIntentToolsTests.swift
@@ -250,6 +250,26 @@ final class VoiceIntentToolsTests: XCTestCase {
         }
     }
 
+    /// The two conditional tools are undeclared by default, so a call for either against a
+    /// composition that did not ask for it lands in the same place a name nobody wrote down
+    /// does. The gates default closed; nothing here has to remember to turn them off.
+    func testTheConditionalToolsAreProtocolFailuresUnlessTheirGateIsOpen() {
+        let conditional = [
+            call("ask_about_work", #"{"question":"what did you run?"}"#),
+            call("start_task", #"{"goal":"run the tests and tell me"}"#),
+        ]
+        for one in conditional {
+            guard case .malformed = VoiceIntentTools.resolve(one, windowOpen: true) else {
+                return XCTFail("\(one.name) ran on a composition that never declared it")
+            }
+        }
+        guard case .startTask = VoiceIntentTools.resolve(
+            call("start_task", #"{"goal":"run the tests and tell me"}"#),
+            windowOpen: true, startTaskDeclared: true) else {
+            return XCTFail("start_task must run where a loop is composed")
+        }
+    }
+
     func testUnreadableArgumentsAreAProtocolFailure() {
         let broken = [
             call("select_item", "{not json"),
@@ -271,6 +291,17 @@ final class VoiceIntentToolsTests: XCTestCase {
             call("queue_instruction", #"{"text":"   "}"#), windowOpen: true) else {
             return XCTFail("an empty instruction must be refused, not fatal")
         }
+    }
+
+    /// A goal that captured silence is the same kind of event, and gets the same sentence:
+    /// the wearer spoke, nothing was heard, and there is nothing to say but "say it again".
+    func testAnEmptyGoalIsRefusedWithTheSameSentenceAsAnEmptyInstruction() {
+        guard case .refused(_, let speak) = VoiceIntentTools.resolve(
+            call("start_task", #"{"goal":"   "}"#),
+            windowOpen: true, startTaskDeclared: true) else {
+            return XCTFail("an empty goal must be refused, not fatal")
+        }
+        XCTAssertEqual(speak, VoiceIntentTools.emptyInstructionNotice)
     }
 
     /// A kind outside the declared enum reaches here only if the service let it through.

--- a/Tests/TapQVoiceBackendsTests/StartTaskRealtimeRoundTripTests.swift
+++ b/Tests/TapQVoiceBackendsTests/StartTaskRealtimeRoundTripTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+import Foundation
+@testable import TapQVoiceBackends
+import TapQContracts
+@testable import TapQInteractionBaseline
+
+/// The deliberation tool as one stack: a real `VoiceBackendCommandProvider` on top of the
+/// real OpenAI Realtime adapter talking to a scripted server, with a fake loop at the far end.
+///
+/// Everything below has its own tests; these are the ones that would catch a surface that is
+/// individually correct and jointly wrong — a declaration that never reaches the wire, an
+/// acknowledgment that never becomes a frame, a tool result that leaves the peer parked
+/// because the goal took a different path out of the provider.
+@MainActor
+final class StartTaskRealtimeRoundTripTests: XCTestCase {
+    private func settle() async {
+        for _ in 0..<12 { await Task.yield() }
+    }
+
+    /// Answers with whatever the test scripted and records what it was offered.
+    private final class Loop: WearerTaskStarting, @unchecked Sendable {
+        private let start: WearerTaskStart
+        /// Written inside `startTask` and read by the test after it has awaited the round
+        /// trip, so the `await` is the ordering and no lock is needed — which also keeps this
+        /// out of the "a lock taken across an await is an error in Swift 6" rule.
+        nonisolated(unsafe) private(set) var goals: [String] = []
+
+        init(_ start: WearerTaskStart) { self.start = start }
+
+        func startTask(goal: String) async -> WearerTaskStart {
+            goals.append(goal)
+            return start
+        }
+    }
+
+    private struct Stack {
+        let server: ScriptedRealtimeServer
+        let realtime: OpenAIRealtimeVoiceBackend
+        let loop: Loop
+        let provider: VoiceBackendCommandProvider
+    }
+
+    private func makeStack(_ start: WearerTaskStart) -> Stack {
+        let server = ScriptedRealtimeServer()
+        let realtime = OpenAIRealtimeVoiceBackend(transport: server, monotonicNow: { 0 })
+        let loop = Loop(start)
+        return Stack(
+            server: server,
+            realtime: realtime,
+            loop: loop,
+            provider: VoiceBackendCommandProvider(
+                backend: realtime,
+                intentSource: .modelToolCalls,
+                sessionPolicy: .conversation(idleClose: 60),
+                supportsBargeIn: true,
+                startWearerTask: loop,
+                // Bounded, so the timer this leaves behind cannot stall the next test in the
+                // process. The policy's own idle close is unchanged.
+                idleSleep: { _ in try? await Task.sleep(for: .seconds(1)) }
+            )
+        )
+    }
+
+    private func pcm16(_ frames: Int) -> VoiceAudioChunk {
+        VoiceAudioChunk(data: Data(repeating: 0x11, count: frames * 2),
+                        format: OpenAIRealtimeVoiceBackend.audioFormat, timestamp: 0)
+    }
+
+    /// Opens a window, gives the turn something to commit, and commits it — the state a tool
+    /// call actually arrives in on this path.
+    ///
+    /// The audio is not decoration. The scripted server polices the input buffer exactly as
+    /// the service does, so a commit over an empty one creates no response at all — and a
+    /// fixture in that state would be asserting about a tool call arriving inside a response
+    /// that never existed.
+    private func openRespondingWindow(_ stack: Stack) async {
+        stack.provider.start { _ in }
+        await settle()
+        stack.realtime.sendAudio(pcm16(2_400))
+        stack.provider.endActiveTurn()
+        await settle()
+    }
+
+    private func toolFrame(_ arguments: String, id: String = "call_1") -> String {
+        RealtimeToolFrame.functionCall(callID: id, name: "start_task", arguments: arguments)
+    }
+
+    /// The instructions of every `response.create` that carried any, in order.
+    ///
+    /// By search rather than by index, because the commit that ends the wearer's turn also
+    /// creates a response and that one carries none: the scripted sentence is not reliably
+    /// the first `response.create` on the wire, only the first one with words in it.
+    private func spokenSentences(_ server: ScriptedRealtimeServer) -> [String] {
+        server.sent
+            .filter { $0["type"] as? String == "response.create" }
+            .compactMap { ($0["response"] as? [String: Any])?["instructions"] as? String }
+    }
+
+    private func wasSpoken(_ sentence: String, on server: ScriptedRealtimeServer) -> Bool {
+        spokenSentences(server).contains { $0.contains(sentence) }
+    }
+
+    /// The declaration rides the handshake frame, exactly as the reflex six do, and the
+    /// session the model actually sees has seven tools on it.
+    func testTheToolReachesTheWireOnTheHandshakeFrame() async {
+        let stack = makeStack(.accepted(spoken: "On it."))
+
+        stack.provider.start { _ in }
+        await settle()
+
+        let session = stack.server.sessionConfiguration
+        let names = (session?["tools"] as? [[String: Any]])?.compactMap { $0["name"] as? String }
+        XCTAssertEqual(names, [
+            "approve", "deny", "select_item", "queue_instruction", "query_status", "start_task",
+        ])
+    }
+
+    /// The whole round trip against the real adapter: a function call inside a response TapQ
+    /// asked for, the goal handed to the loop, the peer answered with a
+    /// `function_call_output` item, and the acknowledgment leaving as TapQ's own out-of-band
+    /// scripted response — one sentence, verbatim, in the words the loop chose.
+    func testAGoalRoundTripsAndTheAcknowledgmentLeavesAsScriptedSpeech() async {
+        let stack = makeStack(.accepted(spoken: "I'm on it — I'll tell you what the tests say."))
+        await openRespondingWindow(stack)
+        let callResponse = stack.realtime.activeResponseIdentity
+
+        stack.server.push(toolFrame(#"{"goal":"run the tests and tell me if anything fails"}"#))
+        await settle()
+        // The response the call arrived in finishes; TapQ's sentence is a separate one.
+        stack.server.push(RealtimeFrame.responseDone(id: callResponse ?? ""))
+        await settle()
+
+        XCTAssertEqual(stack.loop.goals, ["run the tests and tell me if anything fails"])
+        XCTAssertTrue(stack.server.sentTypes.contains("conversation.item.create"),
+                      "the peer was left parked on the call: \(stack.server.sentTypes)")
+
+        XCTAssertTrue(
+            wasSpoken("I'm on it — I'll tell you what the tests say.", on: stack.server),
+            "the acknowledgment never left as speech: \(spokenSentences(stack.server))")
+        XCTAssertNotEqual(stack.realtime.activeResponseIdentity, callResponse,
+                          "TapQ's sentence must be its own response")
+    }
+
+    /// A busy loop is the same round trip with a different sentence. Nothing about it is a
+    /// failure: the peer is answered, the wearer is told, and the session carries on.
+    func testABusyLoopRoundTripsTheSameWayWithItsOwnSentence() async {
+        let busy = "I'm still on the last one — ask me again in a minute."
+        let stack = makeStack(.busy(spoken: busy))
+        var failures: [String] = []
+        stack.provider.onIntentPipelineFailed = { failures.append($0) }
+        stack.provider.onScriptedSpeechUndeliverable = { failures.append($0) }
+        await openRespondingWindow(stack)
+        let callResponse = stack.realtime.activeResponseIdentity
+
+        stack.server.push(toolFrame(#"{"goal":"tell Codex to review that"}"#))
+        await settle()
+        stack.server.push(RealtimeFrame.responseDone(id: callResponse ?? ""))
+        await settle()
+
+        XCTAssertEqual(stack.loop.goals, ["tell Codex to review that"])
+        XCTAssertTrue(wasSpoken(busy, on: stack.server),
+                      "the busy sentence never left: \(spokenSentences(stack.server))")
+        XCTAssertTrue(failures.isEmpty, "a busy loop is not a broken pipe")
+    }
+
+    /// Nothing is resolved by a task, right down to the wire: no window command is delivered,
+    /// the window stays open, and no `response.cancel` is sent — the response the call arrived
+    /// in is left to finish, because nothing about a task means the wearer moved on.
+    func testATaskResolvesNothingAndCancelsNothing() async {
+        let stack = makeStack(.accepted(spoken: "On it."))
+        var delivered: [VoiceCommand] = []
+        stack.provider.start { delivered.append($0) }
+        await settle()
+        stack.realtime.sendAudio(pcm16(2_400))
+        stack.provider.endActiveTurn()
+        await settle()
+
+        stack.server.push(toolFrame(#"{"goal":"find out why the build broke"}"#))
+        await settle()
+
+        XCTAssertEqual(delivered, [])
+        XCTAssertTrue(stack.provider.isWindowOpenForTesting)
+        XCTAssertFalse(stack.server.sentTypes.contains("response.cancel"))
+    }
+
+    /// A blank goal is refused out loud through the same two frames — the peer gets its
+    /// output item, the wearer gets a sentence — and the loop is never handed it.
+    func testABlankGoalIsRefusedOutLoudOverTheWire() async {
+        let stack = makeStack(.accepted(spoken: "should not be reached"))
+        await openRespondingWindow(stack)
+        let callResponse = stack.realtime.activeResponseIdentity
+
+        stack.server.push(toolFrame(#"{"goal":"  "}"#))
+        await settle()
+        stack.server.push(RealtimeFrame.responseDone(id: callResponse ?? ""))
+        await settle()
+
+        XCTAssertTrue(stack.loop.goals.isEmpty)
+        XCTAssertTrue(stack.server.sentTypes.contains("conversation.item.create"))
+        XCTAssertTrue(wasSpoken(VoiceIntentTools.emptyGoalNotice, on: stack.server),
+                      "the refusal never left: \(spokenSentences(stack.server))")
+    }
+}

--- a/docs/AGENT_M1_M2_SMOKE_CHECKLIST.md
+++ b/docs/AGENT_M1_M2_SMOKE_CHECKLIST.md
@@ -1,0 +1,91 @@
+# Agent M1 + M2 hardware smoke checklist
+
+Verifies milestones M1 (wearer memory + transcript answers, PR #40) and M2
+(the deliberation loop, PR #41) of TAPQ_AGENT_PLAN.md on real hardware.
+Order matters: each part builds on the previous one's state.
+
+Setup: runtime launched with `--voice-backend openai-realtime
+--voice-freeform --voice-trust environment --voice-instructions
+--voice-session`; a Claude Code session in ~/tapq-arena with hooks
+installed; AirPods in. The ready block must show `openai-realtime`,
+semantic turn detection, and the voice-session hold. Log signatures below
+are grep-able in the runtime's TAPQ_DEBUG stderr log.
+
+## Part A — ask about the work (M1 Pillar B)
+
+- [ ] **A1 — transcript attaches.** In Claude Code, run something with
+  visible output (`git status`). Approve by voice; let it finish.
+  Log: `transcript.attached`, then `transcript.tailed bytes=…`.
+- [ ] **A2 — the answer quotes reality.** Say: *"What did git status
+  say?"* Expect a spoken answer quoting the actual output (branch name,
+  clean/dirty). Under M2 the hold can reach ~35 s worst case; typical is
+  a few seconds. Log: `ask.requested`, `ask.answered latency_ms=…
+  slices=…`. Note the latency — it is a pending maintainer call.
+- [ ] **A3 — honest unavailability.** Ask about an agent with no
+  transcript: *"What did Codex run?"* Expect a plain spoken "can't see
+  that history" — never silence — and the session stays alive.
+- [ ] **A4 — follow-ups cohere.** Immediately ask: *"Which branch was
+  that on?"* The answer should follow from A2's exchange (grounding).
+
+## Part B — TapQ's own memory (M1 Pillar A)
+
+- [ ] **B1 — recall within the run.** Minutes after some exchanges, ask:
+  *"What was the thing I asked you earlier?"* Expect a correct recall of
+  your earlier request (verbatim-ish — your words are stored verbatim).
+- [ ] **B2 — memory survives a restart.** Have the runtime restarted,
+  then ask the same question. The answer must survive the restart.
+  The file: `wearer-conversation.jsonl` under the runtime's
+  application-support dir.
+- [ ] **B3 — `tapq memory clear` wipes.** Run it in a terminal (it
+  confirms; names the path and entry count). Ask again — expect an
+  honest "nothing remembered", not a fabricated memory.
+
+## Part C — the deliberation loop (M2)
+
+- [ ] **C1 — a knowledge task.** Say: *"Check what Claude Code is doing
+  and tell me."* Expect an immediate spoken acknowledgment, then a
+  spoken result when the loop finishes. Log: `tool.start_task_requested`,
+  `task.started`, `task.step n=… tool=…`, `task.finished steps=…`.
+- [ ] **C2 — a task that acts.** Say: *"Run the tests and tell me if
+  anything fails."* Expect: acknowledgment; the loop announces the
+  instruction it queues ("I told Claude Code to …"); the command still
+  hits the normal approval gate (approve it by voice — the loop cannot
+  approve); later, a spoken outcome. The loop's authority is only what
+  dictation already had.
+- [ ] **C3 — one task at a time.** While C2's task is still running,
+  hand TapQ another goal. Expect a spoken busy refusal, not a queue.
+  Log: `task.busy`.
+- [ ] **C4 — the loop asks you.** Give a goal that needs a decision:
+  *"Tell the agent to clean up the scratch files, but check with me
+  first."* Expect TapQ to ask a question, pause, and resume with your
+  answer. An unanswered question ends the task audibly at the question
+  machinery's own bound (~4 min).
+- [ ] **C5 — honest failure.** Give an impossible goal: *"Figure out why
+  the production deploy failed."* Expect a spoken "I couldn't finish /
+  couldn't find that" — never silent abandonment.
+- [ ] **C6 — memory and transcript combine.** Say: *"What did I ask you
+  to do earlier, and did Claude Code actually do it?"* The answer should
+  draw on both your conversation record and the agent's transcript.
+- [ ] **C7 — cancellation is the one silent ending.** End the voice
+  session (tap/gesture) mid-task. The task cancels without speech (the
+  session itself is ending); the started record stays in memory.
+  Log: `task.cancelled reason=…`.
+
+## Part D — the loop stays subordinate (M2 guardrails)
+
+- [ ] **D1 — no approval bypass.** During C2, confirm the approval
+  question reached you before the command ran, and that denying it works:
+  repeat with a deny — the loop's task should surface the denial honestly.
+- [ ] **D2 — reflex stays instant.** With and without a task running,
+  a plain "approve" on a pending request must resolve immediately — no
+  loop in that path.
+
+## Part E — optional, destructive
+
+- [ ] **E1 — voice break is loud.** Drop the network mid-question.
+  Expect the ratified break: one local notice, dead voice for the run,
+  clear error-level diagnostics. No half-alive session, no second voice.
+
+Findings go back into TAPQ_AGENT_PLAN.md; the known pending calls this
+smoke should inform: the ~35 s worst-case answer hold, the missing
+`--no-memory` flag, and M3's initiative budgets.

--- a/docs/REALTIME_INTENT_PLAN.md
+++ b/docs/REALTIME_INTENT_PLAN.md
@@ -39,6 +39,14 @@ only when the wearer's meaning is unambiguous, and TapQ executes it.
   (unknown agent → the same spoken refusal as today, via the tool result).
 - `query_status(kind)` — "who's waiting?", "what changed?" style queries,
   answered from the same context TapQ uses today.
+- `start_task(goal)` — added by milestone M2 of `TAPQ_AGENT_PLAN.md`, and
+  declared only where a deliberation loop is composed (its own gate, the same
+  shape as `ask_about_work`'s). Everything above it is the reflex tier and is
+  unchanged: single-step intents resolve directly, with no loop in the path.
+  This one hands the wearer's goal across the `WearerTaskStarting` seam and
+  speaks the sentence that comes back — an acknowledgment, or that TapQ is
+  busy — verbatim on the scripted channel. It resolves nothing, needs no open
+  window, and starts nothing the wearer will not still be asked to approve.
 
 Contract details:
 

--- a/docs/TAPQ_AGENT_PLAN.md
+++ b/docs/TAPQ_AGENT_PLAN.md
@@ -2,11 +2,11 @@
 
 Status: direction ratified by the maintainer 2026-08-28 ("TapQ itself will
 become a small agent with its own agent loop, and this agent will be
-controlling other agents such as Claude Code"). **Milestone M1 implemented
-2026-08-29** (both pillars; see the "As built" sections and the answered
-open questions below); **M2's loop built 2026-08-29** (engine, internal
-tools, `ask_about_work` folded in, composition — see "As built (Pillar C,
-M2)"); M3–M4 not started. Everything here is
+controlling other agents such as Claude Code"). **Milestones M1 and M2
+implemented 2026-08-29** (M1: both pillars; M2: `start_task`, the loop, its
+seven internal tools, `ask_about_work` folded in — see the "As built"
+sections and the answered open questions below); M3–M4 not started.
+Everything here is
 **cloud-backend-only** — composed on the
 `.openaiRealtime` branch (and future model-backed backends); the Apple path
 keeps today's reactive, event-level behavior, structurally absent not
@@ -147,9 +147,12 @@ slices with TapQ's own memory.
   a spoken "approve" must stay instant.
 - **Deliberation tier (new):** the realtime model gains one tool,
   `start_task(goal)`, for anything that needs knowledge or multiple steps —
-  "what did the tests say?", "tell Codex to do what Claude just did",
-  "run the tests and let me know if anything fails". The goal is handed to
-  the TapQ loop and the wearer hears an acknowledgment.
+  "tell Codex to do what Claude just did", "run the tests and let me know
+  if anything fails". The goal is handed to the TapQ loop and the wearer
+  hears an acknowledgment. (A pure work-history *question* — "what did the
+  tests say?" — stays on `ask_about_work`, which since M2 runs through the
+  loop's bounded question lane anyway; the original example here predated
+  M1 shipping that tool.)
 
 ### The loop itself
 

--- a/docs/TAPQ_AGENT_PLAN.md
+++ b/docs/TAPQ_AGENT_PLAN.md
@@ -4,7 +4,9 @@ Status: direction ratified by the maintainer 2026-08-28 ("TapQ itself will
 become a small agent with its own agent loop, and this agent will be
 controlling other agents such as Claude Code"). **Milestone M1 implemented
 2026-08-29** (both pillars; see the "As built" sections and the answered
-open questions below); M2–M4 not started. Everything here is
+open questions below); **M2's loop built 2026-08-29** (engine, internal
+tools, `ask_about_work` folded in, composition — see "As built (Pillar C,
+M2)"); M3–M4 not started. Everything here is
 **cloud-backend-only** — composed on the
 `.openaiRealtime` branch (and future model-backed backends); the Apple path
 keeps today's reactive, event-level behavior, structurally absent not
@@ -170,6 +172,107 @@ something to say, and can pause on `ask_wearer` and resume with the answer.
 Task state is held in memory (Pillar A), so a restart mid-task loses the
 loop but not the record of what was asked.
 
+### As built (Pillar C, M2, 2026-08-29)
+
+Where the implementation is more specific than the plan above, or differs.
+Engine and composition only; the realtime `start_task` tool is its own half
+and lands with it.
+
+- **One engine, two lanes, split by who is waiting.** `WearerTaskLoop`
+  (`Sources/TapQContextBaseline`) has a *task lane* — `start_task`, six steps,
+  runs off the voice turn — and a *question lane*, which is `ask_about_work`
+  folded in. They are not the same shape because the question lane runs
+  *inside* the realtime peer's tool call while the task lane runs with nobody
+  parked, and one set of bounds could not serve both.
+- **The question lane costs one bound, and it is the M1 hold.** M1 answered in
+  one model call under a 15 s timeout. The lane takes at most 3 calls and stops
+  asking for another past a 20 s wall clock, so the peer's hold is ~35 s worst
+  case against a typical two calls. The rejected alternative was answering the
+  peer immediately and speaking later, which would leave the realtime model free
+  to talk over TapQ's own answer. **Maintainer call wanted** if 35 s is too long.
+- **The question lane keeps M1's wearer-facing behavior and widens one case.**
+  `answered` / `unavailable` / `failed` still mean what they meant, the answer is
+  still the model's words spoken verbatim, and the two failure classes are still
+  apart. The widening: `unavailable` now also carries "I couldn't work that out
+  in time" for a lane that ran out of steps. That is the right *handling* —
+  spoken, error-logged, session alive — and `failed` would break the voice over a
+  slow think, which the ratified posture reserves for cloud calls that failed.
+- **The question lane does not take the task slot.** `.busy` governs `start_task`
+  only. The lane resolves nothing, declares three read-only tools (`search_memory`,
+  `read_transcript`, `finish` — it cannot speak, ask, or queue), and refusing to
+  answer a question because a background task was running would regress M1 for no
+  safety gained.
+- **`read_transcript` returns excerpts, not an answer.** That is what the fold-in
+  buys: one sentence composed from the agent's history *and* TapQ's own memory.
+  `TranscriptQuestionAnswerer` gained `excerpts(question:agentDisplayName:)` —
+  session resolution, the tail, the on-demand re-read, selection, the three
+  unavailability sentences — and its `answer(_:)` now calls it. The direct path is
+  kept, not deleted: it is the one-call shape and the composition's fallback.
+- **`search_memory` is relevance-first, the mirror of the transcript selector.**
+  `WearerMemorySearch` ranks the whole retained record by how many of the query's
+  words an entry carries — over its text, outcome, agent, *and* tool name — with
+  recency only breaking ties, because the recent window is already in the realtime
+  grounding and the loop's job is the older history. A query whose every word is a
+  stop word falls back to the recent past; a query with real words that matched
+  nothing says so, because handing back unrelated dialogue is how a loop invents a
+  memory. No embeddings, same as transcripts.
+- **`queue_instruction` requires a name and announces itself.** Two differences
+  from the dictation flow, both deliberate. A name is required because the loop is
+  not standing in a window and "the agent that just asked me something" does not
+  exist off one; the model calls `get_status` (which lists the addressable names)
+  first. And what was sent is spoken, because a sentence delivered in the wearer's
+  name while they are not listening has to be audible. Rung E's resolver, its
+  ambiguity case, and its fail-closed refusal are reused unchanged.
+- **`ask_wearer` deliberately skips `resolveApproval`.** It builds the same
+  `ApprovalRequest(kind: .question)` the narrated-boundary path builds and runs it
+  through the same gate, but not through the approval *wrapper*: that wrapper opens
+  a session window, which would put "TapQ" in the roster as an agent the loop could
+  then address, and it runs the stage-2 assessment and the delegation filter —
+  which could auto-answer TapQ's own question without the wearer. The durable
+  record is written at the loop's call site instead.
+- **Every ending is audible except the two where nobody is listening.** `finish`
+  speaks its summary; the step cap speaks "I couldn't finish: …"; an `ask_wearer`
+  nobody answered speaks "I asked you something and didn't hear back…" and stops.
+  A cloud failure speaks nothing (the latch has its own notice, and a second
+  sentence would be the degraded half-agent). A cancellation speaks nothing
+  because both its causes — the wearer ending the voice session, the runtime
+  shutting down — take away the channel a sentence would go out on.
+- **The `ask_wearer` bound is the question machinery's own.** A window nobody
+  answers inside `InteractionBudget.total` (245 s) resolves `.ask`, and the loop
+  ends the task there rather than resuming into a turn the wearer is not listening
+  to. First unanswered question ends it; there is no second ask.
+- **The record is two entries, and the pair is the point.** `WearerDialogueKind`
+  gained `.task` — one `static let` plus one recorder, exactly the M3 migration
+  story that type documented — written once at the start with outcome `started`
+  and once at the end with the ending. A runtime that dies mid-task leaves a
+  `started` with no ending, which is the honest record: the loop is gone, the
+  request is not. Only speech-cleared text: the goal (read back out loud on
+  acceptance, same provenance as a dictated instruction) and one outcome word.
+- **One client family, a third method.** `OpenAINarrationModel` now also conforms
+  to `WearerTaskReasoning`. Same endpoint, key, timeout race, and failure posture;
+  the transport was split out of `perform` because a loop turn reads a
+  `function_call` item where the other two read `output_text`. Responses API flat
+  function tools with `tool_choice: "required"`, `reasoning.effort: none`,
+  `store: false` — so the rendered step history *is* the loop's memory of itself
+  and no second copy of the task exists at the vendor. A turn that comes back as
+  prose, as a refusal, or as two calls at once is a protocol failure and breaks
+  the voice, the same answer an undeclared realtime tool gets.
+- **Composition.** `.openaiRealtime` arm only; the Apple path builds no loop, so
+  there is nothing to disable and no flag. `onLoopBroken` is the fourth sibling on
+  the `VoiceBrokenState` latch, named separately so an operator can tell "could not
+  think" from "could not be heard" / "could not understand" / "could not answer".
+  The loop is cancelled on runtime shutdown, on the wearer ending the voice
+  session, and on the voice pipe breaking. The `start_task` hookup is one line,
+  marked `// M2 hookup:`.
+- **Verification.** `WearerTaskLoopTests` (multi-step, progress speech, busy
+  refusal, empty goal, step cap spoken, last-turn wording, `ask_wearer`
+  pause/resume, unanswered bound, cloud break latch, local-file loudness,
+  cancellation, the two-entry record across a reopen, an interrupted task's
+  dangling `started`, the queued-instruction announcement), `WearerTaskQuestionLaneTests`
+  (M1's three outcomes preserved, three-tool declaration, the two failure classes
+  apart, the step bound, a question answered while a task runs),
+  `WearerTaskContractTests`, `WearerMemorySearchTests`, `OpenAITaskTurnTests`.
+
 ### Initiative (M3, the guarded step)
 
 Standing directives — wearer sentences like "watch the build and tell me if
@@ -212,6 +315,9 @@ Guardrails, non-negotiable:
   shippable and useful with zero loop. **Both pillars built 2026-08-29.**
 - **M2 — the loop, wearer-initiated only:** `start_task`, internal tools,
   `ask_about_work` folded in as a loop task, pause/resume on `ask_wearer`.
+  **Engine and composition built 2026-08-29** (see "As built (Pillar C, M2)");
+  the realtime `start_task` tool is the other half and lands with it. Hardware
+  smoke pending, as for M1.
 - **M3 — initiative:** standing directives, boundary-review invocation,
   the guardrail set above.
 - **M4 (with FLEET_ROSTER_PLAN rung F):** the loop conducting multiple


### PR DESCRIPTION
Milestone M2 of [`docs/TAPQ_AGENT_PLAN.md`](../blob/main/docs/TAPQ_AGENT_PLAN.md): the deliberation loop, wearer-initiated only. Stacks on #40 (M1). Cloud-backend-only throughout; the Apple path composes none of it.

## The two tiers

The reflex tier is untouched: approve, deny, select, queue_instruction, query_status stay instant, no loop in their path. A new `start_task(goal)` tool is the deliberation tier's front door — declared only when the loop is composed, acknowledged out loud when it takes a goal, and refusing ("busy") a second goal while one runs.

## The loop

`WearerTaskLoop` reasons with `gpt-5.6-luna` through the narration client (one client family — the failure posture cannot diverge) over seven injected tools: `search_memory` (the whole retained record, ranked — the retrieval half M1 deferred), `read_transcript`, `get_status`, `queue_instruction` (the existing fail-closed path; every queued instruction is announced before the loop continues), `speak`, `ask_wearer` (through the interaction gate directly — not `resolveApproval`, which would register TapQ as an addressable agent and could auto-answer TapQ's own question), and `finish`. Six steps, one task at a time, run off the voice turn.

Every ending is audible by design: a spoken summary, a spoken "I couldn't finish", or an unanswered `ask_wearer` timing out on the question machinery's own 245s budget. The one silent ending is cancellation at session/runtime death, where the session itself is ending; the `started` record in the memory store is the honest artifact. Cloud failure anywhere in the loop breaks the voice on the narration latch. Task lifecycles persist to the wearer conversation store as a new open `.task` entry kind — speech-cleared text only.

## ask_about_work folds in

Per the plan's one Pillar B revision: questions now run through a bounded question lane of the same loop (3 steps, 20s wall clock), so answers can combine transcript slices with TapQ's own memory. The M1 outcome vocabulary, verbatim speech, and two-class failure split are preserved; the direct M1 answerer stays behind the route as the fallback shape. The question lane does not take the task slot — a running background task never makes a question refuse.

## Decisions that want maintainer eyes

- **Answer latency**: the question lane can hold the peer's tool call up to ~35s worst case (was ≤15s in M1) — typically two model calls. Acknowledge-then-speak was rejected because it frees the realtime model to talk over the answer.
- A question lane that runs out of steps is spoken as an honest "couldn't work that out in time" (`unavailable`), not a voice break — `failed` stays reserved for cloud calls that actually failed.
- The committed seam has no empty-goal case; the surface refuses blank goals before dispatch, so the engine's defensive path (spoken, but labeled `.busy`) is unreachable in the shipped composition.

## Verification

74 new tests across 7 suites (loop happy path, step cap, busy, pause/resume, unanswered bound, break latch, cancellation, memory search, contract/turn rendering, tool declaration gating, spoken acknowledgment/busy/refusal, realtime round trips), on top of the M1 suites re-run green. Slim check from the main tree with all new + touched suites appended; host `swift build` clean. Banked in CLAUDE.md: Linux cannot register synchronous test methods on `@MainActor` XCTestCases — all new suites are fully `async`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
