### PR TITLE
Anchor the window clock at the drain edge; derive the floors; defer notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -597,6 +597,28 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Fixed
 
+- **The command window's clock now starts when you can actually speak.** Measured live:
+  12 of 40 eight-second windows opened with the microphone still held closed by TapQ's own
+  draining audio, so the drain — plus the second of endpointing after your last word — came
+  out of your answering time. The window's deadline is now anchored at the drain edge
+  (waiting out the same signal that holds the microphone, plus a pace estimate for audio
+  the backend has accepted but not yet begun sounding), a window's closing sentence is
+  carried into the next window's anchor, and mid-window answers no longer leave the
+  residual listen expiring before the microphone reopens. Eight seconds of open microphone
+  are now actually eight seconds.
+- **Prompts that cannot be answered are no longer asked.** The "is there enough time
+  left?" margin was a hand-picked 12 seconds; the longest selection prompt takes ~21
+  seconds to say on the Apple voice. The margin is now derived from each prompt's real
+  length and the voice's real pace, re-checked before every mid-loop re-speak, and a
+  request that fails it defers to the screen out loud. `--timeout` below the derived
+  minimum (35 s) is refused at parse time with the reason, instead of silently making
+  every approval unanswerable.
+- **"Claude Code finished." no longer lands inside an open command window**, where it tore
+  down speech recognition while the window's timer kept counting. Notifications now defer
+  and replay at the next legal moment; duplicates within a window, notices superseded by a
+  fresh prompt, and sixty-second expiries are counted in diagnostics rather than silently
+  dropped — and an expired notice is safe to drop because it was already recorded, so
+  "what changed?" still answers.
 - **TapQ no longer answers its own echo** (`--voice-backend openai-realtime`, no
   AirPods). With answers playing through speakers into an open microphone, the backend's
   turn detection heard the tail of TapQ's own voice as wearer speech and asked the model

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -767,6 +767,23 @@ import Darwin
         )
         let voice: (any VoiceCommandProviding)? = voiceAuthorized ? gatedVoice : nil
 
+        // The run's one record of what TapQ's own voice is doing (sweep finding F3). Command
+        // windows read it to decide when their eight seconds may start counting: the window
+        // that just closed spoke its last answer on the way out, and without this the next
+        // window's countdown runs through audio `gatedVoice` is holding the microphone shut
+        // for. Measured at 12 of 40 windows on hardware.
+        //
+        // `isSpeaking` is *read*, never subscribed to: `activitySignal.onSpeakingChange` is a
+        // single-observer slot and `SpeechGatedVoice` owns it two lines up. Reading the same
+        // property the gate reads is what makes the window's clock and the microphone agree
+        // by construction rather than by estimate — this is the same signal, engine plus
+        // player, that decides whether the microphone opens at all.
+        //
+        // Captured strongly, deliberately: the drain outlives no one here (the composition
+        // holds it for the run) and there is no cycle to make, while a weak capture that went
+        // nil would report "quiet" — the one answer that silently restores the bug.
+        let voiceChannelDrain = VoiceChannelDrain { activitySignal.isSpeaking }
+
         // -- IMU turn coordinator (WP7) --
         // When --imu-turn-control is enabled, the coordinator watches the wearer-speech
         // signal and calls endActiveTurn (endpointing) or interrupts playback (barge-in).
@@ -1206,7 +1223,11 @@ import Darwin
                         instructionAddressResolver: memory.instructionAddressResolver,
                         voiceTrust: configuration.voiceTrust,
                         gestureConfirmation: gestureConfirmation,
-                        intentSource: voiceIntentSource
+                        intentSource: voiceIntentSource,
+                        // The run's shared record, so an attention window that opens while a
+                        // notice or an earlier answer is still sounding waits for the
+                        // microphone instead of counting through it.
+                        voiceChannelDrain: voiceChannelDrain
                     )
                 }
             )
@@ -1279,7 +1300,12 @@ import Darwin
                         voiceTrust: configuration.voiceTrust,
                         voiceMayEndSession: voiceMayEndSession,
                         gestureConfirmation: gestureConfirmation,
-                        intentSource: voiceIntentSource
+                        intentSource: voiceIntentSource,
+                        // The window this matters most to, and the one the sweep measured.
+                        // The loop below opens window N+1 in the same actor turn that window
+                        // N spoke its closing sentence in, so *every* window after the first
+                        // opens under drain unless this record crosses between them.
+                        voiceChannelDrain: voiceChannelDrain
                     )
                 }
             )

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -252,6 +252,17 @@ import Darwin
     /// boundary silent.
     private var voiceSessionListening: VoiceSessionListening?
 
+    /// Whether the wearer is inside a command window right now — either the attention window
+    /// an onset opened, or any of the windows a held turn boundary keeps re-opening.
+    ///
+    /// The voice-session arm reads `isListening` rather than a per-window flag deliberately.
+    /// That loop opens eight-second windows back to back for as long as the boundary is
+    /// held, and the gaps between them are microseconds; a notice timed into one of those
+    /// gaps would be spoken into the window that opened immediately after it.
+    private var isCommandWindowOpen: Bool {
+        attentionArming?.isWindowOpen == true || voiceSessionListening?.isListening == true
+    }
+
     func serve(
         configuration: TapQRuntimeConfiguration,
         reasonerLoader: TapQReasonerLoading?,
@@ -1074,6 +1085,15 @@ import Darwin
             gestureConfirmation: gestureConfirmation,
             intentSource: voiceIntentSource
         )
+        // Which voice is doing the talking, told to the two controllers that size their
+        // viability floor by it. The backend voice reads about twice as fast as the local
+        // synthesizer, so the same prompt is a very different fraction of the same window,
+        // and a floor that assumed one of them would be wrong on the other in whichever
+        // direction hurts: too small refuses nothing, too large refuses everything.
+        let speechPath: SpokenPace.Path =
+            configuration.voiceBackend == .apple ? .apple : .realtime
+        interaction.speechPath = speechPath
+        selection.speechPath = speechPath
         let interactionGate = InteractionGate()
 
         // -- Notification routing (RD5) --
@@ -1085,12 +1105,24 @@ import Darwin
         // It reads the wait registry conversation memory already keeps, rather than a
         // second one: "is this session already queued at the gate?" has exactly one right
         // answer per run, and two registries could disagree about it.
+        //
+        // It also asks whether a command window is open before making a sound. A
+        // cross-session notification spoken into one is spoken at `.notification` priority
+        // into the wearer's own listening window: the speech gate tears the recognizer down
+        // for the utterance while the window's timer keeps counting, so most of eight
+        // seconds goes on a sentence about a different agent and the wearer is recorded as
+        // having said nothing. Held instead, and folded into the next legal moment.
         let notificationPolicy = NotificationPolicy(
             settings: .init(
                 quiet: configuration.quietEnabled,
                 announcementsEnabled: configuration.announcementsEnabled
             ),
-            waits: memory.waitRegistry
+            waits: memory.waitRegistry,
+            // Late-bound on purpose: both window owners are built two hundred lines below
+            // this, and the closure is not called until a notification arrives — which
+            // cannot happen before the broker is serving, which is later still.
+            commandWindowOpen: { [weak self] in self?.isCommandWindowOpen ?? false },
+            diagnosticSink: diagnostics
         )
 
         // Said once, or never: the sentence that explains a voice-only run. It has two
@@ -1166,7 +1198,10 @@ import Darwin
                 )
             case .chime(let cue):
                 playCue(cue)
-            case .suppress:
+            case .suppress, .deferred:
+                // A motion loss is never deferred — no `whenDeferred` is passed, and the
+                // policy will not hold what it cannot hand back. Listed so the switch stays
+                // exhaustive and this stays a decision rather than an omission.
                 break
             }
             approvalArbiter.cancel()
@@ -1988,21 +2023,30 @@ import Darwin
                 // "what changed?" and be told nothing had. Suppressing a sound and
                 // forgetting an event are different acts; only the first is a flag.
                 memory.record(notification: notification)
