### PR TITLE
One-call answers and a loop that says no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -597,6 +597,19 @@ All notable changes to TapQ will be recorded in this file. The project uses
 
 ### Fixed
 
+- **Asking about the work is one model call again.** Folding `ask_about_work` into the
+  deliberation loop had doubled its latency — one call to decide to read the transcript,
+  another to compose. The loop now looks the evidence up before its first call — the
+  transcript excerpts and TapQ's own memory both ride the opening turn — so the typical
+  answer costs one call at M1's speed while still combining both sources. The bounds
+  stay for a sharper second lookup when the first evidence isn't enough.
+- **TapQ says what it can't do instead of forwarding it.** "Start a new session in Claude
+  Code" was relayed verbatim as an instruction into the session already running — a
+  bewildering order in the wearer's name, surfacing minutes later as an approval they
+  never asked for. A goal beyond every composed tool's reach — session lifecycle,
+  applications, TapQ itself — now ends on a first-turn spoken refusal naming the limit
+  ("I can't start or stop agent sessions — I can only instruct ones already connected"),
+  recorded as refused, never as done.
 - **The command window's clock now starts when you can actually speak.** Measured live:
   12 of 40 eight-second windows opened with the microphone still held closed by TapQ's own
   draining audio, so the drain — plus the second of endpointing after your last word — came

--- a/Executables/tapq/AppleTapQRuntimeService.swift
+++ b/Executables/tapq/AppleTapQRuntimeService.swift
@@ -1699,7 +1699,9 @@ import Darwin
                                 "dropped": "\(found.droppedEntries)",
                             ]
                         ))
-                        return .ok(found.text)
+                        // The count rides along so the question lane's latency line can say
+                        // what it answered from without a second log line to correlate.
+                        return .ok(found.text, itemCount: found.matches.count)
                     },
                     // Pillar B retrieval. Excerpts, not an answer: the loop writes the
                     // answer itself, which is the whole of what folding `ask_about_work`
@@ -1726,9 +1728,12 @@ import Darwin
                                     "dropped_chars": "\(droppedCharacters)",
                                 ]
                             ))
-                            return .ok(TranscriptExcerpts.rendered(
-                                slices: slices, agentDisplayName: agent
-                            ))
+                            return .ok(
+                                TranscriptExcerpts.rendered(
+                                    slices: slices, agentDisplayName: agent
+                                ),
+                                itemCount: slices.count
+                            )
                         case let .unavailable(reason, notice):
                             // The other failure class, and it stays the other one: loud in
                             // the log, honest to the model, and the session lives. Only a

--- a/Sources/TapQContextBaseline/WearerTaskContract.swift
+++ b/Sources/TapQContextBaseline/WearerTaskContract.swift
@@ -16,12 +16,13 @@ public enum WearerTaskMode: String, Sendable, Equatable {
     case question
 }
 
-/// The seven internal tools, by wire name.
+/// The eight internal tools, by wire name.
 ///
-/// Exactly the seven the plan names, and the set is closed at both ends: the loop declares
-/// only these, and a call for anything else is a malformed turn rather than a tool that
-/// quietly did nothing. Nothing here is new authority — every one of them is a surface the
-/// runtime already exposes to the wearer, reached through a closure the composition wires.
+/// Seven the plan names plus ``cannotDo``, and the set is closed at both ends: the loop
+/// declares only these, and a call for anything else is a malformed turn rather than a tool
+/// that quietly did nothing. Nothing here is new authority — every one of them is a surface
+/// the runtime already exposes to the wearer, reached through a closure the composition
+/// wires, and the eighth is the absence of one.
 public enum WearerTaskToolName {
     public static let searchMemory = "search_memory"
     public static let readTranscript = "read_transcript"
@@ -30,6 +31,10 @@ public enum WearerTaskToolName {
     public static let speak = "speak"
     public static let askWearer = "ask_wearer"
     public static let finish = "finish"
+    /// The eighth, added 2026-08-30 after a live failure: a goal no tool here reaches must
+    /// have somewhere to go that is not `finish` pretending and not `queue_instruction`
+    /// forwarding. See ``WearerTaskDecision/cannotDo(spoken:)``.
+    public static let cannotDo = "cannot_do"
 }
 
 /// What the model asked for on one turn.
@@ -46,6 +51,16 @@ public enum WearerTaskDecision: Sendable, Equatable {
     case speak(String)
     case askWearer(question: String)
     case finish(summary: String)
+    /// The goal is beyond every tool here, and TapQ says so. An *ending*, like `finish`, and
+    /// deliberately not a flavor of it: the wearer hears a can't-do that names the limit, and
+    /// the record keeps ``WearerTaskOutcome/refused`` rather than "finished".
+    ///
+    /// It exists because of a live failure on 2026-08-30. The goal was "start a new session
+    /// in Claude Code" — which nothing composed here can do — and the loop, having no way to
+    /// say so, sent the sentence verbatim to the session that was *already* running, where it
+    /// surfaced minutes later as a bewildering approval request. A refusal that depends on
+    /// the model dressing itself up as a `finish` is a lucky refusal; this is a declared one.
+    case cannotDo(spoken: String)
 
     /// The wire name, for diagnostics and for the rendered history. Counts and names only —
     /// never the arguments.
@@ -58,6 +73,7 @@ public enum WearerTaskDecision: Sendable, Equatable {
         case .speak: return WearerTaskToolName.speak
         case .askWearer: return WearerTaskToolName.askWearer
         case .finish: return WearerTaskToolName.finish
+        case .cannotDo: return WearerTaskToolName.cannotDo
         }
     }
 }
@@ -85,28 +101,41 @@ public struct WearerTaskStep: Sendable, Equatable {
     }
 }
 
