### PR TITLE
Voice drain fixes: announced instructions, surviving grounding, no self-echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -597,6 +597,32 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Fixed
 
+- **A dictated instruction is no longer lost to the confirmation it cannot give**
+  (`--voice-backend openai-realtime`). On hardware (2026-08-30, `--voice-trust environment
+  --voice-session`) the wearer said "tell Claude Code to create a temporary testing file…".
+  The model resolved it into a `queue_instruction` call, TapQ routed it correctly — and then
+  queued a 125-character read-back and re-listened with 1.96 seconds left in the eight-second
+  window. TapQ holds the microphone closed while it speaks, so the countdown ran out during
+  its own playback and the instruction was discarded for silence. Structurally, every time
+  the read-back outlasted what was left of the window.
+
+  Where a model resolved the wearer's sentence into a tool call there is no longer a
+  confirmation: the instruction is queued on routing and **announced** — "Queued for Claude
+  Code: '⟨what you said⟩'", with the same drop-oldest disclosure and the same refusal to say
+  "queued" about anything the mailbox did not take. The read-back was built for the keyword
+  era, where the intent was guessed from a transcript and could be the wrong sentence
+  entirely; on the tool path the guess is gone, and an instruction still authorizes nothing.
+  The Apple path keeps its read-back for exactly that reason — and its deadline is fixed too:
+  a turn that asks the wearer something now gets its own playback plus a real answering
+  window, instead of whatever seconds the window happened to have left.
+
+  Two defects found with it, in the same flow: a read-back nobody answered discarded the
+  instruction **in silence** (the notice the class documents for this case was written and
+  never spoken), and a window ending wiped the model's record of what TapQ had just said even
+  while the wearer was still listening to it — so the next window's context claimed TapQ had
+  said nothing, and whatever the wearer said next reached a model that did not know what it
+  was answering.
+
 - **The realtime session's standing rules survive grounding.** Every turn replaces the
   session instructions with what the model needs to know about the window in front of it, and
   because the OpenAI session object restates the whole `instructions` field, the first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -597,6 +597,17 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Fixed
 
+- **TapQ no longer answers its own echo** (`--voice-backend openai-realtime`, no
+  AirPods). With answers playing through speakers into an open microphone, the backend's
+  turn detection heard the tail of TapQ's own voice as wearer speech and asked the model
+  to respond to it — so answers repeated themselves after a little silence. A turn whose
+  detected speech fell entirely within TapQ's own playback (plus a 600 ms echo tail,
+  `TAPQ_SELF_AUDIO_HYSTERESIS_MS`) is now suppressed and scrubbed from the conversation,
+  and the microphone stops uploading captured audio while TapQ is audible on this path —
+  barge-in there is IMU-driven, and the IMU is exactly what is absent. Anything ambiguous
+  fails open: the price of guessing wrong that way is one repeated answer, the other way
+  a dropped question. Real questions whose transcription merely arrived late still get
+  their turn, and the AirPods path is untouched.
 - **A dictated instruction is no longer lost to the confirmation it cannot give**
   (`--voice-backend openai-realtime`). On hardware (2026-08-30, `--voice-trust environment
   --voice-session`) the wearer said "tell Claude Code to create a temporary testing file…".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,13 @@ Container facts, all hard-won — do not rediscover them by hanging:
   methods on a `@MainActor` XCTestCase — hard errors in the container,
   invisible on macOS. Every test method in a `@MainActor` suite must be
   `async`, even pure assertions.
+- Agent worktrees are sometimes created at a stale base (seen twice at an
+  old main). First act in any worktree: `git log --oneline -1` and
+  fast-forward to the intended branch tip before writing code.
+- Voice-timing tests need the drain-aware doubles (speech occupies the
+  injected clock and holds the voice channel — see
+  InstructionAnnouncementTests / RealtimeSelfAudioTests). The instantaneous
+  `onFinish?()` doubles cannot express any deadline-vs-playback race.
 - The build dir is the shared volume `tapq-linux-build` via `--scratch-path
   /build`. Never run two containers against it at once — they starve each other.
 - Only the host `swift build` covers the Apple adapters and runtime app; they

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -941,6 +941,17 @@ import Darwin
         // either, so the loop is let go by the session budget, by a gesture or a tap, or by
         // shutting the runtime down. Ratified 2026-08-28; see docs/REALTIME_INTENT_PLAN.md.
         let voiceMayEndSession = configuration.voiceBackend == .apple
+        // Where the wearer's intent comes from, handed to every window that can dictate.
+        // It is the same fact the provider is composed with above (`intentSource:
+        // .modelToolCalls` on the realtime branch) and must stay the same fact: a window
+        // that believed it was reading a grammar's guess while the model was resolving tool
+        // calls would put a confirmation in front of an instruction that has already been
+        // resolved — which is the step that discarded a live dictation on 2026-08-30.
+        //
+        // On the model path a routed instruction is announced rather than confirmed; on the
+        // Apple path the read-back-and-confirm flow is exactly what it has always been.
+        let voiceIntentSource: VoiceIntentSource =
+            configuration.voiceBackend == .apple ? .transcriptGrammar : .modelToolCalls
         // Fail-closed by composition, not by convention: with no gate there is no object
         // to ask, and the answer is no. The gate outlives every window (the voice chain
         // holds it), so the weak capture is bookkeeping rather than a lifetime it depends
@@ -994,7 +1005,8 @@ import Darwin
             // looks for an address at all.
             instructionAddressResolver: memory.instructionAddressResolver,
             voiceTrust: configuration.voiceTrust,
-            gestureConfirmation: gestureConfirmation
+            gestureConfirmation: gestureConfirmation,
+            intentSource: voiceIntentSource
         )
 
         // The detector reads the *default output device's* volume, which without AirPods is
@@ -1042,7 +1054,8 @@ import Darwin
             instructionEnqueue: memory.instructionEnqueue,
             instructionAddressResolver: memory.instructionAddressResolver,
             voiceTrust: configuration.voiceTrust,
-            gestureConfirmation: gestureConfirmation
+            gestureConfirmation: gestureConfirmation,
+            intentSource: voiceIntentSource
         )
         let interactionGate = InteractionGate()
 
@@ -1192,7 +1205,8 @@ import Darwin
                         // other than the last one TapQ served.
                         instructionAddressResolver: memory.instructionAddressResolver,
                         voiceTrust: configuration.voiceTrust,
-                        gestureConfirmation: gestureConfirmation
+                        gestureConfirmation: gestureConfirmation,
+                        intentSource: voiceIntentSource
                     )
                 }
             )
@@ -1264,7 +1278,8 @@ import Darwin
                         kind: .voiceSession,
                         voiceTrust: configuration.voiceTrust,
                         voiceMayEndSession: voiceMayEndSession,
-                        gestureConfirmation: gestureConfirmation
+                        gestureConfirmation: gestureConfirmation,
+                        intentSource: voiceIntentSource
                     )
                 }
             )

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -476,6 +476,13 @@ import Darwin
             // a dead output device to the one object allowed to act on it. Assigned inside
             // the decorator closure, which runs synchronously during `select`.
             var playbackDependent: PlaybackDependentVoiceBackend?
+            // The two halves that have to be able to tell TapQ's own voice from the
+            // wearer's, held for the same reason and assigned in the same closure. The
+            // player they ask about does not exist yet — it is built below, and it reports
+            // its dead output to `playbackDependent` above — so the question is wired the
+            // moment it does.
+            var realtimeAdapter: OpenAIRealtimeVoiceBackend?
+            var microphonePump: MicrophonePumpVoiceBackend?
             // Throwing aborts serve, like a misconfigured question classifier: the operator
             // asked for a specific pipe and must not be given a different one in silence.
             let selection = try VoiceBackendFactory.select(
@@ -490,11 +497,13 @@ import Darwin
                 // there is no state in which TapQ is still listening to a wearer it cannot
                 // answer.
                 decorateRealtimePrimary: { primary in
+                    realtimeAdapter = primary as? OpenAIRealtimeVoiceBackend
                     let pumped = MicrophonePumpVoiceBackend(
                         inner: primary,
                         voiceProcessingEnabled: configuration.voiceProcessingEnabled,
                         diagnosticSink: diagnostics
                     )
+                    microphonePump = pumped
                     let dependent = PlaybackDependentVoiceBackend(
                         inner: pumped,
                         diagnosticSink: diagnostics
@@ -538,6 +547,42 @@ import Darwin
                 playbackDependent?.notePlaybackUnavailable(detail: detail)
             }
             playback = player
+            // -- Self-hearing, the half `SpeechGatedVoice` cannot cover --
+            //
+            // The gate closes the microphone while TapQ speaks, and on this path that is not
+            // enough. With no AirPods there is no wearer turn signal, so the backend's own
+            // VAD decides where sentences end, and TapQ's answer leaves the Mac's speaker
+            // into the same room as the microphone the gate reopens the instant playback
+            // drains. On hardware (2026-08-30) the service heard the tail, called it the
+            // wearer's turn, committed it, and TapQ answered its own last sentence — a
+            // repeat after a beat of silence, over and over.
+            //
+            // So both halves of the pipe get to ask what TapQ's voice was doing at a given
+            // instant: the pump, so echo is never captured in the first place, and the
+            // adapter, so a segment that slipped through anyway is dropped rather than
+            // turned into a model turn. The player is the only thing that knows, and its
+            // one observer slot is already spoken for by `CombinedSpeechActivity`, so the
+            // question is a read of the span it records rather than a second subscription.
+            //
+            // Weak: the player is owned by the provider and the activity signal below, and
+            // neither of these two should keep an output device alive on its own.
+            let selfAudio: @MainActor () -> VoiceSelfAudioActivity = { [weak player] in
+                player?.selfAudioActivity ?? .silent
+            }
+            realtimeAdapter?.selfAudioActivity = selfAudio
+            microphonePump?.selfAudioActivity = selfAudio
+            // Both halves are wired through optionals, and a nil here is a fix that is half
+            // off with nothing to show for it. Said out loud rather than left to be inferred
+            // from an echo that came back.
+            diagnostics.record(.init(
+                category: "VoiceBackend",
+                name: "self_audio.wired",
+                level: (realtimeAdapter != nil && microphonePump != nil) ? .info : .warning,
+                fields: [
+                    "adapter": "\(realtimeAdapter != nil)",
+                    "microphone": "\(microphonePump != nil)",
+                ]
+            ))
 
             // -- Transcript context (TRANSCRIPT_CONTEXT_PLAN.md, phase 1) --
             //

--- a/Sources/TapQAppleAdapters/BackendAudioPlayback.swift
+++ b/Sources/TapQAppleAdapters/BackendAudioPlayback.swift
@@ -208,6 +208,20 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
     public private(set) var isPlaying: Bool = false
     public var onPlayingChange: (@MainActor (Bool) -> Void)?
 
+    /// When the current — or most recent — stretch of TapQ's own audio began and ended.
+    ///
+    /// The single-observer `onPlayingChange` slot is spoken for (`CombinedSpeechActivity`
+    /// owns it, and a second assignment would silently disable the self-hearing guard), so
+    /// the span is recorded here for anyone who has to ask about an instant that has already
+    /// passed. That is the whole shape of the echo problem: a remote VAD reports the speech
+    /// it heard hundreds of milliseconds late, by which time `isPlaying` has long since gone
+    /// false, and a sample of the flag then answers a question about the wrong moment.
+    public private(set) var selfAudioActivity: VoiceSelfAudioActivity = .silent
+
+    /// The clock the span is stamped on. `systemUptime` by default, matching what the
+    /// realtime adapter and the microphone pump compare against.
+    private let monotonicNow: @MainActor () -> TimeInterval
+
     /// Fired when the engine could not start, or refused a buffer: this machine cannot
     /// render backend response audio, and the caller must decide what a voice session
     /// without a voice is worth. Composition points it at
@@ -221,14 +235,19 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
     /// Production initializer: uses the live ObjC bridge through `LiveAudioPlaybackScheduler`.
     public init(diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
         self.scheduler = LiveAudioPlaybackScheduler()
+        self.monotonicNow = { ProcessInfo.processInfo.systemUptime }
         self.diagnostics = TapQDiagnosticEmitter(category: "Playback", sink: diagnosticSink)
     }
 
     /// Test seam: injects a fake scheduler so tests exercise the full state machine without
     /// touching audio hardware.
     init(scheduler: AudioPlaybackScheduling,
+         monotonicNow: @escaping @MainActor () -> TimeInterval = {
+             ProcessInfo.processInfo.systemUptime
+         },
          diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
         self.scheduler = scheduler
+        self.monotonicNow = monotonicNow
         self.diagnostics = TapQDiagnosticEmitter(category: "Playback", sink: diagnosticSink)
     }
 
@@ -392,6 +411,14 @@ struct AudioPlaybackSchedulerFailure: Error, Equatable, CustomStringConvertible 
     private func setPlaying(_ value: Bool) {
         guard value != isPlaying else { return }
         isPlaying = value
+        // Recorded before the observer runs, for the same reason the flag rises inside
+        // `enqueue`: whatever the gate does on this edge, it must never see a span that
+        // disagrees with the flag it was woken for.
+        let now = monotonicNow()
+        selfAudioActivity = value
+            ? VoiceSelfAudioActivity(startedAt: now, stoppedAt: nil)
+            : VoiceSelfAudioActivity(startedAt: selfAudioActivity.startedAt ?? now,
+                                     stoppedAt: now)
         onPlayingChange?(value)
     }
 

--- a/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
+++ b/Sources/TapQAppleAdapters/MicrophonePumpVoiceBackend.swift
@@ -33,6 +33,23 @@ import AVFoundation
 ///   "never always-on" guarantee.
 /// - **The pump never ends a turn.** It delivers audio; only TapQ decides when the turn
 ///   is over.
+///
+/// ## The one thing it refuses to carry
+///
+/// On the voice-only path — no AirPods, so no wearer turn signal and the backend's own VAD
+/// deciding where sentences end — TapQ's answers play out of the Mac's speaker into this
+/// microphone. Captured while that is sounding, they are uploaded as the wearer's audio,
+/// transcribed as the wearer's words, and endpointed as the wearer's turn; on hardware
+/// (2026-08-30) that had TapQ answering its own last sentence back to the wearer.
+///
+/// So while `selfAudioActivity` says TapQ's voice is in the room (plus the echo hysteresis)
+/// and native turn detection is on, captured buffers are dropped rather than sent. Nothing
+/// is lost by it: barge-in on that path is IMU-driven and the IMU is precisely what is
+/// missing, so wearer speech over TapQ's playback was never going to interrupt anything.
+///
+/// It is deliberately inert on the AirPods path (`setNativeTurnDetection(false)`), where the
+/// wearer's own turn signal is live, barge-in works, and audio does not leak from headphones
+/// into the microphone in the first place.
 @MainActor public final class MicrophonePumpVoiceBackend: VoiceBackend {
     public var capabilities: VoiceBackendCapabilities { inner.capabilities }
 
@@ -45,6 +62,35 @@ import AVFoundation
     private let wireFormat: VoiceAudioFormat
     private let makeAudioSource: @MainActor () -> any VoiceAudioSource
     private let diagnostics: TapQDiagnosticEmitter
+
+    /// What TapQ's own voice is doing in the room, or `nil` where nothing renders it.
+    ///
+    /// Composition wires this to the audio player. Left unwired — every test that does not
+    /// ask for it, and any host with no backend playback — the gate never closes and this
+    /// pump sends exactly what it has always sent.
+    public var selfAudioActivity: (@MainActor () -> VoiceSelfAudioActivity)?
+
+    /// How long after TapQ's audio drains the microphone is still assumed to be hearing it.
+    private let selfAudioHysteresis: TimeInterval
+
+    /// The clock the audibility question is asked on. The same one the player stamps its own
+    /// transitions with, or the comparison would be between two unrelated timelines.
+    private let monotonicNow: @MainActor () -> TimeInterval
+
+    /// Whether the backend's own VAD owns turn ends — which on this composition is the same
+    /// question as "does this run have a wearer turn signal", and therefore the same question
+    /// as "can TapQ's speaker reach this microphone". Tracked from the call that passes
+    /// through rather than asked of the inner backend: the pump is the layer that has to act
+    /// on it, and a mode it learned by reaching downwards would be a mode it could disagree
+    /// with.
+    private var nativeTurnDetectionOn = false
+
+    /// Captured blocks dropped as TapQ's own voice since the last one that got through, and
+    /// their duration. Counted rather than logged per block: buffers arrive every few
+    /// milliseconds, and one line per buffer would bury the run's log in the middle of the
+    /// event an operator is reading it for.
+    private var suppressedBlocks = 0
+    private var suppressedBytes = 0
 
     private var audioController: VoiceAudioSourceController?
     private var callerOnEvent: (@MainActor (VoiceBackendEvent) -> Void)?
@@ -84,6 +130,7 @@ import AVFoundation
         inner: any VoiceBackend,
         format: VoiceAudioFormat = .pcm16Mono24k,
         voiceProcessingEnabled: Bool = false,
+        selfAudioHysteresis: TimeInterval = VoiceSelfAudioEcho.resolvedHysteresis(),
         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
     ) {
         self.inner = inner
@@ -91,6 +138,8 @@ import AVFoundation
         self.makeAudioSource = {
             AVAudioEngineVoiceAudioSource(voiceProcessingEnabled: voiceProcessingEnabled)
         }
+        self.selfAudioHysteresis = selfAudioHysteresis
+        self.monotonicNow = { ProcessInfo.processInfo.systemUptime }
         self.diagnostics = TapQDiagnosticEmitter(category: "MicPump", sink: diagnosticSink)
     }
 
@@ -99,11 +148,17 @@ import AVFoundation
         inner: any VoiceBackend,
         format: VoiceAudioFormat = .pcm16Mono24k,
         makeAudioSource: @escaping @MainActor () -> any VoiceAudioSource,
+        selfAudioHysteresis: TimeInterval = VoiceSelfAudioEcho.defaultHysteresis,
+        monotonicNow: @escaping @MainActor () -> TimeInterval = {
+            ProcessInfo.processInfo.systemUptime
+        },
         diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()
     ) {
         self.inner = inner
         self.wireFormat = format
         self.makeAudioSource = makeAudioSource
+        self.selfAudioHysteresis = selfAudioHysteresis
+        self.monotonicNow = monotonicNow
         self.diagnostics = TapQDiagnosticEmitter(category: "MicPump", sink: diagnosticSink)
     }
 
@@ -179,6 +234,7 @@ import AVFoundation
     /// VAD commit would make every second sentence in a window inaudible. The mic still
     /// closes exactly where it always did: in `endUserTurn`, and nowhere else.
     public func setNativeTurnDetection(_ enabled: Bool) {
+        nativeTurnDetectionOn = enabled
         inner.setNativeTurnDetection(enabled)
     }
 
@@ -340,6 +396,10 @@ import AVFoundation
                       self.turnGeneration == generation,
                       self.turnActive else { return }
                 self.onInputLevel?(block.rms)
+                // The level hook still sees every block: it reports what the microphone
+                // heard, and what the microphone heard while TapQ was speaking is TapQ.
+                // Only the pipe is gated.
+                guard !self.dropAsSelfAudio(block) else { continue }
                 let chunk = VoiceAudioChunk(
                     data: block.data,
                     format: self.wireFormat,
@@ -350,7 +410,46 @@ import AVFoundation
         }
     }
 