-                switch notificationPolicy.route(
+                // How this notification is played, whenever it is played. Named because it
+                // has two callers now: the verdict below, and — when a command window is
+                // open — the policy's own deferral, which hands the same verdict back once
+                // the window has closed rather than speaking across it.
+                let play: @MainActor (NotificationPolicy.Verdict) -> Void = { verdict in
+                    switch verdict {
+                    case .speak:
+                        interaction.announce(notification)
+                    case .chime(let cue):
+                        // Played directly rather than through `announce`, whose utterance
+                        // the quiet decorator would convert into a second cue for the same
+                        // event.
+                        playCue(cue)
+                    case .suppress, .deferred:
+                        break
+                    }
+                }
+                play(notificationPolicy.route(
                     .agentNotification(
                         kind: notification.kind,
                         sessionID: notification.sessionID
-                    )
-                ) {
-                case .speak:
-                    interaction.announce(notification)
-                case .chime(let cue):
-                    // Played directly rather than through `announce`, whose utterance the
-                    // quiet decorator would convert into a second cue for the same event.
-                    playCue(cue)
-                case .suppress:
-                    break
-                }
+                    ),
+                    whenDeferred: play
+                ))
             },
             onSelection: { request in
                 let deadline = ContinuousClock.now + .seconds(InteractionBudget.total)

--- a/Package.swift
+++ b/Package.swift
@@ -248,7 +248,10 @@ var targets: [Target] = [
     .testTarget(
         name: "TapQCLITests",
         dependencies: [
-            "TapQCLI", "TapQContextBaseline", "TapQDetectionBaseline", "TapQWireProtocol",
+            "TapQCLI", "TapQContextBaseline", "TapQDetectionBaseline",
+            // The `--timeout` floor is the interaction layer's own viability arithmetic, and
+            // the parser test asserts that rather than a number retyped into the assertion.
+            "TapQInteractionBaseline", "TapQWireProtocol",
         ],
         swiftSettings: swiftSettings
     ),

--- a/Sources/TapQCLI/CLICommand.swift
+++ b/Sources/TapQCLI/CLICommand.swift
@@ -419,7 +419,7 @@ enum CLICommandParser {
             case "--tap-profile":
                 options.tapProfilePath = try cursor.requireValue(for: argument)
             case "--timeout":
-                options.interactionTimeout = try duration(
+                options.interactionTimeout = try interactionTimeout(
                     cursor.requireValue(for: argument), flag: argument)
             case "--no-voice":
                 options.voiceEnabled = false
@@ -1007,6 +1007,30 @@ enum CLICommandParser {
     private static func duration(_ value: String, flag: String) throws -> TimeInterval {
         guard let parsed = Double(value), parsed.isFinite, parsed > 0, parsed <= 3_600 else {
             throw CLIUsageError(message: "\(flag) must be a number greater than 0 and no more than 3600.")
+        }
+        return parsed
+    }
+
+    /// `--timeout`, which unlike every other duration on this command line is the length of
+    /// a window somebody has to *answer inside*.
+    ///
+    /// The upper end has always been clamped, silently, against the shim's socket timeout.
+    /// The lower end was not checked at all, and `tapq serve --timeout 5` was accepted and
+    /// then made every approval and every selection of the run structurally unanswerable:
+    /// TapQ holds the microphone shut for its own playback, so a five-second listen is five
+    /// seconds of a prompt that is still being read out when the window closes. Nothing said
+    /// so, at any point — the run simply never resolved a question by voice.
+    ///
+    /// The floor is the controllers' own viability arithmetic (`SpokenPace`), so the number
+    /// refused here is the number they would have refused every individual prompt against.
+    private static func interactionTimeout(_ value: String, flag: String) throws -> TimeInterval {
+        let parsed = try duration(value, flag: flag)
+        let floor = SpokenPace.minimumListenSeconds
+        guard parsed >= floor else {
+            throw CLIUsageError(
+                message: "\(flag) must be at least \(Int(floor)) seconds: a shorter window "
+                    + "cannot finish reading the longest prompt and still leave time to answer it."
+            )
         }
         return parsed
     }

--- a/Sources/TapQCLI/TapQCLIApplication.swift
+++ b/Sources/TapQCLI/TapQCLIApplication.swift
@@ -1867,7 +1867,9 @@ public struct TapQCLIIO {
       --broker-dir PATH        Override the runtime discovery/socket directory
       --gesture-profile PATH   Override the gesture calibration profile
       --tap-profile PATH       Override the tap calibration profile
-      --timeout SECONDS        Per-listen input timeout (default: 240; values are capped at 240)
+      --timeout SECONDS        Per-listen input timeout (default: 240; minimum 35, values
+                               are capped at 240). Below the minimum a window cannot finish
+                               reading the longest prompt and still leave time to answer it
       --no-voice               Disable microphone speech recognition
       --speech-voice VOICE     Voice for spoken output: a language tag (en-US, zh-CN) or
                                a system voice identifier (default: en-US, also settable

--- a/Sources/TapQContracts/InteractionBudget.swift
+++ b/Sources/TapQContracts/InteractionBudget.swift
@@ -16,13 +16,21 @@ public enum InteractionBudget {
     public static let shimSocketTimeout: TimeInterval = total + 10
     /// The per-hook timeout written into each agent's hook configuration.
     public static let hookTimeout: TimeInterval = shimSocketTimeout + 5
-    /// Don't START an interaction with less than this much budget left: enough to speak
-    /// a typical prompt and still leave the user time to answer inside the shim window.
-    /// A request that queued past this threshold defers silently — its asker is better
-    /// served by the on-screen prompt than by a question it can't answer.
-    public static let minViableRemaining: TimeInterval = 12
     /// Longest a single listen window may be, leaving TTS headroom inside `total`.
     public static let maxListenWindow: TimeInterval = total - 5
+
+    // The viability floor — "is there enough budget left to even ask?" — is deliberately
+    // NOT here.
+    //
+    // It used to be, as a hand-picked twelve seconds, and being here is why it was wrong:
+    // the answer is a number of characters divided by a speaking rate, and this module knows
+    // nothing about either. It could not see that the presenters' own maximum prompts are
+    // longer than twelve seconds of speech on the slower voice, so a maximum-length prompt
+    // spent the entire margin before the question had finished being asked. The derivation
+    // now lives with the pace model that can state it — `SpokenPace.viableSeconds` in
+    // `TapQInteractionBaseline` — and each controller reads its own presenter's bound
+    // through it. `SpokenPace.minimumListenSeconds` is the same arithmetic exported for the
+    // command line's `--timeout` floor.
 }
 
 public extension ContinuousClock.Instant {

--- a/Sources/TapQInteractionBaseline/CommandWindowController.swift
+++ b/Sources/TapQInteractionBaseline/CommandWindowController.swift
@@ -179,6 +179,19 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     /// Clock seam, as on the other controllers: deadline math reads time through this so
     /// tests can drive a virtual clock instead of racing a real eight seconds.
     var now: () -> ContinuousClock.Instant = { .now }
+    /// What TapQ's own voice is still doing. Shared across the windows of a run, because the
+    /// audio a window has to wait out is usually the *previous* window's closing sentence.
+    ///
+    /// A window builds its own when the composition hands it none, which keeps every existing
+    /// host working and still covers the single-window case (a cue, an answer, a read-back all
+    /// occupy the channel). Only the shared instance can see across windows, which is why the
+    /// composition passes one in.
+    private let drain: VoiceChannelDrain
+    /// Sleep seam for the drain deferral, so the wait is virtual in tests. Production sleeps
+    /// for real; a test injects one that advances its own clock.
+    var drainSleep: (TimeInterval) async -> Void = { seconds in
+        try? await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
+    }
 
     /// - Parameters:
     ///   - gate: the same gate the approval and selection windows use. A private one would
@@ -205,7 +218,9 @@ public struct CommandWindowOutcome: Sendable, Equatable {
                 voiceTrust: VoiceTrust = .wearer,
                 voiceMayEndSession: Bool = true,
                 gestureConfirmation: GestureConfirmationQuerying? = nil,
-                intentSource: VoiceIntentSource = .transcriptGrammar) {
+                intentSource: VoiceIntentSource = .transcriptGrammar,
+                voiceChannelDrain: VoiceChannelDrain? = nil) {
+        self.drain = voiceChannelDrain ?? VoiceChannelDrain()
         self.voiceMayEndSession = voiceMayEndSession
         self.speech = speech
         self.arbiter = arbiter
@@ -233,7 +248,10 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     }
 
     private func loop() async -> CommandWindowOutcome {
-        let deadline = now() + .seconds(Self.windowSeconds)
+        // The window's clock starts where the microphone can actually open, not where the
+        // controller happened to be entered. See `WindowClock` for the measurement that put
+        // this here; `anchor()` is the whole of the fix.
+        let deadline = await anchor() + .seconds(Self.windowSeconds)
         diagnostics.record("window.opened", fields: ["seconds": "\(Self.windowSeconds)"])
         var answers = 0
         var ignored = 0
@@ -319,6 +337,7 @@ public struct CommandWindowOutcome: Sendable, Equatable {
                 // Said now rather than left pending: the loop is over, so there is no next
                 // listen to carry it, and a wearer who ended the session should hear that
                 // it ended.
+                drain.willSpeak(Self.voiceSessionEnded, at: now())
                 speech.speak(Self.voiceSessionEnded, priority: .notification, onFinish: nil)
                 pending = nil
                 break
@@ -327,12 +346,64 @@ public struct CommandWindowOutcome: Sendable, Equatable {
         // The window ran out with something still to say (a last answer, or a turn that
         // never got its listen). Said now, because the listen that would have carried it
         // is not going to happen.
-        if let pending { speech.speak(pending, priority: .notification, onFinish: nil) }
+        //
+        // This sentence is the one the sweep caught stealing: the loop opens the next window
+        // in the same actor turn, and this audio is still draining when it does. Recording it
+        // is what lets that window's `anchor()` wait it out instead of counting through it.
+        if let pending {
+            drain.willSpeak(pending, at: now())
+            speech.speak(pending, priority: .notification, onFinish: nil)
+        }
         diagnostics.record("window.closed", fields: [
             "answers": "\(answers)", "ignored": "\(ignored)", "dictations": "\(dictations)",
         ])
         return CommandWindowOutcome(answers: answers, ignored: ignored,
                                     dictations: dictations, endedByWearer: endedByWearer)
+    }
+
+    /// Where this window's eight seconds begin: the instant the microphone can actually open.
+    ///
+    /// Both readings of `VoiceChannelDrain`, in the order only one of them can be taken in.
+    /// The live signal is a `Bool`, so the only way to consume it is to wait it out — which
+    /// costs nothing while it is honest, because a microphone `SpeechGatedVoice` is holding
+    /// shut is not hearing the wearer either way. The estimate is a duration, so it is added
+    /// rather than waited: the first listen simply runs that much longer, exactly as round
+    /// one's `SpokenPace.listenSeconds` does for a turn that asks a question.
+    ///
+    /// The estimate goes second because of the blind spot `SpokenTurnBudget` documents: a
+    /// sentence handed to a backend has been accepted but is not sounding yet, so the live
+    /// signal reads quiet for the first few hundred milliseconds of audio that has not
+    /// started. Waiting on the signal alone would sail straight through that; the estimate is
+    /// what covers it.
+    ///
+    /// Bounded by `WindowClock.maxDrainWait`, and the bound is load-bearing: this runs inside
+    /// the shared `InteractionGate`, and a signal stuck at `true` must cost one window rather
+    /// than every window after it.
+    private func anchor() async -> ContinuousClock.Instant {
+        let opened = now()
+        let limit = opened.advanced(by: .seconds(WindowClock.maxDrainWait))
+        while drain.isLiveSounding, now() < limit {
+            await drainSleep(WindowClock.drainPollInterval)
+        }
+        let settled = now()
+        let waited = settled.seconds(after: opened)
+        let estimated = min(drain.estimatedRemainder(at: settled),
+                            max(0, limit.seconds(after: settled)))
+        let anchored = settled.advanced(by: .seconds(estimated))
+        let deferred = waited + estimated
+        if deferred > 0 {
+            // Counts only. What TapQ was saying is already in the log where it was said.
+            diagnostics.record("window.clock_deferred", fields: [
+                "drain_ms": "\(Self.milliseconds(deferred))",
+                "signal_ms": "\(Self.milliseconds(waited))",
+                "estimate_ms": "\(Self.milliseconds(estimated))",
+            ])
+        }
+        return anchored
+    }
+
+    private nonisolated static func milliseconds(_ seconds: TimeInterval) -> Int {
+        Int((max(0, seconds) * 1000).rounded())
     }
 
     /// One turn: speak (barge-in) and listen for whatever is left of the window.
@@ -350,8 +421,32 @@ public struct CommandWindowOutcome: Sendable, Equatable {
     /// *asks* the wearer to confirm something is the exception: TapQ's own read-back plays
     /// with the microphone held closed, so a listen sized to the residue can expire before
     /// the question has finished being asked. That turn covers its playback and then leaves
-    /// a real answering window (`TurnBudget.afterSpeaking`), and the eight-second cap does
-    /// not apply to it — a cap shorter than the question is the same bug in another place.
+    /// a real answering window (`TurnBudget.afterSpeaking`) — a listen shorter than the
+    /// question is the same bug in another place.
+    ///
+    /// A `.remainingWindow` turn now carries two additions, and neither lengthens the design:
+    ///
+    /// 1. **Its own playback is not charged to it** (sweep finding F7). The residue is what
+    ///    the wearer gets to *speak into*, and TapQ speaking first does not shorten it. The
+    ///    evidence was a 102-character answer — eight and a half seconds of audio — spoken
+    ///    into a 2.19-second residual listen, which is a listen that expires before the
+    ///    microphone opens at all. This is round one's rule for confirmations, applied to the
+    ///    turns that only *tell* the wearer something; the difference from
+    ///    `.afterSpeaking` stays exactly what it was, which is the six-second answering
+    ///    window a question earns and a statement does not.
+    /// 2. **The commit allowance** (F11). The wearer speaking at the deadline is answered
+    ///    about a second later, once the detector's hangover and the endpoint delay have run.
+    ///    A listen that closes on the deadline throws that answer away. See
+    ///    `WindowClock.commitAllowance`: it buys no extra window, only the wait for a turn
+    ///    already taken.
+    ///
+    /// The `min(windowSeconds, remaining)` cap that used to sit on both branches is gone, and
+    /// its absence is part of the fix rather than a loosening. It was a no-op for as long as
+    /// the deadline was born at `now() + 8s`: `remaining` started at exactly eight seconds and
+    /// only shrank. Against an anchored deadline it is actively wrong — it clips off exactly
+    /// the drain `anchor()` credited, which is to say it steals the time the anchor gave back,
+    /// one line later. The deadline is the bound now, and it is the only one: `remaining` can
+    /// exceed eight seconds only by drain the wearer could not have spoken into anyway.
     private func listen(speaking text: String?,
                         until deadline: ContinuousClock.Instant,
                         budget: TurnBudget = .remainingWindow) async -> ResolvedInput? {
@@ -360,12 +455,16 @@ public struct CommandWindowOutcome: Sendable, Equatable {
         let window: TimeInterval
         switch budget {
         case .remainingWindow:
-            window = min(Self.windowSeconds, remaining)
+            window = SpokenPace.drainSeconds(of: text) + remaining
+                + WindowClock.commitAllowance
         case .afterSpeaking(let answering):
-            window = SpokenPace.listenSeconds(asking: text,
-                                              remaining: min(Self.windowSeconds, remaining),
+            window = SpokenPace.listenSeconds(asking: text, remaining: remaining,
                                               answering: answering)
         }
+        // Recorded for the window *after* this one, whose clock has to wait this out. Every
+        // utterance, both budgets: the record is about the voice channel, not about which
+        // kind of turn happened to occupy it.
+        drain.willSpeak(text, at: now())
         return await BargeIn.listen(speech: speech, text: text, priority: .notification) {
             await self.arbiter.listenForInput(timeout: window)
         }

--- a/Sources/TapQInteractionBaseline/InteractionController.swift
+++ b/Sources/TapQInteractionBaseline/InteractionController.swift
@@ -14,6 +14,15 @@ public protocol ApprovalRequestPresenting: Sendable {
     func voiceConfirmationCue() -> String
     /// Spoken when a two-channel request still needs the gesture half.
     func gestureConfirmationCue() -> String
+    /// The longest prompt this presenter will ever compose, in characters.
+    ///
+    /// A *promise*, not a measurement, and it is what the controller's viability floor is
+    /// derived from: before a request is spoken at all the controller has to know whether
+    /// the budget could carry the worst prompt this presenter might return, and it must
+    /// know it without composing one. A host whose wording runs longer than the default
+    /// overrides this; a host that overrides it too low is caught by the controller's
+    /// per-utterance re-check, which measures the sentence actually in hand.
+    func maximumPromptCharacters() -> Int
 }
 
 /// Defaults for the confirmation cues, so a host that wrote a presenter before risk
@@ -35,6 +44,12 @@ public extension ApprovalRequestPresenting {
     /// Nod and tap are the two approve inputs that are not speech; either completes the
     /// gesture half.
     func gestureConfirmationCue() -> String { "Risky action. Nod or tap to confirm." }
+    /// The shipped presenter's bound, which is the right default precisely because a host
+    /// that did not think about this question is also a host that did not lengthen the
+    /// wording.
+    func maximumPromptCharacters() -> Int {
+        DefaultApprovalRequestPresenter.maximumPromptCharacters
+    }
 }
 
 /// Agent-neutral wording suitable for SDK examples and tests.
@@ -51,6 +66,26 @@ public struct DefaultApprovalRequestPresenter: ApprovalRequestPresenting {
     public init(speaksNotificationSummary: Bool = false) {
         self.speaksNotificationSummary = speaksNotificationSummary
     }
+
+    /// The arithmetic of `prompt(for:)` at every cap at once, so the viability floor can be
+    /// derived rather than guessed. Each term is one of the caps below, plus what
+    /// `SpokenText.condensed` and `SpokenText.sentence` may add to it (an ellipsis when
+    /// truncated, a full stop when not):
+    ///
+    ///     display name            24   see the note below
+    ///     ": "                     2
+    ///     preamble               122   120 cap + terminator + separating space
+    ///     summary                 65   64 cap + terminator
+    ///     " Yes or no?"           11   the longer of the two closers
+    ///     ────────────────────────────
+    ///                            224
+    ///
+    /// The display-name allowance is the one number here that is not a cap in this file:
+    /// `AgentIdentity.displayName` is a plain `String` on a public contract. Twenty-four
+    /// characters is comfortably past every identity this repo ships ("Claude Code" is
+    /// eleven), and a host that names an agent more extravagantly than that is a host whose
+    /// prompt is measured exactly anyway on the controller's per-utterance re-check.
+    public static let maximumPromptCharacters = 24 + 2 + 122 + 65 + 11
 
     /// The preamble, when there is one, is one spoken sentence in front of the prompt:
     /// "<Name>: <preamble> <summary> Yes or no?". The prompt sentence itself is condensed
@@ -629,8 +664,34 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
     private let presenter: any ApprovalRequestPresenting
     private let diagnostics: TapQDiagnosticEmitter
     public var timeout: TimeInterval
-    /// Minimum remaining budget required to begin speaking (see InteractionBudget.minViableRemaining).
-    public var entryMargin: TimeInterval = InteractionBudget.minViableRemaining
+    /// Which voice this composition speaks with, because the viability floor is a number of
+    /// characters divided by it. Settable rather than an init parameter for the reason the
+    /// margin below is: the two voices are chosen at the top of `serve`, long before this
+    /// controller is assembled, and every host that never says anything gets the slower of
+    /// them — which is the safe guess.
+    public var speechPath: SpokenPace.Path = SpokenPace.defaultPath
+    private var entryMarginOverride: TimeInterval?
+    /// Minimum remaining budget required to begin speaking.
+    ///
+    /// Derived, not chosen: the presenter says how long its worst prompt can be
+    /// (`maximumPromptCharacters`), `speechPath` says how fast that is spoken, and
+    /// `SpokenPace.viableSeconds` adds the answering and endpointing time the wearer needs
+    /// after it. The old hand-picked twelve seconds was shorter than the prompts it was
+    /// guarding — on the Apple path a maximum-length prompt is seventeen seconds of speech
+    /// with the microphone held shut, so the margin was spent before the question was over.
+    ///
+    /// Assignable, and an assignment wins: a test that wants to watch what the loop does
+    /// with no margin at all sets it to zero, and a host with an unusual composition can
+    /// say so. Reading it back after an assignment returns what was assigned.
+    public var entryMargin: TimeInterval {
+        get {
+            entryMarginOverride ?? SpokenPace.viableSeconds(
+                utteranceCharacters: presenter.maximumPromptCharacters(),
+                on: speechPath
+            )
+        }
+        set { entryMarginOverride = newValue }
+    }
     /// Clock seam: all deadline math reads time through this, so tests can advance a
     /// virtual clock instead of racing real sub-second deadlines against CI preemption.
     var now: () -> ContinuousClock.Instant = { .now }
@@ -700,12 +761,23 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
     ) async -> Decision {
         let deadline = deadline ?? now() + .seconds(InteractionBudget.total)
         diagnostics.record("resolve.started", fields: ["tool": request.toolName, "id": request.id])
-        // Expired (or nearly so) while queued behind other requests: the shim may have
-        // already failed open, and there isn't enough budget left to speak the prompt and
-        // still leave the user time to answer — don't speak, don't open a window.
-        guard deadline.seconds(after: now()) > entryMargin else {
-            diagnostics.record("resolve.insufficient_budget", fields: ["id": request.id])
-            return .ask
+        // Expired (or nearly so) while queued behind other requests: there isn't enough
+        // budget left to speak the prompt and still leave the user time to answer, so no
+        // window is opened.
+        let remainingAtEntry = deadline.seconds(after: now())
+        guard remainingAtEntry > entryMargin else {
+            diagnostics.record("resolve.insufficient_budget", fields: [
+                "id": request.id,
+                "remaining": secondsField(remainingAtEntry),
+                "floor": secondsField(entryMargin),
+            ])
+            // Two refusals, and the difference is whether anyone is still there. A request
+            // whose deadline has *passed* is refused in silence: its shim has already failed
+            // open, the on-screen prompt is up, and a sentence about it would arrive after
+            // the fact. A request that merely arrived too short still has an asker blocked on
+            // it — and a wearer with no screen cannot tell a question that went to the screen
+            // from one that was never asked, so that one is refused out loud.
+            return remainingAtEntry > 0 ? deferToScreen() : .ask
         }
         // Spoken concurrently with the next listen window (barge-in), so a nod during
         // the prompt is not lost. nil = keep listening without re-speaking.
@@ -761,9 +833,15 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
             case .none:
                 return deferToScreen()
             case .repeatRequest:
-                utterance = promptText(for: request)
+                guard let text = respeakable(promptText(for: request),
+                                             deadline: deadline, kind: "repeat")
+                else { return deferToScreen() }
+                utterance = text
             case .details:
-                utterance = detailText(for: request)
+                guard let text = respeakable(detailText(for: request),
+                                             deadline: deadline, kind: "details")
+                else { return deferToScreen() }
+                utterance = text
             case .status:
                 utterance = recallText(for: .status)
             case .whatChanged:
@@ -796,6 +874,20 @@ public typealias InstructionDictating = @MainActor (String) -> InstructionQueueO
             "recorded": answer == SpokenRecall.nothingRecorded ? "false" : "true",
         ])
         return answer
+    }
+
+    /// The text, if there is still room to ask it and hear the answer; `nil` when the caller
+    /// must refuse instead.
+    ///
+    /// The entry floor is checked once, against a maximum, before the loop starts. This is
+    /// the same question asked again with the sentence in hand, because `repeat` and
+    /// `details` re-speak a full prompt into whatever is left — and what is left has been
+    /// shrinking for every turn the wearer has taken since.
+    private func respeakable(_ text: String,
+                             deadline: ContinuousClock.Instant,
+                             kind: String) -> String? {
+        canRespeak(text, before: deadline, now: now(), on: speechPath,
+                   kind: kind, diagnostics: diagnostics) ? text : nil
     }
 
     /// Runs the dictation flow against this window, returning what to say on the next

--- a/Sources/TapQInteractionBaseline/NotificationPolicy.swift
+++ b/Sources/TapQInteractionBaseline/NotificationPolicy.swift
@@ -23,6 +23,18 @@ public enum Announcement: Sendable, Equatable {
     /// chime back has been given a worse answer than silence, because they cannot tell it
     /// from a misheard question.
     case wearerInitiated
+
+    /// The session this announcement is about, when it is about one. Read by the deferral
+    /// queue, which has to know when a held notice has been overtaken by fresher news about
+    /// the same agent.
+    public var sessionID: String? {
+        switch self {
+        case .agentNotification(_, let sessionID), .requestPrompt(let sessionID):
+            return sessionID
+        case .deferToScreen, .motionLost, .wearerInitiated:
+            return nil
+        }
+    }
 }
 
 /// A short non-speech sound. Two of them, because the wearer has to be able to tell
@@ -60,7 +72,22 @@ public enum NotificationCue: String, Sendable, Equatable {
         /// Nothing is played. The event is still recorded by the caller — see the note on
         /// the type.
         case suppress
+        /// Nothing is played *now*. The policy is holding this one and will play it —
+        /// through the caller's own `whenDeferred` closure — at the next moment it is legal
+        /// to make a sound. The caller does nothing; in particular it must not fall back to
+        /// speaking, which is the race this case exists to end.
+        case deferred
     }
+
+    /// Whether a command window is open right now.
+    ///
+    /// A question rather than a notification, and that is load-bearing: a voice session
+    /// re-opens eight-second windows back to back for as long as a turn boundary is held, so
+    /// a "window closed" callback would fire in the gap between two windows of the same
+    /// session and the notice would land in the next one. Asking gets the true answer —
+    /// "is the wearer inside a listening window" — instead of an edge that means something
+    /// narrower than it looks.
+    public typealias CommandWindowPresence = @MainActor () -> Bool
 
     /// The two flags that shape routing, as they were parsed.
     public struct Settings: Sendable, Equatable {
@@ -78,15 +105,63 @@ public enum NotificationCue: String, Sendable, Equatable {
         }
     }
 
+    /// How often the pending queue asks whether the window has closed yet. A quarter of a
+    /// second against an eight-second window: fine enough that the notice lands in the pause
+    /// after the window rather than a beat later, cheap enough to be uninteresting.
+    static let deferralPollSeconds: TimeInterval = 0.25
+
+    /// How long a notice may wait for a window to close before it is dropped.
+    ///
+    /// There has to be a bound, because a voice session holds windows open for as long as
+    /// the wearer keeps talking to it and that is deliberately indefinite. At the bound the
+    /// notice is dropped rather than finally spoken: speaking it would be the exact race
+    /// this deferral exists to end, only later and with worse timing. Dropping is safe here
+    /// in a way it is nowhere else, because the caller recorded the event unconditionally
+    /// before asking for a verdict — the wearer can still ask what changed and be told. A
+    /// minute is about as long as "the agent finished" is news.
+    static let maximumDeferralSeconds: TimeInterval = 60
+
     private let settings: Settings
     private let waits: SessionWaitRegistry
+    private let commandWindowOpen: CommandWindowPresence?
     /// Sessions announced as waiting and not yet finished or forgotten.
     private var announced: Set<String> = []
+    /// Notices held back while a command window is open, oldest first.
+    private var pending: [Pending] = []
+    /// The task watching for the window to close. One at a time; `nil` when nothing is held.
+    private var drainTask: Task<Void, Never>?
+    /// Clock and sleep seams, so the deferral's timing can be driven by a test instead of
+    /// waited out. The same shape the controllers use for `now`.
+    var now: () -> ContinuousClock.Instant = { .now }
+    var sleep: (TimeInterval) async -> Void = { try? await Task.sleep(for: .seconds($0)) }
 
-    public init(settings: Settings = Settings(), waits: SessionWaitRegistry) {
+    /// One held notice: what it would have played, who plays it, and when it started waiting.
+    private struct Pending {
+        let announcement: Announcement
+        let verdict: Verdict
+        let deferredAt: ContinuousClock.Instant
+        /// The caller's own replay. The policy composes no utterances and holds no
+        /// `AgentNotification`, so the only honest way to say a held sentence later is to
+        /// hand the verdict back to whoever knew how to say it in the first place.
+        let play: @MainActor (Verdict) -> Void
+        /// What two notices have to share to be the same piece of news.
+        let key: String
+    }
+
+    /// - Parameter commandWindowOpen: absent means this policy never defers, which is what
+    ///   every composition without command windows wants and what the tests that predate
+    ///   them assert.
+    public init(settings: Settings = Settings(),
+                waits: SessionWaitRegistry,
+                commandWindowOpen: CommandWindowPresence? = nil,
+                diagnosticSink: any TapQDiagnosticSink = NoOpTapQDiagnosticSink()) {
         self.settings = settings
         self.waits = waits
+        self.commandWindowOpen = commandWindowOpen
+        self.diagnostics = TapQDiagnosticEmitter(category: "Notification", sink: diagnosticSink)
     }
+
+    private let diagnostics: TapQDiagnosticEmitter
 
     /// Routes one announcement, spending its dedupe slot.
     ///
@@ -95,15 +170,27 @@ public enum NotificationCue: String, Sendable, Equatable {
     /// know the verdict without consuming the slot wants `Verdict` arithmetic it does not
     /// have — deliberately, because a "peek" that drifted out of sync with the route would
     /// announce the same wait twice.
-    public func route(_ announcement: Announcement) -> Verdict {
+    /// - Parameter whenDeferred: how to play this announcement later, if the policy holds it
+    ///   back. Only `.agentNotification` is ever held, and only while a command window is
+    ///   open. A caller that supplies nothing cannot be handed `.deferred` — it would have no
+    ///   way to honour it, and "later" with no later is the silent drop this whole mechanism
+    ///   is against — so such a call routes exactly as it always did.
+    public func route(_ announcement: Announcement,
+                      whenDeferred: (@MainActor (Verdict) -> Void)? = nil) -> Verdict {
         switch announcement {
         case .agentNotification(let kind, let sessionID):
-            return routeAgentNotification(kind: kind, sessionID: sessionID)
+            let verdict = routeAgentNotification(kind: kind, sessionID: sessionID)
+            return hold(announcement, verdict: verdict, play: whenDeferred) ?? verdict
         case .requestPrompt(let sessionID):
             // The wearer is being asked about this session right now, which is the
             // strongest possible form of "already announced": a `waitingForInput` arriving
             // behind the prompt says nothing the prompt did not.
+            //
+            // Which is also true of anything about that session still waiting in the
+            // deferral queue — see `markSuperseded`. A prompt is never itself deferred: it
+            // is the one announcement the wearer has to hear to be able to answer at all.
             announced.insert(sessionID)
+            markSuperseded(sessionID: sessionID)
             return settings.quiet ? .chime(.prompt) : .speak
         case .deferToScreen, .motionLost:
             // Never suppressed outright. Both are TapQ telling the wearer that the thing
@@ -133,6 +220,138 @@ public enum NotificationCue: String, Sendable, Equatable {
     /// tests, never a substitute for `route`.
     public func hasAnnounced(sessionID: String) -> Bool {
         announced.contains(sessionID)
+    }
+
+    /// How many notices are waiting for a window to close. Read-only; for diagnostics and
+    /// tests.
+    public var deferredCount: Int { pending.count }
+
+    // MARK: - Deferral
+
+    /// Holds `announcement` back if it would make a sound into an open command window.
+    ///
+    /// The shape is ratified and it is *defer, not race*: the alternative — speak now, at
+    /// `.notification` priority, into a window whose recognizer the speech gate then tears
+    /// down while the window's own timer keeps counting — spends most of an eight-second
+    /// window on a sentence about a different session, and the wearer's answer to the
+    /// question they were actually being asked lands in a microphone that was closed for it.
+    /// `StopQuestionCoordinator.noteNarrationNotice` is the precedent: a notice that cannot
+    /// be said now is queued for the next legal moment, not shouted over the moment in hand.
+    ///
+    /// Returns `.deferred` when it took the announcement, `nil` when the caller should
+    /// proceed with the verdict it already has.
+    private func hold(_ announcement: Announcement,
+                      verdict: Verdict,
+                      play: (@MainActor (Verdict) -> Void)?) -> Verdict? {
+        // Nothing to hold back: a suppressed announcement makes no sound to begin with, and
+        // there is no window to protect.
+        guard verdict != .suppress, commandWindowOpen?() == true else { return nil }
+        guard let play else {
+            // A caller with no replay is told to go ahead. It is the lesser wrong: speaking
+            // into a window is a bad turn, and holding a notice nobody can ever play is a
+            // notice that vanishes — and the one thing this type may not do is lose an event
+            // quietly. Recorded, so a log can tell the two apart.
+            diagnostics.record("notification.deferral_unavailable", level: .warning,
+                               fields: ["announcement": Self.key(announcement)])
+            return nil
+        }
+        let key = Self.key(announcement)
+        if pending.contains(where: { $0.key == key }) {
+            // The same sentence twice, both of them waiting out the *same* window. Two
+            // finishes separated by real time are two pieces of news and both are still
+            // announced — that rule is untouched. Two finishes separated by nothing are one
+            // sentence said twice in a row, which is not news, it is a stutter.
+            diagnostics.record("notification.dropped_stale",
+                               fields: ["reason": "duplicate", "held": "\(pending.count)"])
+            return .deferred
+        }
+        pending.append(Pending(announcement: announcement, verdict: verdict,
+                               deferredAt: now(), play: play, key: key))
+        diagnostics.record("notification.deferred",
+                           fields: ["held": "\(pending.count)"])
+        startDraining()
+        return .deferred
+    }
+
+    /// Marks everything held for `sessionID` stale, because the wearer has just been told
+    /// something more current about it through a route that was not deferred.
+    ///
+    /// "Claude Code finished" is worth saying until the wearer is being asked a fresh
+    /// question from that same session, at which point it is a sentence about the past
+    /// arriving after the present. Dropped, and counted — never silently.
+    private func markSuperseded(sessionID: String) {
+        let before = pending.count
+        pending.removeAll { $0.announcement.sessionID == sessionID }
+        let dropped = before - pending.count
+        guard dropped > 0 else { return }
+        diagnostics.record("notification.dropped_stale",
+                           fields: ["reason": "superseded", "count": "\(dropped)"])
+    }
+
+    /// Watches for the window to close, then plays what is held.
+    ///
+    /// One task at a time, and it owns the whole queue rather than one entry: notices that
+    /// arrive while it is already watching join the queue it will drain.
+    private func startDraining() {
+        guard drainTask == nil else { return }
+        drainTask = Task { @MainActor [weak self] in
+            while true {
+                guard let self, !self.pending.isEmpty else { break }
+                guard self.commandWindowOpen?() == true else {
+                    self.deliverPending()
+                    break
+                }
+                self.expireOverdue()
+                guard !self.pending.isEmpty else { break }
+                await self.sleep(Self.deferralPollSeconds)
+            }
+            self?.drainTask = nil
+        }
+    }
+
+    /// Plays everything held, oldest first, and empties the queue.
+    ///
+    /// The queue is emptied *before* anything is played: a replay closure speaks, speaking
+    /// can re-enter this actor, and a re-entrant drain that still saw the entries would say
+    /// them twice.
+    private func deliverPending() {
+        let due = pending
+        pending.removeAll()
+        let current = now()
+        for entry in due {
+            diagnostics.record("notification.delivered", fields: [
+                "waited": secondsField(current.seconds(after: entry.deferredAt)),
+            ])
+            entry.play(entry.verdict)
+        }
+    }
+
+    /// Drops notices that have waited longer than a notice is worth. See
+    /// `maximumDeferralSeconds` for why the bound exists and why expiry drops rather than
+    /// finally speaks.
+    private func expireOverdue() {
+        let current = now()
+        let before = pending.count
+        pending.removeAll {
+            current.seconds(after: $0.deferredAt) >= Self.maximumDeferralSeconds
+        }
+        let dropped = before - pending.count
+        guard dropped > 0 else { return }
+        diagnostics.record("notification.dropped_expired", level: .warning, fields: [
+            "count": "\(dropped)",
+            "after": secondsField(Self.maximumDeferralSeconds),
+        ])
+    }
+
+    /// What two announcements have to share to be the same piece of news.
+    private static func key(_ announcement: Announcement) -> String {
+        switch announcement {
+        case .agentNotification(let kind, let sessionID): return "\(kind)/\(sessionID)"
+        case .requestPrompt(let sessionID): return "prompt/\(sessionID)"
+        case .deferToScreen: return "deferToScreen"
+        case .motionLost: return "motionLost"
+        case .wearerInitiated: return "wearerInitiated"
+        }
     }
 
     private func routeAgentNotification(kind: AgentNotification.Kind,

--- a/Sources/TapQInteractionBaseline/SelectionController.swift
+++ b/Sources/TapQInteractionBaseline/SelectionController.swift
@@ -18,8 +18,25 @@ import TapQContracts
     private let arbiter: SelectionArbitrating
     private let diagnostics: TapQDiagnosticEmitter
     public var timeout: TimeInterval
-    /// Minimum remaining budget required to begin speaking (see InteractionBudget.minViableRemaining).
-    public var entryMargin: TimeInterval = InteractionBudget.minViableRemaining
+    /// Which voice this composition speaks with. Same seam, same default, and the same
+    /// reason as `InteractionController.speechPath`.
+    public var speechPath: SpokenPace.Path = SpokenPace.defaultPath
+    private var entryMarginOverride: TimeInterval?
+    /// Minimum remaining budget required to begin speaking.
+    ///
+    /// Derived from this controller's own worst prompt and the path's pace — see
+    /// `InteractionController.entryMargin`, which does the same arithmetic against its
+    /// presenter. A selection's floor is the larger of the two: it reads a question, a
+    /// position, an option label, and the controls, where an approval reads one summary.
+    public var entryMargin: TimeInterval {
+        get {
+            entryMarginOverride ?? SpokenPace.viableSeconds(
+                utteranceCharacters: Self.maximumPromptCharacters,
+                on: speechPath
+            )
+        }
+        set { entryMarginOverride = newValue }
+    }
     /// Clock seam: all deadline math reads time through this, so tests can advance a
     /// virtual clock instead of racing real sub-second deadlines against CI preemption.
     var now: () -> ContinuousClock.Instant = { .now }
@@ -99,12 +116,18 @@ import TapQContracts
             diagnostics.record("selection.empty", level: .warning)
             return .noSelection
         }
-        // Expired (or nearly so) while queued: the shim may have already failed open, and
-        // there isn't enough budget left to speak the prompt and still leave the user time
-        // to answer — stay silent.
-        guard deadline.seconds(after: now()) > entryMargin else {
-            diagnostics.record("resolve.insufficient_budget", fields: ["id": request.id])
-            return .noSelection
+        // Expired (or nearly so) while queued: there isn't enough budget left to speak the
+        // prompt and still leave the user time to answer, so no window is opened. Refused
+        // out loud unless the deadline has actually passed — the split, and the reason for
+        // it, is `InteractionController.resolve`'s.
+        let remainingAtEntry = deadline.seconds(after: now())
+        guard remainingAtEntry > entryMargin else {
+            diagnostics.record("resolve.insufficient_budget", fields: [
+                "id": request.id,
+                "remaining": secondsField(remainingAtEntry),
+                "floor": secondsField(entryMargin),
+            ])
+            return remainingAtEntry > 0 ? deferToScreen() : .noSelection
         }
         var cursor = 0
         // Spoken concurrently with the next listen window (barge-in), so input while
@@ -167,7 +190,16 @@ import TapQContracts
             case .repeatRequest:
                 // An explicit repeat is the one moment the user has signalled they are
                 // lost, so the controls come back even after the session's first prompt.
-                utterance = promptText(request, cursor: cursor, includeControls: true)
+                // And it is the longest thing this flow ever says, into whatever the
+                // navigation so far has left — hence the re-check.
+                guard let text = respeakable(
+                    promptText(request, cursor: cursor, includeControls: true),
+                    deadline: deadline, kind: "repeat"
+                ) else {
+                    outcome = "timeout"
+                    return deferToScreen()
+                }
+                utterance = text
             case .freeform(let text):
                 // Read-back confirmation: the wearer spoke a free-text answer.
                 // Speak it back, then wait for nod (confirm) or shake (discard).
@@ -200,10 +232,19 @@ import TapQContracts
                                        fields: ["length": "\(text.count)"])
                     return SelectionResult(choices: [], freeText: text)
                 case .deny:
-                    // Discard and re-listen for a new answer.
+                    // Discard and re-listen for a new answer. Putting the question again is
+                    // a full re-speak like `repeat` is, and gets the same check: a discarded
+                    // answer followed by a question the wearer cannot hear the end of is two
+                    // lost turns rather than one.
                     diagnostics.record("freeform.discarded")
-                    utterance = promptText(request, cursor: cursor,
-                                           includeControls: false)
+                    guard let text = respeakable(
+                        promptText(request, cursor: cursor, includeControls: false),
+                        deadline: deadline, kind: "freeform_reprompt"
+                    ) else {
+                        outcome = "timeout"
+                        return deferToScreen()
+                    }
+                    utterance = text
                     continue
                 case .none:
                     outcome = "timeout"
@@ -211,11 +252,17 @@ import TapQContracts
                     return deferToScreen()
                 default:
                     // Any other intent (navigation, etc.) during read-back confirmation
-                    // is treated as a discard — re-listen.
+                    // is treated as a discard — re-listen, under the same check.
                     diagnostics.record("freeform.discarded",
                                        fields: ["reason": "unexpected_intent"])
-                    utterance = promptText(request, cursor: cursor,
-                                           includeControls: false)
+                    guard let text = respeakable(
+                        promptText(request, cursor: cursor, includeControls: false),
+                        deadline: deadline, kind: "freeform_reprompt"
+                    ) else {
+                        outcome = "timeout"
+                        return deferToScreen()
+                    }
+                    utterance = text
                     continue
                 }
             // Informational, and deliberately not in the bail-out group below: a wearer
@@ -278,6 +325,15 @@ import TapQContracts
         }
     }
 
+    /// The text, if there is still room to ask it and hear the answer; `nil` when the caller
+    /// must refuse instead. `InteractionController.respeakable`'s twin — see `canRespeak`.
+    private func respeakable(_ text: String,
+                             deadline: ContinuousClock.Instant,
+                             kind: String) -> String? {
+        canRespeak(text, before: deadline, now: now(), on: speechPath,
+                   kind: kind, diagnostics: diagnostics) ? text : nil
+    }
+
     /// The spoken answer to a recall question, or the sentence that says there is nothing
     /// recorded. Speaking it is the whole effect: the selection is not advanced, not
     /// confirmed, and not abandoned.
@@ -312,6 +368,30 @@ import TapQContracts
     /// teaching nothing — it is the runtime telling them to do something that cannot
     /// resolve the question.
     public static let voiceOnlyControlsHint = "Say next, previous, or select."
+
+    /// The arithmetic of `promptText` at every cap at once, so the viability floor can be
+    /// derived rather than guessed — the counterpart to
+    /// `DefaultApprovalRequestPresenter.maximumPromptCharacters`, which documents the shape
+    /// of this sum in more detail:
+    ///
+    ///     introduction           122   120 cap + terminator + separating space
+    ///     question                97   96 cap + terminator
+    ///     " "                      1
+    ///     "N of M:"               12   an allowance; the shipped flows offer a handful
+    ///     " "                      1
+    ///     label                   49   48 cap + terminator
+    ///     " " + controls          48   an allowance; the two shipped hints are 30 and 37
+    ///     ────────────────────────────
+    ///                            330
+    ///
+    /// The last two are allowances rather than caps because `controlsHint` is an injected
+    /// closure and the option count is the caller's. Both are measured exactly on the
+    /// per-utterance re-check, which is what the entry floor's promise is checked against.
+    ///
+    /// `nonisolated` for `CommandWindowController.windowSeconds`'s reason: the viability
+    /// floor is derived off the main actor, at the command line, before any controller
+    /// exists.
+    public nonisolated static let maximumPromptCharacters = 122 + 97 + 1 + 12 + 1 + 49 + 48
 
     private func promptText(
         _ request: SelectionRequest,

--- a/Sources/TapQInteractionBaseline/SpokenTurnBudget.swift
+++ b/Sources/TapQInteractionBaseline/SpokenTurnBudget.swift
@@ -1,4 +1,46 @@
 import Foundation
+import TapQContracts
+
+/// Whether a full re-speak still fits: can `text` be asked, and the answer heard, before
+/// `deadline`?
+///
+/// One function because two controllers ask it, and a drift between them would be a runtime
+/// where `repeat` is guarded inside an approval and unguarded inside a selection — the sort
+/// of difference nobody notices until a wearer is standing in it.
+///
+/// The measurement is of the sentence actually in hand, not of the presenter's declared
+/// maximum. That is the point of having it at all: the entry floor is a promise made before
+/// any text exists, and `details` returns the request's own `detail` string, which no cap in
+/// this package bounds.
+///
+/// `false` is not "say it anyway, shorter". There is no shorter version of a question, and a
+/// question asked into a window that ends mid-sentence is recorded as the wearer having
+/// nothing to say about something they never heard. The caller refuses, out loud.
+@MainActor func canRespeak(_ text: String,
+                           before deadline: ContinuousClock.Instant,
+                           now: ContinuousClock.Instant,
+                           on path: SpokenPace.Path,
+                           kind: String,
+                           diagnostics: TapQDiagnosticEmitter) -> Bool {
+    let remaining = deadline.seconds(after: now)
+    let needed = SpokenPace.viableSeconds(asking: text, on: path)
+    guard remaining >= needed else {
+        diagnostics.record("respeak.insufficient_budget", fields: [
+            "kind": kind,
+            "characters": "\(text.count)",
+            "remaining": secondsField(remaining),
+            "needed": secondsField(needed),
+            "pace": path.rawValue,
+        ])
+        return false
+    }
+    return true
+}
+
+/// One decimal place, so a diagnostic line is readable and two of them are comparable.
+func secondsField(_ value: TimeInterval) -> String {
+    String(format: "%.1f", value)
+}
 
 /// How much open microphone one turn of a windowed flow needs.
 ///
@@ -42,13 +84,55 @@ enum TurnBudget: Equatable {
 /// and tested with a virtual clock. It deliberately errs long: an over-long listen costs an
 /// already-open window a few seconds that a wearer can end by answering, while a short one
 /// costs them the sentence they were dictating.
-enum SpokenPace {
+public enum SpokenPace {
+    /// Which of TapQ's two voices is doing the speaking.
+    ///
+    /// One number cannot carry this once the question is "is there time to *ask* something".
+    /// The paces differ by about a factor of two, so a floor derived from the fast voice
+    /// refuses almost nothing on the slow one — and the slow one is exactly where a
+    /// maximum-length prompt outlasts the margin that was supposed to protect it.
+    public enum Path: String, Sendable, Equatable {
+        /// The backend voice (`--voice-backend openai-realtime`).
+        case realtime
+        /// `AVSpeechSynthesizer`, the local voice.
+        case apple
+
+        /// Characters of ordinary prose per second, measured and then shortened by a fifth
+        /// — the same margin `charactersPerSecond` carries and for the same reason: erring
+        /// long spends a few seconds of an already-open window, erring short costs the
+        /// wearer the answer they were in the middle of giving.
+        var charactersPerSecond: Double {
+            switch self {
+            case .realtime: return 23   // ~29 measured
+            case .apple: return 12      // ~15 measured — `charactersPerSecond` below, same sum
+            }
+        }
+    }
+
+    /// What a composition that has not said which voice it speaks with is assumed to use.
+    ///
+    /// The slower of the two, deliberately. Guessing fast makes TapQ ask questions the
+    /// wearer cannot answer, which is the bug this whole file exists to close; guessing slow
+    /// makes it decline a question early and out loud, which the wearer can hear and act on.
+    public static let defaultPath = Path.apple
+
     /// Characters of ordinary prose per second of synthesized speech.
     ///
     /// ~150 words per minute at ~5.5 characters plus a space is a shade under 15 characters
     /// a second; 12 is that with the margin the paragraph above argues for, and covers the
     /// slower of the two voices TapQ speaks with.
-    static let charactersPerSecond: Double = 12
+    static let charactersPerSecond: Double = Path.apple.charactersPerSecond
+
+    /// Silence the wearer is owed after their last word, before anything commits their turn:
+    /// the detector's hangover plus `WearerTurnCoordinator`'s endpoint delay. An answering
+    /// window budgeted without it charges the wearer for a second they cannot speak in.
+    static let endpointingSeconds: TimeInterval =
+        detectorHangoverSeconds + WearerTurnCoordinator.defaultEndpointDelay
+
+    /// `WearerSpeechConfig.hangoverSeconds`'s default, restated rather than imported:
+    /// `TapQDetectionBaseline` is not a dependency of this module, and should not become one
+    /// to carry a constant across.
+    static let detectorHangoverSeconds: TimeInterval = 0.6
 
     /// How long the wearer gets to answer once the question has finished being asked.
     ///
@@ -74,4 +158,56 @@ enum SpokenPace {
                               answering: TimeInterval = answeringSeconds) -> TimeInterval {
         max(remaining, drainSeconds(of: utterance) + answering)
     }
+
+    // MARK: - Viability: is there enough budget to even ask?
+
+    /// The least budget in which an utterance of `characters` can be **asked and answered**.
+    ///
+    /// Three terms, and the bug was that the old hand-picked 12 seconds contained none of
+    /// them explicitly:
+    ///
+    /// 1. **The asking.** TapQ holds the microphone shut for the whole of its own playback,
+    ///    so every character of the question is a second the wearer cannot use.
+    /// 2. **The answering.** `answeringSeconds` — hear the end of the sentence, take a
+    ///    breath, say the word.
+    /// 3. **The committing.** `endpointingSeconds` sits between the wearer's last syllable
+    ///    and the turn closing; a window that ends on the syllable ends before the answer.
+    ///
+    /// Twelve seconds covered (2) and (3) and about four seconds of (1), which is why the
+    /// presenters' own maximum prompts — 200-plus characters, seventeen seconds at the Apple
+    /// pace — sailed past it and were spoken into a window that could not carry them.
+    static func viableSeconds(utteranceCharacters characters: Int,
+                              on path: Path = defaultPath,
+                              answering: TimeInterval = answeringSeconds) -> TimeInterval {
+        Double(characters) / path.charactersPerSecond + answering + endpointingSeconds
+    }
+
+    /// The same, for an utterance in hand.
+    ///
+    /// Nothing to say needs no asking budget: a turn with no utterance is a *listening* turn,
+    /// which takes whatever is left of the window and is owed nothing — the distinction
+    /// `TurnBudget` opens this file with.
+    static func viableSeconds(asking utterance: String?,
+                              on path: Path = defaultPath,
+                              answering: TimeInterval = answeringSeconds) -> TimeInterval {
+        guard let utterance, !utterance.isEmpty else { return 0 }
+        return viableSeconds(utteranceCharacters: utterance.count,
+                             on: path,
+                             answering: answering)
+    }
+
+    /// The shortest listen window a run may be configured with (`--timeout`).
+    ///
+    /// Public because the command line has to refuse an unusable one at parse time rather
+    /// than let every prompt of the run turn out to be structurally unanswerable, and the
+    /// CLI cannot reach the internals above.
+    ///
+    /// It is the *widest* of the two flows' floors, at the slower voice: `--timeout` is one
+    /// number for a run that does not yet know which kind of question it will be asked, and
+    /// a floor sized for approvals would still leave every selection unanswerable. Rounded
+    /// up to the second so the number in the refusal is the number that is enforced.
+    public static let minimumListenSeconds: TimeInterval = (viableSeconds(
+        utteranceCharacters: max(DefaultApprovalRequestPresenter.maximumPromptCharacters,
+                                 SelectionController.maximumPromptCharacters)
+    )).rounded(.up)
 }

--- a/Sources/TapQInteractionBaseline/SpokenTurnBudget.swift
+++ b/Sources/TapQInteractionBaseline/SpokenTurnBudget.swift
@@ -126,13 +126,13 @@ public enum SpokenPace {
     /// Silence the wearer is owed after their last word, before anything commits their turn:
     /// the detector's hangover plus `WearerTurnCoordinator`'s endpoint delay. An answering
     /// window budgeted without it charges the wearer for a second they cannot speak in.
-    static let endpointingSeconds: TimeInterval =
-        detectorHangoverSeconds + WearerTurnCoordinator.defaultEndpointDelay
+    /// One value with `WindowClock.commitAllowance` by construction — both read the same
+    /// mirrored hangover, which `WindowClock` owns (and a detection-side test pins).
+    static let endpointingSeconds: TimeInterval = WindowClock.commitAllowance
 
-    /// `WearerSpeechConfig.hangoverSeconds`'s default, restated rather than imported:
-    /// `TapQDetectionBaseline` is not a dependency of this module, and should not become one
-    /// to carry a constant across.
-    static let detectorHangoverSeconds: TimeInterval = 0.6
+    /// The one in-module home of the restated `WearerSpeechConfig.hangoverSeconds` default
+    /// is `WindowClock.detectorHangover`; see its comment for why it is a mirror.
+    static let detectorHangoverSeconds: TimeInterval = WindowClock.detectorHangover
 
     /// How long the wearer gets to answer once the question has finished being asked.
     ///

--- a/Sources/TapQInteractionBaseline/WindowClock.swift
+++ b/Sources/TapQInteractionBaseline/WindowClock.swift
@@ -1,0 +1,125 @@
+import Foundation
+import TapQContracts
+
+/// When a command window's eight seconds are allowed to start counting, and how long a
+/// listen has to stay open for speech that happened inside them.
+///
+/// ## The bug these constants exist for
+///
+/// A command window used to set `deadline = now() + 8s` at controller entry, consulting
+/// nothing about whether TapQ was still talking. It very often was: the window before it
+/// speaks its last answer *as it closes* (`CommandWindowController.loop`'s residual
+/// `pending`), and `VoiceSessionListening` opens the next window in the same actor turn. So
+/// the countdown started while the audio was still draining, and `SpeechGatedVoice` — doing
+/// exactly its job — held the microphone shut for the first several seconds of it.
+///
+/// The sweep measured it on hardware: 12 of 40 eight-second voice-session windows opened
+/// with `[SpeechGate] microphone.held_closed`. The clock and the microphone disagreed about
+/// when the window began, and the wearer paid the difference.
+///
+/// The cure is stated once, here, and applied in `CommandWindowController`: **a window
+/// delivers eight seconds of microphone that can actually hear, and TapQ's own voice is
+/// never charged to the wearer.**
+enum WindowClock {
+    /// How long after the wearer stops speaking their turn actually commits.
+    ///
+    /// Two delays in series, both on the IMU turn-control path: the wearer-speech detector's
+    /// own hangover keeps the state `speaking` for a beat after the last active window, and
+    /// `WearerTurnCoordinator` then waits out an endpoint delay before calling `endpoint()`.
+    /// Sweep finding F11: a listen that closes exactly on the deadline throws away speech
+    /// that arrived inside the window and was still being committed when it closed.
+    ///
+    /// The endpoint delay is read from its owner. The hangover is mirrored rather than read:
+    /// it lives in `WearerSpeechConfig.hangoverSeconds` (TapQDetectionBaseline), and this
+    /// module depends only on TapQContracts. `VoiceSessionE2ETests` — a target that can see
+    /// both — pins the two numbers together so the mirror cannot drift in silence.
+    static let detectorHangover: TimeInterval = 0.6
+
+    /// The allowance a listen adds so speech that started inside the window can finish
+    /// committing. Not extra window: extra *wait* for an answer already given.
+    static var commitAllowance: TimeInterval {
+        WearerTurnCoordinator.defaultEndpointDelay + detectorHangover
+    }
+
+    /// The longest a window will hold its clock back waiting for TapQ's own audio to stop.
+    ///
+    /// Long enough for any sentence TapQ composes — `SpokenText.condensed` caps a read-back
+    /// at 160 characters, about 13 seconds at `SpokenPace.charactersPerSecond` — and short
+    /// enough that a wedged synthesizer or a stuck player costs one window rather than the
+    /// session. Waiting is cheap while the signal is honest (the microphone really is shut,
+    /// so nothing is being missed) and this bound is what keeps it cheap when it is not.
+    static let maxDrainWait: TimeInterval = 15
+
+    /// How often the deferral loop re-reads the busy signal.
+    ///
+    /// A poll rather than an edge: `SpeechActivitySignaling.onSpeakingChange` is a
+    /// single-observer slot and `SpeechGatedVoice` owns it. Reading `isSpeaking` takes
+    /// nothing away from that owner, which is the whole reason the seam below is a getter and
+    /// not a subscription.
+    static let drainPollInterval: TimeInterval = 0.1
+}
+
+/// What TapQ's own voice is doing, asked in the two ways it can be answered.
+///
+/// Neither reading is sufficient alone, which is why this type holds both:
+///
+/// - **The live signal** (`isSounding`) is the truth about whether audio is sounding *right
+///   now*, and it is the same signal `SpeechGatedVoice` gates the microphone on — on the
+///   Apple path the speech engine, and with a backend player composed the
+///   `CombinedSpeechActivity` merge of engine and player. It is the only thing that knows
+///   about audio TapQ never handed over as text, which on the realtime path is most of what
+///   the wearer hears. What it cannot say is *how much longer*: it is a `Bool`.
+/// - **The pace estimate** (`estimatedRemainder`) knows how much longer, because it is
+///   computed from the text at hand-over time by `SpokenPace`. It is also the only reading
+///   that covers the gap `SpokenTurnBudget` documents at length: `onFinish` fires when the
+///   backend *accepts* a sentence, and playback starts hundreds of milliseconds later, so
+///   for that window "not speaking yet" and "already drained" are the same reading from the
+///   live signal.
+///
+/// So a window waits out the live signal and then credits whatever the estimate still has
+/// ahead of it. Where no signal is reachable the estimate carries the whole weight, which is
+/// the honest degrade: it is deterministic, it errs long, and a window that over-waits costs
+/// the wearer a pause, while one that under-waits costs them the sentence.
+///
+/// ## Why it is shared, and by whom
+///
+/// One instance per run, held by the composition and handed to every window it builds. The
+/// sentence a window speaks as it closes is drained by the window *after* it — different
+/// controller, same voice — so the record has to outlive any one of them. Only
+/// `CommandWindowController` writes to it.
+@MainActor public final class VoiceChannelDrain {
+    /// Reads the live busy signal. `nil` where no signal is reachable, and the estimate is
+    /// then the only reading — never an assumption that the channel is quiet.
+    private let isSounding: (@MainActor () -> Bool)?
+    /// When everything handed over so far will have finished sounding, by the pace estimate.
+    private var quietAt: ContinuousClock.Instant?
+
+    /// - Parameter isSounding: a *read* of `SpeechActivitySignaling.isSpeaking`, never a
+    ///   claim on `onSpeakingChange` — that slot belongs to `SpeechGatedVoice`, and a second
+    ///   assignment would silently disable the self-hearing guard.
+    public init(isSounding: (@MainActor () -> Bool)? = nil) {
+        self.isSounding = isSounding
+    }
+
+    /// Whether the live signal says audio is sounding. `false` when there is no signal —
+    /// callers pair this with `estimatedRemainder`, which is what actually covers that case.
+    var isLiveSounding: Bool { isSounding?() ?? false }
+
+    /// Records that `text` has been handed to the speech channel at `instant`.
+    ///
+    /// Utterances queue rather than overlap — the speech engine speaks them in order — so a
+    /// sentence handed over while the previous one is still sounding starts when that one
+    /// ends. Empty and absent text occupy nothing.
+    func willSpeak(_ text: String?, at instant: ContinuousClock.Instant) {
+        guard let text, !text.isEmpty else { return }
+        let starts = max(instant, quietAt ?? instant)
+        quietAt = starts.advanced(by: .seconds(SpokenPace.drainSeconds(of: text)))
+    }
+
+    /// Estimated seconds of TapQ's own audio still ahead at `instant`; zero once it has
+    /// drained, and zero before anything has been said.
+    func estimatedRemainder(at instant: ContinuousClock.Instant) -> TimeInterval {
+        guard let quietAt else { return 0 }
+        return max(0, quietAt.seconds(after: instant))
+    }
+}

--- a/Tests/TapQCLITests/CLICommandParserTests.swift
+++ b/Tests/TapQCLITests/CLICommandParserTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import TapQCLI
 import TapQContextBaseline
+import TapQInteractionBaseline
 import TapQVoiceBackends
 
 final class CLICommandParserTests: XCTestCase {
@@ -29,7 +30,7 @@ final class CLICommandParserTests: XCTestCase {
     func testServeOptions() throws {
         let command = try CLICommandParser.parse([
             "serve", "--broker-dir", "runtime", "--gesture-profile", "gesture.json",
-            "--tap-profile", "tap.json", "--timeout", "20", "--no-voice",
+            "--tap-profile", "tap.json", "--timeout", "60", "--no-voice",
             "--no-announcements", "--steering",
             "--question-classifier", "anthropic",
         ])
@@ -37,7 +38,7 @@ final class CLICommandParserTests: XCTestCase {
             brokerDirectoryPath: "runtime",
             gestureProfilePath: "gesture.json",
             tapProfilePath: "tap.json",
-            interactionTimeout: 20,
+            interactionTimeout: 60,
             voiceEnabled: false,
             announcementsEnabled: false,
             steeringEnabled: true,
@@ -103,6 +104,31 @@ final class CLICommandParserTests: XCTestCase {
             ]) else { return XCTFail("Expected a serve command.") }
             XCTAssertEqual(options.speechSummarizer, provider)
         }
+    }
+
+    /// F9. `--timeout 5` used to be accepted, and then every approval and every selection of
+    /// the run was structurally unanswerable: TapQ holds the microphone shut while it reads
+    /// the prompt, so a five-second window closes with the question still being asked.
+    /// Nothing said so at any point — the run simply never resolved anything by voice.
+    func testServeRejectsATimeoutTooShortToAnswerIn() {
+        XCTAssertThrowsError(try CLICommandParser.parse([
+            "serve", "--timeout", "5",
+        ])) { error in
+            XCTAssertEqual(
+                (error as? CLIUsageError)?.message,
+                "--timeout must be at least 35 seconds: a shorter window cannot finish "
+                    + "reading the longest prompt and still leave time to answer it."
+            )
+        }
+    }
+
+    /// The floor is the controllers' own arithmetic, not a number typed into the parser.
+    func testTheTimeoutFloorIsTheSpokenViabilityFloor() throws {
+        XCTAssertEqual(SpokenPace.minimumListenSeconds, 35)
+        XCTAssertThrowsError(try CLICommandParser.parse([
+            "serve", "--timeout", "34",
+        ]))
+        XCTAssertNoThrow(try CLICommandParser.parse(["serve", "--timeout", "35"]))
     }
 
     func testServeRejectsUnknownSpeechSummarizer() {

--- a/Tests/TapQCLITests/TapQCLIApplicationTests.swift
+++ b/Tests/TapQCLITests/TapQCLIApplicationTests.swift
@@ -390,7 +390,7 @@ final class TapQCLIApplicationTests: XCTestCase {
 
         let status = await app.run(arguments: [
             "serve", "--broker-dir", "runtime", "--gesture-profile", "gesture.json",
-            "--tap-profile", "tap.json", "--timeout", "25", "--no-voice",
+            "--tap-profile", "tap.json", "--timeout", "45", "--no-voice",
             "--no-announcements", "--steering",
             "--question-classifier", "anthropic",
         ])
@@ -401,7 +401,7 @@ final class TapQCLIApplicationTests: XCTestCase {
         XCTAssertEqual(configuration.brokerDirectory?.path, directory.appendingPathComponent("runtime").path)
         XCTAssertEqual(configuration.gestureProfileURL.path, directory.appendingPathComponent("gesture.json").path)
         XCTAssertEqual(configuration.tapProfileURL.path, directory.appendingPathComponent("tap.json").path)
-        XCTAssertEqual(configuration.interactionTimeout, 25)
+        XCTAssertEqual(configuration.interactionTimeout, 45)
         XCTAssertFalse(configuration.voiceEnabled)
         XCTAssertFalse(configuration.announcementsEnabled)
         XCTAssertTrue(configuration.steeringEnabled)

--- a/Tests/TapQDetectionE2ETests/AttentionAndQuietE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/AttentionAndQuietE2ETests.swift
@@ -209,7 +209,9 @@ private final class NotificationChokepoint {
             spoken.append(notification.summary ?? "")
         case .chime(let cue):
             cues.append(cue)
-        case .suppress:
+        case .suppress, .deferred:
+            // This harness composes no command-window presence, so the policy has nothing
+            // to defer around and never returns `.deferred` here.
             break
         }
     }

--- a/Tests/TapQDetectionE2ETests/VoiceDegradeAndQuietE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/VoiceDegradeAndQuietE2ETests.swift
@@ -570,7 +570,9 @@ private final class DegradePath {
             harness.speech.speak(Self.notice, priority: .notification, onFinish: nil)
         case .chime(let cue):
             cues.record(cue)
-        case .suppress:
+        case .suppress, .deferred:
+            // A motion loss is never deferred: it is not a cross-session notification, and
+            // no replay is offered for it.
             break
         }
         harness.inputArbiter.cancel()

--- a/Tests/TapQDetectionE2ETests/VoiceSessionE2ETests.swift
+++ b/Tests/TapQDetectionE2ETests/VoiceSessionE2ETests.swift
@@ -4,6 +4,7 @@ import TapQBrokerRuntime
 import TapQCLI
 import TapQContextBaseline
 import TapQContracts
+import TapQDetectionBaseline
 import TapQWireProtocol
 @testable import TapQInteractionBaseline
 
@@ -16,6 +17,24 @@ import TapQWireProtocol
 @MainActor
 final class VoiceSessionE2ETests: XCTestCase {
     private static let session = "s1"
+
+    /// The mirror pin for sweep finding F11's commit allowance.
+    ///
+    /// `WindowClock.commitAllowance` is the detector's hangover plus `WearerTurnCoordinator`'s
+    /// endpoint delay — the two things that elapse between the wearer falling silent and
+    /// their turn committing. The endpoint delay is read from its owner; the hangover cannot
+    /// be, because it lives in `WearerSpeechConfig` and TapQInteractionBaseline depends only
+    /// on TapQContracts. This target can see both, so the copy is checked here rather than
+    /// left to drift the next time the capture study moves the number.
+    func testTheWindowClockMirrorsTheDetectorHangover() async {
+        XCTAssertEqual(WindowClock.detectorHangover,
+                       WearerSpeechConfig().hangoverSeconds, accuracy: 0.0001,
+                       "WindowClock.detectorHangover no longer matches WearerSpeechConfig")
+        XCTAssertEqual(WindowClock.commitAllowance,
+                       WearerSpeechConfig().hangoverSeconds
+                           + WearerTurnCoordinator.defaultEndpointDelay,
+                       accuracy: 0.0001)
+    }
 
     private struct NeverAQuestion: ResponseQuestionClassifying {
         func classify(_ text: String) async -> ResponseQuestionClassification? { nil }

--- a/Tests/TapQInteractionBaselineTests/CommandWindowControllerTests.swift
+++ b/Tests/TapQInteractionBaselineTests/CommandWindowControllerTests.swift
@@ -270,11 +270,26 @@ final class CommandWindowControllerTests: XCTestCase {
         let clock = VirtualClock()
         let arbiter = ScriptedArbiter([nil], clock: clock)
         _ = await controller(arbiter, speech: FakeSpeech(), clock: clock).run()
-        XCTAssertEqual(arbiter.timeouts, [8])
+        // Eight seconds of microphone the wearer can speak into, which is what the constant
+        // has always promised and what sweep finding F3 found it was not delivering. The
+        // listen is longer than the promise by exactly the two things that are not window:
+        // the cue's own playback (the microphone is shut for it) and the commit allowance
+        // (`WindowClock`), which is the wait for an answer already given.
+        XCTAssertEqual(arbiter.timeouts.count, 1)
+        XCTAssertEqual(
+            arbiter.timeouts[0],
+            SpokenPace.drainSeconds(of: CommandWindowController.defaultCue)
+                + CommandWindowController.windowSeconds + WindowClock.commitAllowance,
+            accuracy: 0.001
+        )
     }
 
     /// The deadline is the bound, and it shrinks: three turns of three seconds each is all
     /// eight seconds buys, however much the wearer keeps saying.
+    ///
+    /// The deadline itself is untouched by the F3 fix — it is the *listens* that stopped
+    /// being charged for TapQ's own voice, so each one runs past the deadline by its own
+    /// playback plus the commit allowance while the residue it offers keeps shrinking 8, 5, 2.
     func testTheDeadlineEndsTheWindowMidConversation() async {
         let clock = VirtualClock()
         let speech = FakeSpeech()
@@ -282,7 +297,16 @@ final class CommandWindowControllerTests: XCTestCase {
         let outcome = await controller(arbiter, speech: speech, clock: clock,
                                        recall: { _ in "Nothing waiting." }).run()
         XCTAssertEqual(outcome.answers, 3)
-        XCTAssertEqual(arbiter.timeouts, [8, 5, 2])
+        let spokenFirst = SpokenPace.drainSeconds(of: CommandWindowController.defaultCue)
+        let spokenAfter = SpokenPace.drainSeconds(of: "Nothing waiting.")
+        let residues: [TimeInterval] = [8, 5, 2]
+        let drains = [spokenFirst, spokenAfter, spokenAfter]
+        XCTAssertEqual(arbiter.timeouts.count, 3)
+        for (index, residue) in residues.enumerated() {
+            XCTAssertEqual(arbiter.timeouts[index],
+                           drains[index] + residue + WindowClock.commitAllowance,
+                           accuracy: 0.001, "turn \(index + 1)")
+        }
         XCTAssertEqual(speech.spoken.last, "Nothing waiting.",
                        "the last answer is spoken even though no listen follows it")
     }

--- a/Tests/TapQInteractionBaselineTests/InstructionAnnouncementTests.swift
+++ b/Tests/TapQInteractionBaselineTests/InstructionAnnouncementTests.swift
@@ -488,6 +488,12 @@ final class InstructionAnnouncementTests: XCTestCase {
     // MARK: - What the fix must not extend
 
     /// A window with nothing to confirm is the eight-second window it has always been.
+    ///
+    /// "Eight seconds" is eight seconds of microphone the wearer can speak into. The listen
+    /// covers the cue's own playback on top of that (sweep finding F3: TapQ's voice is not
+    /// charged to the wearer) and the commit allowance (F11), and neither is answering time —
+    /// what this test guards is that the turn does not get `TurnBudget.afterSpeaking`'s six
+    /// seconds, which is what would turn the window into an open microphone.
     func testAnOrdinaryTurnStillGetsOnlyTheWindow() async {
         let clock = VirtualClock()
         let speech = DrainingSpeech(clock: clock)
@@ -499,8 +505,15 @@ final class InstructionAnnouncementTests: XCTestCase {
         ).run()
 
         XCTAssertEqual(arbiter.timeouts.count, 1)
-        XCTAssertEqual(arbiter.timeouts[0], CommandWindowController.windowSeconds,
-                       accuracy: 0.01)
+        XCTAssertEqual(
+            arbiter.timeouts[0],
+            SpokenPace.drainSeconds(of: CommandWindowController.voiceSessionCue)
+                + CommandWindowController.windowSeconds + WindowClock.commitAllowance,
+            accuracy: 0.01
+        )
+        XCTAssertLessThan(arbiter.timeouts[0],
+                          CommandWindowController.windowSeconds + SpokenPace.answeringSeconds,
+                          "an ordinary turn was given a confirmation turn's answering window")
     }
 
     /// The dictation cue is not a question about a sentence the wearer has already said, so
@@ -521,9 +534,19 @@ final class InstructionAnnouncementTests: XCTestCase {
 
         XCTAssertGreaterThanOrEqual(arbiter.timeouts.count, 2,
                                     "timeouts: \(arbiter.timeouts)")
-        XCTAssertLessThanOrEqual(arbiter.timeouts[1],
-                                 CommandWindowController.windowSeconds - 6.04 + 0.001,
-                                 "the cue turn took more than the window had left")
+        // The residue is still all the *window* the cue turn gets. What it also gets, and
+        // what no amount of window would have covered, is its own playback and the commit
+        // allowance — see `WindowClock`. Neither is answering time, which is the thing this
+        // test exists to keep the cue turn from being handed.
+        XCTAssertLessThanOrEqual(
+            arbiter.timeouts[1],
+            SpokenPace.drainSeconds(of: InstructionDictation.cue)
+                + (CommandWindowController.windowSeconds - 6.04)
+                + WindowClock.commitAllowance + 0.001,
+            "the cue turn took more than the window had left"
+        )
+        XCTAssertLessThan(arbiter.timeouts[1], SpokenPace.answeringSeconds,
+                          "the cue turn was given an answering window it did not ask for")
     }
 
     // MARK: - Plain doubles, for the tests that are not about time

--- a/Tests/TapQInteractionBaselineTests/InteractionDeadlineTests.swift
+++ b/Tests/TapQInteractionBaselineTests/InteractionDeadlineTests.swift
@@ -59,8 +59,13 @@ final class InteractionDeadlineTests: XCTestCase {
         let decision = await controller.resolve(request(), deadline: deadline)
 
         XCTAssertEqual(decision, .ask)
-        XCTAssertEqual(arbiter.timeouts.count, 5,
-                       "245s budget at 60s per repeat-listen reaches a fifth, shortened window")
+        XCTAssertEqual(arbiter.timeouts.count, 4,
+                       """
+                       245s budget at 60s per repeat-listen leaves 5s after the fourth. \
+                       A fifth listen used to open there and re-speak the whole prompt \
+                       into it; the prompt alone outlasts 5s, so the repeat is refused \
+                       instead of asked into nothing.
+                       """)
         XCTAssertTrue(speech.spoken.contains { $0.text.contains("screen") },
                       "deadline expiry must be announced")
     }
@@ -97,19 +102,97 @@ final class InteractionDeadlineTests: XCTestCase {
                       "a request that expired in the queue must not speak at all")
     }
 
-    func testEntryWithInsufficientBudgetReturnsAskSilently() async {
+    /// F5(1). A request that arrives under the floor is refused *out loud*.
+    ///
+    /// It used to be refused in silence, and silence is the one answer a wearer cannot read:
+    /// with no screen in front of them, a question that went to the screen and a question
+    /// that was never asked sound exactly alike. The expired case above stays silent, and
+    /// the difference is whether anyone is still waiting on the other end.
+    func testEntryWithInsufficientBudgetIsRefusedAudibly() async {
         let clock = VirtualClock()
         let speech = FakeSpeech()
-        let controller = InteractionController(
-            speech: speech, arbiter: RepeatForeverArbiter(clock: clock, advancing: 60))
+        let arbiter = RepeatForeverArbiter(clock: clock, advancing: 60)
+        let controller = InteractionController(speech: speech, arbiter: arbiter)
         controller.now = { clock.now }
-        // Default entryMargin (12s) applies; 5s remaining is not enough to start.
+        // Under the derived floor (~26s at the Apple pace), over zero.
         let deadline = clock.now + .seconds(5)
 
         let decision = await controller.resolve(request(), deadline: deadline)
 
         XCTAssertEqual(decision, .ask)
-        XCTAssertTrue(speech.spoken.isEmpty)
+        XCTAssertTrue(arbiter.timeouts.isEmpty, "no window may open under the floor")
+        XCTAssertEqual(speech.spoken.count, 1)
+        XCTAssertTrue(speech.spoken[0].text.contains("screen"),
+                      "the refusal must say where the question went: \(speech.spoken)")
+    }
+
+    /// F5(3). The floor is characters divided by a speaking rate, so the faster voice needs
+    /// less of the budget for the same prompt — and a request the Apple path refuses is one
+    /// the realtime path can still ask.
+    func testTheFloorScalesWithTheSpeechPath() async {
+        let apple = InteractionController(speech: FakeSpeech(), arbiter: NeverArbiter())
+        apple.speechPath = .apple
+        let realtime = InteractionController(speech: FakeSpeech(), arbiter: NeverArbiter())
+        realtime.speechPath = .realtime
+
+        XCTAssertGreaterThan(apple.entryMargin, realtime.entryMargin,
+                             "the slower voice needs more budget to ask the same prompt")
+        let unstated = InteractionController(speech: FakeSpeech(), arbiter: NeverArbiter())
+        XCTAssertEqual(apple.entryMargin, unstated.entryMargin,
+                       "a composition that says nothing is assumed to use the slower voice")
+
+        // And the difference is load-bearing, not decorative: a budget between the two
+        // floors is refused by one and accepted by the other.
+        let between = (apple.entryMargin + realtime.entryMargin) / 2
+        let clock = VirtualClock()
+        let appleSpeech = FakeSpeech()
+        let refusing = InteractionController(
+            speech: appleSpeech, arbiter: RepeatForeverArbiter(clock: clock, advancing: 60))
+        refusing.now = { clock.now }
+        refusing.speechPath = .apple
+        _ = await refusing.resolve(request(), deadline: clock.now + .seconds(between))
+
+        let fasterClock = VirtualClock()
+        let fasterArbiter = RepeatForeverArbiter(clock: fasterClock, advancing: 60)
+        let asking = InteractionController(speech: FakeSpeech(), arbiter: fasterArbiter)
+        asking.now = { fasterClock.now }
+        asking.speechPath = .realtime
+        _ = await asking.resolve(request(), deadline: fasterClock.now + .seconds(between))
+
+        XCTAssertEqual(appleSpeech.spoken.count, 1, "Apple path: refused before any window")
+        XCTAssertFalse(fasterArbiter.timeouts.isEmpty,
+                       "realtime path: the same budget is enough to ask")
+    }
+
+    /// F5(2). `repeat` re-speaks the whole prompt, and the budget it re-speaks it into has
+    /// been shrinking for every turn the wearer has taken. Checked again each time, against
+    /// the sentence actually in hand.
+    func testMidLoopRepeatWithoutRoomIsRefusedAudibly() async {
+        let clock = VirtualClock()
+        let speech = FakeSpeech()
+        // One listen, long enough to leave a residue that is over zero and under the
+        // prompt's own playback plus an answering window.
+        let arbiter = RepeatForeverArbiter(clock: clock, advancing: 47)
+        let controller = InteractionController(speech: speech, arbiter: arbiter)
+        controller.now = { clock.now }
+        let deadline = clock.now + .seconds(50)
+
+        let decision = await controller.resolve(request(), deadline: deadline)
+
+        XCTAssertEqual(decision, .ask)
+        XCTAssertEqual(arbiter.timeouts.count, 1,
+                       "the repeat must not open a second window it cannot fill")
+        XCTAssertTrue(speech.spoken.contains { $0.text.contains("screen") },
+                      "a mid-loop refusal is spoken, never a silent stop: \(speech.spoken)")
+        XCTAssertFalse(speech.spoken.dropFirst().contains { $0.text.contains("Approve?") },
+                       "and the unanswerable prompt is not spoken into the residue")
+    }
+
+    /// An arbiter that never answers: for assertions about margins, where no window should
+    /// open at all.
+    @MainActor
+    final class NeverArbiter: InputArbitrating {
+        func listen(timeout: TimeInterval) async -> InputIntent? { nil }
     }
 
     @MainActor
@@ -147,7 +230,9 @@ final class InteractionDeadlineTests: XCTestCase {
 
         XCTAssertTrue(result.timedOut)
         XCTAssertTrue(result.choices.isEmpty)
-        XCTAssertEqual(arbiter.timeouts.count, 5)
+        XCTAssertEqual(arbiter.timeouts.count, 4,
+                       "the fifth listen would have re-read question, option, and controls "
+                           + "into the 5s left; refused instead")
         XCTAssertTrue(speech.spoken.contains { $0.text.contains("screen") })
     }
 
@@ -180,17 +265,57 @@ final class InteractionDeadlineTests: XCTestCase {
         XCTAssertEqual(arbiter.timeouts[1], 20, accuracy: 1e-9)
     }
 
-    func testSelectionEntryWithInsufficientBudgetReturnsNoSelectionSilently() async {
+    /// The selection half of F5(1): same split, same reason.
+    func testSelectionEntryWithInsufficientBudgetIsRefusedAudibly() async {
         let clock = VirtualClock()
         let speech = FakeSpeech()
-        let controller = SelectionController(
-            speech: speech, arbiter: NavigateForeverArbiter(clock: clock, advancing: 60))
+        let arbiter = NavigateForeverArbiter(clock: clock, advancing: 60)
+        let controller = SelectionController(speech: speech, arbiter: arbiter)
         controller.now = { clock.now }
         let deadline = clock.now + .seconds(5)
 
         let result = await controller.resolve(selectionRequest(), deadline: deadline)
 
         XCTAssertTrue(result.timedOut)
-        XCTAssertTrue(speech.spoken.isEmpty)
+        XCTAssertTrue(arbiter.timeouts.isEmpty)
+        XCTAssertEqual(speech.spoken.count, 1)
+        XCTAssertTrue(speech.spoken[0].text.contains("screen"), "\(speech.spoken)")
+    }
+
+    /// A selection's floor is the larger of the two: it reads a question, a position, an
+    /// option label, and the controls, where an approval reads one summary.
+    func testSelectionFloorIsWiderThanAnApprovalsAndScalesToo() async {
+        let selection = SelectionController(speech: FakeSpeech(),
+                                            arbiter: NoNavigationArbiter())
+        let approval = InteractionController(speech: FakeSpeech(), arbiter: NeverArbiter())
+        XCTAssertGreaterThan(selection.entryMargin, approval.entryMargin)
+
+        selection.speechPath = .realtime
+        let faster = selection.entryMargin
+        selection.speechPath = .apple
+        XCTAssertGreaterThan(selection.entryMargin, faster)
+    }
+
+    /// F5(2), selection side: `repeat` re-reads the question, the option, *and* the
+    /// controls — the longest thing this flow ever says — into whatever navigating has left.
+    func testSelectionMidLoopRepeatWithoutRoomIsRefusedAudibly() async {
+        let clock = VirtualClock()
+        let speech = FakeSpeech()
+        let arbiter = NavigateForeverArbiter(clock: clock, advancing: 47)
+        let controller = SelectionController(speech: speech, arbiter: arbiter)
+        controller.now = { clock.now }
+
+        let result = await controller.resolve(selectionRequest(),
+                                              deadline: clock.now + .seconds(50))
+
+        XCTAssertTrue(result.timedOut)
+        XCTAssertEqual(arbiter.timeouts.count, 1)
+        XCTAssertTrue(speech.spoken.contains { $0.text.contains("screen") },
+                      "\(speech.spoken)")
+    }
+
+    @MainActor
+    final class NoNavigationArbiter: SelectionArbitrating {
+        func listen(timeout: TimeInterval) async -> InputIntent? { nil }
     }
 }

--- a/Tests/TapQInteractionBaselineTests/NotificationPolicyTests.swift
+++ b/Tests/TapQInteractionBaselineTests/NotificationPolicyTests.swift
@@ -174,7 +174,7 @@ final class NotificationPolicyTests: XCTestCase {
     /// here, which is the point of writing the switch out.
     func testEveryVerdictIsAnAudioDecision() async {
         let all: [NotificationPolicy.Verdict] = [
-            .speak, .chime(.prompt), .chime(.notification), .suppress,
+            .speak, .chime(.prompt), .chime(.notification), .suppress, .deferred,
         ]
         var played: [String] = []
         for verdict in all {
@@ -182,9 +182,13 @@ final class NotificationPolicyTests: XCTestCase {
             case .speak: played.append("speech")
             case .chime(let cue): played.append(cue.rawValue)
             case .suppress: played.append("nothing")
+            // Still an audio decision, and still nothing about recording: "not now" is a
+            // statement about when a sound is made, not about whether an event happened.
+            case .deferred: played.append("nothing yet")
             }
         }
-        XCTAssertEqual(played, ["speech", "prompt", "notification", "nothing"])
+        XCTAssertEqual(played,
+                       ["speech", "prompt", "notification", "nothing", "nothing yet"])
     }
 
     /// Suppressing a sound touches nothing a caller would record from, and does not
@@ -197,5 +201,267 @@ final class NotificationPolicyTests: XCTestCase {
                        .suppress)
         XCTAssertEqual(waits.waitingCount, 1)
         XCTAssertEqual(waits.waitingAgentNames, ["Codex"])
+    }
+
+    // MARK: - Deferral around a command window (F10)
+
+    /// A test double for the window: open until the test closes it.
+    @MainActor
+    private final class Window {
+        var isOpen = false
+    }
+
+    /// Records what a diagnostic sink was told. The same double the other interaction suites
+    /// use.
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock()
+            storage.append(event)
+            lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        func fields(of name: String) -> [[String: String]] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.filter { $0.name == name }.map(\.fields)
+        }
+    }
+
+    /// A virtual clock, so the deferral's own timing is driven rather than waited out.
+    @MainActor
+    private final class VirtualClock {
+        private(set) var now: ContinuousClock.Instant = .now
+        func advance(by seconds: TimeInterval) { now = now.advanced(by: .seconds(seconds)) }
+    }
+
+    /// Builds a policy whose deferral is fully under the test's control: the window is a
+    /// flag, the clock is virtual, and every poll yields so the drain task can be stepped
+    /// with `Task.yield()` instead of a real quarter-second.
+    @MainActor
+    private func deferringPolicy(
+        window: Window,
+        clock: VirtualClock,
+        sink: RecordingSink,
+        quiet: Bool = false
+    ) -> NotificationPolicy {
+        let policy = NotificationPolicy(
+            settings: .init(quiet: quiet, announcementsEnabled: true),
+            waits: SessionWaitRegistry(),
+            commandWindowOpen: { window.isOpen },
+            diagnosticSink: sink
+        )
+        policy.now = { clock.now }
+        policy.sleep = { _ in await Task.yield() }
+        return policy
+    }
+
+    /// Lets the drain task run until it settles. The poll sleep is a yield, so a handful of
+    /// turns is more than the loop needs.
+    private func settle() async {
+        for _ in 0..<20 { await Task.yield() }
+    }
+
+    /// F10(5). A `.finished` arriving during an open command window is held, not spoken into
+    /// it, and it is delivered once the window closes.
+    ///
+    /// Spoken into the window it would be spoken at `.notification` priority: the speech gate
+    /// tears the recognizer down for its playback while the window's own timer keeps running,
+    /// so up to seven of eight seconds go on a sentence about a different agent and the
+    /// wearer is recorded as having said nothing.
+    func testAFinishDuringACommandWindowIsDeferredNotSpokenIntoIt() async {
+        let window = Window()
+        let clock = VirtualClock()
+        let sink = RecordingSink()
+        let policy = deferringPolicy(window: window, clock: clock, sink: sink)
+        var played: [NotificationPolicy.Verdict] = []
+
+        window.isOpen = true
+        let verdict = policy.route(
+            .agentNotification(kind: .finished, sessionID: "s1"),
+            whenDeferred: { played.append($0) }
+        )
+
+        XCTAssertEqual(verdict, .deferred)
+        XCTAssertEqual(policy.deferredCount, 1)
+        XCTAssertTrue(played.isEmpty, "nothing may be played into the open window")
+        XCTAssertEqual(sink.fields(of: "notification.deferred").count, 1)
+
+        window.isOpen = false
+        await settle()
+
+        XCTAssertEqual(played, [.speak], "and it is said at the next legal moment")
+        XCTAssertEqual(policy.deferredCount, 0)
+        XCTAssertEqual(sink.fields(of: "notification.delivered").count, 1)
+    }
+
+    /// The held verdict is the verdict that was computed, not a fresh one: under `--quiet` a
+    /// deferred notification comes back as the cue it would have been.
+    func testTheHeldVerdictIsTheOneThatWasComputed() async {
+        let window = Window()
+        let clock = VirtualClock()
+        let policy = deferringPolicy(window: window, clock: clock, sink: RecordingSink(),
+                                     quiet: true)
+        var played: [NotificationPolicy.Verdict] = []
+
+        window.isOpen = true
+        _ = policy.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                         whenDeferred: { played.append($0) })
+        window.isOpen = false
+        await settle()
+
+        XCTAssertEqual(played, [.chime(.notification)])
+    }
+
+    /// F10(6). Two finishes for the same session, both waiting out the same window, are one
+    /// sentence — and the collapse is *counted*, never silent. Two finishes separated by real
+    /// time are still two pieces of news; that rule is untouched, and the test above it holds.
+    func testADeferredNoticeThatWentStaleIsDedupedWithADiagnostic() async {
+        let window = Window()
+        let clock = VirtualClock()
+        let sink = RecordingSink()
+        let policy = deferringPolicy(window: window, clock: clock, sink: sink)
+        var played: [NotificationPolicy.Verdict] = []
+        let hold: @MainActor (NotificationPolicy.Verdict) -> Void = { played.append($0) }
+
+        window.isOpen = true
+        XCTAssertEqual(policy.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                                    whenDeferred: hold), .deferred)
+        XCTAssertEqual(policy.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                                    whenDeferred: hold), .deferred)
+        XCTAssertEqual(policy.deferredCount, 1, "the stutter is collapsed")
+
+        window.isOpen = false
+        await settle()
+
+        XCTAssertEqual(played.count, 1)
+        XCTAssertEqual(sink.fields(of: "notification.dropped_stale").map { $0["reason"] },
+                       ["duplicate"],
+                       "dropped, and said so — a count, never a vanishing")
+    }
+
+    /// The other staleness: the wearer is now being asked a fresh question about the very
+    /// session the held notice is about. A prompt is never deferred, so it overtakes the
+    /// notice — which is then a sentence about the past arriving after the present.
+    func testAHeldNoticeIsDroppedWhenAFreshPromptOvertakesIt() async {
+        let window = Window()
+        let clock = VirtualClock()
+        let sink = RecordingSink()
+        let policy = deferringPolicy(window: window, clock: clock, sink: sink)
+        var played: [NotificationPolicy.Verdict] = []
+
+        window.isOpen = true
+        _ = policy.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                         whenDeferred: { played.append($0) })
+        XCTAssertEqual(policy.route(.requestPrompt(sessionID: "s1")), .speak,
+                       "a prompt is never held: the wearer has to hear it to answer it")
+        XCTAssertEqual(policy.deferredCount, 0)
+
+        window.isOpen = false
+        await settle()
+
+        XCTAssertTrue(played.isEmpty)
+        XCTAssertEqual(sink.fields(of: "notification.dropped_stale").map { $0["reason"] },
+                       ["superseded"])
+    }
+
+    /// A window that never closes must not hold a notice for ever, and must not eventually
+    /// speak it into the window either — that is the race, only later. Dropped at the bound,
+    /// counted, and the caller's own record of the event is untouched.
+    func testANoticeHeldPastTheBoundIsDroppedLoudlyRatherThanSpokenLate() async {
+        let window = Window()
+        let clock = VirtualClock()
+        let sink = RecordingSink()
+        let policy = deferringPolicy(window: window, clock: clock, sink: sink)
+        var played: [NotificationPolicy.Verdict] = []
+
+        window.isOpen = true
+        _ = policy.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                         whenDeferred: { played.append($0) })
+        clock.advance(by: 61)
+        await settle()
+
+        XCTAssertEqual(policy.deferredCount, 0)
+        XCTAssertTrue(played.isEmpty, "never spoken into the window it was held for")
+        XCTAssertEqual(sink.fields(of: "notification.dropped_expired").count, 1)
+    }
+
+    /// F10(7). Outside a window nothing changes: same verdicts, same dedupe, no queue, and
+    /// no diagnostics about deferral at all.
+    func testNotificationsOutsideAWindowBehaveExactlyAsBefore() async {
+        let window = Window()
+        let clock = VirtualClock()
+        let sink = RecordingSink()
+        let policy = deferringPolicy(window: window, clock: clock, sink: sink)
+        var played: [NotificationPolicy.Verdict] = []
+        let hold: @MainActor (NotificationPolicy.Verdict) -> Void = { played.append($0) }
+
+        XCTAssertEqual(policy.route(.agentNotification(kind: .waitingForInput,
+                                                       sessionID: "s1"),
+                                    whenDeferred: hold), .speak)
+        XCTAssertEqual(policy.route(.agentNotification(kind: .waitingForInput,
+                                                       sessionID: "s1"),
+                                    whenDeferred: hold), .suppress)
+        XCTAssertEqual(policy.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                                    whenDeferred: hold), .speak)
+        XCTAssertEqual(policy.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                                    whenDeferred: hold), .speak,
+                       "two finishes apart in time are two pieces of news, as they always were")
+
+        XCTAssertEqual(policy.deferredCount, 0)
+        XCTAssertTrue(played.isEmpty, "nothing was held, so nothing is replayed")
+        XCTAssertFalse(sink.names.contains { $0.hasPrefix("notification.") },
+                       "no deferral bookkeeping happens outside a window: \(sink.names)")
+    }
+
+    /// A caller that offers no way to replay is not told "later": there would be no later,
+    /// and losing an event quietly is the one thing this type may not do. It routes as it
+    /// always did, and the compromise is recorded.
+    func testACallerWithNoReplayIsNeverHandedADeferral() async {
+        let window = Window()
+        let clock = VirtualClock()
+        let sink = RecordingSink()
+        let policy = deferringPolicy(window: window, clock: clock, sink: sink)
+
+        window.isOpen = true
+        XCTAssertEqual(policy.route(.agentNotification(kind: .finished, sessionID: "s1")),
+                       .speak)
+        XCTAssertEqual(policy.deferredCount, 0)
+        XCTAssertEqual(sink.fields(of: "notification.deferral_unavailable").count, 1)
+    }
+
+    /// A policy composed without a window presence — every host that has no command windows,
+    /// and every test written before they existed — never defers.
+    func testAPolicyWithNoWindowPresenceNeverDefers() async {
+        var played: [NotificationPolicy.Verdict] = []
+        let windowless = policy()
+        XCTAssertEqual(windowless.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                                        whenDeferred: { played.append($0) }), .speak)
+        XCTAssertTrue(played.isEmpty)
+    }
+
+    /// Suppressed announcements are not held: there is no sound to keep out of the window.
+    func testASuppressedNotificationIsNotDeferred() async {
+        let window = Window()
+        let clock = VirtualClock()
+        let policy = NotificationPolicy(
+            settings: .init(quiet: false, announcementsEnabled: false),
+            waits: SessionWaitRegistry(),
+            commandWindowOpen: { window.isOpen }
+        )
+        policy.now = { clock.now }
+        window.isOpen = true
+
+        XCTAssertEqual(policy.route(.agentNotification(kind: .finished, sessionID: "s1"),
+                                    whenDeferred: { _ in }), .suppress)
+        XCTAssertEqual(policy.deferredCount, 0)
     }
 }

--- a/Tests/TapQInteractionBaselineTests/WindowClockDrainTests.swift
+++ b/Tests/TapQInteractionBaselineTests/WindowClockDrainTests.swift
@@ -1,0 +1,478 @@
+import XCTest
+@testable import TapQInteractionBaseline
+import TapQContracts
+
+/// Sweep finding F3: the window's countdown and the window's microphone disagreed about when
+/// the window began.
+///
+/// A command window set `deadline = now() + 8s` at controller entry and consulted nothing
+/// about whether TapQ was still talking. It usually was — the previous window speaks its last
+/// answer *as it closes*, and the voice-session loop opens the next window in the same actor
+/// turn — so `SpeechGatedVoice` held the microphone shut through the first seconds of a
+/// countdown that was already running. On hardware, 12 of 40 eight-second voice-session
+/// windows opened with `[SpeechGate] microphone.held_closed`.
+///
+/// Every test here measures the quantity the wearer actually gets: **seconds of microphone
+/// that can hear them**. `DrainAwareArbiter.micOpenSeconds` is that number per listen, and it
+/// is the one the old code could make zero.
+///
+/// ## The doubles
+///
+/// Round one (`InstructionAnnouncementTests`) established the pair this file needs: an
+/// utterance occupies the clock for as long as its text takes to say, and the arbiter cannot
+/// hear the wearer until it drains. The part round one had to fake — *when TapQ's voice
+/// stops* — is now production code, so ``SelfAudio`` models the audio and
+/// `VoiceChannelDrain` reads it exactly as the runtime does: the live `isSpeaking` signal
+/// `SpeechGatedVoice` gates on, plus the `SpokenPace` estimate for audio that has been
+/// accepted but has not started sounding.
+@MainActor
+final class WindowClockDrainTests: XCTestCase {
+    /// A 102-character answer: the F7 evidence, at the length that broke it. Eight and a half
+    /// seconds of audio at `SpokenPace.charactersPerSecond`.
+    private static let longAnswer =
+        "The last thing that changed was the test suite, which is now passing on both of the "
+        + "two platforms now."
+
+    // MARK: - Doubles
+
+    private final class RecordingSink: TapQDiagnosticSink, @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [TapQDiagnosticEvent] = []
+
+        func record(_ event: TapQDiagnosticEvent) {
+            lock.lock(); storage.append(event); lock.unlock()
+        }
+
+        var names: [String] {
+            lock.lock(); defer { lock.unlock() }
+            return storage.map(\.name)
+        }
+
+        func fields(of name: String) -> [[String: String]] {
+            lock.lock(); defer { lock.unlock() }
+            return storage.filter { $0.name == name }.map(\.fields)
+        }
+    }
+
+    @MainActor
+    private final class VirtualClock {
+        private(set) var now: ContinuousClock.Instant = .now
+        func advance(by seconds: TimeInterval) { now = now.advanced(by: .seconds(seconds)) }
+        func advance(to instant: ContinuousClock.Instant) {
+            guard instant > now else { return }
+            now = instant
+        }
+    }
+
+    /// TapQ's own voice, as both of the readings in `VoiceChannelDrain` see it.
+    ///
+    /// One object because they are one thing: `isSounding` is what the runtime's
+    /// `SpeechActivitySignaling` reports, and `opensAt` is when `SpeechGatedVoice` would let
+    /// the microphone back open. `playbackLatency` is the gap `SpokenTurnBudget` documents —
+    /// a sentence the backend has accepted is not sounding yet, so for those milliseconds the
+    /// live signal reads quiet about audio that is certainly coming.
+    @MainActor
+    private final class SelfAudio {
+        private let clock: VirtualClock
+        private var audibleFrom: ContinuousClock.Instant
+        private(set) var quietAt: ContinuousClock.Instant
+        var playbackLatency: TimeInterval = 0
+
+        init(clock: VirtualClock) {
+            self.clock = clock
+            self.audibleFrom = clock.now
+            self.quietAt = clock.now
+        }
+
+        /// TapQ handed a sentence to the voice channel. Utterances queue rather than overlap.
+        func accepted(_ text: String) {
+            guard !text.isEmpty else { return }
+            let seconds = SpokenPace.drainSeconds(of: text)
+            if clock.now >= quietAt {
+                audibleFrom = clock.now.advanced(by: .seconds(playbackLatency))
+                quietAt = audibleFrom.advanced(by: .seconds(seconds))
+            } else {
+                quietAt = quietAt.advanced(by: .seconds(seconds))
+            }
+        }
+
+        /// The live `isSpeaking` reading.
+        var isSounding: Bool { clock.now >= audibleFrom && clock.now < quietAt }
+
+        /// When a listen opened now would first be able to hear the wearer.
+        var opensAt: ContinuousClock.Instant { max(clock.now, quietAt) }
+    }
+
+    /// A voice that takes time to say things. `onFinish` still fires immediately — that is
+    /// what `BackendSpeechSink` does, and why no caller can use it to sequence a listen.
+    @MainActor
+    private final class DrainingSpeech: SpeechPresenting {
+        private let audio: SelfAudio
+        private(set) var spoken: [String] = []
+
+        init(audio: SelfAudio) { self.audio = audio }
+
+        func speak(_ text: String, priority: SpeechPriority, onFinish: (() -> Void)?) {
+            spoken.append(text)
+            audio.accepted(text)
+            onFinish?()
+        }
+
+        func stopAll() {}
+    }
+
+    /// An input window that spends real time and cannot hear through TapQ's own voice.
+    @MainActor
+    private final class DrainAwareArbiter: InputArbitrating {
+        struct Answer {
+            let intent: InputIntent?
+            /// Seconds after the *microphone opens* before the wearer speaks or gestures.
+            let after: TimeInterval
+        }
+
+        private let clock: VirtualClock
+        private let audio: SelfAudio
+        private let script: [Answer]
+        private(set) var timeouts: [TimeInterval] = []
+        /// The number this whole file is about: seconds of microphone that could actually
+        /// hear the wearer. Zero is the bug.
+        private(set) var micOpenSeconds: [TimeInterval] = []
+
+        init(clock: VirtualClock, audio: SelfAudio, script: [Answer]) {
+            self.clock = clock
+            self.audio = audio
+            self.script = script
+        }
+
+        func listen(timeout: TimeInterval) async -> InputIntent? {
+            let index = timeouts.count
+            timeouts.append(timeout)
+            let expiresAt = clock.now.advanced(by: .seconds(timeout))
+            // `SpeechGatedVoice`: the channel opens when the engine drains, not when the
+            // listen starts.
+            let opensAt = audio.opensAt
+            micOpenSeconds.append(max(0, expiresAt.seconds(after: opensAt)))
+            guard index < script.count, let intent = script[index].intent else {
+                clock.advance(to: expiresAt)
+                return nil
+            }
+            let heardAt = opensAt.advanced(by: .seconds(script[index].after))
+            guard heardAt <= expiresAt else {
+                clock.advance(to: expiresAt)
+                return nil
+            }
+            clock.advance(to: heardAt)
+            return intent
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// A voice-session window composed the way the runtime composes it: the shared drain
+    /// record, reading the same live signal `SpeechGatedVoice` gates the microphone on.
+    private func window(
+        clock: VirtualClock,
+        audio: SelfAudio,
+        speech: DrainingSpeech,
+        arbiter: DrainAwareArbiter,
+        drain: VoiceChannelDrain,
+        sink: RecordingSink,
+        cue: String?,
+        recall: RecallResponding? = nil
+    ) -> CommandWindowController {
+        let controller = CommandWindowController(
+            speech: speech,
+            arbiter: arbiter,
+            gate: InteractionGate(),
+            cue: cue,
+            agentDisplayName: "Claude Code",
+            diagnosticSink: sink,
+            recallResponder: recall,
+            kind: .voiceSession,
+            voiceMayEndSession: false,
+            voiceChannelDrain: drain
+        )
+        controller.now = { clock.now }
+        // The deferral's sleep, virtualized: the wait is real seconds in the runtime and
+        // clock ticks here.
+        controller.drainSleep = { seconds in clock.advance(by: seconds) }
+        return controller
+    }
+
+    private func drainRecord(_ audio: SelfAudio) -> VoiceChannelDrain {
+        VoiceChannelDrain { audio.isSounding }
+    }
+
+    // MARK: - The clock starts at the drain edge
+
+    /// The fix, in the shape the hardware produced the bug: a window opens while the previous
+    /// window's closing sentence is still sounding, and the wearer who answers just after it
+    /// stops is heard.
+    ///
+    /// Under the old clock this is the `microphone.held_closed` window: the countdown started
+    /// at controller entry, the microphone opened eight seconds later, and the deadline had
+    /// already passed when it did.
+    func testAWindowOpeningUnderDrainAnchorsItsClockAtTheDrainEdge() async {
+        let clock = VirtualClock()
+        let audio = SelfAudio(clock: clock)
+        let speech = DrainingSpeech(audio: audio)
+        let drain = drainRecord(audio)
+        let sink = RecordingSink()
+
+        // The previous window's residual sentence: ninety-six characters, eight seconds.
+        speech.speak(String(repeating: "a", count: 96), priority: .notification,
+                     onFinish: nil)
+        drain.willSpeak(String(repeating: "a", count: 96), at: clock.now)
+        let opened = clock.now
+
+        // The wearer answers half a second after the microphone can hear them.
+        let arbiter = DrainAwareArbiter(clock: clock, audio: audio,
+                                        script: [.init(intent: .status, after: 0.5)])
+        let outcome = await window(clock: clock, audio: audio, speech: speech,
+                                   arbiter: arbiter, drain: drain, sink: sink,
+                                   cue: CommandWindowController.voiceSessionCue,
+                                   recall: { _ in "Nothing waiting." }).run()
+
+        XCTAssertEqual(outcome.answers, 1,
+                       "the wearer answered after the drain and was not heard")
+        XCTAssertGreaterThan(
+            arbiter.micOpenSeconds[0], CommandWindowController.windowSeconds - 0.001,
+            "the window gave the wearer less open microphone than it promises"
+        )
+        // The old clock would have expired here: the wearer was heard past the nominal
+        // eight seconds from entry, which is exactly what the anchor bought them.
+        XCTAssertGreaterThan(clock.now.seconds(after: opened),
+                             CommandWindowController.windowSeconds,
+                             "the answer landed inside the old deadline, so this proves nothing")
+        let deferrals = sink.fields(of: "window.clock_deferred")
+        XCTAssertEqual(deferrals.count, 1, "the deferral was not recorded")
+        XCTAssertEqual(Double(deferrals[0]["signal_ms"] ?? "0") ?? 0, 8000, accuracy: 150,
+                       "the deferral should be the eight seconds the live signal was busy")
+    }
+
+    /// The estimate's own job, and the reason the live signal is not enough on its own.
+    ///
+    /// A sentence the backend has accepted has not started sounding yet, so `isSpeaking`
+    /// reads quiet for those milliseconds. A window anchored on the signal alone would sail
+    /// straight through the gap and be back where it started.
+    func testTheEstimateCoversAudioThatHasNotStartedSounding() async {
+        let clock = VirtualClock()
+        let audio = SelfAudio(clock: clock)
+        audio.playbackLatency = 0.5
+        let speech = DrainingSpeech(audio: audio)
+        let drain = drainRecord(audio)
+
+        // Handed over, accepted, not yet audible.
+        let residual = String(repeating: "a", count: 60) // five seconds
+        speech.speak(residual, priority: .notification, onFinish: nil)
+        drain.willSpeak(residual, at: clock.now)
+        XCTAssertFalse(audio.isSounding, "the fixture must start in the blind spot")
+
+        let arbiter = DrainAwareArbiter(clock: clock, audio: audio,
+                                        script: [.init(intent: .status, after: 0.5)])
+        let outcome = await window(clock: clock, audio: audio, speech: speech,
+                                   arbiter: arbiter, drain: drain, sink: RecordingSink(),
+                                   cue: nil, recall: { _ in "Nothing waiting." }).run()
+
+        XCTAssertEqual(outcome.answers, 1)
+        XCTAssertGreaterThan(
+            arbiter.micOpenSeconds[0], CommandWindowController.windowSeconds - 0.001,
+            "the window counted through audio the live signal could not see yet"
+        )
+    }
+
+    // MARK: - What the fix must not extend
+
+    /// A window that opens into silence is the window it has always been: eight seconds of
+    /// microphone, plus the commit allowance, and no deferral at all.
+    func testAFullyOpenWindowStillTimesOutAtItsNominalLength() async {
+        let clock = VirtualClock()
+        let audio = SelfAudio(clock: clock)
+        let speech = DrainingSpeech(audio: audio)
+        let sink = RecordingSink()
+        let opened = clock.now
+        let arbiter = DrainAwareArbiter(clock: clock, audio: audio,
+                                        script: [.init(intent: nil, after: 0)])
+
+        let outcome = await window(clock: clock, audio: audio, speech: speech,
+                                   arbiter: arbiter, drain: drainRecord(audio),
+                                   sink: sink, cue: nil).run()
+
+        XCTAssertTrue(outcome.isEmpty)
+        XCTAssertEqual(arbiter.timeouts.count, 1)
+        XCTAssertEqual(arbiter.timeouts[0],
+                       CommandWindowController.windowSeconds + WindowClock.commitAllowance,
+                       accuracy: 0.001)
+        XCTAssertEqual(clock.now.seconds(after: opened),
+                       CommandWindowController.windowSeconds + WindowClock.commitAllowance,
+                       accuracy: 0.001,
+                       "a silent window must not outlive its own eight seconds")
+        XCTAssertFalse(sink.names.contains("window.clock_deferred"),
+                       "nothing was draining, so nothing should have been deferred")
+    }
+
+    /// The deferral is bounded. A signal stuck at `true` — a wedged synthesizer, a player
+    /// that never reports idle — costs one window, not the session.
+    func testAStuckSignalCannotHoldTheClockForever() async {
+        let clock = VirtualClock()
+        let audio = SelfAudio(clock: clock)
+        let speech = DrainingSpeech(audio: audio)
+        let sink = RecordingSink()
+        let opened = clock.now
+        // A signal that never goes quiet.
+        let drain = VoiceChannelDrain { true }
+        let arbiter = DrainAwareArbiter(clock: clock, audio: audio,
+                                        script: [.init(intent: nil, after: 0)])
+
+        _ = await window(clock: clock, audio: audio, speech: speech, arbiter: arbiter,
+                         drain: drain, sink: sink, cue: nil).run()
+
+        XCTAssertEqual(arbiter.timeouts.count, 1, "the window never opened a listen")
+        let deferred = sink.fields(of: "window.clock_deferred")
+        XCTAssertEqual(deferred.count, 1)
+        XCTAssertLessThanOrEqual(
+            Double(deferred[0]["drain_ms"] ?? "0") ?? 0,
+            (WindowClock.maxDrainWait + WindowClock.drainPollInterval) * 1000,
+            "the deferral ran past its bound"
+        )
+        XCTAssertLessThan(clock.now.seconds(after: opened),
+                          WindowClock.maxDrainWait + CommandWindowController.windowSeconds
+                              + WindowClock.commitAllowance + 1,
+                          "a stuck signal held the gate longer than the bound allows")
+    }
+
+    // MARK: - F7: the residual listen
+
+    /// Sweep finding F7, verified rather than assumed: a 102-character answer spoken into a
+    /// 2.19-second residual listen.
+    ///
+    /// Anchoring the window's *birth* does not reach this — the answer is spoken in the
+    /// middle of an already-open window — so the same rule has to hold for the listen that
+    /// carries it: TapQ's own playback is not charged to the wearer's residue. Under the old
+    /// sizing this listen expired more than six seconds before the microphone opened, so the
+    /// answering window was not short, it was zero.
+    func testAResidualListenAfterALongAnswerStillLeavesAnAnsweringWindow() async {
+        let clock = VirtualClock()
+        let audio = SelfAudio(clock: clock)
+        let speech = DrainingSpeech(audio: audio)
+        let sink = RecordingSink()
+        XCTAssertEqual(SpokenPace.drainSeconds(of: Self.longAnswer), 8.5, accuracy: 0.1,
+                       "the fixture answer is no longer the length the finding measured")
+
+        // The wearer asks at 5.81 s, leaving 2.19 s of the window, and answers again half a
+        // second after the answer stops sounding.
+        let cue = CommandWindowController.voiceSessionCue
+        let toAsk = 5.81 - SpokenPace.drainSeconds(of: cue)
+        let arbiter = DrainAwareArbiter(
+            clock: clock, audio: audio,
+            script: [.init(intent: .whatChanged, after: toAsk),
+                     .init(intent: .status, after: 0.5)]
+        )
+        let outcome = await window(clock: clock, audio: audio, speech: speech,
+                                   arbiter: arbiter, drain: drainRecord(audio), sink: sink,
+                                   cue: cue, recall: { _ in Self.longAnswer }).run()
+
+        XCTAssertEqual(arbiter.timeouts.count, 2, "the residual listen never happened")
+        XCTAssertGreaterThan(arbiter.micOpenSeconds[1], 2.19,
+                             "the residual listen expired before the microphone opened")
+        XCTAssertEqual(outcome.answers, 2,
+                       "the wearer spoke into the residual window and was not heard")
+        XCTAssertFalse(sink.names.contains("window.clock_deferred"),
+                       "the window opened into silence; only the listen needed the fix")
+    }
+
+    // MARK: - F11: the commit allowance
+
+    /// Sweep finding F11: the wearer speaks inside the window, and their turn commits about a
+    /// second later — the detector's hangover plus `WearerTurnCoordinator`'s endpoint delay.
+    /// A listen that closes exactly on the deadline throws that answer away.
+    func testSpeechEndingJustInsideTheDeadlineStillCommits() async {
+        let clock = VirtualClock()
+        let audio = SelfAudio(clock: clock)
+        let speech = DrainingSpeech(audio: audio)
+        let opened = clock.now
+        // Spoken inside the window; delivered 0.9 s after the nominal deadline.
+        let commitsAt = CommandWindowController.windowSeconds + 0.9
+        XCTAssertLessThan(commitsAt,
+                          CommandWindowController.windowSeconds + WindowClock.commitAllowance,
+                          "the fixture must land inside the allowance, not beyond it")
+        let arbiter = DrainAwareArbiter(clock: clock, audio: audio,
+                                        script: [.init(intent: .status, after: commitsAt)])
+
+        let outcome = await window(clock: clock, audio: audio, speech: speech,
+                                   arbiter: arbiter, drain: drainRecord(audio),
+                                   sink: RecordingSink(), cue: nil,
+                                   recall: { _ in "Nothing waiting." }).run()
+
+        XCTAssertEqual(outcome.answers, 1,
+                       "the wearer spoke inside the window and lost the turn to commit latency")
+        XCTAssertGreaterThan(clock.now.seconds(after: opened),
+                             CommandWindowController.windowSeconds,
+                             "the fixture did not exercise the allowance")
+        XCTAssertEqual(speech.spoken.last, "Nothing waiting.",
+                       "the answer is still spoken once the window is over")
+    }
+
+    /// The allowance is a wait for an answer already given, not extra window. It is built from
+    /// the two delays that actually elapse, read from the coordinator that owns one of them.
+    func testTheCommitAllowanceIsTheEndpointDelayPlusTheHangover() async {
+        XCTAssertEqual(WindowClock.commitAllowance,
+                       WearerTurnCoordinator.defaultEndpointDelay + WindowClock.detectorHangover,
+                       accuracy: 0.0001)
+        XCTAssertEqual(WindowClock.commitAllowance, 1.0, accuracy: 0.0001)
+    }
+
+    // MARK: - The loop that opens windows
+
+    /// The anti-spin invariant, over the sequence `VoiceSessionListening` runs: windows are
+    /// re-opened for as long as a boundary is held, each one immediately after the last.
+    ///
+    /// Slow-draining audio used to make that loop churn — a window whose eight seconds were
+    /// spent entirely on TapQ's own voice closed almost at once and the next one opened into
+    /// the same audio. The invariant that forbids it is per-window and simple: no window
+    /// completes having offered less than its eight seconds of microphone.
+    func testTheVoiceSessionLoopDoesNotSpinWindowsWhileAudioDrains() async {
+        let clock = VirtualClock()
+        let audio = SelfAudio(clock: clock)
+        let speech = DrainingSpeech(audio: audio)
+        let drain = drainRecord(audio)
+        let sink = RecordingSink()
+        let started = clock.now
+        var micPerWindow: [TimeInterval] = []
+
+        // Four windows, as the loop opens them: the cue only on the first, and each window
+        // leaving a long answer still sounding as it closes — the residual the sweep caught.
+        for index in 0..<4 {
+            let cue = index == 0 ? CommandWindowController.voiceSessionCue : nil
+            // Asked late enough that the answer becomes the closing residual.
+            let arbiter = DrainAwareArbiter(
+                clock: clock, audio: audio,
+                script: [.init(intent: .whatChanged,
+                               after: CommandWindowController.windowSeconds + 0.5)]
+            )
+            _ = await window(clock: clock, audio: audio, speech: speech, arbiter: arbiter,
+                             drain: drain, sink: sink, cue: cue,
+                             recall: { _ in Self.longAnswer }).run()
+            micPerWindow.append(arbiter.micOpenSeconds.reduce(0, +))
+        }
+
+        XCTAssertEqual(micPerWindow.count, 4)
+        for (index, seconds) in micPerWindow.enumerated() {
+            XCTAssertGreaterThan(
+                seconds, CommandWindowController.windowSeconds - 0.001,
+                "window \(index) offered \(seconds)s of open microphone, not its eight"
+            )
+        }
+        // Every window after the first opened under the previous one's closing sentence, and
+        // said so. The first opened into silence.
+        XCTAssertEqual(sink.fields(of: "window.clock_deferred").count, 3,
+                       "windows 2-4 open under the residual answer and must defer")
+        // The rate follows: four drain-aware windows cannot fit in the wall time four
+        // stolen ones did.
+        XCTAssertGreaterThan(
+            clock.now.seconds(after: started),
+            4 * CommandWindowController.windowSeconds,
+            "four windows completed in the time four stolen windows took — still spinning"
+        )
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -53,7 +53,7 @@ Source-development examples:
 ```bash
 scripts/run-runtime-app.sh serve
 scripts/run-runtime-app.sh serve --no-voice
-TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 30
+TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 60
 scripts/run-runtime-app.sh serve --steering
 # With ANTHROPIC_API_KEY already present in the launcher environment:
 scripts/run-runtime-app.sh serve --question-classifier anthropic
@@ -73,7 +73,7 @@ The underlying command syntax is `tapq serve [options]`.
 | `--broker-dir PATH` | Override the discovery and socket directory |
 | `--gesture-profile PATH` | Override the gesture profile |
 | `--tap-profile PATH` | Override the tap profile |
-| `--timeout SECONDS` | Input timeout; default and maximum are 240 seconds |
+| `--timeout SECONDS` | Input timeout; default and maximum are 240 seconds, **minimum 35**. The minimum is not a taste: TapQ holds the microphone shut while it speaks, so a window has to outlast the longest prompt it might read *and* leave the wearer time to answer. Below it every approval and every selection of the run would be structurally unanswerable, which used to be accepted silently. The number is derived from the prompt lengths and the slower voice's speaking rate — see `SpokenPace` |
 | `--no-voice` | Do not request microphone/Speech access or start voice input |
 | `--speech-voice VOICE` | Voice used for spoken output: a language tag (`en-US`, `zh-CN`) or a macOS voice identifier. Default `en-US`; also settable with `TAPQ_SPEECH_VOICE`. Unrelated to `--no-voice`, which gates the microphone |
 | `--no-announcements` | Suppress non-blocking waiting and completion announcements |

--- a/docs/CODEX_ADAPTER_MANUAL_TEST_PLAN.md
+++ b/docs/CODEX_ADAPTER_MANUAL_TEST_PLAN.md
@@ -329,7 +329,7 @@ absolute path.
 In terminal 1, from the TapQ checkout:
 
 ```bash
-TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 30
+TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 60
 ```
 
 Expected readiness output includes:
@@ -721,7 +721,7 @@ printf '%s\n' "$CODEX_ADAPTER_USER_PROMPT" | "$CODEX_ADAPTER_HOOK"
 2. Stop that runtime and restart it with:
 
    ```bash
-   TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 30 --steering
+   TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 60 --steering
    ```
 
 3. Pipe the same payload to `"$CODEX_ADAPTER_HOOK"` again and format its stdout with
@@ -765,7 +765,7 @@ Restart TapQ with an isolated runtime directory and no cloud classifier:
 ```bash
 TAPQ_BROKER_DIR="$CODEX_ADAPTER_RUN_DIR/reasoner-runtime" \
 TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve \
-  --timeout 30 \
+  --timeout 60 \
   --reasoner apple \
   --reasoner-mode shadow \
   --question-classifier local

--- a/docs/CURSOR_ADAPTER_MANUAL_TEST_PLAN.md
+++ b/docs/CURSOR_ADAPTER_MANUAL_TEST_PLAN.md
@@ -317,7 +317,7 @@ finding.
 In terminal 1, from the TapQ checkout:
 
 ```bash
-TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 30
+TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 60
 ```
 
 Expected readiness output includes:

--- a/docs/OPENCODE_ADAPTER_MANUAL_TEST_PLAN.md
+++ b/docs/OPENCODE_ADAPTER_MANUAL_TEST_PLAN.md
@@ -311,7 +311,7 @@ moves later, reinstall and repeat this case because the stored hook path is abso
 In terminal 1, from the TapQ checkout:
 
 ```bash
-TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 30
+TAPQ_DEBUG=1 scripts/run-runtime-app.sh serve --timeout 60
 ```
 
 Expected readiness output includes:


### PR DESCRIPTION
Round 2 of the deadline-vs-playback sweep — the structural cure plus the floors. Stacks on #42. With this, every confirmed-broken sweep finding (F1–F5, F7–F10) is fixed; only F12 (the 2s attribution window, `--wearer-gate` only) stays deferred by maintainer call.

## The window clock starts at the drain edge (F3, absorbing F7 and F11)

Measured live: 12 of 40 eight-second windows opened with the microphone already held closed by TapQ's own draining audio. The window deadline is now anchored where the microphone can actually open — waiting out the same activity signal the speech gate closes the mic on (bounded at 15s), **plus** a pace estimate for audio the backend has accepted but not yet begun sounding (the signal alone reads quiet through that gap; a test proves the estimate is load-bearing). A window's closing sentence is recorded into a run-shared drain so the next window anchors past it, and the ~1s commit allowance (endpoint delay + detector hangover) rides the arbiter timeout.

F7 did **not** simply inherit — a mid-window answer still left the residual listen expiring ~6s before the mic opened — so residual listens now cover their own utterance's drain. And the old `min(windowSeconds, remaining)` cap is gone: against an anchored deadline it re-stole exactly what the anchor gave back. Eight seconds of open mic are now eight seconds; nothing got longer.

## Prompts that cannot be answered are not asked (F5 + F9)

The viability margin is derived, not hand-picked: each presenter declares its maximum prompt, each path its measured pace (with the same one-fifth margin round 1 documented), endpointing on top — approval 25.7s Apple / 16.7s realtime, selection 34.5s / 21.4s. Checked at entry **and before every mid-loop re-speak**, against the actual utterance (details are unbounded by any cap). Failure defers to the screen audibly; the unanswerable prompt is never spoken. `--timeout` below 35s is refused at parse time: *"a shorter window cannot finish reading the longest prompt and still leave time to answer it."*

## Notifications defer instead of stealing the window (F10)

"Claude Code finished." spoken into an open command window tore down recognition while the window's timer counted. Notifications now defer — via a presence *query*, not a window-closed edge that would fire in the microsecond gap between back-to-back windows — and replay FIFO at the next legal moment. Nothing vanishes silently: same-window duplicates, notices superseded by a fresh prompt, and 60s expiries each get a counting diagnostic; expiry can afford to drop because the memory record already ran, so "what changed?" still answers.

## Behavior changes to know at review

- Entry refusal below the floor is now **audible** ("Deferring to the screen.") where it was silent; a burst of simultaneously-aged requests will each say it — no dedupe on that sentence.
- A `detail` longer than the whole budget always routes `.details` to the screen.
- A window may hold the interaction gate up to 15s longer while waiting out a drain (mic is shut either way — bounded, deliberate).
- Docs/fixtures using `--timeout 20/25/30` were updated to legal values.
- `WindowClock.detectorHangover` mirrors `WearerSpeechConfig.hangoverSeconds` across a module boundary (pinned by a detection-side test); `SpokenTurnBudget` reads the one mirror.

## Verified

665 tests / 25 suites green via the slim check (22 new tests across three new suites, all on the round-1 drain-aware doubles), host build clean, boundary checks green in-container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