-/// One turn of the loop: the goal, what has happened, and how much room is left.
+/// One turn of the loop: the goal, what was looked up for it, what has happened, and how
+/// much room is left.
 public struct WearerTaskTurnRequest: Sendable, Equatable {
     public let goal: String
     public let mode: WearerTaskMode
     /// The agent the question named, when the wearer named one. `question` lane only;
     /// `nil` everywhere else.
     public let agentDisplayName: String?
+    /// Lookups the loop ran *before* the first model call, carried on every turn.
+    ///
+    /// The question lane's pre-fetch (`WearerTaskLoop.answerWorkQuestion`) and nothing else:
+    /// the transcript slices for the question and the memory search over it, both local
+    /// reads, both taken before the first turn with no model call spent — so the typical
+    /// question costs one call rather than two. Rendered apart from ``steps`` because they
+    /// are not steps — the model did not
+    /// choose them, and a model told it had already called a tool it never called is a model
+    /// that will not call it when it should.
+    public let evidence: [WearerTaskStep]
     public let steps: [WearerTaskStep]
     /// Tool calls left, this one included. Never zero — the loop stops rather than asking
-    /// for a turn it would not honor.
+    /// for a turn it would not honor. Counts *model* calls: the pre-fetch above costs none.
     public let stepsRemaining: Int
 
     public init(
         goal: String,
         mode: WearerTaskMode,
         agentDisplayName: String? = nil,
+        evidence: [WearerTaskStep] = [],
         steps: [WearerTaskStep],
         stepsRemaining: Int
     ) {
         self.goal = goal
         self.mode = mode
         self.agentDisplayName = agentDisplayName
+        self.evidence = evidence
         self.steps = steps
         self.stepsRemaining = stepsRemaining
     }
@@ -133,12 +162,15 @@ public enum WearerTaskContract {
     /// Written for a model that has the goal and its own tool results and nothing else. Each
     /// paragraph exists because of a specific way this can go wrong: talking the wearer
     /// through steps they did not ask to hear, inventing an agent to instruct, treating a
-    /// question as permission to act, and running out of steps without saying so.
+    /// question as permission to act, running out of steps without saying so, and — added
+    /// 2026-08-30 after the live failure ``WearerTaskDecision/cannotDo(spoken:)`` records —
+    /// forwarding a goal the loop could not act on to an agent that never asked for it.
     public static let taskInstructions = """
         You are TapQ, a hands-free assistant a person wears while coding agents work for \
         them. Their hands and eyes are busy and they cannot see a screen. They have handed \
-        you one goal out loud. You work on it by calling tools, one per turn, and you finish \
-        by calling finish.
+        you one goal out loud. You work on it by calling tools, one per turn. You end either \
+        by calling finish, or — when the goal needs something none of your tools can do — by \
+        calling cannot_do.
 
         Rules:
 
@@ -152,6 +184,15 @@ public enum WearerTaskContract {
         the answer or the outcome.
         - If you run out of turns without calling finish, the wearer hears that you could \
         not finish. Prefer finishing honestly one turn early over being cut off.
+        - Some goals are not work for an agent at all, and no tool of yours reaches them. \
+        You cannot start, stop, restart, or switch an agent's session; you cannot open or \
+        close an application, a window, or a file; and you cannot change TapQ itself — its \
+        settings, its wiring, or what it is able to do. Your reach is the agents already \
+        connected, TapQ's memory, and this conversation. When the goal needs anything \
+        outside that, call cannot_do on your first turn and name the limit plainly: "I \
+        can't start or stop agent sessions — I can only instruct ones already connected." \
+        Do not spend turns looking for a way round it, and do not finish as though you had \
+        done it.
         - Answer only from what your tools returned. Never infer what an agent probably did, \
         never fill a gap from general knowledge, never describe work you did not see.
         - Quote technical tokens exactly: file paths, command lines, flags, identifiers, \
@@ -165,6 +206,12 @@ public enum WearerTaskContract {
         name, never substitute an agent that happens to be live, and never send an \
         instruction the wearer's goal did not ask for. Queuing authorizes nothing: whatever \
         the agent then tries still asks the wearer for approval.
+        - queue_instruction is for work the target agent should do. It is never a way to \
+        relay a goal you could not act on yourself. Sending "start a new session in Claude \
+        Code" to the Claude Code session that is already running does not start anything — \
+        it drops a bewildering order into that agent's work in the wearer's name, and they \
+        find out when it asks them to approve something they never asked for. If you cannot \
+        do it, say so with cannot_do.
         - ask_wearer asks the wearer a yes-or-no question and waits for them. Use it only \
         when the goal genuinely cannot be carried out without their answer. If they do not \
         answer, the task ends.
@@ -173,26 +220,38 @@ public enum WearerTaskContract {
     /// The rules for the question lane.
     ///
     /// Deliberately the four rules ``WorkAnswerContract/instructions`` already ratified for
-    /// `ask_about_work`, restated for a model that fetches its own evidence. Preserving them
-    /// word-for-word in substance is what keeps the M1 answer the wearer hears the same
-    /// answer after the fold-in: only *where the slices come from* changed.
+    /// `ask_about_work`, restated for a model whose evidence is already in front of it.
+    /// Preserving them word-for-word in substance is what keeps the M1 answer the wearer
+    /// hears the same answer after the fold-in: only *where the slices come from* changed.
+    ///
+    /// The opening changed again on 2026-08-30. Measured live, every question cost two
+    /// sequential calls — one to fetch, one to answer — roughly doubling M1's latency for a
+    /// wearer standing there waiting. The loop now runs both lookups before the first turn
+    /// and hands them over, so the typical question is one call; the tools stay declared for
+    /// the case the pre-fetch did not cover.
     public static let questionInstructions = """
         You are the voice of TapQ, a hands-free assistant a person wears while a coding \
         agent works for them. Their hands and eyes are busy; they cannot see a screen. They \
-        have asked you one question out loud. You gather what you need with read_transcript \
-        (the agent's own session history) and search_memory (TapQ's record of its \
-        conversation with the wearer), then you call finish with the single answer TapQ will \
-        speak.
+        have asked you one question out loud, and TapQ has already looked up both of the \
+        places an answer could come from — the agent's own session history and TapQ's record \
+        of its conversation with the wearer — using their question. Both results are in \
+        front of you. Read them and call finish with the single answer TapQ will speak.
 
         Rules:
 
-        - Every turn is exactly one tool call, and you have very few turns. In most cases \
-        one lookup is enough; then finish.
+        - Answer from what is already in front of you. In almost every case that is enough: \
+        call finish on this first turn. The wearer is standing there waiting, and every \
+        further turn is another wait.
+        - Look something up yourself only when what you were given genuinely does not \
+        answer the question — read_transcript for a different agent's session, search_memory \
+        with sharper words than the wearer happened to use. Never repeat a lookup you were \
+        already handed the result of.
+        - Every turn is exactly one tool call, and you have very few turns.
         - Your finish summary is spoken aloud word for word, so write speech, not prose: no \
         markdown, no bullet points, no headings, no emoji, no stage directions.
-        - Answer only from what your tools returned. Never infer what the agent probably \
-        did, never fill a gap from general knowledge about the tools involved, and never \
-        describe work that is not in what you read.
+        - Answer only from what your tools returned and what was looked up for you. Never \
+        infer what the agent probably did, never fill a gap from general knowledge about the \
+        tools involved, and never describe work that is not in what you read.
         - If what you read does not answer the question, say so plainly and briefly — "that \
         isn't in what I can see of the session" — and stop. A short honest miss is worth \
         more to someone who cannot look at a screen than a confident guess.
@@ -235,6 +294,7 @@ public enum WearerTaskContract {
                 speakTool,
                 askWearerTool,
                 finishTool,
+                cannotDoTool,
             ]
         }
     }
@@ -254,8 +314,20 @@ public enum WearerTaskContract {
             }
             lines.append("The wearer asked: \(request.goal)")
         }