+    /// Whether this captured block is TapQ's own voice coming back, and must not be sent.
+    ///
+    /// Three conditions, all required. Native turn detection is on, so this is the path with
+    /// no wearer turn signal and no barge-in to protect. A player is wired, so there is a
+    /// voice that could be echoing at all. And TapQ's audio was in the room at this instant
+    /// — sounding, or inside the hysteresis after it stopped, which is where the speaker's
+    /// own output latency and the room's ring live.
+    private func dropAsSelfAudio(_ block: RawAudioBlock) -> Bool {
+        guard nativeTurnDetectionOn, let selfAudioActivity else {
+            flushSelfAudioSuppression()
+            return false
+        }
+        guard selfAudioActivity().wasAudible(at: monotonicNow(),
+                                             hysteresis: selfAudioHysteresis) else {
+            flushSelfAudioSuppression()
+            return false
+        }
+        suppressedBlocks += 1
+        suppressedBytes += block.data.count
+        return true
+    }
+
+    /// Reports one stretch of dropped capture, once, when the gate opens again.
+    private func flushSelfAudioSuppression() {
+        guard suppressedBlocks > 0 else { return }
+        let bytesPerFrame = max(1, 2 * wireFormat.channels)
+        let milliseconds = Int(
+            (Double(suppressedBytes / bytesPerFrame) / wireFormat.sampleRate * 1_000).rounded())
+        diagnostics.record("mic.self_audio_suppressed", fields: [
+            "blocks": "\(suppressedBlocks)",
+            "ms": "\(milliseconds)",
+        ])
+        suppressedBlocks = 0
+        suppressedBytes = 0
+    }
+
     private func stopMicrophone() {
+        // The turn is ending with the gate still closed on a stretch nobody will see the
+        // other side of. Reported here so the log never silently loses the last one.
+        flushSelfAudioSuppression()
         turnGeneration &+= 1
         continuation?.finish()
         continuation = nil

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -1956,8 +1956,10 @@ public struct TapQCLIIO {
                                their case: the attribution check is skipped (recorded as
                                instruction.trusted_environment, never silent) and the
                                read-backs stop asking for a nod when no nod can arrive.
-                               The read-back confirmation itself stays — it catches
-                               mis-transcription, not just misattribution. Approvals are
+                               Whether a dictation is confirmed or announced is the
+                               backend's business, not this flag's: a grammar's guess is
+                               read back and confirmed, a sentence the model resolved into
+                               a tool call is queued and announced. Approvals are
                                untouched under either value: anyone audible to the
                                microphone can instruct, and still cannot approve, deny,
                                select, or defer anything.
@@ -1971,7 +1973,8 @@ public struct TapQCLIIO {
                                is held on a renewable lease and is let go only by the wearer,
                                by a break in the voice pipeline, or by stopping the runtime.
                                Inside a waiting window an
-                               unmatched sentence needs no "tell it to" prefix — it is
+                               unmatched sentence needs no "tell it to" prefix — on
+                               openai-realtime it is queued and announced, on apple it is
                                read back and queued on a spoken yes; status, what changed,
                                and repeat answer as they always do. The instruction loop
                                cap does not apply here; the four-deep queue does. Nothing
@@ -1981,9 +1984,12 @@ public struct TapQCLIIO {
                                (default: off). Requires --wearer-gate under
                                --voice-trust wearer. Inside any open
                                prompt, "new instruction" or "tell it to <…>" opens a
-                               dictation: TapQ reads the sentence back and queues it
-                               only on a nod or a spoken yes, then delivers it at the
-                               agent's next turn boundary. Fail-closed on attribution —
+                               dictation, delivered at the agent's next turn boundary. On
+                               --voice-backend apple a grammar guessed the intent, so TapQ
+                               reads the sentence back and queues it only on a nod or a
+                               spoken yes. On openai-realtime the model resolved it into a
+                               queue_instruction call, so TapQ queues it and says what it
+                               queued and for whom. Fail-closed on attribution —
                                a voice TapQ cannot prove is the wearer's, or a signal
                                that cannot say, is refused out loud and discarded. An
                                instruction authorizes nothing: whatever it asks for

--- a/Sources/TapQContracts/VoiceSelfAudio.swift
+++ b/Sources/TapQContracts/VoiceSelfAudio.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// What TapQ's own voice is doing in the room, as the thing rendering it knows.
+///
+/// It exists because two components that never meet — the realtime adapter, which sees a
+/// remote VAD say "speech started", and the microphone pump, which decides what audio leaves
+/// this machine — both have to answer the same question: *was that TapQ?* On a run with no
+/// AirPods every sentence TapQ says goes out of the Mac's speaker into the open microphone,
+/// so "the wearer spoke" and "TapQ spoke and the microphone heard it" are the same event on
+/// the wire, and nothing downstream of the microphone can tell them apart.
+///
+/// The value is a *span* rather than a bare `isPlaying` flag, and that is the whole of its
+/// design. The events this is compared against arrive late — a semantic VAD reports where
+/// speech began some hundreds of milliseconds after the audio was appended, and the report
+/// still has to cross a socket — so by the time TapQ asks, the playback that caused them has
+/// usually already drained. A flag sampled then says "silent" and the echo is taken for the
+/// wearer, which is exactly the 2026-08-30 defect. Knowing when the sound started and
+/// stopped lets a caller ask about the instant it cares about instead of about now.
+public struct VoiceSelfAudioActivity: Equatable, Sendable {
+    /// When the current — or most recent — stretch of TapQ's own audio began sounding, on
+    /// the same monotonic clock the caller stamps its own events with. `nil` before TapQ has
+    /// said anything at all.
+    public let startedAt: TimeInterval?
+    /// When that stretch stopped, or `nil` while it is still sounding.
+    public let stoppedAt: TimeInterval?
+
+    public init(startedAt: TimeInterval? = nil, stoppedAt: TimeInterval? = nil) {
+        self.startedAt = startedAt
+        self.stoppedAt = stoppedAt
+    }
+
+    /// A renderer that has never played anything, and the honest answer for a composition
+    /// that wires no player at all: TapQ has no voice here, so nothing can be TapQ's echo.
+    public static let silent = VoiceSelfAudioActivity()
+
+    /// TapQ's audio is reaching the speaker right now.
+    public var isSounding: Bool { startedAt != nil && stoppedAt == nil }
+
+    /// Whether TapQ's own voice was in the room at `instant`.
+    ///
+    /// `hysteresis` extends the span *forward* only, and it covers two different lags with
+    /// one number: the room (a speaker does not stop being audible the moment the last
+    /// sample is handed to the hardware — output latency and reverb both outlive the buffer)
+    /// and the report (a remote VAD's "speech started" for that tail arrives after it).
+    /// Extending backwards would be wrong in a way the forward extension is not: speech
+    /// detected *before* TapQ started speaking cannot be TapQ, and treating it as such would
+    /// throw away the wearer's own opening words.
+    ///
+    /// Only the most recent span is knowable from one sample, which is why callers evaluate
+    /// this at the moment an event arrives rather than saving instants up and asking later.
+    public func wasAudible(at instant: TimeInterval, hysteresis: TimeInterval) -> Bool {
+        guard let startedAt else { return false }
+        guard instant >= startedAt else { return false }
+        guard let stoppedAt else { return true }
+        return instant <= stoppedAt + max(0, hysteresis)
+    }
+}
+
+/// How long after TapQ stops speaking the microphone is still assumed to be hearing TapQ.
+public enum VoiceSelfAudioEcho {
+    /// 600 ms, and the number is a sum rather than a guess: an `AVAudioPlayerNode` reports a
+    /// buffer complete when it has been handed to the hardware rather than when it has been
+    /// heard, a Mac speaker in a small room rings for a beat after that, and the service's
+    /// own report of the speech it heard crosses a socket before TapQ can act on it. Short
+    /// enough that a wearer answering promptly is still heard; long enough that TapQ
+    /// answering itself is not.
+    public static let defaultHysteresis: TimeInterval = 0.6
+
+    /// The tuning seam, following the convention `TAPQ_TURN_EAGERNESS` set: an environment
+    /// key rather than a flag, because this is a property of a room and a machine, not of a
+    /// run an operator is composing.
+    public static let hysteresisEnvironmentKey = "TAPQ_SELF_AUDIO_HYSTERESIS_MS"
+
+    /// The largest value this knob will take. A hysteresis longer than a couple of seconds
+    /// stops being echo suppression and becomes a microphone that ignores the wearer, so a
+    /// mistyped value is clamped rather than obeyed.
+    public static let maximumHysteresis: TimeInterval = 2.0
+
+    /// The hysteresis this run uses: the environment override when it names a number TapQ
+    /// can read, otherwise ``defaultHysteresis``.
+    ///
+    /// An unreadable value falls back rather than throwing, for the reason
+    /// `RealtimeDefaults.resolvedTurnEagerness` does: a misspelled tuning knob must not be
+    /// why a wearer's only channel refuses to start.
+    public static func resolvedHysteresis(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> TimeInterval {
+        guard let raw = environment[hysteresisEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty,
+            let milliseconds = Double(raw),
+            milliseconds.isFinite else { return defaultHysteresis }
+        return min(max(0, milliseconds / 1_000), maximumHysteresis)
+    }
+}

--- a/Sources/TapQInteractionBaseline/CommandWindowController.swift
+++ b/Sources/TapQInteractionBaseline/CommandWindowController.swift
@@ -204,7 +204,8 @@ public struct CommandWindowOutcome: Sendable, Equatable {
                 kind: CommandWindowKind = .attention,
                 voiceTrust: VoiceTrust = .wearer,
                 voiceMayEndSession: Bool = true,
-                gestureConfirmation: GestureConfirmationQuerying? = nil) {
+                gestureConfirmation: GestureConfirmationQuerying? = nil,
+                intentSource: VoiceIntentSource = .transcriptGrammar) {
         self.voiceMayEndSession = voiceMayEndSession
         self.speech = speech
         self.arbiter = arbiter
@@ -221,7 +222,8 @@ public struct CommandWindowOutcome: Sendable, Equatable {
                                               diagnostics: diagnostics,
                                               resolveAddress: instructionAddressResolver,
                                               trust: voiceTrust,
-                                              gestureConfirmation: gestureConfirmation)
+                                              gestureConfirmation: gestureConfirmation,
+                                              intentSource: intentSource)
     }
 
     /// Opens the window and runs it to its deadline. Serialized against every other window
@@ -342,12 +344,30 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     /// on every path, and an intent with no provenance cannot be held to that. Arbiters that
     /// report nothing get the protocol's `.unspecified` default and behave as they always
     /// have.
+    ///
+    /// `budget` is what a turn is for. Every turn of the loop itself is
+    /// `.remainingWindow` — the window is eight seconds and stays eight seconds. A turn that
+    /// *asks* the wearer to confirm something is the exception: TapQ's own read-back plays
+    /// with the microphone held closed, so a listen sized to the residue can expire before
+    /// the question has finished being asked. That turn covers its playback and then leaves
+    /// a real answering window (`TurnBudget.afterSpeaking`), and the eight-second cap does
+    /// not apply to it — a cap shorter than the question is the same bug in another place.
     private func listen(speaking text: String?,
-                        until deadline: ContinuousClock.Instant) async -> ResolvedInput? {
+                        until deadline: ContinuousClock.Instant,
+                        budget: TurnBudget = .remainingWindow) async -> ResolvedInput? {
         let remaining = deadline.seconds(after: now())
         guard remaining > 0 else { return nil }
+        let window: TimeInterval
+        switch budget {
+        case .remainingWindow:
+            window = min(Self.windowSeconds, remaining)
+        case .afterSpeaking(let answering):
+            window = SpokenPace.listenSeconds(asking: text,
+                                              remaining: min(Self.windowSeconds, remaining),
+                                              answering: answering)
+        }
         return await BargeIn.listen(speech: speech, text: text, priority: .notification) {
-            await self.arbiter.listenForInput(timeout: min(Self.windowSeconds, remaining))
+            await self.arbiter.listenForInput(timeout: window)
         }
     }
 
@@ -357,12 +377,12 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     private func dictate(_ capturedText: String?,
                          until deadline: ContinuousClock.Instant) async -> String? {
         await dictation.run(capturedText: capturedText,
-                            agentDisplayName: agentDisplayName) { utterance in
+                            agentDisplayName: agentDisplayName) { utterance, budget in
             // The dictation flow decides on the intent alone: a read-back is confirmed by a
             // nod, a tap, or a spoken yes, and all three are the same answer to the same
             // question. Provenance matters to the loop above, which is deciding whether the
             // *session* may end, and to nothing in here.
-            await self.listen(speaking: utterance, until: deadline)?.intent
+            await self.listen(speaking: utterance, until: deadline, budget: budget)?.intent
         }
     }
 

--- a/Sources/TapQInteractionBaseline/InteractionController.swift
+++ b/Sources/TapQInteractionBaseline/InteractionController.swift
@@ -237,20 +237,35 @@ public enum InstructionQueueOutcome: Sendable, Equatable {
 /// both of its cases mean the sentence was accepted.
 public typealias InstructionDictating = @MainActor (String) -> InstructionQueueOutcome
 
-/// The RC3 dictation flow — capability, attribution, capture, read-back, confirm, queue —
-/// in one place, so the approval window and the selection window can never drift into
-/// dictating on different terms.
+/// The RC3 dictation flow — capability, attribution, capture, route, queue — in one place,
+/// so the approval window and the selection window can never drift into dictating on
+/// different terms.
+///
+/// The last step has two shapes and the choice between them is `intentSource`'s, not a
+/// caller's: a sentence a *grammar* guessed at is read back and confirmed before it is
+/// queued, and a sentence a *model* resolved into a tool call is queued and announced. Both
+/// end the same way — one bounded utterance handed back to the caller, and a window that
+/// picks up exactly where it left off.
 ///
 /// A value that runs *inside* the caller's loop rather than a controller of its own. The
-/// window's deadline belongs to the caller and is never extended, paused, or restarted
+/// window's deadline belongs to the caller and is never read, written, paused, or restarted
 /// here; when the flow ends the caller picks its own loop back up exactly where it left
 /// off, with at most one sentence to say. Dictation is something that happens during a
 /// window, not instead of one.
+///
+/// The flow says what each turn is *for* (``TurnBudget``) and the caller decides what that
+/// costs its clock. That is still the same division: this type cannot extend a window, and
+/// a caller that gives a confirmation turn enough time to be answered is spending its own
+/// budget on a question it chose to ask.
 @MainActor struct InstructionDictation {
     /// One turn of the caller's window: speak `utterance` (barge-in, at the caller's own
     /// priority) and return the next intent, or `nil` when the window produced nothing.
     /// Supplying this is how each controller keeps ownership of its arbiter and its clock.
-    typealias Turn = (String?) async -> InputIntent?
+    ///
+    /// The budget says what the turn is *for*, and the caller sizes its listen from it. A
+    /// turn that asks the wearer to confirm something has to outlive its own playback — see
+    /// ``TurnBudget``, and the hardware log that put it there.
+    typealias Turn = (String?, TurnBudget) async -> InputIntent?
 
     let capability: InstructionCapabilityChecking?
     let attribution: WearerAttributionQuerying?
@@ -266,6 +281,34 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
     /// Whether the read-back may still ask for a nod. `nil` means yes, which is the
     /// wearer-trust composition and the wording every earlier build spoke.
     var gestureConfirmation: GestureConfirmationQuerying?
+    /// Where the intent behind this dictation came from, and therefore whether the routed
+    /// sentence is confirmed or announced. `.transcriptGrammar` — the default, and every
+    /// composition written before this distinction existed — keeps the read-back-and-confirm
+    /// flow exactly as it was. See ``announcesWithoutConfirming``.
+    var intentSource: VoiceIntentSource = .transcriptGrammar
+
+    /// Whether a routed instruction is delivered and announced rather than read back and
+    /// confirmed. True on the model-tool-call path and nowhere else (ratified 2026-08-30).
+    ///
+    /// ## Why the confirmation goes away here, and only here
+    ///
+    /// The read-back was built for the keyword era, where `.beginInstruction` was *guessed*
+    /// from a transcript by `VoiceCommandMatcher` and could easily be the wrong sentence, or
+    /// no instruction at all. It was the only thing standing between a misheard phrase and an
+    /// agent's inbox, and on that path it still is.
+    ///
+    /// Under `.modelToolCalls` there is no guess to catch. The model that heard the wearer
+    /// resolved their sentence into `queue_instruction` with the text as an argument
+    /// (2026-08-28: no keyword matching, intent via tools), and the run said out loud whose
+    /// voice may instruct it. What the confirmation cost instead was the instruction itself:
+    /// TapQ's own read-back plays with the microphone held closed for the drain, so a window
+    /// with less time left than the read-back takes to say expires in silence and discards
+    /// the sentence — every time, structurally (hardware, 2026-08-30). A confirmation the
+    /// wearer cannot give is not a safety property.
+    ///
+    /// What does not change: the instruction still authorizes nothing. Whatever the agent
+    /// tries to do with it meets the approval gate on its own terms.
+    var announcesWithoutConfirming: Bool { intentSource == .modelToolCalls }
 
     /// Spoken when the wearer opened the flow without saying what to dictate.
     static let cue = "Go ahead."
@@ -351,7 +394,9 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
 
         var dictated = Self.speechSafe(capturedText)
         if dictated == nil {
-            switch await turn(Self.cue) {
+            // A capture turn asks for a sentence rather than an answer, and "Go ahead." is
+            // two words: it takes the window's residue exactly as it always has.
+            switch await turn(Self.cue, .remainingWindow) {
             case .freeform(let spoken):
                 dictated = Self.speechSafe(spoken)
             case .none:
@@ -403,36 +448,77 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
         // been stripped must not be spoken back as part of the sentence, and a wearer
         // confirming a routed dictation must hear which agent they are confirming it for.
         let readBack = SpokenText.condensed(text, maxWords: 24, maxCharacters: 160)
-        switch await turn("Instruction: '\(SpokenText.sentence(readBack))' \(confirmCue)") {
+
+        // The model-tool-call path delivers here and says so. No listen, no deadline, and
+        // nothing the wearer has to be quick enough to answer — see
+        // `announcesWithoutConfirming` for why the confirmation belongs to the other path.
+        guard !announcesWithoutConfirming else {
+            return queue(text, to: target, via: deliver, announcing: readBack)
+        }
+
+        switch await turn("Instruction: '\(SpokenText.sentence(readBack))' \(confirmCue)",
+                          .answering) {
         case .allow, .select:
             // Nod, tap, or "yes" — the same dual channel that confirms anything else, and
             // for the same reason: the read-back is the only moment the wearer hears what
             // the agent is about to be told.
-            let outcome = deliver(text)
-            diagnostics.record("instruction.queued",
-                               fields: ["agent": target,
-                                        "characters": "\(text.count)",
-                                        "outcome": "\(outcome)"])
-            switch outcome {
-            case .queued:
-                return "Queued for \(target)."
-            case .queuedDroppingOldest:
-                // Appended to the confirmation rather than replacing it, because two
-                // separate things are true and the wearer needs both: this sentence is on
-                // its way, and an earlier one no longer is. Which earlier one is not said —
-                // it would be the wearer's own words read back at them minutes late, and the
-                // remedy is the same either way.
-                return "Queued for \(target). This replaced the oldest waiting instruction."
-            case .notQueued:
-                return Self.notQueuedNotice
-            }
+            return queue(text, to: target, via: deliver, announcing: nil)
         case .none:
+            // Spoken, not swallowed. This is the class's own rule — `discardedNotice` exists
+            // because "silence would be indistinguishable from success" — and until
+            // 2026-08-30 this one branch broke it: a read-back nobody answered returned `nil`,
+            // so a wearer who dictated a sentence and then heard nothing had no way to tell a
+            // lost instruction from a queued one. The capture turn above stays silent on
+            // purpose; nothing was put to the wearer there, and the window simply resumes.
             diagnostics.record("instruction.discarded", fields: ["reason": "silence"])
-            return nil
+            return Self.discardedNotice
         default:
             diagnostics.record("instruction.discarded", fields: ["reason": "declined"])
             return Self.discardedNotice
         }
+    }
+
+    /// Hands the sentence to the mailbox and composes what the wearer hears about it.
+    ///
+    /// One function for both paths, so a confirmed dictation and an announced one can never
+    /// drift into saying different things about the same outcome — and so the truthfulness
+    /// rule holds by construction on both: the sentence is composed *after* the mailbox has
+    /// answered, and the word "Queued" is only ever spoken about something that queued.
+    ///
+    /// `announcing` is the read-back on the path that has no read-back turn: an announcement
+    /// is the wearer's only chance to hear what was captured, so it carries the sentence,
+    /// while a confirmation is the answer to a question they were just read and does not.
+    private func queue(_ text: String,
+                       to target: String,
+                       via deliver: InstructionDictating,
+                       announcing readBack: String?) -> String {
+        let outcome = deliver(text)
+        diagnostics.record("instruction.queued",
+                           fields: ["agent": target,
+                                    "characters": "\(text.count)",
+                                    "outcome": "\(outcome)",
+                                    "confirmation": readBack == nil ? "confirmed" : "announced"])
+        switch outcome {
+        case .queued:
+            return queuedNotice(target: target, reading: readBack)
+        case .queuedDroppingOldest:
+            // Appended to the confirmation rather than replacing it, because two separate
+            // things are true and the wearer needs both: this sentence is on its way, and an
+            // earlier one no longer is. Which earlier one is not said — it would be the
+            // wearer's own words read back at them minutes late, and the remedy is the same
+            // either way.
+            return queuedNotice(target: target, reading: readBack)
+                + " This replaced the oldest waiting instruction."
+        case .notQueued:
+            return Self.notQueuedNotice
+        }
+    }
+
+    /// "Queued for ⟨agent⟩." when the wearer has just confirmed the sentence, and
+    /// "Queued for ⟨agent⟩: '⟨sentence⟩'" when they have not heard it yet.
+    private func queuedNotice(target: String, reading readBack: String?) -> String {
+        guard let readBack, !readBack.isEmpty else { return "Queued for \(target)." }
+        return "Queued for \(target): '\(SpokenText.sentence(readBack))'"
     }
 
     /// What an address on the dictated sentence did.
@@ -579,7 +665,8 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
                 instructionEnqueue: InstructionDictating? = nil,
                 instructionAddressResolver: InstructionAddressResolving? = nil,
                 voiceTrust: VoiceTrust = .wearer,
-                gestureConfirmation: GestureConfirmationQuerying? = nil) {
+                gestureConfirmation: GestureConfirmationQuerying? = nil,
+                intentSource: VoiceIntentSource = .transcriptGrammar) {
         self.speech = speech
         self.arbiter = arbiter
         self.timeout = timeout
@@ -594,7 +681,8 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
                                               diagnostics: diagnostics,
                                               resolveAddress: instructionAddressResolver,
                                               trust: voiceTrust,
-                                              gestureConfirmation: gestureConfirmation)
+                                              gestureConfirmation: gestureConfirmation,
+                                              intentSource: intentSource)
     }
 
     /// `requiredConfirmation` is how much the user has to do to approve. `.standard` — the
@@ -631,7 +719,16 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
         var answeredQuestions = 0
         while true {
             let remaining = deadline.seconds(after: now())
-            guard remaining > 0 else { return deferToScreen() }
+            guard remaining > 0 else {
+                // Something is still to be said and there is no listen left to carry it —
+                // a dictation's discard notice, most often, which is the sentence that keeps
+                // a lost instruction from being indistinguishable from a queued one. Said
+                // before the deferral rather than dropped with the window.
+                if let utterance {
+                    speech.speak(utterance, priority: .approval, onFinish: nil)
+                }
+                return deferToScreen()
+            }
             let input = await BargeIn.listen(speech: speech, text: utterance, priority: .approval) {
                 await arbiter.listenForInput(timeout: min(timeout, remaining))
             }
@@ -704,21 +801,40 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
     /// Runs the dictation flow against this window, returning what to say on the next
     /// listen.
     ///
-    /// The deadline handed in is the window's own and is read, never written: each turn of
-    /// the flow gets whatever is left of it, and a dictation that outlives the budget ends
-    /// the same way an unanswered prompt does — the loop below sees no time remaining and
-    /// defers to the screen.
+    /// The deadline handed in is the window's own and is read, never written: a listening
+    /// turn gets whatever is left of it, and a dictation that outlives the budget ends the
+    /// same way an unanswered prompt does — the loop below sees no time remaining and defers
+    /// to the screen.
+    ///
+    /// The one exception is a turn that *asks* the wearer something. TapQ holds the
+    /// microphone closed while it speaks, so a read-back sized to the window's residue can
+    /// expire before the question has finished being asked; that turn is given its own
+    /// playback plus a real answering window (`TurnBudget.afterSpeaking`). It buys the
+    /// dictation nothing else — the request in front of the wearer is still resolved by the
+    /// loop's own clock, which has already passed.
     private func dictate(
         _ capturedText: String?,
         for request: ApprovalRequest,
         deadline: ContinuousClock.Instant
     ) async -> String? {
         await dictation.run(capturedText: capturedText,
-                            agentDisplayName: request.agent.displayName) { utterance in
+                            agentDisplayName: request.agent.displayName) { utterance, budget in
             let remaining = deadline.seconds(after: now())
+            // A window that is already over ends the flow exactly as it always did. What
+            // changes is the window that is nearly over: it no longer asks a question it
+            // cannot hear the answer to.
             guard remaining > 0 else { return nil }
+            let window: TimeInterval
+            switch budget {
+            case .remainingWindow:
+                window = min(timeout, remaining)
+            case .afterSpeaking(let answering):
+                window = min(timeout, SpokenPace.listenSeconds(asking: utterance,
+                                                               remaining: remaining,
+                                                               answering: answering))
+            }
             return await BargeIn.listen(speech: speech, text: utterance, priority: .approval) {
-                await arbiter.listenForInput(timeout: min(timeout, remaining))
+                await arbiter.listenForInput(timeout: window)
             }?.intent
         }
     }

--- a/Sources/TapQInteractionBaseline/SelectionController.swift
+++ b/Sources/TapQInteractionBaseline/SelectionController.swift
@@ -58,7 +58,8 @@ import TapQContracts
                 instructionEnqueue: InstructionDictating? = nil,
                 instructionAddressResolver: InstructionAddressResolving? = nil,
                 voiceTrust: VoiceTrust = .wearer,
-                gestureConfirmation: GestureConfirmationQuerying? = nil) {
+                gestureConfirmation: GestureConfirmationQuerying? = nil,
+                intentSource: VoiceIntentSource = .transcriptGrammar) {
         self.speech = speech
         self.arbiter = arbiter
         self.timeout = timeout
@@ -73,7 +74,8 @@ import TapQContracts
                                               diagnostics: diagnostics,
                                               resolveAddress: instructionAddressResolver,
                                               trust: voiceTrust,
-                                              gestureConfirmation: gestureConfirmation)
+                                              gestureConfirmation: gestureConfirmation,
+                                              intentSource: intentSource)
     }
 
     /// The free-form read-back's confirmation cue, narrowed to speech where no gesture can
@@ -126,6 +128,12 @@ import TapQContracts
             let remaining = deadline.seconds(after: now())
             guard remaining > 0 else {
                 outcome = "timeout"
+                // A sentence with no listen left to carry it is still said — the dictation
+                // flow's discard notice is the case that matters, and a discard the wearer
+                // cannot hear is indistinguishable from a queued instruction.
+                if let utterance {
+                    speech.speak(utterance, priority: .approval, onFinish: nil)
+                }
                 return deferToScreen()
             }
             let intent = await BargeIn.listen(speech: speech, text: utterance, priority: .approval) {
@@ -167,15 +175,22 @@ import TapQContracts
                 utterance = "You said: '\(SpokenText.sentence(condensedText))' \(freeformConfirmCue)"
                 diagnostics.record("freeform.readback",
                                    fields: ["length": "\(text.count)"])
+                // The read-back is spoken with the microphone held closed for its drain, so
+                // this listen covers the utterance's own playback and then leaves the wearer
+                // a real answering window — the same rule the dictation read-back follows,
+                // and for the same hardware reason (2026-08-30). Sizing it to the residue
+                // alone would time out a confirmation the wearer never got to give.
                 let confirmRemaining = deadline.seconds(after: now())
                 guard confirmRemaining > 0 else {
                     outcome = "timeout"
                     return deferToScreen()
                 }
+                let confirmWindow = SpokenPace.listenSeconds(asking: utterance,
+                                                             remaining: confirmRemaining)
                 let confirmation = await BargeIn.listen(
                     speech: speech, text: utterance, priority: .approval
                 ) {
-                    await arbiter.listen(timeout: min(timeout, confirmRemaining))
+                    await arbiter.listen(timeout: min(timeout, confirmWindow))
                 }
                 utterance = nil
                 switch confirmation {
@@ -233,17 +248,32 @@ import TapQContracts
     /// The deadline is the selection's own and is read, never written: dictating cannot buy
     /// the wearer more time to choose, and a flow that outlives the budget lands in the
     /// same timeout the loop already has.
+    ///
+    /// The read-back turn is the one place a listen may outlast the residue, and it buys the
+    /// wearer nothing but the chance to answer: TapQ holds the microphone closed while it
+    /// speaks, so a confirmation window shorter than its own question is one the wearer
+    /// cannot give (`TurnBudget.afterSpeaking`). The selection itself is still decided by
+    /// the loop's clock.
     private func dictate(
         _ capturedText: String?,
         for request: SelectionRequest,
         deadline: ContinuousClock.Instant
     ) async -> String? {
         await dictation.run(capturedText: capturedText,
-                            agentDisplayName: request.agent.displayName) { utterance in
+                            agentDisplayName: request.agent.displayName) { utterance, budget in
             let remaining = deadline.seconds(after: now())
             guard remaining > 0 else { return nil }
+            let window: TimeInterval
+            switch budget {
+            case .remainingWindow:
+                window = min(timeout, remaining)
+            case .afterSpeaking(let answering):
+                window = min(timeout, SpokenPace.listenSeconds(asking: utterance,
+                                                               remaining: remaining,
+                                                               answering: answering))
+            }
             return await BargeIn.listen(speech: speech, text: utterance, priority: .approval) {
-                await arbiter.listen(timeout: min(timeout, remaining))
+                await arbiter.listen(timeout: window)
             }
         }
     }

--- a/Sources/TapQInteractionBaseline/SpokenTurnBudget.swift
+++ b/Sources/TapQInteractionBaseline/SpokenTurnBudget.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// How much open microphone one turn of a windowed flow needs.
+///
+/// The distinction is between a turn that is *listening* and a turn that is *asking*. A
+/// listening turn takes whatever is left of the window: nothing has been put to the wearer,
+/// so nothing is owed to them. A turn that asks a question is different in kind — TapQ holds
+/// the microphone closed for the whole of its own playback (`SpeechGatedVoice`), so a listen
+/// sized to the window's residue can expire while the question is still being asked, and the
+/// wearer is recorded as silent about a sentence they never got to answer.
+///
+/// That is not hypothetical. On hardware, 2026-08-30: a 125-character read-back was queued,
+/// the arbiter re-listened with `timeout=1.96` left in the window, the microphone was held
+/// closed for the drain, and the instruction was discarded `reason=silence` — every time,
+/// structurally, whenever the read-back outlasted the residue.
+enum TurnBudget: Equatable {
+    /// Whatever is left of the caller's window, capped as the caller always capped it.
+    case remainingWindow
+    /// The turn asks something the wearer must answer. The listen must cover the utterance's
+    /// own playback *and* leave `answering` seconds of open microphone after it, even when
+    /// that outlives what is left of the window.
+    case afterSpeaking(answering: TimeInterval)
+
+    /// The default answering budget, for the callers that have no reason to name their own.
+    static let answering = TurnBudget.afterSpeaking(answering: SpokenPace.answeringSeconds)
+}
+
+/// Deterministic estimates of how long TapQ's own speech holds the channel.
+///
+/// ## Why an estimate and not a measurement
+///
+/// Nothing in this layer can be told when an utterance has actually drained.
+/// `SpeechPresenting.speak`'s `onFinish` fires when the *backend accepts* the sentence, not
+/// when its audio ends (`BackendSpeechSink` documents exactly that: the wire has no finish
+/// callback to relay). The one true drain signal — `SpeechActivitySignaling` — is a
+/// single-observer slot owned by `SpeechGatedVoice` at composition time, and even with a
+/// multicast it would not answer this question: on the realtime path playback starts
+/// hundreds of milliseconds *after* acceptance, so "not speaking yet" and "already drained"
+/// are the same reading at the moment a listen opens.
+///
+/// So the pace is estimated from the text, deterministically, where it can be reasoned about
+/// and tested with a virtual clock. It deliberately errs long: an over-long listen costs an
+/// already-open window a few seconds that a wearer can end by answering, while a short one
+/// costs them the sentence they were dictating.
+enum SpokenPace {
+    /// Characters of ordinary prose per second of synthesized speech.
+    ///
+    /// ~150 words per minute at ~5.5 characters plus a space is a shade under 15 characters
+    /// a second; 12 is that with the margin the paragraph above argues for, and covers the
+    /// slower of the two voices TapQ speaks with.
+    static let charactersPerSecond: Double = 12
+
+    /// How long the wearer gets to answer once the question has finished being asked.
+    ///
+    /// Long enough to hear the end of a read-back, take a breath, and say "yes" — and short
+    /// enough that a window nobody answers still closes while the wearer is standing there.
+    static let answeringSeconds: TimeInterval = 6
+
+    /// How long `text` will be sounding, in seconds. Nothing to say drains instantly.
+    static func drainSeconds(of text: String?) -> TimeInterval {
+        guard let text, !text.isEmpty else { return 0 }
+        return Double(text.count) / charactersPerSecond
+    }
+
+    /// The listen a spoken question needs: never shorter than the window's own residue, and
+    /// never shorter than the question's playback plus a real answering window.
+    ///
+    /// The `max` is the whole of it. Where the window has time, this is what the caller
+    /// always did; where it does not, the turn is extended by exactly what it takes for the
+    /// question to be answerable at all. A confirmation the wearer structurally cannot give
+    /// is not a shorter interaction, it is a lost one.
+    static func listenSeconds(asking utterance: String?,
+                              remaining: TimeInterval,
+                              answering: TimeInterval = answeringSeconds) -> TimeInterval {
+        max(remaining, drainSeconds(of: utterance) + answering)
+    }
+}

--- a/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
+++ b/Sources/TapQInteractionBaseline/VoiceBackendCommandProvider.swift
@@ -1774,10 +1774,6 @@ public enum SessionPolicy: Sendable, Equatable {
         windowEndRan = true
         windowGeneration &+= 1
         handler = nil
-        // The window this grounding described is over. Whatever is spoken next belongs to the
-        // next one, and a model told about a question that has already been answered would
-        // answer it again.
-        spokenSinceWindowEnded.removeAll()
         pendingUserTurn = false
         windowPaused = false
         switch ending {
@@ -1801,6 +1797,29 @@ public enum SessionPolicy: Sendable, Equatable {
             } else {
                 responseAudio?.stopAndFlush()
             }
+        }
+        // The window this grounding described is over, and whatever is spoken next belongs to
+        // the next one: a model told about a question that has already been answered would
+        // answer it again. That was the whole rule until 2026-08-30, when it turned out to
+        // have a hole the size of a read-back.
+        //
+        // A sentence is not over when its window is. TapQ's audio routinely outlives the
+        // rotation that ended the window it was spoken in — the flush above deliberately
+        // spares a scripted sentence, and a timed-out rotation spares everything — and the
+        // wearer is still listening to it while the next window's grounding is being written.
+        // Wiping there told the model "TapQ has not said anything" about audio the wearer
+        // could hear at that moment, which is how a wearer's answer to a still-playing
+        // question arrives at a model that does not know the question was asked.
+        //
+        // So the wipe waits for the audio, not for the window. Read after the switch above,
+        // so a flush that just emptied the player is already accounted for — the condition is
+        // "is any of TapQ's voice still to be heard", not "was it a moment ago".
+        if playbackIsSounding || isResponsePending {
+            diagnostics.record("grounding.kept_undrained", level: .debug,
+                               fields: ["sentences": "\(spokenSinceWindowEnded.count)",
+                                        "ending": "\(ending)"])
+        } else {
+            spokenSinceWindowEnded.removeAll()
         }
         if turnActive {
             turnActive = false

--- a/Sources/TapQInteractionBaseline/VoiceIntentTools.swift
+++ b/Sources/TapQInteractionBaseline/VoiceIntentTools.swift
@@ -114,11 +114,12 @@ public enum VoiceIntentTools {
             description: """
                 The wearer is dictating something to be sent to a coding agent rather than \
                 answering a question. Pass their sentence through as they said it — do not \
-                summarize, translate, or tidy it. TapQ reads it back to them for confirmation \
-                before anything is sent, so a slightly wrong capture is recoverable and a \
-                rewritten one is not. This sends one sentence and does nothing else, so a \
-                request TapQ would first have to find something out to carry out — what \
-                another agent just did, what a run produced — is not this tool.
+                summarize, translate, or tidy it. TapQ queues it and says out loud what it \
+                queued and for whom, so the wearer hears a slightly wrong capture and can say \
+                it again; a rewritten one they cannot recognize is not recoverable. This sends \
+                one sentence and does nothing else, so a request TapQ would first have to find \
+                something out to carry out — what another agent just did, what a run produced \
+                — is not this tool.
                 """,
             parameters: [
                 VoiceToolParameter(
@@ -390,9 +391,11 @@ public enum VoiceIntentTools {
     ///
     /// - Parameter windowOpen: whether a window is armed to receive a command. Every tool
     ///   that resolves *something* delivers through one — including `queue_instruction`,
-    ///   whose read-back and fail-closed attribution check *are* the window's dictation
-    ///   flow. Executing one without a window would not be a shortcut, it would be the
-    ///   instruction path with its confirmation removed. `ask_about_work` and `start_task`
+    ///   whose attribution check, addressing, mailbox, and spoken outcome *are* the window's
+    ///   dictation flow. Executing one without a window would not be a shortcut: it would be
+    ///   the instruction path with everything that makes it honest — the fail-closed check,
+    ///   the refusals, the sentence that tells the wearer what was queued — removed.
+    ///   `ask_about_work` and `start_task`
     ///   are the exceptions, and deliberately: neither resolves anything, so there is nothing
     ///   for a window to receive, and a sentence TapQ can speak on its own channel is not
     ///   made safer by refusing it because a prompt happened to have closed a beat earlier.
@@ -444,9 +447,9 @@ public enum VoiceIntentTools {
                 )
             }
             // The address is re-attached to the sentence rather than carried beside it, and
-            // the reason is that the dictation flow — read-back, fail-closed attribution,
-            // confirm, unknown-agent refusal — already resolves an address out of the text
-            // it is given. Composing here is the inverse of the parse that runs there, not a
+            // the reason is that the dictation flow — fail-closed attribution, routing,
+            // the spoken outcome, the unknown-agent refusal — already resolves an address
+            // out of the text it is given. Composing here is the inverse of the parse that runs there, not a
             // new grammar: nothing about it reads the wearer's transcript, and the name it
             // encodes came from the model as a structured argument. Rung E's fail-closed
             // semantics then apply unchanged, including the spoken refusal for a name
@@ -457,7 +460,8 @@ public enum VoiceIntentTools {
                 .map { InstructionAddress.compose(name: $0, rest: text) }
             return windowed(
                 .beginInstruction(addressed ?? text),
-                output: "Reading the instruction back to the wearer for confirmation.",
+                output: "Queueing the instruction and telling the wearer out loud what was "
+                    + "queued and for whom.",
                 windowOpen: windowOpen,
                 speak: notListeningNotice
             )

--- a/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
@@ -21,6 +21,12 @@ import TapQContracts
 ///   and may not do anything else. The empty-turn guard, the "a response happens only when
 ///   TapQ asks" rule, and the half-duplex policy are all untouched by it. See the carve-out
 ///   on `VoiceBackend` for why TapQ ever asks.
+/// - A native turn the adapter can prove was TapQ's own voice is dropped rather than
+///   reported. With no AirPods the answer TapQ just spoke comes back through the open
+///   microphone, the service's VAD calls it speech because it is speech, and the commit that
+///   follows would have TapQ answering its own last sentence. `selfAudioActivity` is the one
+///   thing that can tell the two apart; everything ambiguous is treated as the wearer. See
+///   `committedSegmentWasSelfAudio()`.
 /// - A cancel is bookkeeping, not an ending: the peer answers `response.cancel` with the
 ///   rest of the frames it had already produced and then that response's own
 ///   `response.done`, so the id is tombstoned rather than forgotten and its tail is drained
@@ -163,6 +169,50 @@ import TapQContracts
     /// change under a wearer mid-session, and the whole point of `sendSessionUpdate`
     /// restating turn detection is that the frame says what TapQ believes.
     private let nativeTurnDetection: RealtimeTurnDetection
+    /// What TapQ's own voice is doing in the room, or `nil` where nothing renders it.
+    ///
+    /// The one seam that lets this adapter tell a wearer from an echo. On the voice-only
+    /// path — no AirPods, no IMU turn signal — every sentence TapQ says leaves the Mac's
+    /// speaker and arrives back at the open microphone, and the service's VAD reports it as
+    /// speech because it *is* speech. Nothing in a frame distinguishes it. Composition wires
+    /// this to the audio player that is producing the sound; a composition that wires nothing
+    /// — every test that does not ask for it, and the Apple path, which has no realtime
+    /// session at all — suppresses nothing and behaves exactly as it did before 2026-08-30.
+    ///
+    /// A closure rather than a reference because this target is portable and the renderer is
+    /// `AVAudioEngine`-shaped, and because the answer is a fact about *now* rather than a
+    /// dependency: it is sampled at the instant an event arrives and never held.
+    public var selfAudioActivity: (@MainActor () -> VoiceSelfAudioActivity)?
+
+    /// How long after TapQ's audio stops the microphone is still assumed to be hearing it.
+    /// Resolved once per adapter, from the environment, for the reason `turnEagerness` is:
+    /// a value re-read per window could change under a wearer mid-session.
+    private let selfAudioHysteresis: TimeInterval
+
+    /// When the service's VAD last said speech began, and whether TapQ's own voice was in
+    /// the room at that instant and again when it said the speech ended.
+    ///
+    /// Sampled at the moment each event arrives rather than reconstructed at the commit,
+    /// because only the *most recent* stretch of self-audio is knowable from one sample: a
+    /// segment that began during one sentence and ended during the next would be judged
+    /// against the wrong span if the question were asked late.
+    private var nativeSpeechStartedAt: TimeInterval?
+    private var nativeSpeechStoppedAt: TimeInterval?
+    private var nativeSpeechBeganInSelfAudio = false
+    private var nativeSpeechEndedInSelfAudio: Bool?
+
+    /// How many native turns this session has dropped as TapQ's own voice. A count only —
+    /// what was said is the wearer's and the log is not the place for it.
+    private var selfAudioSuppressions = 0
+
+    /// `conversation.item.delete` frames whose outcome has not landed yet. The service
+    /// answers a delete with `conversation.item.deleted`, which decodes to `.unsupported`
+    /// and is ignored; a delete it refuses arrives as an `error`, and that error must not
+    /// take a wearer's only channel down over a piece of bookkeeping about audio nobody
+    /// wanted. Bounded by the round trip: one is added per delete and one is spent per
+    /// absorbed error.
+    private var pendingItemDeletes = 0
+
     /// Commits this adapter issued that the service has not yet echoed back as
     /// `input_audio_buffer.committed`.
     ///
@@ -179,6 +229,8 @@ import TapQContracts
     ///   - turnEagerness: how readily the model ends a turn once TapQ has handed it
     ///     end-of-speech detection. Read from the environment once, here, so the whole run
     ///     shares one setting; injectable so a test can state it rather than export it.
+    ///   - selfAudioHysteresis: how long after TapQ's own audio drains the microphone is
+    ///     still assumed to be hearing it. Same environment-once rule, same reason.
     public init(transport: any RealtimeTransporting,
                 configuration: RealtimeSessionConfiguration = RealtimeSessionConfiguration(
                     // instructions(grounding: nil), not baseInstructions: tools are declared
@@ -187,6 +239,7 @@ import TapQContracts
                 ),
                 timeout: TimeInterval = OpenAIRealtimeVoiceBackend.defaultTimeout,
                 turnEagerness: RealtimeTurnEagerness = RealtimeDefaults.resolvedTurnEagerness(),
+                selfAudioHysteresis: TimeInterval = VoiceSelfAudioEcho.resolvedHysteresis(),
                 monotonicNow: @escaping @Sendable () -> TimeInterval = {
                     ProcessInfo.processInfo.systemUptime
                 },
@@ -198,6 +251,7 @@ import TapQContracts
         manualTurns.turnDetection = nil
         self.configuration = manualTurns
         self.nativeTurnDetection = .semanticVAD(eagerness: turnEagerness)
+        self.selfAudioHysteresis = selfAudioHysteresis
         self.timeout = timeout
         self.monotonicNow = monotonicNow
         self.diagnostics = TapQDiagnosticEmitter(category: "OpenAIRealtime", sink: diagnosticSink)
@@ -210,6 +264,10 @@ import TapQContracts
         diagnostics.record("turn_detection.configured", fields: [
             "type": nativeTurnDetection.type,
             "eagerness": turnEagerness.rawValue,
+            // The echo knob rides the same line for the same reason: an operator reading a
+            // "it answered itself" or "it ignored me" report needs both numbers this run
+            // was tuned to, and neither has a flag to grep the command line for.
+            "self_audio_hysteresis_ms": "\(Int((selfAudioHysteresis * 1_000).rounded()))",
         ])
     }
 
@@ -258,6 +316,9 @@ import TapQContracts
         // lands — a reconnect must come back up in the mode the caller asked for.
         nativeTurnDetectionApplied = false
         pendingOwnCommits = 0
+        pendingItemDeletes = 0
+        selfAudioSuppressions = 0
+        clearNativeSpeechEvidence()
         activeResponseID = nil
         cancelledResponseIDs.removeAll()
 
@@ -311,6 +372,10 @@ import TapQContracts
         }
         transcript = ""
         turnAudioByteCount = 0
+        // A new turn hears nothing of the last one's segment: whatever the service said
+        // about speech before this microphone opened is evidence about audio that is
+        // already committed or already discarded.
+        clearNativeSpeechEvidence()
         // Neither `expectCancelAck` nor `cancelledResponseIDs` is cleared here. A cancelled
         // response's tail arrives *after* the window that cancelled it has opened — that is
         // the whole shape of the race — so a turn boundary is precisely the wrong place to
@@ -676,16 +741,15 @@ import TapQContracts
         case .sessionUpdated:
             settleHandshake(.success(()), generation: generation)
         case .speechStarted:
-            // Recorded, never acted on. The service's opinion about where speech began is
-            // not an event TapQ has any use for — it does not open windows, does not
-            // attribute the speaker, and does not arm barge-in — but a "voice did nothing"
-            // report is far easier to read when the log shows whether the service heard
-            // anything at all.
-            diagnostics.record("native_turn.speech_started")
+            // Still not acted on: this does not open a window, attribute a speaker, or arm
+            // barge-in. What it now does is *witness* — the instant it names is the one
+            // moment TapQ can ask whether its own voice was in the room, and asking later
+            // would be asking about a playback that has already drained.
+            noteNativeSpeechStarted()
         case .speechStopped:
-            diagnostics.record("native_turn.speech_stopped")
-        case .inputAudioCommitted:
-            handleInputAudioCommitted(generation: generation)
+            noteNativeSpeechStopped()
+        case .inputAudioCommitted(let itemID):
+            handleInputAudioCommitted(itemID: itemID, generation: generation)
         case .transcriptDelta(let delta):
             guard !delta.isEmpty else { return }
             transcript += delta
@@ -716,6 +780,17 @@ import TapQContracts
                                    fields: ["message": failure.message])
                 return
             }
+            if pendingItemDeletes > 0, !failure.isAuthorization {
+                // A delete the service would not carry out — the item was already gone, or
+                // it will not remove that kind. The mirror of the cancel race above and
+                // absorbed for the same reason, one narrow window wide: the frame was
+                // housekeeping about audio TapQ never wanted, and ending a wearer's only
+                // channel over it would be a worse outcome than the echo it was tidying up.
+                pendingItemDeletes -= 1
+                diagnostics.record("item_delete.refused", level: .warning,
+                                   fields: ["message": failure.message])
+                return
+            }
             let mapped: VoiceBackendFailure = failure.isAuthorization
                 ? .authorization(failure.message)
                 : .protocolViolation(failure.message)
@@ -725,9 +800,75 @@ import TapQContracts
         }
     }
 
+    // MARK: - Self-audio
+
+    /// Whether TapQ's own voice was in the room at `instant`.
+    ///
+    /// `false` for a composition that wired no player: with no renderer there is no echo,
+    /// and a run that guessed one would drop the wearer's turns for nothing.
+    private func selfAudioWasAudible(at instant: TimeInterval) -> Bool {
+        guard let selfAudioActivity else { return false }
+        return selfAudioActivity().wasAudible(at: instant, hysteresis: selfAudioHysteresis)
+    }
+
+    /// Starts a fresh piece of evidence about one native segment.
+    private func noteNativeSpeechStarted() {
+        let now = monotonicNow()
+        nativeSpeechStartedAt = now
+        nativeSpeechStoppedAt = nil
+        nativeSpeechEndedInSelfAudio = nil
+        nativeSpeechBeganInSelfAudio = selfAudioWasAudible(at: now)
+        diagnostics.record("native_turn.speech_started",
+                           fields: ["self_audio": "\(nativeSpeechBeganInSelfAudio)"])
+    }
+
+    private func noteNativeSpeechStopped() {
+        let now = monotonicNow()
+        nativeSpeechStoppedAt = now
+        let audible = selfAudioWasAudible(at: now)
+        nativeSpeechEndedInSelfAudio = audible
+        diagnostics.record("native_turn.speech_stopped",
+                           fields: ["self_audio": "\(audible)"])
+    }
+
+    /// Forgets the current segment's evidence. Every commit spends it, whichever way the
+    /// commit went: the next segment is judged on its own.
+    private func clearNativeSpeechEvidence() {
+        nativeSpeechStartedAt = nil
+        nativeSpeechStoppedAt = nil
+        nativeSpeechBeganInSelfAudio = false
+        nativeSpeechEndedInSelfAudio = nil
+    }
+
+    /// Whether the segment the service just committed was TapQ hearing itself.
+    ///
+    /// The rule is deliberately narrow: **the whole of the detected speech has to have lain
+    /// inside TapQ's own audible playback** (plus the echo hysteresis). Both ends are
+    /// required, and the evidence for both is sampled at the instant the service reported
+    /// them, so a segment that started before TapQ spoke — the wearer talking, with TapQ's
+    /// answer landing on top of them — is not this and is left alone.
+    ///
+    /// Everything ambiguous falls the other way, on purpose. A commit with no
+    /// `speech_started` behind it, a peer that skipped `speech_stopped` and whose commit
+    /// arrives after the hysteresis, a composition with no player wired: all of them are
+    /// "not proven to be TapQ", and they keep the empty-transcript rescue that a wearer
+    /// whose transcription lagged depends on. The cost of guessing wrong in this direction
+    /// is one repeated answer; the cost in the other direction is a question the wearer
+    /// asked out loud and TapQ silently dropped.
+    private func committedSegmentWasSelfAudio() -> Bool {
+        // Only ever true in the mode that produces these events at all. Restated rather
+        // than assumed: an adapter that suppressed a commit while TapQ owned turns would be
+        // hiding the protocol violation that check exists to make fatal.
+        guard nativeTurnDetectionApplied else { return false }
+        guard nativeSpeechStartedAt != nil, nativeSpeechBeganInSelfAudio else { return false }
+        // A peer that named the end of speech is believed about it; one that did not is
+        // asked about now, which is the closest instant TapQ has.
+        return nativeSpeechEndedInSelfAudio ?? selfAudioWasAudible(at: monotonicNow())
+    }
+
     /// Sorts an `input_audio_buffer.committed` into an ack for a commit TapQ sent and a
     /// commit the service's own VAD made, and lets only the second one reach the caller.
-    private func handleInputAudioCommitted(generation: UInt64) {
+    private func handleInputAudioCommitted(itemID: String?, generation: UInt64) {
         if pendingOwnCommits > 0 {
             pendingOwnCommits -= 1
             diagnostics.record("commit.acked")
@@ -753,12 +894,46 @@ import TapQContracts
         // out of two half-heard ones.
         turnAudioByteCount = 0
         transcript = ""
+        let wasSelfAudio = committedSegmentWasSelfAudio()
+        let speechMilliseconds = nativeSpeechStartedAt.map { started in
+            Int((((nativeSpeechStoppedAt ?? monotonicNow()) - started) * 1_000).rounded())
+        }
+        clearNativeSpeechEvidence()
         guard endedUtterance else {
             // A segment that closed outside an open user turn: between windows, or while a
             // response is playing. Tolerated (the service's VAD tracks the audio stream, not
             // TapQ's windows) and reported to nobody — there is no window it could resolve.
             diagnostics.record("native_turn.commit_ignored",
                                fields: ["state": turns.state.rawValue])
+            return
+        }
+        guard !wasSelfAudio else {
+            // TapQ answering itself. Reported and dropped: the caller never learns of this
+            // commit, so it never ends its turn and never asks for the model turn that
+            // would have the model reading its own last answer back as a wearer's question
+            // — the repeated-answer loop observed on hardware 2026-08-30.
+            //
+            // The microphone stays open and the window stays exactly as it was: the wearer
+            // may be about to speak for real, and this segment was never theirs to lose.
+            selfAudioSuppressions += 1
+            let deleted = itemID != nil
+            diagnostics.record("native_turn.suppressed_self_audio", fields: [
+                "speech_ms": speechMilliseconds.map { "\($0)" } ?? "unknown",
+                "hysteresis_ms": "\(Int((selfAudioHysteresis * 1_000).rounded()))",
+                "count": "\(selfAudioSuppressions)",
+                "item_deleted": "\(deleted)",
+            ])
+            if let itemID {
+                // The immediate repeat is already prevented above; this is about the next
+                // turn. The item the service just created holds TapQ's own answer as
+                // something the wearer said, and a model handed that as context answers it
+                // again a window later. Deleting it is the only way to say it never
+                // happened. No buffer clear goes with it: the service took the buffer with
+                // this commit, and TapQ does not send frames about a buffer it believes is
+                // already empty.
+                pendingItemDeletes += 1
+                enqueue(.deleteConversationItem(id: itemID), generation: generation)
+            }
             return
         }
         diagnostics.record("native_turn.committed")
@@ -983,6 +1158,9 @@ import TapQContracts
         expectCancelAck = false
         turnAudioByteCount = 0
         pendingOwnCommits = 0
+        pendingItemDeletes = 0
+        selfAudioSuppressions = 0
+        clearNativeSpeechEvidence()
         // The session boundary is where cancelled-response bookkeeping ends: ids are the
         // peer's, and the next connection's are a different peer's.
         activeResponseID = nil

--- a/Sources/TapQVoiceBackends/RealtimeMessages.swift
+++ b/Sources/TapQVoiceBackends/RealtimeMessages.swift
@@ -513,6 +513,17 @@ public enum RealtimeClientEvent: Equatable, Sendable {
     ///   out-of-band response still reads the conversation as input, which is how a
     ///   "repeat this sentence" job turns into an answer to whatever was said last.
     case createScriptedResponse(text: String)
+    /// Removes one item from the conversation.
+    ///
+    /// Sent at one moment only, and it is the one moment TapQ ever wants something the
+    /// service heard to *not* have happened: a segment the service's VAD committed that was
+    /// TapQ's own voice coming back through the speaker. Left in place, that item is the
+    /// model's answer re-presented to it as something the wearer said, and the next turn
+    /// reads it as context — which is how a run answers a question nobody asked twice.
+    ///
+    /// Suppressing the model turn (see `native_turn.suppressed_self_audio`) stops the
+    /// immediate repeat; this stops the echo from outliving it in the conversation.
+    case deleteConversationItem(id: String)
     /// Hands back what one of TapQ's tools produced, as a `function_call_output` item.
     ///
     /// It goes into the conversation rather than out of band — the opposite of
@@ -551,6 +562,8 @@ public enum RealtimeClientEvent: Equatable, Sendable {
                         instructions: RealtimeDefaults.scriptedSpeechInstructions(for: text)
                     )
                 ))
+            case .deleteConversationItem(let id):
+                data = try encoder.encode(ItemDeleteFrame(itemID: id))
             case .sendToolOutput(let callID, let output):
                 data = try encoder.encode(ToolOutputFrame(
                     item: .init(callID: callID, output: output)
@@ -574,6 +587,7 @@ public enum RealtimeClientEvent: Equatable, Sendable {
         case .createResponse: return "response.create"
         case .createScriptedResponse: return "response.create"
         case .sendToolOutput: return "conversation.item.create"
+        case .deleteConversationItem: return "conversation.item.delete"
         case .cancelResponse: return "response.cancel"
         }
     }
@@ -624,6 +638,17 @@ public enum RealtimeClientEvent: Equatable, Sendable {
 
     private struct ResponseCancelFrame: Encodable {
         let type = "response.cancel"
+    }
+
+    /// `conversation.item.delete`, which names the item and nothing else.
+    private struct ItemDeleteFrame: Encodable {
+        let type = "conversation.item.delete"
+        let itemID: String
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case itemID = "item_id"
+        }
     }
 
     /// `conversation.item.create` carrying one tool's answer.
@@ -693,7 +718,13 @@ public enum RealtimeServerEvent: Equatable, Sendable {
     /// The input buffer was committed and a conversation item created. Sent for TapQ's own
     /// `input_audio_buffer.commit` *and* for a commit the service's VAD made on its own —
     /// the adapter tells them apart by counting the commits it issued.
-    case inputAudioCommitted
+    ///
+    /// The id names the item the commit created. It was deliberately dropped until
+    /// 2026-08-30 — the service's bookkeeping, not TapQ's — and it is read now for one
+    /// reason: a commit the adapter recognizes as TapQ's own voice echoing back has to be
+    /// removed from the conversation, and `conversation.item.delete` needs a name for it.
+    /// `nil` for a peer that omits it, which costs the deletion and nothing else.
+    case inputAudioCommitted(itemID: String?)
     /// Incremental transcript of the *wearer's* audio.
     case transcriptDelta(String)
     /// Settled transcript of the wearer's audio for the committed turn.
@@ -744,7 +775,7 @@ public enum RealtimeServerEvent: Equatable, Sendable {
         case "input_audio_buffer.speech_stopped":
             return .speechStopped
         case "input_audio_buffer.committed":
-            return .inputAudioCommitted
+            return .inputAudioCommitted(itemID: envelope.itemID)
         case "conversation.item.input_audio_transcription.delta":
             return .transcriptDelta(envelope.delta ?? "")
         case "conversation.item.input_audio_transcription.completed":
@@ -839,5 +870,20 @@ public enum RealtimeServerEvent: Equatable, Sendable {
         let error: ErrorBody?
         let response: ResponseBody?
         let item: ItemBody?
+        /// Top-level on `input_audio_buffer.committed`, and the only frame this is read
+        /// from. Spelled `item_id` on the wire, which is why this struct has explicit keys
+        /// at all.
+        let itemID: String?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case delta
+            case transcript
+            case text
+            case error
+            case response
+            case item
+            case itemID = "item_id"
+        }
     }
 }

--- a/Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift
+++ b/Tests/TapQAppleAdaptersTests/BackendAudioPlaybackTests.swift
@@ -98,17 +98,65 @@ final class BackendAudioPlaybackTests: XCTestCase {
 
     // MARK: - Fixture
 
+    /// A clock the test moves by hand, so the recorded self-audio span can be asserted
+    /// against instants rather than against whatever `systemUptime` happened to be.
+    private final class TestClock {
+        var now: TimeInterval = 1_000
+        func advance(_ seconds: TimeInterval) { now += seconds }
+    }
+
     private struct Fixture {
         let playback: BackendAudioPlayback
         let scheduler: FakeScheduler
         let sink: RecordingSink
+        let clock: TestClock
     }
 
     private func makeFixture() -> Fixture {
         let scheduler = FakeScheduler()
         let sink = RecordingSink()
-        let playback = BackendAudioPlayback(scheduler: scheduler, diagnosticSink: sink)
-        return Fixture(playback: playback, scheduler: scheduler, sink: sink)
+        let clock = TestClock()
+        let playback = BackendAudioPlayback(scheduler: scheduler,
+                                            monotonicNow: { clock.now },
+                                            diagnosticSink: sink)
+        return Fixture(playback: playback, scheduler: scheduler, sink: sink, clock: clock)
+    }
+
+    // MARK: - The self-audio span
+
+    /// The span is the half of the self-hearing guard `isPlaying` cannot carry: a remote VAD
+    /// reports the speech it heard hundreds of milliseconds late, and by then the flag has
+    /// gone false. What the echo check needs is not "is TapQ speaking" but "was TapQ
+    /// speaking *then*".
+    func testTheSpanRecordsWhenTapQsVoiceStartedAndStopped() {
+        let f = makeFixture()
+        XCTAssertEqual(f.playback.selfAudioActivity, .silent)
+
+        f.playback.enqueue(pcm16Chunk())
+        XCTAssertEqual(f.playback.selfAudioActivity.startedAt, 1_000)
+        XCTAssertTrue(f.playback.selfAudioActivity.isSounding)
+
+        f.clock.advance(3)
+        f.playback.finishStream()
+        f.scheduler.fireAllCompletions()
+
+        XCTAssertFalse(f.playback.selfAudioActivity.isSounding)
+        XCTAssertEqual(f.playback.selfAudioActivity.startedAt, 1_000)
+        XCTAssertEqual(f.playback.selfAudioActivity.stoppedAt, 1_003)
+    }
+
+    /// And it outlives the drain, which is the whole point: the microphone reopens on that
+    /// falling edge, and the question about the tail arrives after it.
+    func testTheSpanAnswersAboutTheTailAfterTheDrain() {
+        let f = makeFixture()
+        f.playback.enqueue(pcm16Chunk())
+        f.clock.advance(2)
+        f.playback.stopAndFlush()
+
+        let span = f.playback.selfAudioActivity
+        XCTAssertTrue(span.wasAudible(at: 1_002.3, hysteresis: 0.6),
+                      "a room does not go quiet the moment the last buffer is handed over")
+        XCTAssertFalse(span.wasAudible(at: 1_003, hysteresis: 0.6))
     }
 
     // MARK: - Chunk helpers

--- a/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
+++ b/Tests/TapQAppleAdaptersTests/MicrophonePumpVoiceBackendTests.swift
@@ -618,6 +618,144 @@ final class MicrophonePumpVoiceBackendTests: XCTestCase {
         XCTAssertEqual(first.stops, 1)
     }
 
+    // MARK: - Self-audio: what the pump refuses to carry
+
+    /// A clock and a self-audio span the test drives, standing in for `BackendAudioPlayback`.
+    private final class FakeSelfAudio {
+        var now: TimeInterval = 1_000
+        var activity: VoiceSelfAudioActivity = .silent
+
+        func beginSpeaking() {
+            activity = VoiceSelfAudioActivity(startedAt: now, stoppedAt: nil)
+        }
+
+        /// TapQ's audio plays out: the clock moves with it, and only then does the room go
+        /// quiet — the shape a real player has, where the last buffer is heard long after
+        /// the response completed on the wire.
+        func drain(seconds: TimeInterval) {
+            now += seconds
+            activity = VoiceSelfAudioActivity(startedAt: activity.startedAt ?? now,
+                                              stoppedAt: now)
+        }
+    }
+
+    private struct SelfAudioFixture {
+        let pump: MicrophonePumpVoiceBackend
+        let inner: FakeInnerBackend
+        let audioSource: FakeAudioSource
+        let sink: RecordingSink
+        let selfAudio: FakeSelfAudio
+    }
+
+    private func makeSelfAudioFixture() -> SelfAudioFixture {
+        let inner = FakeInnerBackend()
+        let source = FakeAudioSource()
+        let sink = RecordingSink()
+        let selfAudio = FakeSelfAudio()
+        let pump = MicrophonePumpVoiceBackend(
+            inner: inner,
+            makeAudioSource: { source },
+            selfAudioHysteresis: 0.6,
+            monotonicNow: { selfAudio.now },
+            diagnosticSink: sink
+        )
+        pump.selfAudioActivity = { selfAudio.activity }
+        return SelfAudioFixture(pump: pump, inner: inner, audioSource: source,
+                                sink: sink, selfAudio: selfAudio)
+    }
+
+    private func audioSendCount(_ inner: FakeInnerBackend) -> Int {
+        inner.calls.filter { if case .sendAudio = $0 { return true } else { return false } }
+            .count
+    }
+
+    /// On the voice-only path TapQ's answers leave the Mac's speaker into this microphone.
+    /// Captured and sent, they are transcribed as the wearer and endpointed as the wearer's
+    /// turn — which is how a run ends up answering its own last sentence. So they are not
+    /// sent.
+    func testTapQsOwnVoiceIsNotPumpedBackToTheBackend() async throws {
+        let fixture = makeSelfAudioFixture()
+        let log = EventLog()
+        fixture.pump.setNativeTurnDetection(true)
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.selfAudio.beginSpeaking()
+        fixture.audioSource.emit(try monoFloatBuffer(
+            values: [Float](repeating: 0.5, count: 480)))
+        for _ in 0..<30 { await Task.yield() }
+
+        XCTAssertEqual(audioSendCount(fixture.inner), 0,
+                       "a microphone open over TapQ's own voice must not upload it")
+
+        // The room goes quiet, the hysteresis passes, and the wearer is heard again.
+        fixture.selfAudio.drain(seconds: 2)
+        fixture.selfAudio.now += 0.7
+        fixture.audioSource.emit(try monoFloatBuffer(
+            values: [Float](repeating: 0.5, count: 480)))
+        for _ in 0..<30 { await Task.yield() }
+
+        XCTAssertGreaterThanOrEqual(audioSendCount(fixture.inner), 1,
+                                    "and the microphone is the wearer's again afterwards")
+        XCTAssertTrue(fixture.sink.names.contains("mic.self_audio_suppressed"),
+                      "a stretch of dropped capture is reported once, with counts only")
+    }
+
+    /// Inside the hysteresis it is still TapQ: a speaker does not stop being audible the
+    /// moment the last buffer is handed to the hardware.
+    func testTheEchoTailIsStillTapQ() async throws {
+        let fixture = makeSelfAudioFixture()
+        let log = EventLog()
+        fixture.pump.setNativeTurnDetection(true)
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.selfAudio.beginSpeaking()
+        fixture.selfAudio.drain(seconds: 2)
+        fixture.selfAudio.now += 0.3
+        fixture.audioSource.emit(try monoFloatBuffer(
+            values: [Float](repeating: 0.5, count: 480)))
+        for _ in 0..<30 { await Task.yield() }
+
+        XCTAssertEqual(audioSendCount(fixture.inner), 0)
+    }
+
+    /// The AirPods path is untouched, and deliberately: there the wearer's turn signal is
+    /// live, barge-in works, and audio played into headphones does not reach this
+    /// microphone. Gating capture there would cost a wearer their interruption for nothing.
+    func testTheGateIsInertWhileTapQOwnsTurns() async throws {
+        let fixture = makeSelfAudioFixture()
+        let log = EventLog()
+        fixture.pump.setNativeTurnDetection(false)
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.selfAudio.beginSpeaking()
+        fixture.audioSource.emit(try monoFloatBuffer(
+            values: [Float](repeating: 0.5, count: 480)))
+        for _ in 0..<30 { await Task.yield() }
+
+        XCTAssertGreaterThanOrEqual(audioSendCount(fixture.inner), 1)
+        XCTAssertFalse(fixture.sink.names.contains("mic.self_audio_suppressed"))
+    }
+
+    /// A composition that wires no player sends everything, exactly as this pump always has.
+    func testWithNoPlayerWiredTheGateNeverCloses() async throws {
+        let fixture = makeSelfAudioFixture()
+        fixture.pump.selfAudioActivity = nil
+        let log = EventLog()
+        fixture.pump.setNativeTurnDetection(true)
+        try await fixture.pump.open { log.append($0) }
+        fixture.pump.beginUserTurn()
+
+        fixture.selfAudio.beginSpeaking()
+        fixture.audioSource.emit(try monoFloatBuffer(
+            values: [Float](repeating: 0.5, count: 480)))
+        for _ in 0..<30 { await Task.yield() }
+
+        XCTAssertGreaterThanOrEqual(audioSendCount(fixture.inner), 1)
+    }
+
     // MARK: - Inner session failure during beginUserTurn (defect 2)
 
     /// An inner backend that synchronously emits `sessionFailed` from `beginUserTurn`,

--- a/Tests/TapQInteractionBaselineTests/InstructionAnnouncementTests.swift
+++ b/Tests/TapQInteractionBaselineTests/InstructionAnnouncementTests.swift
@@ -1,0 +1,551 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+/// The 2026-08-30 fix, from both ends: an instruction the model resolved is announced rather
+/// than confirmed, and wherever a confirmation *does* survive it is one the wearer can
+/// actually give.
+///
+/// The bug was hardware-confirmed under `--voice-backend openai-realtime --voice-trust
+/// environment --voice-session`. The wearer said "tell Claude Code to create a temporary
+/// testing file…", the model called `queue_instruction`, the runtime routed it — and then
+/// TapQ queued a 125-character read-back and re-listened with `timeout=1.96` left in the
+/// window. TapQ's own playback holds the microphone closed for its drain
+/// (`SpeechGatedVoice`), so the countdown ran out while the question was still being asked,
+/// and the instruction was discarded `reason=silence`. Structurally, every time the read-back
+/// outlasted the residue.
+///
+/// ## The double this file is built around
+///
+/// No test in this repo could fail on that bug, because every `SpeechPresenting` double
+/// speaks instantaneously: `onFinish?()` fires immediately, no time passes, and the
+/// microphone the runtime holds shut is never shut in a test. ``DrainingSpeech`` and
+/// ``DrainAwareArbiter`` put that back — an utterance occupies the clock for as long as its
+/// text takes to say, and the arbiter cannot hear the wearer until it drains. A listen
+/// shorter than the sentence it is asking about therefore resolves as silence, exactly as it
+/// did on hardware.
+@MainActor
+final class InstructionAnnouncementTests: XCTestCase {
+    /// The sentence from the live log, at the length that broke it.
+    private static let dictated =
+        "Create a temporary testing file in the current directory, just a small empty file."
+
+    // MARK: - Doubles
+
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        func fields(of name: String) -> [[String: String]] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.filter { $0.name == name }.map(\.fields)
+        }
+    }
+
+    @MainActor
+    private final class VirtualClock {
+        private(set) var now: ContinuousClock.Instant = .now
+        func advance(by seconds: TimeInterval) { now = now.advanced(by: .seconds(seconds)) }
+        func advance(to instant: ContinuousClock.Instant) {
+            guard instant > now else { return }
+            now = instant
+        }
+    }
+
+    /// A voice that takes time to say things, and a microphone that stays shut while it does.
+    ///
+    /// `onFinish` still fires immediately — that is what `BackendSpeechSink` does, and why no
+    /// caller can use it to sequence a listen — but `quietAt` records when the audio actually
+    /// stops, and utterances queue behind one another rather than overlapping.
+    @MainActor
+    private final class DrainingSpeech: SpeechPresenting {
+        private let clock: VirtualClock
+        private(set) var spoken: [String] = []
+        /// When the last thing TapQ said stops sounding.
+        private(set) var quietAt: ContinuousClock.Instant
+
+        init(clock: VirtualClock) {
+            self.clock = clock
+            self.quietAt = clock.now
+        }
+
+        func speak(_ text: String, priority: SpeechPriority, onFinish: (() -> Void)?) {
+            spoken.append(text)
+            let starts = max(clock.now, quietAt)
+            quietAt = starts.advanced(by: .seconds(SpokenPace.drainSeconds(of: text)))
+            onFinish?()
+        }
+
+        func stopAll() { quietAt = clock.now }
+
+        func said(containing needle: String) -> Bool {
+            spoken.contains { $0.contains(needle) }
+        }
+    }
+
+    /// An input window that spends real time and cannot hear through TapQ's own voice.
+    ///
+    /// Each scripted entry says what the wearer does and how long after the *microphone
+    /// opens* they do it. The window resolves only if that moment falls inside the timeout it
+    /// was given — which is the whole of the bug: a listen that expires during the drain
+    /// hears nothing at all.
+    @MainActor
+    private final class DrainAwareArbiter: InputArbitrating {
+        struct Answer {
+            let intent: InputIntent?
+            /// Seconds after the microphone opens before the wearer speaks or gestures.
+            let after: TimeInterval
+        }
+
+        private let clock: VirtualClock
+        private let speech: DrainingSpeech
+        private let script: [Answer]
+        private(set) var timeouts: [TimeInterval] = []
+        /// Whether each listen ran out while TapQ was still speaking.
+        private(set) var expiredWhileSpeaking: [Bool] = []
+        var calls: Int { timeouts.count }
+
+        init(clock: VirtualClock, speech: DrainingSpeech, script: [Answer]) {
+            self.clock = clock
+            self.speech = speech
+            self.script = script
+        }
+
+        func listen(timeout: TimeInterval) async -> InputIntent? {
+            let index = timeouts.count
+            timeouts.append(timeout)
+            let expiresAt = clock.now.advanced(by: .seconds(timeout))
+            // `SpeechGatedVoice`: the channel opens when the engine drains, not when the
+            // listen starts.
+            let opensAt = max(clock.now, speech.quietAt)
+            guard index < script.count, let intent = script[index].intent else {
+                expiredWhileSpeaking.append(expiresAt < speech.quietAt)
+                clock.advance(to: expiresAt)
+                return nil
+            }
+            let heardAt = opensAt.advanced(by: .seconds(script[index].after))
+            guard heardAt <= expiresAt else {
+                expiredWhileSpeaking.append(expiresAt < speech.quietAt)
+                clock.advance(to: expiresAt)
+                return nil
+            }
+            expiredWhileSpeaking.append(false)
+            clock.advance(to: heardAt)
+            return intent
+        }
+    }
+
+    @MainActor
+    private final class Inbox {
+        var queued: [String] = []
+        var outcome: InstructionQueueOutcome = .queued
+        var enqueue: InstructionDictating {
+            { [self] text in queued.append(text); return outcome }
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func request() -> ApprovalRequest {
+        ApprovalRequest(id: "1", sessionID: "s1", agent: .claudeCode, toolName: "Bash",
+                        summary: "run npm test", detail: "full detail")
+    }
+
+    /// The live window, rebuilt: eight seconds, a sentence that takes six of them to say, and
+    /// a residue too short to ask anything in.
+    private func voiceSessionWindow(
+        intentSource: VoiceIntentSource,
+        clock: VirtualClock,
+        arbiter: DrainAwareArbiter,
+        speech: DrainingSpeech,
+        sink: RecordingSink,
+        inbox: Inbox
+    ) -> CommandWindowController {
+        let controller = CommandWindowController(
+            speech: speech,
+            arbiter: arbiter,
+            gate: InteractionGate(),
+            cue: CommandWindowController.voiceSessionCue,
+            agentDisplayName: "Claude Code",
+            diagnosticSink: sink,
+            instructionCapability: { true },
+            wearerAttribution: { true },
+            instructionEnqueue: inbox.enqueue,
+            kind: .voiceSession,
+            voiceTrust: .environment,
+            voiceMayEndSession: false,
+            gestureConfirmation: { false },
+            intentSource: intentSource
+        )
+        controller.now = { clock.now }
+        return controller
+    }
+
+    // MARK: - The model path announces
+
+    /// The regression, in the shape the hardware produced it: the wearer's sentence leaves
+    /// two seconds of window, and the instruction reaches the mailbox anyway.
+    ///
+    /// Nothing here waits for the wearer. There is no confirmation to expire, no silence to
+    /// misread as a refusal, and no `instruction.discarded` — the sentence is delivered on
+    /// routing and TapQ says what it did.
+    func testAToolResolvedInstructionSurvivesAReadBackThatOutlastsTheWindow() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let sink = RecordingSink()
+        let inbox = Inbox()
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .beginInstruction(Self.dictated), after: 6.04)]
+        )
+        let outcome = await voiceSessionWindow(
+            intentSource: .modelToolCalls, clock: clock, arbiter: arbiter,
+            speech: speech, sink: sink, inbox: inbox
+        ).run()
+
+        XCTAssertEqual(inbox.queued, [Self.dictated],
+                       "the instruction was lost to a window it never had to survive")
+        XCTAssertEqual(outcome.dictations, 1)
+        XCTAssertFalse(sink.names.contains("instruction.discarded"),
+                       "nothing on this path may discard for silence: \(sink.names)")
+        XCTAssertFalse(speech.said(containing: "queue it"),
+                       "no confirmation may be asked for: \(speech.spoken)")
+        XCTAssertTrue(speech.said(containing: "Queued for Claude Code:"),
+                      "the wearer was not told what happened: \(speech.spoken)")
+    }
+
+    /// What the wearer hears: who it went to, and the sentence that went.
+    ///
+    /// The announcement carries the read-back because it *replaces* one — it is the only
+    /// moment the wearer learns what was captured, and a bare "Queued for Claude Code."
+    /// would leave a mis-transcription undetectable.
+    func testTheAnnouncementNamesTheAgentAndSaysWhatWasQueued() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let inbox = Inbox()
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .beginInstruction(Self.dictated), after: 1)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .modelToolCalls, clock: clock, arbiter: arbiter,
+            speech: speech, sink: RecordingSink(), inbox: inbox
+        ).run()
+
+        XCTAssertTrue(
+            speech.said(containing: "Queued for Claude Code: '\(Self.dictated)'"),
+            "spoke: \(speech.spoken)"
+        )
+    }
+
+    /// A sentence too long to say in full is announced as shortened, never as though the
+    /// whole of it had been read out: what was queued is the wearer's whole sentence, and the
+    /// ellipsis is how they hear that the announcement is not all of it.
+    func testALongInstructionIsAnnouncedAsShortened() async {
+        let long = String(repeating: "run every single one of the integration tests ", count: 6)
+            .trimmingCharacters(in: .whitespaces)
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let inbox = Inbox()
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .beginInstruction(long), after: 1)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .modelToolCalls, clock: clock, arbiter: arbiter,
+            speech: speech, sink: RecordingSink(), inbox: inbox
+        ).run()
+
+        XCTAssertEqual(inbox.queued, [long], "the queued sentence is never the shortened one")
+        XCTAssertTrue(speech.said(containing: "…'"),
+                      "a shortened announcement must say so: \(speech.spoken)")
+    }
+
+    /// Truthfulness, unchanged by the new path: "Queued" is said about something that
+    /// queued, and never about anything else.
+    func testNothingIsCalledQueuedWhenTheMailboxTookNothing() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let inbox = Inbox()
+        inbox.outcome = .notQueued
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .beginInstruction(Self.dictated), after: 1)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .modelToolCalls, clock: clock, arbiter: arbiter,
+            speech: speech, sink: RecordingSink(), inbox: inbox
+        ).run()
+
+        XCTAssertFalse(speech.said(containing: "Queued for"),
+                       "TapQ claimed to have queued something it did not: \(speech.spoken)")
+        XCTAssertTrue(speech.said(containing: InstructionDictation.notQueuedNotice),
+                      "the wearer was told nothing at all: \(speech.spoken)")
+    }
+
+    /// The drop-oldest disclosure survives the change: both facts are still spoken, in the
+    /// clause the confirmed path has said since 2026-08-28.
+    func testTheAnnouncementStillDisclosesADisplacedInstruction() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let inbox = Inbox()
+        inbox.outcome = .queuedDroppingOldest
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .beginInstruction(Self.dictated), after: 1)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .modelToolCalls, clock: clock, arbiter: arbiter,
+            speech: speech, sink: RecordingSink(), inbox: inbox
+        ).run()
+
+        XCTAssertEqual(inbox.queued, [Self.dictated])
+        XCTAssertTrue(
+            speech.said(containing: "This replaced the oldest waiting instruction."),
+            "the displacement went unsaid: \(speech.spoken)"
+        )
+    }
+
+    /// The diagnostic says which posture queued it, so a log can always tell an announced
+    /// instruction from a confirmed one.
+    func testTheQueuedDiagnosticRecordsThePosture() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let sink = RecordingSink()
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .beginInstruction(Self.dictated), after: 1)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .modelToolCalls, clock: clock, arbiter: arbiter,
+            speech: speech, sink: sink, inbox: Inbox()
+        ).run()
+
+        XCTAssertEqual(sink.fields(of: "instruction.queued").map { $0["confirmation"] },
+                       ["announced"])
+    }
+
+    /// An approval window on the model path: the sentence is queued in passing, and the
+    /// wearer's next word answers the question they were actually asked.
+    ///
+    /// The other half of removing the confirmation. A "yes" no longer disappears into the
+    /// dictation flow, so the input after a tool-resolved instruction resolves the request —
+    /// which is what a wearer who has just been told "Queued" expects their next word to do.
+    func testTheNextInputAfterAnAnnouncementAnswersTheRequest() async {
+        let speech = InstantSpeech()
+        let inbox = Inbox()
+        let arbiter = ScriptedArbiter([.beginInstruction("run the tests again"), .allow])
+        let controller = InteractionController(
+            speech: speech, arbiter: arbiter,
+            instructionCapability: { true },
+            wearerAttribution: { true },
+            instructionEnqueue: inbox.enqueue,
+            intentSource: .modelToolCalls
+        )
+
+        let decision = await controller.resolve(request())
+
+        XCTAssertEqual(inbox.queued, ["run the tests again"])
+        XCTAssertEqual(decision, .allow,
+                       "the allow was consumed by a confirmation nobody asked for")
+        XCTAssertEqual(arbiter.calls, 2)
+    }
+
+    // MARK: - The grammar path keeps its confirmation, and can answer it
+
+    /// The deadline half of the fix, and the test that fails without it.
+    ///
+    /// Same window, same residue: two seconds left when the read-back is spoken. The wearer
+    /// answers a second after the microphone opens — which it does only when TapQ's own
+    /// sentence has drained, some ten seconds in. A listen sized to the residue never hears
+    /// them; a listen sized to its own question does.
+    func testAConfirmationIsAskedWithEnoughTimeToAnswerIt() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let sink = RecordingSink()
+        let inbox = Inbox()
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .freeform(Self.dictated), after: 6.04),
+                     .init(intent: .allow, after: 1)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .transcriptGrammar, clock: clock, arbiter: arbiter,
+            speech: speech, sink: sink, inbox: inbox
+        ).run()
+
+        XCTAssertTrue(speech.said(containing: "Instruction: 'Create a temporary"),
+                      "spoke: \(speech.spoken)")
+        XCTAssertTrue(speech.said(containing: "Say yes to queue it."),
+                      "the grammar path must still ask: \(speech.spoken)")
+        XCTAssertEqual(inbox.queued, [Self.dictated],
+                       "the wearer answered and was not heard: \(arbiter.timeouts)")
+        XCTAssertEqual(sink.fields(of: "instruction.queued").map { $0["confirmation"] },
+                       ["confirmed"])
+        XCTAssertEqual(arbiter.expiredWhileSpeaking, [false, false],
+                       "no listen may run out while TapQ is still talking")
+    }
+
+    /// The listen is sized from the question, not from the window: it covers the read-back's
+    /// own playback and then leaves a real answering window.
+    func testTheConfirmationListenOutlastsItsOwnReadBack() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .freeform(Self.dictated), after: 6.04),
+                     .init(intent: .allow, after: 1)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .transcriptGrammar, clock: clock, arbiter: arbiter,
+            speech: speech, sink: RecordingSink(), inbox: Inbox()
+        ).run()
+
+        XCTAssertEqual(arbiter.timeouts.count, 2, "timeouts: \(arbiter.timeouts)")
+        XCTAssertLessThan(CommandWindowController.windowSeconds - 6.04, 2.0,
+                          "the fixture must reproduce the race")
+        let readBack = speech.spoken.first { $0.hasPrefix("Instruction:") }
+        XCTAssertNotNil(readBack)
+        let needed = SpokenPace.drainSeconds(of: readBack) + SpokenPace.answeringSeconds
+        XCTAssertGreaterThanOrEqual(
+            arbiter.timeouts[1], needed,
+            "the confirmation was asked with less time than it takes to ask it"
+        )
+    }
+
+    /// The confirmation still means something: a read-back nobody answers queues nothing.
+    /// The grammar path guesses at intent, and the read-back is the only thing that catches a
+    /// wrong guess.
+    func testAnUnansweredReadBackStillQueuesNothingAndSaysSo() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let sink = RecordingSink()
+        let inbox = Inbox()
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .freeform(Self.dictated), after: 6.04)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .transcriptGrammar, clock: clock, arbiter: arbiter,
+            speech: speech, sink: sink, inbox: inbox
+        ).run()
+
+        XCTAssertEqual(inbox.queued, [], "an unconfirmed sentence must not be queued")
+        XCTAssertEqual(sink.fields(of: "instruction.discarded").map { $0["reason"] },
+                       ["silence"])
+        // The 2026-08-30 sweep's second finding: this discard used to be mute, so a wearer
+        // who dictated and heard nothing could not tell a lost sentence from a queued one.
+        XCTAssertTrue(speech.said(containing: InstructionDictation.discardedNotice),
+                      "the discard was silent: \(speech.spoken)")
+    }
+
+    /// The same silent discard inside an approval window, where the window is over by the
+    /// time there is anything to say. The notice is spoken before the deferral rather than
+    /// dropped with the window.
+    func testASilentDiscardIsSpokenEvenWhenTheApprovalWindowIsOver() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let sink = RecordingSink()
+        let inbox = Inbox()
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .beginInstruction(Self.dictated), after: 1)]
+        )
+        let controller = InteractionController(
+            speech: speech, arbiter: arbiter, diagnosticSink: sink,
+            instructionCapability: { true },
+            wearerAttribution: { true },
+            instructionEnqueue: inbox.enqueue,
+            gestureConfirmation: { false }
+        )
+        controller.now = { clock.now }
+        controller.entryMargin = 0
+
+        let decision = await controller.resolve(request(),
+                                                deadline: clock.now.advanced(by: .seconds(20)))
+
+        XCTAssertEqual(decision, .ask, "an unanswered approval still defers to the screen")
+        XCTAssertEqual(inbox.queued, [])
+        XCTAssertTrue(speech.said(containing: InstructionDictation.discardedNotice),
+                      "the discard was silent: \(speech.spoken)")
+        XCTAssertEqual(sink.fields(of: "instruction.discarded").map { $0["reason"] },
+                       ["silence"])
+    }
+
+    // MARK: - What the fix must not extend
+
+    /// A window with nothing to confirm is the eight-second window it has always been.
+    func testAnOrdinaryTurnStillGetsOnlyTheWindow() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let arbiter = DrainAwareArbiter(clock: clock, speech: speech,
+                                        script: [.init(intent: nil, after: 0)])
+        _ = await voiceSessionWindow(
+            intentSource: .modelToolCalls, clock: clock, arbiter: arbiter,
+            speech: speech, sink: RecordingSink(), inbox: Inbox()
+        ).run()
+
+        XCTAssertEqual(arbiter.timeouts.count, 1)
+        XCTAssertEqual(arbiter.timeouts[0], CommandWindowController.windowSeconds,
+                       accuracy: 0.01)
+    }
+
+    /// The dictation cue is not a question about a sentence the wearer has already said, so
+    /// it takes the window's residue exactly as it always did. Extending every turn would
+    /// turn an eight-second window into an open microphone.
+    func testTheCaptureCueDoesNotExtendTheWindow() async {
+        let clock = VirtualClock()
+        let speech = DrainingSpeech(clock: clock)
+        let arbiter = DrainAwareArbiter(
+            clock: clock, speech: speech,
+            script: [.init(intent: .beginInstruction(nil), after: 6.04),
+                     .init(intent: nil, after: 0)]
+        )
+        _ = await voiceSessionWindow(
+            intentSource: .transcriptGrammar, clock: clock, arbiter: arbiter,
+            speech: speech, sink: RecordingSink(), inbox: Inbox()
+        ).run()
+
+        XCTAssertGreaterThanOrEqual(arbiter.timeouts.count, 2,
+                                    "timeouts: \(arbiter.timeouts)")
+        XCTAssertLessThanOrEqual(arbiter.timeouts[1],
+                                 CommandWindowController.windowSeconds - 6.04 + 0.001,
+                                 "the cue turn took more than the window had left")
+    }
+
+    // MARK: - Plain doubles, for the tests that are not about time
+
+    @MainActor
+    private final class InstantSpeech: SpeechPresenting {
+        var spoken: [String] = []
+        func speak(_ text: String, priority: SpeechPriority, onFinish: (() -> Void)?) {
+            spoken.append(text)
+            onFinish?()
+        }
+        func stopAll() {}
+    }
+
+    @MainActor
+    private final class ScriptedArbiter: InputArbitrating {
+        private let script: [InputIntent?]
+        private(set) var calls = 0
+        init(_ script: [InputIntent?]) { self.script = script }
+        func listen(timeout: TimeInterval) async -> InputIntent? {
+            defer { calls += 1 }
+            return calls < script.count ? script[calls] : nil
+        }
+    }
+}

--- a/Tests/TapQInteractionBaselineTests/VoiceBackendToolIntentTests.swift
+++ b/Tests/TapQInteractionBaselineTests/VoiceBackendToolIntentTests.swift
@@ -522,4 +522,42 @@ final class VoiceBackendToolIntentTests: XCTestCase {
         }
         XCTAssertFalse(grounding.contains("Run the migration?"), grounding)
     }
+
+    /// A sentence is not over when its window is (2026-08-30).
+    ///
+    /// The wipe above was unconditional, and under `--voice-session` the eight-second window
+    /// rotates while TapQ is still speaking: the read-back the wearer is listening to right
+    /// now belonged to the window that just ended, so the next window's grounding told the
+    /// model "TapQ has not said anything" about audio the wearer could hear. Whatever they
+    /// said next then reached a model that did not know what it was an answer to.
+    ///
+    /// So the wipe waits for the audio rather than for the window. This is the rotation the
+    /// arbiter performs when nothing resolved a window — `stopUnresolved` — with TapQ's own
+    /// sentence still unfinished.
+    func testGroundingSurvivesAWindowThatEndsWhileTapQIsStillSpeaking() async {
+        let backend = ToolBackend()
+        let provider = makeProvider(backend, policy: .conversation(idleClose: 60))
+
+        provider.speakScripted("Queued for Claude Code: 'run the tests again.'")
+        await settle()
+        provider.start { _ in }
+        await settle()
+        // The clock came round. Nothing resolved the window and the sentence is still going.
+        provider.stopUnresolved()
+        await settle()
+
+        provider.start { _ in }
+        backend.emit(.responseCompleted)
+        await settle()
+
+        guard let grounding = backend.instructions.last else {
+            return XCTFail("no grounding was sent")
+        }
+        XCTAssertTrue(grounding.contains("run the tests again"),
+                      "the model was told nothing had been said: \(grounding)")
+        XCTAssertFalse(
+            grounding.contains("TapQ has not said anything"),
+            "the wearer was listening to TapQ at that exact moment: \(grounding)"
+        )
+    }
 }