+        if !request.evidence.isEmpty {
+            lines.append("TapQ looked these up for you before your first turn, using the "
+                + "question itself:")
+            for item in request.evidence {
+                lines.append("--- \(item.tool)(\(item.arguments))")
+                lines.append(item.result)
+            }
+            lines.append("--- end of what was looked up")
+        }
         if request.steps.isEmpty {
-            lines.append("You have not called any tools yet.")
+            lines.append(request.evidence.isEmpty
+                ? "You have not called any tools yet."
+                : "You have not called any tools yourself yet — the lookups above were done "
+                    + "for you.")
         } else {
             lines.append("What you have done so far, oldest first:")
             for (offset, step) in request.steps.enumerated() {
@@ -333,6 +405,11 @@ public enum WearerTaskContract {
             let arguments: SummaryArguments = try decodeArguments(argumentsJSON, tool: name)
             return .finish(
                 summary: try required(arguments.summary, tool: name, field: "summary")
+            )
+        case WearerTaskToolName.cannotDo:
+            let arguments: SpokenArguments = try decodeArguments(argumentsJSON, tool: name)
+            return .cannotDo(
+                spoken: try required(arguments.spoken, tool: name, field: "spoken")
             )
         default:
             throw NarrationFailure.transport(
@@ -519,6 +596,26 @@ public enum WearerTaskContract {
         required: ["summary"]
     )
 
+    private static let cannotDoTool = function(
+        WearerTaskToolName.cannotDo,
+        """
+        End the task because it needs something none of your tools can do. The sentence is \
+        spoken to the wearer word for word and must name the limit: what TapQ cannot do and \
+        what it can. Use it for goals about TapQ itself, about starting, stopping, or \
+        switching an agent's session, or about anything outside the agents already \
+        connected. It is the honest ending for those — never queue_instruction, which would \
+        forward the goal to an agent that did not ask for it.
+        """,
+        properties: [
+            "spoken": [
+                "type": "string",
+                "description": "The exact words TapQ will speak: the limit, plainly, in one "
+                    + "or two sentences. Plain spoken text.",
+            ],
+        ],
+        required: ["spoken"]
+    )
+
     // MARK: - Argument shapes
 
     private struct QueryArguments: Decodable { let query: String? }
@@ -533,4 +630,5 @@ public enum WearerTaskContract {
     private struct TextArguments: Decodable { let text: String? }
     private struct QuestionArguments: Decodable { let question: String? }
     private struct SummaryArguments: Decodable { let summary: String? }
+    private struct SpokenArguments: Decodable { let spoken: String? }
 }

--- a/Sources/TapQContextBaseline/WearerTaskLoop.swift
+++ b/Sources/TapQContextBaseline/WearerTaskLoop.swift
@@ -3,12 +3,21 @@ import TapQContracts
 
 /// How one task ended, in the word the record keeps.
 ///
-/// Five, and every one of them is audible except the two that cannot be: a run whose voice
+/// Six, and every one of them is audible except the two that cannot be: a run whose voice
 /// pipe just broke has nothing left to speak with, and a run being shut down has nobody left
 /// to speak to. Everything else the wearer hears.
 public enum WearerTaskOutcome: String, Sendable, Equatable {
     /// The model called `finish`; its summary was spoken.
     case finished
+    /// The model called `cannot_do`: the goal needed something no composed tool reaches, and
+    /// TapQ said so out loud, naming the limit.
+    ///
+    /// Its own word rather than ``finished``, added 2026-08-30. A wearer asking tomorrow what
+    /// happened to a goal has to find out that TapQ *declined* it, not that it completed —
+    /// and an operator counting refusals is counting the goals TapQ is asked for and cannot
+    /// serve, which is the one number that says where the next tool belongs. ``couldNotFinish``
+    /// could not stand in either: that is a task that ran out of turns trying.
+    case refused
     /// The step cap was reached without a `finish`. TapQ said so out loud.
     case couldNotFinish = "could not finish"
     /// `ask_wearer` got no answer inside the question machinery's own deadline. TapQ said so
@@ -260,6 +269,18 @@ public enum WearerTaskOutcome: String, Sendable, Equatable {
                 surfaces.speak(summary)
                 return end(goal: goal, outcome: .finished, steps: step, started: started)
 
+            case .cannotDo(let spoken):
+                // An ending, and audible like every other ending that has someone to speak
+                // to. The sentence is the model's and is spoken verbatim: what TapQ cannot
+                // do is a fact about this composition, and a canned sentence here would
+                // either be wrong for most goals or so vague it told the wearer nothing.
+                diagnostics.record("task.refused", fields: [
+                    "n": "\(step)",
+                    "length": "\(spoken.count)",
+                ])
+                surfaces.speak(spoken)
+                return end(goal: goal, outcome: .refused, steps: step, started: started)
+
             case .askWearer(let question):
                 let answer = await surfaces.askWearer(question)
                 guard !Task.isCancelled else {
@@ -319,6 +340,20 @@ public enum WearerTaskOutcome: String, Sendable, Equatable {
     /// *handling* — spoken, error-logged, session alive — and the alternative, `failed`,
     /// would break the wearer's voice channel over a slow think, which the ratified
     /// two-class posture reserves for cloud calls that actually failed.
+    ///
+    /// ## One call, typically (2026-08-30)
+    ///
+    /// As first built the lane spent two sequential cloud calls on every question — one to
+    /// decide to read the transcript, one to write the answer from it — measured live at
+    /// ~1.1 s plus ~1.2–3.8 s, roughly double M1's single call, with the wearer standing
+    /// there. Both lookups are *local reads over the question itself*, so nothing was being
+    /// decided by the first call that the loop could not do without it. They now run before
+    /// the first turn and ride it as evidence (``WearerTaskTurnRequest/evidence``), and the
+    /// typical question is one call.
+    ///
+    /// It is not a cap. The bounds are unchanged, and a model whose pre-fetched evidence does
+    /// not answer the question may still spend a turn on `search_memory` with sharper words
+    /// or `read_transcript` for a different agent.
     public func answerWorkQuestion(
         question: String,
         agentDisplayName: String?
@@ -340,6 +375,19 @@ public enum WearerTaskOutcome: String, Sendable, Equatable {
         /// The last local problem a read reported, kept so a lane that runs out of room can
         /// say the true thing rather than the generic one.
         var lastLocalNotice: String?
+        /// Cloud calls actually spent. The number the fix exists to move, so it is on the
+        /// line an operator reads on hardware rather than inferred from `steps`.
+        var modelCalls = 0
+
+        let evidence = prefetchQuestionEvidence(question: question, agent: agentDisplayName)
+        // The transcript's sentence, and only the transcript's. A history that cannot be read
+        // is what `ask_about_work` is *about* being unable to answer, so it is the honest
+        // thing to say if nothing better gets said; a memory file that will not open still
+        // leaves the agent's session to answer from, and speaking about TapQ's own record
+        // would answer a question the wearer did not ask.
+        if let notice = evidence.transcriptNotice {
+            lastLocalNotice = notice
+        }
 
         for step in 1...questionCap {
             if step > 1, started.seconds(elapsedTo: .now) >= wallClock {
@@ -355,13 +403,17 @@ public enum WearerTaskOutcome: String, Sendable, Equatable {
                     goal: question,
                     mode: .question,
                     agentDisplayName: agentDisplayName,
+                    evidence: evidence.steps,
                     steps: steps,
                     stepsRemaining: questionCap - step + 1
                 ))
+                modelCalls += 1
             } catch {
+                modelCalls += 1
                 let reason = (error as? NarrationFailure)?.reason ?? "unknown"
                 diagnostics.record("task.question_failed", level: .error, fields: [
                     "n": "\(step)",
+                    "model_calls": "\(modelCalls)",
                     "reason": reason,
                 ])
                 // Deliberately not `onLoopBroken`: the provider breaks on a `failed`
@@ -376,7 +428,14 @@ public enum WearerTaskOutcome: String, Sendable, Equatable {
             ])
 
             if case .finish(let summary) = decision {
+                // The lane's latency line. `model_calls` is the measurement the pre-fetch
+                // exists to move and `slices` is what it had to answer from; counts and
+                // lengths only, as everywhere on this path.
                 diagnostics.record("task.question_answered", fields: [
+                    "latency_ms": Self.milliseconds(from: started),
+                    "model_calls": "\(modelCalls)",
+                    "slices": evidence.slices.map(String.init) ?? "none",
+                    "memories": evidence.memories.map(String.init) ?? "none",
                     "steps": "\(step)",
                     "length": "\(summary.count)",
                 ])
@@ -395,9 +454,83 @@ public enum WearerTaskOutcome: String, Sendable, Equatable {
         let notice = lastLocalNotice ?? Self.couldNotAnswerNotice
         diagnostics.record("task.question_unavailable", level: .error, fields: [
             "reason": lastLocalNotice == nil ? "no_finish" : "local",
+            "latency_ms": Self.milliseconds(from: started),
+            "model_calls": "\(modelCalls)",
             "steps": "\(steps.count)",
         ])
         return .unavailable(notice)
+    }
+
+    // MARK: - The question lane's pre-fetch
+
+    /// Both lookups an `ask_about_work` answer can draw on, run over the question itself
+    /// before the lane's first model call.
+    ///
+    /// Through the same two surfaces the model would have called — not a second path to the
+    /// same files. That is the whole of why this is safe to do ahead of the model: whatever
+    /// `read_transcript` and `search_memory` would have returned for the wearer's own words
+    /// is exactly what is fetched, including the failures, so the lane cannot drift from the
+    /// tools it still declares.
+    private struct QuestionEvidence {
+        /// What rides the first turn.
+        var steps: [WearerTaskStep] = []
+        /// Excerpt and entry counts, when the surface reported them. Diagnostics only.
+        var slices: Int?
+        var memories: Int?
+        /// The transcript's spoken sentence, when the history could not be read.
+        var transcriptNotice: String?
+    }
+
+    private func prefetchQuestionEvidence(
+        question: String,
+        agent: String?
+    ) -> QuestionEvidence {
+        var evidence = QuestionEvidence()
+
+        let transcript = surfaces.readTranscript(agent, question)
+        evidence.slices = transcript.itemCount
+        evidence.steps.append(WearerTaskStep(
+            tool: WearerTaskToolName.readTranscript,
+            arguments: agent.map { "\($0), \(question)" } ?? question,
+            result: transcript.text
+        ))
+        if let failure = transcript.localFailure {
+            // The two-class split, held at the pre-fetch exactly as it is held mid-lane: a
+            // local file that will not open is loud in the log, honest to the model, and
+            // survivable. The model is told in `text` and usually says something better than
+            // the carried sentence; the sentence is what gets spoken if it does not.
+            diagnostics.record("task.prefetch_unavailable", level: .error, fields: [
+                "tool": WearerTaskToolName.readTranscript,
+                "reason": failure.reason,
+            ])
+            evidence.transcriptNotice = failure.wearerNotice
+        }
+
+        let memory = surfaces.searchMemory(question)
+        evidence.memories = memory.itemCount
+        evidence.steps.append(WearerTaskStep(
+            tool: WearerTaskToolName.searchMemory,
+            arguments: question,
+            result: memory.text
+        ))
+        if let failure = memory.localFailure {
+            // Loud, and then carry on with what there is. No carried sentence: the agent's
+            // history is still in hand, and "I can't read my own memory" is not an answer to
+            // a question about the agent's work.
+            diagnostics.record("task.prefetch_unavailable", level: .error, fields: [
+                "tool": WearerTaskToolName.searchMemory,
+                "reason": failure.reason,
+            ])
+        }
+
+        diagnostics.record("task.question_prefetched", fields: [
+            "slices": evidence.slices.map(String.init) ?? "none",
+            "memories": evidence.memories.map(String.init) ?? "none",
+            "chars": "\(transcript.text.count + memory.text.count)",
+            "transcript_ok": "\(transcript.localFailure == nil)",
+            "memory_ok": "\(memory.localFailure == nil)",
+        ])
+        return evidence
     }
 
     // MARK: - Tool execution
@@ -430,8 +563,8 @@ public enum WearerTaskOutcome: String, Sendable, Equatable {
         case .queueInstruction(let agent, let text):
             arguments = agent.map { "\($0), \(text)" } ?? text
             output = surfaces.queueInstruction(agent, text)
-        case .speak, .askWearer, .finish:
-            // Unreachable: the three are handled by the task lane's own switch and are
+        case .speak, .askWearer, .finish, .cannotDo:
+            // Unreachable: the four are handled by the task lane's own switch and are
             // undeclared in the question lane. Rendered rather than trapped, because a trap
             // inside a voice path is the one failure with no diagnostic at all.
             arguments = ""

--- a/Sources/TapQContextBaseline/WearerTaskSurfaces.swift
+++ b/Sources/TapQContextBaseline/WearerTaskSurfaces.swift
@@ -43,20 +43,30 @@ public struct WearerTaskToolOutput: Sendable, Equatable {
     public let announce: String?
     /// Set when a local file could not be read.
     public let localFailure: WearerTaskLocalFailure?
+    /// How many things the tool found — transcript excerpts, memory entries — or `nil` when
+    /// the tool does not count in items.
+    ///
+    /// Diagnostics only, and it is a count for the same reason every other field on that
+    /// line is: the question lane's latency line has to be readable on hardware, and
+    /// "answered in one call from four excerpts" is the whole measurement. The number never
+    /// reaches the model — it reads ``text``, which already says how many excerpts it has.
+    public let itemCount: Int?
 
     public init(
         text: String,
         announce: String? = nil,
-        localFailure: WearerTaskLocalFailure? = nil
+        localFailure: WearerTaskLocalFailure? = nil,
+        itemCount: Int? = nil
     ) {
         self.text = text
         self.announce = announce
         self.localFailure = localFailure
+        self.itemCount = itemCount
     }
 
     /// A tool that worked.
-    public static func ok(_ text: String) -> WearerTaskToolOutput {
-        .init(text: text)
+    public static func ok(_ text: String, itemCount: Int? = nil) -> WearerTaskToolOutput {
+        .init(text: text, itemCount: itemCount)
     }
 
     /// A tool that worked and did something the wearer must hear about.

--- a/Tests/TapQContextBaselineTests/OpenAITaskTurnTests.swift
+++ b/Tests/TapQContextBaselineTests/OpenAITaskTurnTests.swift
@@ -45,7 +45,7 @@ final class OpenAITaskTurnTests: XCTestCase {
             let tools = try XCTUnwrap(json["tools"] as? [[String: Any]])
             XCTAssertEqual(tools.compactMap { $0["name"] as? String }, [
                 "search_memory", "read_transcript", "get_status", "queue_instruction",
-                "speak", "ask_wearer", "finish",
+                "speak", "ask_wearer", "finish", "cannot_do",
             ])
             let input = try XCTUnwrap(json["input"] as? String)
             XCTAssertTrue(input.contains("check whether the tests passed"), input)

--- a/Tests/TapQContextBaselineTests/WearerTaskContractTests.swift
+++ b/Tests/TapQContextBaselineTests/WearerTaskContractTests.swift
@@ -9,11 +9,13 @@ import TapQContracts
 /// most of this suite is about what is refused.
 @MainActor
 final class WearerTaskContractTests: XCTestCase {
-    func testTheTaskLaneDeclaresExactlyTheSevenToolsThePlanNames() async {
+    func testTheTaskLaneDeclaresTheSevenToolsThePlanNamesPlusTheRefusal() async {
         let names = WearerTaskContract.tools(for: .task).compactMap { $0["name"] as? String }
+        // The plan's seven, and `cannot_do` — the eighth, added 2026-08-30 so a goal beyond
+        // every one of the other seven has an ending of its own.
         XCTAssertEqual(names, [
             "search_memory", "read_transcript", "get_status", "queue_instruction",
-            "speak", "ask_wearer", "finish",
+            "speak", "ask_wearer", "finish", "cannot_do",
         ])
         // The Responses API's flat function shape, not the nested chat-completions one.
         for tool in WearerTaskContract.tools(for: .task) {
@@ -61,6 +63,31 @@ final class WearerTaskContractTests: XCTestCase {
             ),
             .finish(summary: "All green.")
         )
+        XCTAssertEqual(
+            try WearerTaskContract.decode(
+                name: "cannot_do",
+                argumentsJSON: #"{"spoken":"I can't start agent sessions."}"#,
+                mode: .task
+            ),
+            .cannotDo(spoken: "I can't start agent sessions.")
+        )
+    }
+
+    /// The refusal is a *task* ending. The question lane keeps its three read-only tools and
+    /// its own honest-miss rule, so `cannot_do` is undeclared there and a call for it is the
+    /// protocol failure any other undeclared tool would be.
+    func testTheRefusalIsATaskEndingAndTheQuestionLaneDoesNotDeclareIt() async {
+        let names = WearerTaskContract.tools(for: .question)
+            .compactMap { $0["name"] as? String }
+        XCTAssertFalse(names.contains("cannot_do"), "\(names)")
+        XCTAssertThrowsError(try WearerTaskContract.decode(
+            name: "cannot_do", argumentsJSON: #"{"spoken":"x"}"#, mode: .question
+        ))
+        // And an empty sentence is a turn spent saying nothing, like every other required
+        // argument on this path.
+        XCTAssertThrowsError(try WearerTaskContract.decode(
+            name: "cannot_do", argumentsJSON: #"{"spoken":"  "}"#, mode: .task
+        ))
     }
 
     func testAnOmittedAgentIsNilRatherThanAnEmptyName() async throws {
@@ -151,6 +178,74 @@ final class WearerTaskContractTests: XCTestCase {
         XCTAssertTrue(rules.contains("Quote technical tokens exactly"), rules)
         XCTAssertTrue(rules.contains("looks like a credential"), rules)
         XCTAssertTrue(rules.contains("spoken aloud word for word"), rules)
+    }
+
+    /// The prompt half of the 2026-08-30 latency fix. The bounds still allow a second turn,
+    /// so what makes one call the *typical* path is this guidance — pin it.
+    func testTheQuestionLaneIsToldItsEvidenceIsAlreadyInHandAndToFinishOnTurnOne() async {
+        let rules = WearerTaskContract.questionInstructions
+        XCTAssertTrue(rules.contains("TapQ has already looked up"), rules)
+        XCTAssertTrue(rules.contains("call finish on this first turn"), rules)
+        // Still permitted, and named, so a lane whose pre-fetch missed does not guess.
+        XCTAssertTrue(rules.contains("Look something up yourself only when"), rules)
+        XCTAssertTrue(rules.contains("Never repeat a lookup you were already handed"), rules)
+    }
+
+    func testAQuestionTurnCarriesThePreFetchedEvidenceApartFromTheSteps() async {
+        let input = WearerTaskContract.input(for: WearerTaskTurnRequest(
+            goal: "what did the tests say?",
+            mode: .question,
+            agentDisplayName: "Claude Code",
+            evidence: [
+                WearerTaskStep(tool: "read_transcript", arguments: "Claude Code, what did "
+                    + "the tests say?", result: "Session history: 385 tests."),
+                WearerTaskStep(tool: "search_memory", arguments: "what did the tests say?",
+                               result: "Nothing in TapQ's memory matches that."),
+            ],
+            steps: [],
+            stepsRemaining: 3
+        ))
+        XCTAssertTrue(input.contains("TapQ looked these up for you before your first turn"),
+                      input)
+        XCTAssertTrue(input.contains("--- read_transcript(Claude Code, what did the tests "
+            + "say?)"), input)
+        XCTAssertTrue(input.contains("Session history: 385 tests."), input)
+        XCTAssertTrue(input.contains("--- search_memory(what did the tests say?)"), input)
+        XCTAssertTrue(input.contains("--- end of what was looked up"), input)
+        // Not rendered as steps the model took: it did not take them, and a model told it
+        // already called a tool will not call it when it should.
+        XCTAssertFalse(input.contains("What you have done so far"), input)
+        XCTAssertTrue(input.contains("You have not called any tools yourself yet"), input)
+    }
+
+    /// The prompt half of the 2026-08-30 refusal fix. A live goal — "start a new session in
+    /// Claude Code" — was forwarded verbatim into the session that was already running,
+    /// because nothing in the instructions said that goals like it have an ending of their
+    /// own. Pin what now does.
+    func testTheTaskLaneIsToldToRefuseWhatNoToolReachesRatherThanForwardIt() async {
+        let rules = WearerTaskContract.taskInstructions
+        XCTAssertTrue(rules.contains("You cannot start, stop, restart, or switch an agent's "
+            + "session"), rules)
+        XCTAssertTrue(rules.contains("you cannot change TapQ itself"), rules)
+        XCTAssertTrue(rules.contains("call cannot_do on your first turn and name the limit"),
+                      rules)
+        // The spoken exemplar, in the repo's spoken-copy voice: what it cannot do, and what
+        // it can, in one sentence.
+        XCTAssertTrue(rules.contains("I can't start or stop agent sessions — I can only "
+            + "instruct ones already connected."), rules)
+        // And the specific misuse that produced the failure.
+        XCTAssertTrue(rules.contains("queue_instruction is for work the target agent should "
+            + "do"), rules)
+        XCTAssertTrue(rules.contains("never a way to relay a goal you could not act on "
+            + "yourself"), rules)
+        XCTAssertTrue(rules.contains("If you cannot do it, say so with cannot_do."), rules)
+        // The tool's own description carries the same line, for a model that reads tools
+        // more carefully than prose.
+        let cannotDo = WearerTaskContract.tools(for: .task)
+            .first { $0["name"] as? String == "cannot_do" }
+        let description = try? XCTUnwrap(cannotDo?["description"] as? String)
+        XCTAssertEqual(description?.contains("never queue_instruction"), true,
+                       description ?? "no cannot_do description")
     }
 
     func testExcerptsRenderLikeTheAnswerPromptsHistoryBlock() async {

--- a/Tests/TapQContextBaselineTests/WearerTaskLoopTests.swift
+++ b/Tests/TapQContextBaselineTests/WearerTaskLoopTests.swift
@@ -394,4 +394,71 @@ final class WearerTaskLoopTests: XCTestCase {
             "Codex is on it.",
         ])
     }
+
+    // MARK: - cannot_do
+
+    /// The 2026-08-30 failure, in the shape it must now take.
+    ///
+    /// Live, the wearer's goal was "start a new session in Claude Code". Nothing composed
+    /// here can start a session, and the loop — with no ending for that — queued the goal
+    /// verbatim into the Claude Code session that was *already* running, where it surfaced
+    /// minutes later as an approval request the wearer could make no sense of. The ending is
+    /// now first-class: the limit is named out loud, the record says `refused`, and nothing
+    /// is sent to anybody.
+    func testAGoalNoToolReachesEndsInASpokenCantDoAndQueuesNothing() async {
+        let surfaces = RecordingTaskSurfaces()
+        let sink = TaskDiagnosticSink()
+        let refusal = "I can't start or stop agent sessions — I can only instruct ones "
+            + "already connected."
+        let (loop, reasoner) = makeLoop([
+            .decide(.cannotDo(spoken: refusal)),
+        ], surfaces: surfaces, sink: sink)
+
+        let start = loop.begin(goal: "start a new session in Claude Code")
+        XCTAssertEqual(start, .accepted(
+            spoken: "On it — start a new session in Claude Code"
+        ))
+        await awaitIdle(loop)
+
+        // Spoken verbatim, naming the limit — the model's sentence, not a canned one.
+        XCTAssertEqual(surfaces.spoken, [refusal])
+        // And the sentence went nowhere else. This is the whole of the fix.
+        XCTAssertTrue(surfaces.queued.isEmpty, "\(surfaces.queued)")
+        XCTAssertTrue(surfaces.asked.isEmpty, "\(surfaces.asked)")
+
+        // The record says refused, not finished: a wearer asking tomorrow has to find out
+        // that TapQ declined the goal, not that it completed it.
+        XCTAssertEqual(surfaces.recorded.map(\.outcome), ["started", "refused"])
+        XCTAssertEqual(sink.first("task.finished")?.fields["outcome"], "refused")
+        XCTAssertEqual(sink.first("task.refused")?.fields["n"], "1")
+        XCTAssertEqual(reasoner.requests.count, 1, "a refusal costs one turn, not six")
+        // Counts and lengths only: the refusal sentence never reaches the log.
+        for event in sink.events where event.category == "WearerTask" {
+            for value in event.fields.values {
+                XCTAssertFalse(value.contains("agent sessions"), "\(event.name) leaked speech")
+            }
+        }
+    }
+
+    /// A refusal is an ending wherever it lands, not only on turn one — the model may look
+    /// first and discover there is no tool for the goal.
+    func testARefusalAfterALookupStillEndsTheTaskThere() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.statusAnswer = .ok("No agent can be addressed by name right now.")
+        let (loop, reasoner) = makeLoop([
+            .decide(.getStatus),
+            .decide(.cannotDo(spoken: "There's no agent connected for me to tell, and I "
+                + "can't start one.")),
+            .decide(.finish(summary: "unreachable")),
+        ], surfaces: surfaces)
+
+        _ = loop.begin(goal: "tell Codex to rerun the suite")
+        await awaitIdle(loop)
+
+        XCTAssertEqual(surfaces.spoken, [
+            "There's no agent connected for me to tell, and I can't start one.",
+        ])
+        XCTAssertEqual(reasoner.requests.count, 2, "the refusal ends the task where it lands")
+        XCTAssertEqual(surfaces.recorded.map(\.outcome), ["started", "refused"])
+    }
 }

--- a/Tests/TapQContextBaselineTests/WearerTaskQuestionLaneTests.swift
+++ b/Tests/TapQContextBaselineTests/WearerTaskQuestionLaneTests.swift
@@ -34,14 +34,19 @@ final class WearerTaskQuestionLaneTests: XCTestCase {
 
     // MARK: - Answered
 
-    func testAnAnswerCombinesTheTranscriptWithTapQsOwnMemory() async {
+    /// The typical ask, and the whole of the 2026-08-30 fix: both lookups are already in the
+    /// model's hands on its first turn, so the answer costs ONE cloud call rather than the
+    /// two it was measured at live (~1.1 s to decide to read, then ~1.2–3.8 s to answer).
+    func testAnAnswerCombinesTheTranscriptWithTapQsOwnMemoryInOneModelCall() async {
         let surfaces = RecordingTaskSurfaces()
-        surfaces.transcriptAnswer = .ok("Session history: 3 tests failed in VoiceSuite.")
-        surfaces.memoryAnswer = .ok("The wearer asked TapQ to watch VoiceSuite.")
+        surfaces.transcriptAnswer = .ok(
+            "Session history: 3 tests failed in VoiceSuite.", itemCount: 4
+        )
+        surfaces.memoryAnswer = .ok(
+            "The wearer asked TapQ to watch VoiceSuite.", itemCount: 2
+        )
         let sink = TaskDiagnosticSink()
         let (loop, reasoner) = makeLoop([
-            .decide(.readTranscript(agent: "Claude Code", query: "tests")),
-            .decide(.searchMemory(query: "VoiceSuite")),
             .decide(.finish(summary: "Three failed in VoiceSuite — the suite you asked me "
                 + "to watch.")),
         ], surfaces: surfaces, sink: sink)
@@ -53,17 +58,70 @@ final class WearerTaskQuestionLaneTests: XCTestCase {
         XCTAssertEqual(outcome, .answered(
             "Three failed in VoiceSuite — the suite you asked me to watch."
         ))
-        XCTAssertEqual(surfaces.transcriptQueries.map(\.query), ["tests"])
-        XCTAssertEqual(surfaces.memoryQueries, ["VoiceSuite"])
+        XCTAssertEqual(reasoner.requests.count, 1, "the typical question is one cloud call")
+
+        // Both lookups ran, before the model, over the wearer's own question — and through
+        // the same two surfaces the model would have called, so nothing can drift.
+        XCTAssertEqual(surfaces.transcriptQueries.map(\.agent), ["Claude Code"])
+        XCTAssertEqual(surfaces.transcriptQueries.map(\.query), ["what did the tests say?"])
+        XCTAssertEqual(surfaces.memoryQueries, ["what did the tests say?"])
+
+        // And both rode the first turn, where the model could read them.
+        let first = try? XCTUnwrap(reasoner.requests.first)
+        XCTAssertEqual(first?.evidence.map(\.tool), ["read_transcript", "search_memory"])
+        let input = WearerTaskContract.input(for: reasoner.requests[0])
+        XCTAssertTrue(input.contains("looked these up for you before your first turn"), input)
+        XCTAssertTrue(input.contains("Session history: 3 tests failed in VoiceSuite."), input)
+        XCTAssertTrue(input.contains("The wearer asked TapQ to watch VoiceSuite."), input)
+        // Evidence is not history: a model told it had already called a tool it never called
+        // is a model that will not call it when it should.
+        XCTAssertTrue(input.contains("You have not called any tools yourself yet"), input)
+
         // The lane never speaks: the provider speaks the answer, exactly as it did in M1.
         XCTAssertTrue(surfaces.spoken.isEmpty, "\(surfaces.spoken)")
         // The named agent reaches the model in the prompt, as it did through
         // `WorkAnswerContract.input`.
-        XCTAssertEqual(reasoner.requests.first?.agentDisplayName, "Claude Code")
-        XCTAssertTrue(
-            WearerTaskContract.input(for: reasoner.requests[0]).contains("Agent: Claude Code")
+        XCTAssertEqual(first?.agentDisplayName, "Claude Code")
+        XCTAssertTrue(input.contains("Agent: Claude Code"), input)
+
+        // The latency line, which is how the improvement is read on hardware.
+        let answered = sink.first("task.question_answered")
+        XCTAssertEqual(answered?.fields["model_calls"], "1")
+        XCTAssertEqual(answered?.fields["slices"], "4")
+        XCTAssertEqual(answered?.fields["memories"], "2")
+        XCTAssertEqual(answered?.fields["steps"], "1")
+        XCTAssertNotNil(answered?.fields["latency_ms"])
+    }
+
+    /// One call is the typical path, not a cap. Pre-fetched evidence that does not answer the
+    /// question leaves the lane's bounds exactly where they were.
+    func testEvidenceThatDoesNotAnswerStillBuysAnotherLookupWithinTheBounds() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.transcriptAnswer = .ok("Session history: nothing about the migration.")
+        surfaces.memoryAnswer = .ok(WearerMemorySearch.noMatchesText)
+        let sink = TaskDiagnosticSink()
+        let (loop, reasoner) = makeLoop([
+            // The pre-fetch used the wearer's words; the model tries sharper ones.
+            .decide(.searchMemory(query: "schema migration Codex")),
+            .decide(.finish(summary: "You told Codex to run the schema migration on Tuesday.")),
+        ], surfaces: surfaces, sink: sink)
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "what did I say about the migration?", agentDisplayName: nil
         )
-        XCTAssertEqual(sink.first("task.question_answered")?.fields["steps"], "3")
+
+        XCTAssertEqual(outcome, .answered(
+            "You told Codex to run the schema migration on Tuesday."
+        ))
+        XCTAssertEqual(reasoner.requests.count, 2)
+        // The wearer's words first, from the pre-fetch; then the model's sharper ones.
+        XCTAssertEqual(surfaces.memoryQueries,
+                       ["what did I say about the migration?", "schema migration Codex"])
+        // The second turn carries both the evidence and the step the model chose, apart.
+        let second = reasoner.requests[1]
+        XCTAssertEqual(second.evidence.count, 2)
+        XCTAssertEqual(second.steps.map(\.tool), ["search_memory"])
+        XCTAssertEqual(sink.first("task.question_answered")?.fields["model_calls"], "2")
     }
 
     func testTheQuestionLaneDeclaresOnlyItsThreeReadOnlyTools() async throws {
@@ -93,7 +151,96 @@ final class WearerTaskQuestionLaneTests: XCTestCase {
         XCTAssertEqual(sink.first("task.question_unavailable")?.level, .error)
     }
 
-    // MARK: - The two failure classes stay apart
+    // MARK: - The two failure classes stay apart, at the pre-fetch too
+
+    /// The pre-fetch is a local read, so a history that will not open there is the same class
+    /// it is mid-lane: loud in the log, honest to the model, spoken, and the session lives.
+    func testAnUnreadableTranscriptAtPreFetchIsSpokenHonestyNotABreak() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.transcriptAnswer = .localFailure(
+            "unreadable",
+            tellingModel: "TapQ cannot read that session's history, so there are no "
+                + "excerpts. Say so plainly rather than guessing what it contained.",
+            saying: TranscriptQuestionAnswerer.unreadableNotice
+        )
+        let sink = TaskDiagnosticSink()
+        var broken: [String] = []
+        // The model looks elsewhere and never finishes, which is the worst case: the sentence
+        // the wearer hears is the one the pre-fetch carried, not the generic one.
+        let (loop, reasoner) = makeLoop([
+            .decide(.searchMemory(query: "tests")),
+            .decide(.searchMemory(query: "tests again")),
+            .decide(.searchMemory(query: "tests once more")),
+        ], surfaces: surfaces, sink: sink)
+        loop.onLoopBroken = { broken.append($0) }
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "what did the tests say?", agentDisplayName: nil
+        )
+
+        XCTAssertEqual(outcome, .unavailable(TranscriptQuestionAnswerer.unreadableNotice))
+        XCTAssertTrue(broken.isEmpty, "an unreadable file must never break the voice")
+        let prefetchFailures = sink.all("task.prefetch_unavailable")
+        XCTAssertEqual(prefetchFailures.map { $0.fields["tool"] }, ["read_transcript"])
+        XCTAssertEqual(prefetchFailures.first?.level, .error)
+        // Told plainly on the first turn, so it could have been honest in its own words.
+        XCTAssertTrue(
+            WearerTaskContract.input(for: reasoner.requests[0])
+                .contains("Say so plainly rather than guessing"),
+            WearerTaskContract.input(for: reasoner.requests[0])
+        )
+    }
+
+    /// A memory store that will not open is loud and survivable, and the lane answers from
+    /// the agent's history it does have.
+    func testAMemoryFailureAtPreFetchIsLoudAndTheLaneAnswersAnyway() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.transcriptAnswer = .ok("Session history: 385 tests passed.", itemCount: 3)
+        surfaces.memoryAnswer = .localFailure(
+            "memory unreadable",
+            tellingModel: "TapQ cannot read its own record of this conversation.",
+            saying: "I can't read my own notes right now."
+        )
+        let sink = TaskDiagnosticSink()
+        var broken: [String] = []
+        let (loop, reasoner) = makeLoop([
+            .decide(.finish(summary: "All 385 passed.")),
+        ], surfaces: surfaces, sink: sink)
+        loop.onLoopBroken = { broken.append($0) }
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "did the tests pass?", agentDisplayName: nil
+        )
+
+        XCTAssertEqual(outcome, .answered("All 385 passed."))
+        XCTAssertEqual(reasoner.requests.count, 1, "one half failing does not cost a call")
+        XCTAssertTrue(broken.isEmpty)
+        let failure = sink.first("task.prefetch_unavailable")
+        XCTAssertEqual(failure?.fields["tool"], "search_memory")
+        XCTAssertEqual(failure?.level, .error)
+        XCTAssertEqual(sink.first("task.question_prefetched")?.fields["memory_ok"], "false")
+        XCTAssertEqual(sink.first("task.question_prefetched")?.fields["transcript_ok"], "true")
+    }
+
+    /// And a memory failure never becomes the spoken sentence: the wearer asked about the
+    /// agent's work, and "I can't read my own notes" answers a question they did not ask.
+    func testAMemoryFailureDoesNotBecomeTheSentenceTheWearerHears() async {
+        let surfaces = RecordingTaskSurfaces()
+        surfaces.memoryAnswer = .localFailure(
+            "memory unreadable",
+            tellingModel: "TapQ cannot read its own record of this conversation.",
+            saying: "I can't read my own notes right now."
+        )
+        let (loop, _) = makeLoop([
+            .decide(.readTranscript(agent: nil, query: "tests")),
+        ], surfaces: surfaces, questionStepCap: 1)
+
+        let outcome = await loop.answerWorkQuestion(
+            question: "did the tests pass?", agentDisplayName: nil
+        )
+
+        XCTAssertEqual(outcome, .unavailable(WearerTaskLoop.couldNotAnswerNotice))
+    }
 
     func testAnUnreadableTranscriptIsSpokenAndTheSessionLives() async {
         let surfaces = RecordingTaskSurfaces()

--- a/docs/TAPQ_AGENT_PLAN.md
+++ b/docs/TAPQ_AGENT_PLAN.md
@@ -190,9 +190,29 @@ and lands with it.
 - **The question lane costs one bound, and it is the M1 hold.** M1 answered in
   one model call under a 15 s timeout. The lane takes at most 3 calls and stops
   asking for another past a 20 s wall clock, so the peer's hold is ~35 s worst
-  case against a typical two calls. The rejected alternative was answering the
-  peer immediately and speaking later, which would leave the realtime model free
-  to talk over TapQ's own answer. **Maintainer call wanted** if 35 s is too long.
+  case. The rejected alternative was answering the peer immediately and speaking
+  later, which would leave the realtime model free to talk over TapQ's own answer.
+  **Maintainer call wanted** if 35 s is too long.
+- **The evidence is pre-fetched, so the typical question is one model call again
+  (2026-08-30).** Measured live, every `ask_about_work` cost two sequential
+  `gpt-5.6-luna` calls — ~1.1 s to decide to read the transcript, then ~1.2–3.8 s
+  to write the answer — roughly double M1's single call, with the wearer standing
+  there. Both lookups are *local reads over the question itself*, so the first
+  call was deciding nothing the loop could not do without it. The lane now runs
+  `read_transcript` (the question, the named agent) and `search_memory` (the
+  question) through the same two surfaces the model would have called, before the
+  first turn, and hands both to it as `WearerTaskTurnRequest.evidence` — rendered
+  apart from the step history, because a model told it already called a tool it
+  never called will not call it when it should. This is not a new cap: the 3-step
+  and 20 s bounds are untouched, and a model whose pre-fetched evidence does not
+  answer may still spend a turn on a sharper `search_memory` or a different
+  agent's transcript. Pre-fetch failures keep the two classes apart exactly as
+  mid-lane failures do — an unreadable history is loud, honest to the model,
+  spoken, and survivable; a memory read that fails is loud and the lane answers
+  from the transcript anyway, and never speaks about TapQ's own record in place of
+  an answer about the agent's work. `task.question_answered` now carries
+  `latency_ms`, `model_calls`, `slices`, and `memories` so the improvement is
+  readable on hardware.
 - **The question lane keeps M1's wearer-facing behavior and widens one case.**
   `answered` / `unavailable` / `failed` still mean what they meant, the answer is
   still the model's words spoken verbatim, and the two failure classes are still
@@ -233,8 +253,27 @@ and lands with it.
   then address, and it runs the stage-2 assessment and the delegation filter —
   which could auto-answer TapQ's own question without the wearer. The durable
   record is written at the loop's call site instead.
+- **A goal no tool reaches is refused out loud, not forwarded (2026-08-30).**
+  Live, the wearer's goal was "start a new session in Claude Code". Nothing
+  composed here can start a session — that is rung F / M4 — and the loop, having
+  no ending for it, queued the goal *verbatim* into the Claude Code session that
+  was already running, where it combined with unrelated context and surfaced
+  minutes later as an approval request the wearer could make no sense of. The fix
+  is an eighth tool, `cannot_do(spoken)`, and the prompt that steers to it: goals
+  about TapQ itself, about starting/stopping/switching agent sessions, or
+  otherwise outside the agents already connected end with a spoken can't-do that
+  names the limit ("I can't start or stop agent sessions — I can only instruct
+  ones already connected"), and `queue_instruction` is stated to be for work the
+  *target agent* should do, never a way to relay a goal the loop could not act on.
+  No keyword matching: the model decides, per the 2026-08-28 no-heuristics ruling,
+  and the instruction text is pinned in `WearerTaskContractTests`. The outcome
+  vocabulary gained a sixth word, `refused` — `finished` would tell a wearer
+  asking tomorrow that TapQ did it, and `could not finish` is a task that ran out
+  of turns trying. Task lane only; the question lane keeps its three read-only
+  tools and its own honest-miss rule.
 - **Every ending is audible except the two where nobody is listening.** `finish`
-  speaks its summary; the step cap speaks "I couldn't finish: …"; an `ask_wearer`
+  speaks its summary; `cannot_do` speaks the limit; the step cap speaks "I
+  couldn't finish: …"; an `ask_wearer`
   nobody answered speaks "I asked you something and didn't hear back…" and stops.
   A cloud failure speaks nothing (the latch has its own notice, and a second
   sentence would be the degraded half-agent). A cancellation speaks nothing
@@ -271,10 +310,14 @@ and lands with it.
   refusal, empty goal, step cap spoken, last-turn wording, `ask_wearer`
   pause/resume, unanswered bound, cloud break latch, local-file loudness,
   cancellation, the two-entry record across a reopen, an interrupted task's
-  dangling `started`, the queued-instruction announcement), `WearerTaskQuestionLaneTests`
+  dangling `started`, the queued-instruction announcement, the spoken can't-do
+  that queues nothing and records `refused`), `WearerTaskQuestionLaneTests`
   (M1's three outcomes preserved, three-tool declaration, the two failure classes
-  apart, the step bound, a question answered while a task runs),
-  `WearerTaskContractTests`, `WearerMemorySearchTests`, `OpenAITaskTurnTests`.
+  apart at the pre-fetch as well as mid-lane, the one-call typical answer, a
+  second lookup still available inside the bounds, the step bound, a question
+  answered while a task runs), `WearerTaskContractTests` (including the pinned
+  refusal and pre-fetch instruction text), `WearerMemorySearchTests`,
+  `OpenAITaskTurnTests`.
 
 ### Initiative (M3, the guarded step)
 


### PR DESCRIPTION
Two refinements from the first full-stack hardware round, both live-diagnosed. Stacks on #43.

**One model call per answer again.** Folding `ask_about_work` into the loop had doubled answer latency (two sequential luna calls, measured 1.1s + 1.2–3.8s). The lane now pre-fetches its evidence — transcript excerpts and TapQ's own memory, through the same surfaces the model would have called so they cannot drift — and hands both to the opening turn, rendered apart from the step history so the model never believes it already called a tool it didn't. Typical ask: `model_calls=1` at M1 speed, still combining both sources; the 3-step/20s bounds stay for a sharper second lookup. Pre-fetch failures keep the ratified split, and a memory failure never becomes the spoken answer — "I can't read my own notes" answers a question the wearer didn't ask. `task.question_answered` now logs `latency_ms`/`model_calls`/`slices`/`memories` for the hardware read.

**The loop refuses what nothing composed can reach.** "Start a new session in Claude Code" was relayed verbatim into the already-running session — surfacing minutes later as a bewildering approval. A goal beyond every tool's reach (session lifecycle, applications, TapQ itself) now ends on a first-turn `cannot_do` — an eighth tool, task lane only, because a refusal that depends on the model dressing itself as a finish is a lucky refusal — spoken aloud, recorded as a new `refused` outcome (the existing five could not express it: `finished` lies tomorrow, `couldNotFinish` implies it tried). `queue_instruction`'s guidance now states it is for work the target agent should do, never a relay for a goal the loop could not act on.

Verified: 502 tests / 22 suites green via the slim check; the one-call path is asserted exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)