--- a/Tests/TapQVoiceBackendsTests/RealtimeMessagesTests.swift
+++ b/Tests/TapQVoiceBackendsTests/RealtimeMessagesTests.swift
@@ -265,6 +265,15 @@ final class RealtimeMessagesTests: XCTestCase {
                         as? String, "input_audio_buffer.clear")
     }
 
+    /// The one frame TapQ sends about something it wishes had not been heard.
+    func testItemDeleteNamesTheItemAndNothingElse() throws {
+        let json = try object(
+            try RealtimeClientEvent.deleteConversationItem(id: "item_7").encodedFrame())
+        XCTAssertEqual(json["type"] as? String, "conversation.item.delete")
+        XCTAssertEqual(json["item_id"] as? String, "item_7")
+        XCTAssertEqual(json.count, 2, "a delete carries a name and no opinion")
+    }
+
     func testWireTypesMatchTheEncodedFrames() throws {
         let events: [RealtimeClientEvent] = [
             .sessionUpdate(RealtimeSessionConfiguration()),
@@ -273,6 +282,7 @@ final class RealtimeMessagesTests: XCTestCase {
             .clearInputAudio,
             .createResponse(instructions: nil),
             .createScriptedResponse(text: "Listening."),
+            .deleteConversationItem(id: "item_1"),
             .cancelResponse,
         ]
         for event in events {
@@ -424,7 +434,12 @@ final class RealtimeMessagesTests: XCTestCase {
         XCTAssertEqual(
             try RealtimeServerEvent.decode(
                 #"{"type":"input_audio_buffer.committed","item_id":"item_1"}"#),
-            .inputAudioCommitted,
-            "the payload's item id is the service's bookkeeping, not TapQ's")
+            .inputAudioCommitted(itemID: "item_1"),
+            "the item id was the service's bookkeeping until TapQ had a reason to name an "
+                + "item: a segment that was its own voice echoing back has to be deleted")
+        XCTAssertEqual(
+            try RealtimeServerEvent.decode(#"{"type":"input_audio_buffer.committed"}"#),
+            .inputAudioCommitted(itemID: nil),
+            "a peer that names nothing costs the deletion and nothing else")
     }
 }

--- a/Tests/TapQVoiceBackendsTests/RealtimeSelfAudioTests.swift
+++ b/Tests/TapQVoiceBackendsTests/RealtimeSelfAudioTests.swift
@@ -1,0 +1,557 @@
+import XCTest
+import Foundation
+@testable import TapQVoiceBackends
+import TapQContracts
+@testable import TapQInteractionBaseline
+
+/// TapQ answering itself, and the one number that separates that from a wearer answering.
+///
+/// The defect these are built from (hardware, 2026-08-30, `--voice-backend openai-realtime`
+/// with no AirPods): TapQ speaks an answer through the Mac's speaker, the microphone reopens
+/// as the last of it drains, the service's semantic VAD hears the tail and calls it the
+/// wearer's turn, the commit that follows produces an empty transcript, and the empty-turn
+/// rescue asks the model to act on the audio anyway — so the model, handed its own voice as
+/// the wearer's, says the same thing again. After a beat of silence, forever.
+///
+/// What must survive is the rescue itself. The same empty-transcript path is how a real
+/// question whose transcription lagged or came back blank still gets answered, and the log
+/// this fix came from contains both shapes minutes apart. So the two halves of this file are
+/// deliberately the same script with one number changed: how long ago TapQ's own audio
+/// stopped.
+///
+/// The playback double is drain-aware on purpose. A double that went idle the moment the
+/// response completed could not reproduce this bug at all — the whole shape of it is that
+/// `response.done` arrives while seconds of audio are still sitting in the player, so the
+/// window that opens next opens *into* TapQ's own voice.
+@MainActor
+final class RealtimeSelfAudioTests: XCTestCase {
+    // MARK: - Doubles
+
+    /// A monotonic clock the test moves by hand, shared by the adapter and the player so the
+    /// two are comparing instants on one timeline.
+    private final class TestClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: TimeInterval
+
+        init(_ start: TimeInterval = 1_000) { self.value = start }
+
+        var now: TimeInterval {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+
+        func advance(_ seconds: TimeInterval) {
+            lock.lock()
+            value += seconds
+            lock.unlock()
+        }
+    }
+
+    /// A response-audio player that takes as long to play audio as the audio lasts.
+    ///
+    /// `finishStream()` does *not* make it idle — that is the point. A real player is handed
+    /// a whole response's audio in a fraction of the time it takes to say it, so the moment
+    /// the response completes on the wire is the middle of the sentence in the room. Only
+    /// `drain()` ends it, and it advances the clock by the audio's own duration on the way.
+    @MainActor
+    private final class DrainAwarePlayback: VoiceResponseAudioPlaying {
+        private let clock: TestClock
+        private(set) var isPlaying = false
+        var onPlayingChange: (@MainActor (Bool) -> Void)?
+        private(set) var selfAudioActivity: VoiceSelfAudioActivity = .silent
+        private(set) var queuedSeconds: TimeInterval = 0
+        private var streamFinished = false
+
+        init(clock: TestClock) { self.clock = clock }
+
+        func enqueue(_ chunk: VoiceAudioChunk) {
+            if !isPlaying {
+                streamFinished = false
+                isPlaying = true
+                selfAudioActivity = VoiceSelfAudioActivity(startedAt: clock.now, stoppedAt: nil)
+                onPlayingChange?(true)
+            }
+            let bytesPerFrame = max(1, 2 * chunk.format.channels)
+            queuedSeconds += Double(chunk.data.count / bytesPerFrame) / chunk.format.sampleRate
+        }
+
+        func finishStream() { streamFinished = true }
+
+        func stopAndFlush() {
+            queuedSeconds = 0
+            goIdle()
+        }
+
+        /// Plays out everything queued: the clock moves by the audio's own length, and only
+        /// then does the room go quiet.
+        func drain() {
+            clock.advance(queuedSeconds)
+            queuedSeconds = 0
+            goIdle()
+        }
+
+        private func goIdle() {
+            guard isPlaying else { return }
+            isPlaying = false
+            selfAudioActivity = VoiceSelfAudioActivity(
+                startedAt: selfAudioActivity.startedAt ?? clock.now, stoppedAt: clock.now)
+            onPlayingChange?(false)
+        }
+    }
+
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var events: [TapQDiagnosticEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+
+        var names: [String] { events.map(\.name) }
+
+        func first(_ name: String) -> TapQDiagnosticEvent? { events.first { $0.name == name } }
+    }
+
+    @MainActor
+    private final class EventLog {
+        private(set) var events: [VoiceBackendEvent] = []
+        func append(_ event: VoiceBackendEvent) { events.append(event) }
+        var committedByBackend: Int {
+            events.filter {
+                if case .userAudioCommittedByBackend = $0 { return true } else { return false }
+            }.count
+        }
+        var failures: [VoiceBackendFailure] {
+            events.compactMap { if case .sessionFailed(let f) = $0 { return f } else { return nil } }
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static let hysteresis: TimeInterval = 0.6
+
+    private func settle() async {
+        for _ in 0..<12 { await Task.yield() }
+    }
+
+    private func pcm16(_ frames: Int) -> VoiceAudioChunk {
+        VoiceAudioChunk(data: Data(repeating: 0x11, count: frames * 2),
+                        format: OpenAIRealtimeVoiceBackend.audioFormat, timestamp: 0)
+    }
+
+    /// The adapter alone, with a clock and a player the test drives.
+    private func makeBackend(_ server: ScriptedRealtimeServer,
+                             clock: TestClock,
+                             playback: DrainAwarePlayback?,
+                             sink: RecordingSink = RecordingSink())
+        -> OpenAIRealtimeVoiceBackend {
+        let backend = OpenAIRealtimeVoiceBackend(
+            transport: server,
+            timeout: 1,
+            turnEagerness: .low,
+            selfAudioHysteresis: Self.hysteresis,
+            monotonicNow: { clock.now },
+            diagnosticSink: sink
+        )
+        if let playback {
+            backend.selfAudioActivity = { [weak playback] in
+                playback?.selfAudioActivity ?? .silent
+            }
+        }
+        return backend
+    }
+
+    /// The stack the bug lives in: the real provider, on the real adapter, on a scripted
+    /// peer, with a drain-aware player underneath.
+    private struct Stack {
+        let server: ScriptedRealtimeServer
+        let realtime: OpenAIRealtimeVoiceBackend
+        let playback: DrainAwarePlayback
+        let provider: VoiceBackendCommandProvider
+        let clock: TestClock
+        let sink: RecordingSink
+    }
+
+    private func makeStack() -> Stack {
+        let clock = TestClock()
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let playback = DrainAwarePlayback(clock: clock)
+        let realtime = makeBackend(server, clock: clock, playback: playback, sink: sink)
+        let provider = VoiceBackendCommandProvider(
+            backend: realtime,
+            intentSource: .modelToolCalls,
+            sessionPolicy: .conversation(idleClose: 60),
+            supportsBargeIn: true,
+            responseAudio: playback,
+            // The whole premise: no AirPods, so no wearer turn signal, so the service's own
+            // VAD decides where sentences end and TapQ's voice reaches its own microphone.
+            isWearerTurnSignalLive: { false },
+            // Bounded, so the timer this leaves behind cannot stall the next test.
+            idleSleep: { _ in try? await Task.sleep(for: .seconds(1)) },
+            diagnosticSink: sink
+        )
+        return Stack(server: server, realtime: realtime, playback: playback,
+                     provider: provider, clock: clock, sink: sink)
+    }
+
+    /// One whole answer in TapQ's own voice: requested, streamed, completed on the wire —
+    /// and still sounding in the room when this returns.
+    private func speakAnswer(_ stack: Stack, seconds: TimeInterval = 3) async {
+        stack.provider.speakScripted("Codex finished the refactor.")
+        await settle()
+        let id = try? XCTUnwrap(stack.server.currentResponseID)
+        stack.server.push(RealtimeFrame.audioDelta(
+            Data(repeating: 0x22, count: Int(seconds * 24_000) * 2)))
+        await settle()
+        stack.server.push(RealtimeFrame.responseDone(id: id ?? "resp_1"))
+        await settle()
+    }
+
+    private func responseCreateCount(_ stack: Stack) -> Int {
+        stack.server.sentFrames(ofType: "response.create").count
+    }
+
+    // MARK: - The stack, as the hardware ran it
+
+    /// The defect, end to end: the window that opens as TapQ's answer drains must not turn
+    /// the tail of that answer into a question TapQ asks itself.
+    ///
+    /// Every step here is one line of the 2026-08-30 log, in order — the scripted sentence,
+    /// the response completing while the audio is still playing, the microphone reopening on
+    /// the drain, and the service reporting speech a beat later. The assertion is the line
+    /// that must *not* appear after it: a second `response.create`, which is the model turn
+    /// whose answer the wearer heard as a repeat.
+    func testTheEchoOfTapQsOwnAnswerNeverBecomesAModelTurn() async {
+        let stack = makeStack()
+        stack.provider.start { _ in }
+        await settle()
+        stack.provider.stopUnresolved()
+        await settle()
+
+        await speakAnswer(stack)
+        let afterSpeaking = responseCreateCount(stack)
+
+        // The player finally drains — the clock moves by the length of the sentence — and
+        // the gate reopens the microphone into a room that is still ringing.
+        stack.playback.drain()
+        stack.provider.start { _ in }
+        await settle()
+        XCTAssertTrue(stack.provider.isUserTurnActiveForCoordination,
+                      "the window under test is the one that opens on the drain")
+
+        // A beat later, the service reports the tail as the wearer's utterance.
+        stack.clock.advance(0.2)
+        stack.server.reportServerVADUtterance(itemID: "item_echo")
+        await settle()
+
+        XCTAssertEqual(responseCreateCount(stack), afterSpeaking,
+                       "TapQ asked the model to act on its own voice")
+        XCTAssertTrue(stack.sink.names.contains("native_turn.suppressed_self_audio"))
+        XCTAssertFalse(stack.sink.names.contains("turn.model_turn_requested"))
+        XCTAssertTrue(stack.provider.isUserTurnActiveForCoordination,
+                      "the wearer's microphone stays open: nothing of theirs happened here")
+    }
+
+    /// The same script with one number changed: the wearer speaks well after the room went
+    /// quiet, and the rescue that answers them is untouched.
+    func testAWearersTurnAfterTheDrainStillReachesTheModel() async {
+        let stack = makeStack()
+        stack.provider.start { _ in }
+        await settle()
+        stack.provider.stopUnresolved()
+        await settle()
+
+        await speakAnswer(stack)
+        let afterSpeaking = responseCreateCount(stack)
+
+        stack.playback.drain()
+        stack.provider.start { _ in }
+        await settle()
+
+        // Two full seconds of silence — far past the echo hysteresis — and then a wearer.
+        stack.clock.advance(2)
+        stack.server.reportServerVADUtterance(itemID: "item_wearer")
+        await settle()
+
+        XCTAssertEqual(responseCreateCount(stack), afterSpeaking + 1,
+                       "the empty-transcript rescue is what answers a question whose "
+                        + "transcription lagged, and it must survive this fix")
+        XCTAssertTrue(stack.sink.names.contains("turn.model_turn_requested"))
+        XCTAssertFalse(stack.sink.names.contains("native_turn.suppressed_self_audio"))
+        XCTAssertFalse(stack.server.sentTypes.contains("conversation.item.delete"),
+                       "nothing the wearer said is deleted from the conversation")
+    }
+
+    /// A segment TapQ recognized as its own voice does not get to stay in the conversation
+    /// either: a model handed it as context a window later answers it a window later.
+    func testTheSuppressedSegmentIsDeletedFromTheConversation() async {
+        let stack = makeStack()
+        stack.provider.start { _ in }
+        await settle()
+        stack.provider.stopUnresolved()
+        await settle()
+        await speakAnswer(stack)
+        stack.playback.drain()
+        stack.provider.start { _ in }
+        await settle()
+
+        stack.clock.advance(0.2)
+        stack.server.reportServerVADUtterance(itemID: "item_echo")
+        await settle()
+
+        let deletes = stack.server.sentFrames(ofType: "conversation.item.delete")
+        XCTAssertEqual(deletes.count, 1)
+        XCTAssertEqual(deletes.first?["item_id"] as? String, "item_echo")
+        XCTAssertEqual(stack.sink.first("native_turn.suppressed_self_audio")?
+            .fields["item_deleted"], "true")
+    }
+
+    // MARK: - The rule, at the adapter
+
+    /// Speech the service heard entirely inside TapQ's own playback is TapQ, and the caller
+    /// never hears about the commit.
+    func testSpeechEntirelyInsidePlaybackIsSuppressed() async throws {
+        let clock = TestClock()
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let playback = DrainAwarePlayback(clock: clock)
+        let backend = makeBackend(server, clock: clock, playback: playback, sink: sink)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await backend.open { events.append($0) }
+        backend.beginUserTurn()
+        await settle()
+
+        playback.enqueue(pcm16(24_000))  // a second of TapQ's own voice, still sounding
+        clock.advance(0.3)
+        server.reportServerVADUtterance()
+        await settle()
+
+        XCTAssertEqual(events.committedByBackend, 0)
+        XCTAssertEqual(events.failures, [])
+        XCTAssertEqual(backend.turnStateForTesting, .userTurn,
+                       "suppressing a segment must not disturb the turn it arrived in")
+        let suppressed = try XCTUnwrap(sink.first("native_turn.suppressed_self_audio"))
+        XCTAssertEqual(suppressed.fields["count"], "1")
+        XCTAssertEqual(suppressed.fields["hysteresis_ms"], "600")
+    }
+
+    /// The hysteresis is what covers the room and the reporting lag, and it has two sides.
+    func testTheHysteresisBoundaryDecidesTheAmbiguousCase() async throws {
+        for (gap, expectSuppressed) in [(0.5, true), (0.9, false)] {
+            let clock = TestClock()
+            let server = ScriptedRealtimeServer()
+            let sink = RecordingSink()
+            let playback = DrainAwarePlayback(clock: clock)
+            let backend = makeBackend(server, clock: clock, playback: playback, sink: sink)
+            let events = EventLog()
+            backend.setNativeTurnDetection(true)
+            try await backend.open { events.append($0) }
+            backend.beginUserTurn()
+            await settle()
+
+            playback.enqueue(pcm16(24_000))
+            playback.drain()
+            clock.advance(gap)
+            server.reportServerVADUtterance()
+            await settle()
+
+            XCTAssertEqual(events.committedByBackend, expectSuppressed ? 0 : 1,
+                           "a gap of \(gap)s against a \(Self.hysteresis)s hysteresis")
+            XCTAssertEqual(sink.names.contains("native_turn.suppressed_self_audio"),
+                           expectSuppressed)
+        }
+    }
+
+    /// Speech that began before TapQ did is the wearer's, whatever landed on top of it.
+    ///
+    /// The fail direction, stated as a test. TapQ talking over a wearer who was already
+    /// speaking costs them an interruption; TapQ dropping that turn as its own echo costs
+    /// them the question, and on a run with no screen they have no way to discover which
+    /// happened.
+    func testSpeechThatBeganBeforeTapQSpokeIsTheWearers() async throws {
+        let clock = TestClock()
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let playback = DrainAwarePlayback(clock: clock)
+        let backend = makeBackend(server, clock: clock, playback: playback, sink: sink)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await backend.open { events.append($0) }
+        backend.beginUserTurn()
+        await settle()
+
+        // The wearer starts talking into a quiet room.
+        server.push(#"{"type":"input_audio_buffer.speech_started"}"#)
+        await settle()
+        // TapQ starts speaking over them, and is still speaking when they stop.
+        playback.enqueue(pcm16(24_000))
+        clock.advance(0.4)
+        server.push(#"{"type":"input_audio_buffer.speech_stopped"}"#)
+        server.commitFromServerVAD()
+        await settle()
+
+        XCTAssertEqual(events.committedByBackend, 1)
+        XCTAssertFalse(sink.names.contains("native_turn.suppressed_self_audio"))
+    }
+
+    /// A composition that wires no player suppresses nothing at all — every existing test,
+    /// and any host with no backend playback, behaves exactly as it did.
+    func testWithNoPlayerWiredNothingIsEverSuppressed() async throws {
+        let clock = TestClock()
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let backend = makeBackend(server, clock: clock, playback: nil, sink: sink)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await backend.open { events.append($0) }
+        backend.beginUserTurn()
+        await settle()
+
+        server.reportServerVADUtterance()
+        await settle()
+
+        XCTAssertEqual(events.committedByBackend, 1)
+        XCTAssertFalse(sink.names.contains("native_turn.suppressed_self_audio"))
+    }
+
+    /// The AirPods path is untouched. With a wearer turn signal live TapQ owns turns, the
+    /// service makes no commits at all, and a manual turn cycle runs through playback
+    /// exactly as it always has.
+    func testTheManualTurnPathIsUnchangedWhileTapQIsSpeaking() async throws {
+        let clock = TestClock()
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let playback = DrainAwarePlayback(clock: clock)
+        let backend = makeBackend(server, clock: clock, playback: playback, sink: sink)
+        let events = EventLog()
+        try await backend.open { events.append($0) }
+        backend.beginUserTurn()
+        await settle()
+
+        playback.enqueue(pcm16(24_000))
+        backend.sendAudio(pcm16(2_400))
+        await settle()
+        XCTAssertTrue(backend.endUserTurn(expectingResponse: true),
+                      "manual turns commit and ask for a response regardless of playback")
+        await settle()
+
+        XCTAssertTrue(server.sentTypes.contains("input_audio_buffer.commit"))
+        XCTAssertTrue(server.sentTypes.contains("response.create"))
+        XCTAssertFalse(sink.names.contains("native_turn.suppressed_self_audio"))
+        XCTAssertEqual(events.failures, [])
+    }
+
+    /// A delete the service refuses is housekeeping that did not land, not a dead channel.
+    func testARefusedDeleteDoesNotEndTheSession() async throws {
+        let clock = TestClock()
+        let server = ScriptedRealtimeServer()
+        let sink = RecordingSink()
+        let playback = DrainAwarePlayback(clock: clock)
+        let backend = makeBackend(server, clock: clock, playback: playback, sink: sink)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await backend.open { events.append($0) }
+        backend.beginUserTurn()
+        await settle()
+
+        playback.enqueue(pcm16(24_000))
+        clock.advance(0.2)
+        server.reportServerVADUtterance(itemID: "item_echo")
+        await settle()
+        server.push(#"""
+            {"type":"error","error":{"type":"invalid_request_error",\#
+            "code":"item_not_found","message":"no such item"}}
+            """#)
+        await settle()
+
+        XCTAssertEqual(events.failures, [], "a refused delete must not take voice down")
+        XCTAssertTrue(sink.names.contains("item_delete.refused"))
+        XCTAssertNotEqual(backend.turnStateForTesting, .idle)
+    }
+
+    /// And the absorption is exactly one error wide: the next one is the session-ending
+    /// protocol failure it has always been.
+    func testASecondErrorAfterADeleteStillEndsTheSession() async throws {
+        let clock = TestClock()
+        let server = ScriptedRealtimeServer()
+        let playback = DrainAwarePlayback(clock: clock)
+        let backend = makeBackend(server, clock: clock, playback: playback)
+        let events = EventLog()
+        backend.setNativeTurnDetection(true)
+        try await backend.open { events.append($0) }
+        backend.beginUserTurn()
+        await settle()
+
+        playback.enqueue(pcm16(24_000))
+        clock.advance(0.2)
+        server.reportServerVADUtterance(itemID: "item_echo")
+        await settle()
+        let failure = #"{"type":"error","error":{"type":"server_error","message":"boom"}}"#
+        server.push(failure)
+        await settle()
+        server.push(failure)
+        await settle()
+
+        XCTAssertEqual(events.failures.count, 1)
+    }
+
+    /// The tuning knob, and the composition line an operator reads it back from.
+    func testTheHysteresisIsResolvedFromTheEnvironmentAndReported() async {
+        XCTAssertEqual(VoiceSelfAudioEcho.resolvedHysteresis(environment: [:]),
+                       VoiceSelfAudioEcho.defaultHysteresis)
+        XCTAssertEqual(
+            VoiceSelfAudioEcho.resolvedHysteresis(
+                environment: [VoiceSelfAudioEcho.hysteresisEnvironmentKey: "350"]),
+            0.35, accuracy: 0.0001)
+        XCTAssertEqual(
+            VoiceSelfAudioEcho.resolvedHysteresis(
+                environment: [VoiceSelfAudioEcho.hysteresisEnvironmentKey: "not a number"]),
+            VoiceSelfAudioEcho.defaultHysteresis,
+            "a mistyped knob must not be why a wearer's only channel refuses to start")
+        XCTAssertEqual(
+            VoiceSelfAudioEcho.resolvedHysteresis(
+                environment: [VoiceSelfAudioEcho.hysteresisEnvironmentKey: "999999"]),
+            VoiceSelfAudioEcho.maximumHysteresis,
+            "a hysteresis that long is a microphone that ignores the wearer")
+        XCTAssertEqual(
+            VoiceSelfAudioEcho.resolvedHysteresis(
+                environment: [VoiceSelfAudioEcho.hysteresisEnvironmentKey: "-5"]), 0)
+
+        let clock = TestClock()
+        let sink = RecordingSink()
+        _ = makeBackend(ScriptedRealtimeServer(), clock: clock, playback: nil, sink: sink)
+        XCTAssertEqual(sink.first("turn_detection.configured")?
+            .fields["self_audio_hysteresis_ms"], "600")
+    }
+
+    /// The span's own arithmetic, including the two ends it deliberately treats differently.
+    func testAudibilitySpansExtendForwardOnly() async {
+        let sounding = VoiceSelfAudioActivity(startedAt: 10, stoppedAt: nil)
+        XCTAssertTrue(sounding.isSounding)
+        XCTAssertTrue(sounding.wasAudible(at: 10, hysteresis: 0.5))
+        XCTAssertTrue(sounding.wasAudible(at: 9_999, hysteresis: 0.5))
+        XCTAssertFalse(sounding.wasAudible(at: 9.9, hysteresis: 0.5),
+                       "nothing before TapQ started speaking can be TapQ")
+
+        let past = VoiceSelfAudioActivity(startedAt: 10, stoppedAt: 12)
+        XCTAssertFalse(past.isSounding)
+        XCTAssertTrue(past.wasAudible(at: 12.4, hysteresis: 0.5))
+        XCTAssertFalse(past.wasAudible(at: 12.6, hysteresis: 0.5))
+        XCTAssertFalse(past.wasAudible(at: 12.4, hysteresis: 0),
+                       "a hysteresis of nothing is the raw span")
+
+        XCTAssertFalse(VoiceSelfAudioActivity.silent.wasAudible(at: 0, hysteresis: 10),
+                       "a run whose voice has never played has no echo to suppress")
+    }
+}

--- a/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
@@ -201,9 +201,28 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
     /// contract makes an unsolicited commit a session-ending violation, and the adapter's own
     /// tests assert that. Pushing the frame directly is still how a test models the illegal
     /// case.
-    func commitFromServerVAD() {
+    /// - Parameter itemID: the item the commit creates, as the live service always names
+    ///   one. `nil` models the peer that names nothing — the only case that costs TapQ the
+    ///   ability to delete a segment it recognized as its own voice.
+    func commitFromServerVAD(itemID: String? = "item_vad") {
         uncommittedAudio = false
-        push(#"{"type":"input_audio_buffer.committed"}"#)
+        guard let itemID else { return push(#"{"type":"input_audio_buffer.committed"}"#) }
+        push(#"{"type":"input_audio_buffer.committed","item_id":"\#(itemID)"}"#)
+    }
+
+    /// The whole of one utterance as the service's own VAD reports it: where speech began,
+    /// where it ended, and the item the commit created. A method rather than three pushes
+    /// because the *order* is what the adapter's self-audio evidence is built from, and a
+    /// test that pushed them by hand could get it wrong quietly.
+    func reportServerVADUtterance(itemID: String? = "item_vad") {
+        push(#"{"type":"input_audio_buffer.speech_started"}"#)
+        push(#"{"type":"input_audio_buffer.speech_stopped"}"#)
+        commitFromServerVAD(itemID: itemID)
+    }
+
+    /// Frames of one type, in order.
+    func sentFrames(ofType type: String) -> [[String: Any]] {
+        sent.filter { $0["type"] as? String == type }
     }
 
     /// The peer drops the connection mid-stream.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -88,9 +88,9 @@ The underlying command syntax is `tapq serve [options]`.
 | `--wearer-gate` | IMU-based wearer-speech attribution gate (default: off). Voice commands must be attributed to the wearer's own jaw vibration; commands from bystanders or other audio sources are rejected. Fails open when the signal is unavailable or degraded. Uses `wearer-speech-calibration.json` when present, provisional thresholds otherwise |
 | `--imu-turn-control` | IMU-based turn control (default: off). Endpointing: wearer speech-end commits the user turn after a short delay. Barge-in: wearer speech-onset during response audio interrupts playback. Both are additive to gesture/tap/timeout resolution. Shares one signal source with `--wearer-gate`. On `--voice-backend openai-realtime` it also decides who ends user turns: without it, or with no AirPods streaming, the backend's own voice activity detection does — see [Turn detection](#turn-detection) |
 | `--voice-freeform` | Free-form voice answers for selections and multi-option stop questions (default: off). Requires `--voice-backend openai-realtime`. **Inert since 2026-08-28**: promoting an unmatched transcript is a transcript→intent step, and there are none left on that backend. Spoken selections are made with the `select_item` tool; spoken questions are answered by the model itself. See [Free-form voice answers](#free-form-voice-answers) |
-| `--voice-instructions` | Dictated instructions to the agent (default: off). Requires `--wearer-gate` under `--voice-trust wearer`; passing it alone is a startup error there. "New instruction" or "tell it to ⟨…⟩" inside an open prompt opens a read-back-and-confirm dictation, and the confirmed sentence is delivered at the agent's next turn boundary. A leading "tell ⟨agent⟩ to ⟨…⟩" addresses another live session by name, and refuses out loud when the name is unknown or names more than one session. Fail-closed on wearer attribution — the inverse of every other voice path. Claude Code and Codex only. See [Dictated instructions](#dictated-instructions) |
+| `--voice-instructions` | Dictated instructions to the agent (default: off). Requires `--wearer-gate` under `--voice-trust wearer`; passing it alone is a startup error there. "New instruction" or "tell it to ⟨…⟩" inside an open prompt opens a dictation, and the sentence is delivered at the agent's next turn boundary — read back and confirmed on `--voice-backend apple`, where a grammar guessed the intent; queued and announced on `openai-realtime`, where the model resolved it into a tool call. A leading "tell ⟨agent⟩ to ⟨…⟩" addresses another live session by name, and refuses out loud when the name is unknown or names more than one session. Fail-closed on wearer attribution — the inverse of every other voice path. Claude Code and Codex only. See [Dictated instructions](#dictated-instructions) |
 | `--voice-session` | Hold the agent's turn boundary open and keep listening (default: off). Requires `--voice-instructions`. When a turn ends, the Stop hook waits on the broker instead of returning: TapQ says "Listening." and re-opens a command window until an instruction is queued (delivered as the Stop block, so the agent continues) or a gesture or tap ends the session. **Silence does not end it** — the boundary is held indefinitely. On `openai-realtime` no spoken input can end it; on `apple` the shipped end phrases still can. Inside a waiting window a dictated sentence needs no "tell it to" prefix. See [Voice sessions](#voice-sessions) |
-| `--voice-trust wearer\|environment` | Whose voice may dictate an instruction (default: `wearer`). `wearer` is today's behavior byte for byte: dictation is fail-closed on IMU wearer attribution. `environment` trusts the microphone as the user — `--voice-instructions` then needs no `--wearer-gate`, the attribution check is skipped (recorded as `instruction.trusted_environment`), and read-backs stop asking for a nod where no nod can arrive. Approvals are untouched under either value. See [Voice trust](#voice-trust) |
+| `--voice-trust wearer\|environment` | Whose voice may dictate an instruction (default: `wearer`). `wearer` is today's behavior byte for byte: dictation is fail-closed on IMU wearer attribution. `environment` trusts the microphone as the user — `--voice-instructions` then needs no `--wearer-gate`, the attribution check is skipped (recorded as `instruction.trusted_environment`), and read-backs stop asking for a nod where no nod can arrive. Approvals are untouched under either value. Whether a dictation is confirmed or announced is decided by the backend, not by this flag. See [Voice trust](#voice-trust) |
 | `--auto-answer off\|routine` | Delegation filter (default: `off`). `routine` answers `allow` silently, without opening a window, when the stage-2 reasoner called the action routine, its confidence clears the policy floor, and the tool is not on the never-list. Requires `--reasoner` and `--reasoner-mode primary`; both are startup errors when missing. Approvals only. See [Auto-answered approvals](#auto-answered-approvals) |
 | `--attention off\|imu` | Always-on attention (default: `off`). `imu` holds the motion subscription open between requests so an attributed wearer-speech onset opens a short command window that can answer questions and take dictation but can never approve, deny, or select. Requires `--wearer-gate`. Costs continuous IMU power. See [Attention windows](#attention-windows) |
 | `--voice-processing` | Experimental, macOS-only (default: off). Enables Apple's voice-processing IO — echo cancellation and automatic gain control — on the capture input node. Half-duplex is unchanged. See [Voice processing (experimental)](#voice-processing-experimental) |
@@ -377,7 +377,7 @@ TapQ declares five tools on the session, and they are the whole vocabulary:
 | `approve` | — | authorizes the request just read out |
 | `deny` | — | refuses it |
 | `select_item` | `index` (1-based) | picks an entry from the list TapQ just read |
-| `queue_instruction` | `text`, optional `agent` | dictates to an agent, through the ordinary read-back-and-confirm flow |
+| `queue_instruction` | `text`, optional `agent` | dictates to an agent, through the ordinary dictation flow — attribution, addressing, mailbox — which on this backend queues the sentence and announces it rather than asking for a second confirmation of an intent the model already resolved |
 | `query_status` | `kind` — `waiting` or `changed` | answers a question about state; resolves nothing |
 
 Ambiguity is a safe state for *acting*: a window that nothing resolves still ends by gesture,
@@ -548,8 +548,13 @@ Under `environment`:
   '⟨text⟩'. Say yes to queue it." and "You said: '⟨text⟩'. Say yes to send, or no to
   discard." The wording follows the live motion probe, so AirPods that appear mid-run get
   the nod offered again on the next read-back.
-- The read-back confirmation itself stays, always. It catches mis-transcription, not just
-  misattribution, and it is the only thing between a stray sentence and an agent's inbox.
+- The read-back confirmation stays wherever a *grammar* guessed at the intent — the Apple
+  path. It catches mis-transcription, not just misattribution, and there it is the only
+  thing between a misheard phrase and an agent's inbox. Under `--voice-backend
+  openai-realtime` the model resolved the sentence into a `queue_instruction` call before
+  TapQ saw it, so there is no guess to catch: the instruction is queued and *announced* —
+  "Queued for ⟨agent⟩: '⟨text⟩'" — rather than read back and confirmed. See [Dictated
+  instructions](#dictated-instructions).
 
 The honest cost, stated once: under `environment`, **anyone audible to the microphone can
 instruct** — and still cannot approve, deny, select, or defer anything. Approval grammar,
@@ -586,11 +591,27 @@ Inside any open prompt:
 3. TapQ reads it back: "Instruction: '⟨text⟩'. Nod or say yes to queue it." — or "Say yes
    to queue it." where no gesture can arrive; see [Voice trust](#voice-trust).
 4. A nod, a double tap, or "yes" queues it — "Queued for ⟨agent⟩." Anything else discards
-   it — "Instruction discarded." Silence discards it without a word. If queueing it pushed
-   an older instruction out of a full mailbox, the confirmation says so: "Queued for
-   ⟨agent⟩. This replaced the oldest waiting instruction." And in the rare case where the
-   mailbox took nothing after all — the window closed underneath the confirmation — TapQ
-   says that instead of claiming a delivery: "That wasn't queued after all — say it again."
+   it — "Instruction discarded.", and so does silence: a read-back nobody answers says the
+   same sentence rather than ending quietly. If queueing it pushed an older instruction out
+   of a full mailbox, the confirmation says so: "Queued for ⟨agent⟩. This replaced the
+   oldest waiting instruction." And in the rare case where the mailbox took nothing after
+   all — the window closed underneath the confirmation — TapQ says that instead of claiming
+   a delivery: "That wasn't queued after all — say it again."
+
+Steps 3 and 4 are the *grammar* path: `--voice-backend apple`, where `.beginInstruction`
+was guessed from a transcript and the read-back is what catches a wrong guess. Under
+`--voice-backend openai-realtime` the wearer's sentence reached TapQ as a
+`queue_instruction` tool call the model had already resolved, and there the sentence is
+queued on the spot and announced — "Queued for Claude Code: '⟨text⟩'", with the same
+drop-oldest clause and the same "That wasn't queued after all" when the mailbox took
+nothing. Nothing waits for a second answer.
+
+That difference is a fix, not a preference (2026-08-30, hardware). TapQ holds the
+microphone closed while it speaks, so a read-back queued into the last two seconds of an
+eight-second window ran the window out before the wearer could answer, and the instruction
+was discarded for silence every single time. Where a confirmation *is* asked for, its
+listen now covers the read-back's own playback plus a real answering window, so the
+question outlives itself.
 
 
 The prompt the wearer was answering is untouched by all of this. The confirming nod is

--- a/docs/REALTIME_INTENT_PLAN.md
+++ b/docs/REALTIME_INTENT_PLAN.md
@@ -152,3 +152,48 @@ Where the implementation reads differently from the sketch above, and why.
   is the mirror of `onScriptedSpeechUndeliverable` and is wired to the same
   `VoiceBrokenState` latch: that one fires when TapQ cannot be heard, this one when
   the wearer cannot be understood. Neither degrades.
+
+## Amendment, 2026-08-30: a routed instruction is announced, not confirmed
+
+Ratified by the maintainer after a hardware run under `--voice-backend
+openai-realtime --voice-trust environment --voice-session`. The wearer said
+"tell Claude Code to create a temporary testing file…"; the model called
+`queue_instruction`, the runtime logged
+`instruction.trusted_environment stage=begin` → `stage=text` →
+`instruction.routed agent=Claude Code` — and then queued a 125-character
+read-back and re-listened with `timeout=1.96` left in the eight-second window.
+The microphone is held closed for TapQ's own drain (`SpeechGatedVoice`), so the
+countdown expired while the question was still being asked:
+`instruction.discarded reason=silence`. Not a flake — the outcome whenever the
+read-back outlasts the window's residue.
+
+The decision, and the reason it is narrow:
+
+- **On `intentSource == .modelToolCalls`, a routed instruction is delivered to
+  the mailbox on routing and announced** — "Queued for ⟨agent⟩: '⟨text⟩'" — with
+  the drop-oldest clause and the `.notQueued` sentence unchanged. No listen, no
+  discard-on-silence. The read-back guarded the *guess* a keyword grammar made
+  about what the wearer meant; this path has no guess (see "Model routes, never
+  delivers" above — intent arrives resolved, as a tool call), and
+  `--voice-trust environment` has already said out loud that heard speech may
+  instruct. The instruction still authorizes nothing: whatever the agent does
+  with it meets the approval gate.
+- **The grammar path is untouched.** `.transcriptGrammar` still reads back and
+  waits for a nod, a tap, or "yes", because there the sentence was inferred from
+  a transcript and the read-back is the only thing that catches a wrong
+  inference.
+- **Every surviving confirmation gets a deadline it can be answered inside.** A
+  turn that asks the wearer something is sized from the question — the
+  utterance's own playback plus a real answering window (`TurnBudget`,
+  `SpokenPace`) — rather than from whatever the window had left. This covers the
+  dictation read-back on the grammar path and the selection free-text read-back.
+  Turns that ask nothing ("Go ahead.", the window's own listens) are unchanged.
+- **A discarded dictation says so.** The confirm turn's silence branch returned
+  `nil`, so the one discard a wearer most needs to hear was mute; it now speaks
+  `InstructionDictation.discardedNotice`, and a window that ends with that
+  sentence still pending speaks it rather than dropping it.
+- **Grounding waits for the audio, not for the window.** `endWindowKeepSession`
+  wiped `spokenSinceWindowEnded` unconditionally, so a rotation during TapQ's own
+  playback told the next turn's model "TapQ has not said anything" while the
+  wearer was still listening to it. The wipe is now gated on the player and the
+  response being finished.


### PR DESCRIPTION
First round of fixes from the M1 hardware smoke (2026-08-30) and the deadline-vs-playback class sweep it triggered. Stacks on #41. Both bugs were reproduced from the live runtime log before fixing.

## Instructions no longer die to a confirmation you cannot give (sweep F1 + F2)

On the tool-call path, a routed instruction spoke a ~8s read-back-and-confirm against the ~2 seconds left in its window — with the microphone held closed for playback drain — and was then discarded for "silence", silently. Every time.

Ratified fix ("Option B"): where the model resolved the sentence into a tool call there is no confirmation — the instruction queues on routing and is **announced** ("Queued for Claude Code: '…'", drop-oldest disclosure intact, and never the word "Queued" for anything the mailbox refused). The grammar path keeps its confirmation but its listen is now sized from the question itself (drain time + a real answering window), the selection free-text read-back gets the same repair (sweep F8), and any surviving discard speaks the existing notice instead of returning silence.

## The grounding survives the drain (sweep F4)

A timed-out window wiped "what TapQ has said" from the model's grounding while the sentence was still audibly playing — so even a wearer who beat the clock was answered by a model told TapQ had said nothing. The wipe is now gated on the existing `responseOutlivesWindow` condition: an undrained sentence is still "said".

## TapQ no longer answers its own echo

On the no-AirPods path, answers play through speakers into an open mic; semantic VAD heard the tail as wearer speech, committed a turn, and a model turn was requested for it — the model re-answered its own voice ("the answer repeats after a little silence"). A native turn whose speech fell entirely within TapQ's own playback (+600ms tunable hysteresis) is now suppressed and its conversation item deleted, and the mic pump stops uploading audio while TapQ is audible there (barge-in on that path is IMU-driven, and the IMU is exactly what is absent). Ambiguity fails open — one repeated answer is cheaper than one dropped question — and the empty-transcript model-turn rescue, which provably saves real questions with late transcriptions, is untouched. AirPods-path behavior is byte-identical.

## The class is now testable

The sweep proved no existing test could fail on any of this: every speech double "spoke" instantly and never closed the mic. Both fixes land with drain-aware doubles (utterances occupy the injected clock and hold the voice channel). Reverting the instruction fix under them produces 19 assertion failures; reverting the grounding gate, 2.

## Verified

744 tests / 27 suites green via the slim check (26 new tests across two suites), host build clean. Round 2 of the sweep (F3 window-clock-at-drain-edge, F5+F9 viability floors, F10 notification deferral) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
