### PR TITLE
Wake word: level reports on an injected timer, so the deaf-watchdog tests stop racing the runner

### DIFF
--- a/Sources/TapQAppleAdapters/WakeWordListener.swift
+++ b/Sources/TapQAppleAdapters/WakeWordListener.swift
@@ -101,7 +101,11 @@ import AVFoundation
     /// and nothing in the log said whether the microphone was delivering silence or the
     /// recognizer was ignoring speech. This is the line that tells the two apart.
     private var levelMeter: AudioLevelMeter?
-    private var levelTask: Task<Void, Never>?
+    /// The timer behind the level reports. Injected: the deaf watchdog below counts
+    /// reports, so a test that had to wait a wall clock out for each one would be
+    /// racing the runner, and did (macOS CI, 2026-09-04..07).
+    private let levelReportScheduler: any LevelReportScheduling
+    private var levelReports: (any LevelReportCancelling)?
     private let levelReportInterval: TimeInterval
     nonisolated static let defaultLevelReportInterval: TimeInterval = 5
     /// Callbacks of any kind — partial, final, error — on the current request. Zero with
@@ -137,6 +141,7 @@ import AVFoundation
         }
         self.monotonicNow = { ProcessInfo.processInfo.systemUptime }
         #if canImport(AVFoundation)
+        self.levelReportScheduler = SleepingLevelReportScheduler()
         self.levelReportInterval = Self.defaultLevelReportInterval
         #endif
     }
@@ -151,6 +156,7 @@ import AVFoundation
          monotonicNow: @escaping () -> TimeInterval = {
              ProcessInfo.processInfo.systemUptime
          },
+         levelReportScheduler: any LevelReportScheduling = SleepingLevelReportScheduler(),
          levelReportInterval: TimeInterval = WakeWordListener.defaultLevelReportInterval) {
         self.phrase = phrase
         self.recognizer = recognizer
@@ -158,7 +164,14 @@ import AVFoundation
         self.diagnostics = TapQDiagnosticEmitter(category: "WakeWord", sink: diagnosticSink)
         self.sleep = sleep
         self.monotonicNow = monotonicNow
+        self.levelReportScheduler = levelReportScheduler
         self.levelReportInterval = levelReportInterval
+    }
+
+    deinit {
+        // A listener dropped mid-spot without a `stop()` must not leave a report loop
+        // sleeping forever on a closure that will never find it again.
+        levelReports?.cancel()
     }
 
     /// Test seam: `SFSpeechRecognitionResult` has no initializer a test can build, so the
@@ -292,24 +305,23 @@ import AVFoundation
 
     /// Logs the request's peak input level every `levelReportInterval` while it runs.
     ///
-    /// A real sleep rather than the injected one: the injected sleeper is the restart
-    /// ladder's, and a test double that returns at once would spin this loop.
+    /// The timer is the injected scheduler's, not the restart ladder's sleeper: that one
+    /// is a test double that returns at once, and a loop on it would spin. Each report is
+    /// guarded by the generation it was armed for, so a tick that lands after the request
+    /// it belonged to has ended reads nothing and counts nothing.
     private func beginLevelReports(generation: UInt64) {
-        levelTask?.cancel()
-        levelTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                guard let interval = self?.levelReportInterval else { return }
-                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
-                guard !Task.isCancelled, let self, self.generation == generation,
-                      let meter = self.levelMeter else { return }
-                let (peak, buffers) = meter.drain()
-                let decibels = AudioLevelMeter.decibels(peak)
-                self.diagnostics.record("audio.level", level: .debug, fields: [
-                    "peak_db": String(format: "%.1f", decibels),
-                    "buffers": "\(buffers)",
-                ])
-                self.noteLevel(peakDecibels: decibels)
-            }
+        levelReports?.cancel()
+        levelReports = levelReportScheduler.schedule(every: levelReportInterval) {
+            [weak self] in
+            guard let self, self.generation == generation,
+                  let meter = self.levelMeter else { return }
+            let (peak, buffers) = meter.drain()
+            let decibels = AudioLevelMeter.decibels(peak)
+            self.diagnostics.record("audio.level", level: .debug, fields: [
+                "peak_db": String(format: "%.1f", decibels),
+                "buffers": "\(buffers)",
+            ])
+            self.noteLevel(peakDecibels: decibels)
         }
     }
 
@@ -474,8 +486,8 @@ import AVFoundation
     private func endRequest() {
         generation &+= 1
         firedThisRequest = false
-        levelTask?.cancel()
-        levelTask = nil
+        levelReports?.cancel()
+        levelReports = nil
         levelMeter = nil
         audioSource.stop()
         request?.endAudio()
@@ -511,8 +523,8 @@ import AVFoundation
         restartTask?.cancel()
         restartTask = nil
         #if canImport(AVFoundation)
-        levelTask?.cancel()
-        levelTask = nil
+        levelReports?.cancel()
+        levelReports = nil
         levelMeter = nil
         audioSource.stop()
         #endif
@@ -580,6 +592,43 @@ import AVFoundation
 }
 
 #if canImport(AVFoundation)
+/// The timer behind `WakeWordListener`'s level reports.
+///
+/// Every report is one reading of the peak meter and one turn of the deaf-recognizer
+/// watchdog, so *when* reports happen is behaviour, and behaviour is injected: production
+/// sleeps the interval on the main actor (`SleepingLevelReportScheduler`); tests fire
+/// reports by hand, the way `FakeScheduler` fires playback completions for
+/// `BackendAudioPlayback`, and never wait a wall clock out to count them.
+@MainActor protocol LevelReportScheduling: AnyObject {
+    /// Calls `report` on the main actor every `interval` seconds until the returned
+    /// handle is cancelled.
+    func schedule(every interval: TimeInterval,
+                  report: @escaping @MainActor () -> Void) -> any LevelReportCancelling
+}
+
+/// Stops a repeating level report. Non-isolated so a listener's `deinit` can cancel it.
+protocol LevelReportCancelling: Sendable {
+    func cancel()
+}
+
+extension Task: LevelReportCancelling where Success == Void, Failure == Never {}
+
+/// The production timer: a main-actor sleep loop, cancelled through its task.
+@MainActor final class SleepingLevelReportScheduler: LevelReportScheduling {
+    nonisolated init() {}
+
+    func schedule(every interval: TimeInterval,
+                  report: @escaping @MainActor () -> Void) -> any LevelReportCancelling {
+        Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(max(0, interval) * 1_000_000_000))
+                guard !Task.isCancelled else { return }
+                report()
+            }
+        }
+    }
+}
+
 /// Peak-holds the audio thread's buffers until the main actor reads them.
 ///
 /// The audio callback may not block or allocate; a lock held for a few instructions is

--- a/Tests/TapQAppleAdaptersTests/WakeWordListenerTests.swift
+++ b/Tests/TapQAppleAdaptersTests/WakeWordListenerTests.swift
@@ -432,10 +432,12 @@ final class WakeWordListenerTests: XCTestCase {
                        [WakeWordListener.defaultLevelReportInterval])
         XCTAssertTrue(fixture.reports.isScheduled)
 
-        fixture.sources.value.last?.play(peak: 0.5)
+        // Room level, not speech: one loud report on the first request is the deaf
+        // judgment itself, and this test is about the line, not the watchdog.
+        fixture.sources.value.last?.play(peak: 0.05)  // -26 dB
         fixture.reports.fire()
         XCTAssertEqual(fixture.sink.named("audio.level").count, 1)
-        XCTAssertEqual(fixture.sink.named("audio.level").first?.fields["peak_db"], "-6.0")
+        XCTAssertEqual(fixture.sink.named("audio.level").first?.fields["peak_db"], "-26.0")
         XCTAssertEqual(fixture.sink.named("audio.level").first?.fields["buffers"], "1")
 
         fixture.listener.stop()

--- a/Tests/TapQAppleAdaptersTests/WakeWordListenerTests.swift
+++ b/Tests/TapQAppleAdaptersTests/WakeWordListenerTests.swift
@@ -94,12 +94,65 @@ private final class FakeAudioSource: VoiceAudioSource {
     }
 }
 
+/// The level-report timer, fired by hand.
+///
+/// Each `fire()` is one report, as `SleepingLevelReportScheduler` would have delivered it
+/// at the interval. The deaf watchdog counts reports, so a test that waited a wall clock
+/// out for each one was racing the runner: on macOS CI (2026-09-04..07) two of the test's
+/// 30 ms sleeps landed inside one 10 ms tick, or none did, and a request was judged on
+/// two reports instead of three. Nothing here waits for a report; the test delivers it.
+@MainActor
+private final class FakeLevelReportScheduler: LevelReportScheduling {
+    final class Ticket: LevelReportCancelling, @unchecked Sendable {
+        private let lock = NSLock()
+        private var cancelled = false
+
+        var isCancelled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancelled
+        }
+
+        func cancel() {
+            lock.lock()
+            cancelled = true
+            lock.unlock()
+        }
+    }
+
+    /// The interval each `schedule` asked for, one per request the listener opened.
+    private(set) var intervals: [TimeInterval] = []
+    private var current: (ticket: Ticket, report: @MainActor () -> Void)?
+
+    /// Whether a report loop is armed right now.
+    var isScheduled: Bool {
+        guard let current else { return false }
+        return !current.ticket.isCancelled
+    }
+
+    func schedule(every interval: TimeInterval,
+                  report: @escaping @MainActor () -> Void) -> any LevelReportCancelling {
+        intervals.append(interval)
+        let ticket = Ticket()
+        current = (ticket, report)
+        return ticket
+    }
+
+    /// One level report, delivered now. A cancelled loop delivers nothing, as the real
+    /// one would not.
+    func fire() {
+        guard let current, !current.ticket.isCancelled else { return }
+        current.report()
+    }
+}
+
 private enum TestFailure: Error {
     case expected
 }
 
-/// Everything one listener needs, with the recognizer, the microphone, the back-off wait
-/// and the clock all faked, so the restart ladder is exercised in microseconds.
+/// Everything one listener needs, with the recognizer, the microphone, the back-off wait,
+/// the clock and the level-report timer all faked, so the restart ladder and the deaf
+/// watchdog are exercised in microseconds and never against a wall clock.
 @MainActor
 private final class Fixture {
     let recognizer: FakeRecognizer
@@ -107,22 +160,24 @@ private final class Fixture {
     let sources: Box<[FakeAudioSource]>
     let sleeps: Box<[TimeInterval]>
     let clock: Box<TimeInterval>
+    let reports: FakeLevelReportScheduler
     let wakes = Box<[String]>([])
     let stopped = Box<[String]>([])
     let listener: WakeWordListener
 
-    init(phrase: String = WakeWordListener.defaultPhrase,
-         levelReportInterval: TimeInterval = WakeWordListener.defaultLevelReportInterval) {
+    init(phrase: String = WakeWordListener.defaultPhrase) {
         let recognizer = FakeRecognizer()
         let sink = RecordingSink()
         let sources = Box<[FakeAudioSource]>([])
         let sleeps = Box<[TimeInterval]>([])
         let clock = Box<TimeInterval>(0)
+        let reports = FakeLevelReportScheduler()
         self.recognizer = recognizer
         self.sink = sink
         self.sources = sources
         self.sleeps = sleeps
         self.clock = clock
+        self.reports = reports
         self.listener = WakeWordListener(
             phrase: phrase,
             recognizer: recognizer,
@@ -134,7 +189,7 @@ private final class Fixture {
             diagnosticSink: sink,
             sleep: { seconds in sleeps.value.append(seconds) },
             monotonicNow: { clock.value },
-            levelReportInterval: levelReportInterval
+            levelReportScheduler: reports
         )
         let stopped = self.stopped
         listener.onStopped = { stopped.value.append($0) }
@@ -257,11 +312,12 @@ final class WakeWordListenerTests: XCTestCase {
 
     // MARK: - The deaf-recognizer watchdog
 
-    /// Plays speech-level audio into the current request across `reports` level reports.
-    private func speak(into fixture: Fixture, reports: Int) async {
+    /// Plays speech-level audio into the current request and delivers one level report
+    /// per buffer, as the timer would between them.
+    private func speak(into fixture: Fixture, reports: Int) {
         for _ in 0..<reports {
             fixture.sources.value.last?.play(peak: 0.5)  // -6 dB
-            try? await Task.sleep(nanoseconds: 30_000_000)
+            fixture.reports.fire()
         }
     }
 
@@ -270,14 +326,17 @@ final class WakeWordListenerTests: XCTestCase {
     /// 2026-09-04 with buffers reaching Apple's recognition client and no callback ever
     /// coming back — and the reopened request heard at once.
     func testSpeechLevelAudioWithNoCallbackReopensTheFirstRequest() async {
-        let fixture = Fixture(levelReportInterval: 0.01)
+        let fixture = Fixture()
         fixture.start()
 
-        await speak(into: fixture, reports: WakeWordListener.firstRequestDeafReportLimit)
+        speak(into: fixture, reports: WakeWordListener.firstRequestDeafReportLimit)
         await fixture.listener.awaitPendingRestartForTesting()
 
         XCTAssertTrue(fixture.listener.isSpotting)
         XCTAssertEqual(fixture.recognizer.requests.count, 2, "one reopen")
+        XCTAssertEqual(fixture.reports.intervals.count, 2,
+                       "the reopened request gets its own report loop")
+        XCTAssertTrue(fixture.reports.isScheduled)
         XCTAssertEqual(fixture.sleeps.value, [], "a deaf request restarts at once")
         let deaf = fixture.sink.named("recognizer.deaf")
         XCTAssertEqual(deaf.count, 1)
@@ -291,15 +350,15 @@ final class WakeWordListenerTests: XCTestCase {
     /// A later request gets the full fifteen seconds: it is not the suspect one, and a
     /// wearer who starts talking the moment a window closes deserves the benefit.
     func testALaterRequestIsJudgedOnThreeReports() async {
-        let fixture = Fixture(levelReportInterval: 0.01)
+        let fixture = Fixture()
         fixture.start()
-        await speak(into: fixture, reports: WakeWordListener.firstRequestDeafReportLimit)
+        speak(into: fixture, reports: WakeWordListener.firstRequestDeafReportLimit)
         await fixture.listener.awaitPendingRestartForTesting()
         XCTAssertEqual(fixture.recognizer.requests.count, 2)
 
-        await speak(into: fixture, reports: WakeWordListener.deafReportLimit - 1)
+        speak(into: fixture, reports: WakeWordListener.deafReportLimit - 1)
         XCTAssertEqual(fixture.recognizer.requests.count, 2, "two reports are not enough")
-        await speak(into: fixture, reports: 1)
+        speak(into: fixture, reports: 1)
         await fixture.listener.awaitPendingRestartForTesting()
         XCTAssertEqual(fixture.recognizer.requests.count, 3)
         XCTAssertEqual(fixture.sink.named("recognizer.deaf").last?.fields["restarts"], "2")
@@ -319,11 +378,11 @@ final class WakeWordListenerTests: XCTestCase {
     /// A request that has called back once is being heard, however loud the room: only
     /// silence from the recognizer counts, never silence from the wearer.
     func testACallbackDisarmsTheWatchdogForThatRequest() async {
-        let fixture = Fixture(levelReportInterval: 0.01)
+        let fixture = Fixture()
         fixture.start()
         fixture.listener.deliverRecognitionForTesting(transcript: "nothing yet")
 
-        await speak(into: fixture, reports: WakeWordListener.deafReportLimit + 2)
+        speak(into: fixture, reports: WakeWordListener.deafReportLimit + 2)
 
         XCTAssertEqual(fixture.recognizer.requests.count, 1)
         XCTAssertTrue(fixture.sink.named("recognizer.deaf").isEmpty)
@@ -331,26 +390,29 @@ final class WakeWordListenerTests: XCTestCase {
 
     /// Quiet audio never trips it: a room with nobody speaking is not a deaf recognizer.
     func testQuietAudioWithNoCallbackIsNotDeafness() async {
-        let fixture = Fixture(levelReportInterval: 0.01)
+        let fixture = Fixture()
         fixture.start()
         for _ in 0..<(WakeWordListener.deafReportLimit + 2) {
             fixture.sources.value.last?.play(peak: 0.05)  // -26 dB, the room
-            try? await Task.sleep(nanoseconds: 30_000_000)
+            fixture.reports.fire()
         }
         XCTAssertEqual(fixture.recognizer.requests.count, 1)
         XCTAssertTrue(fixture.sink.named("recognizer.deaf").isEmpty)
+        XCTAssertEqual(fixture.sink.named("audio.level").count,
+                       WakeWordListener.deafReportLimit + 2,
+                       "every report is still logged")
     }
 
     /// Three deaf requests in a row, nothing heard between them, and the listener stops
     /// and says why — the honest outcome for a process whose recognizer will not answer.
     func testThreeDeafRequestsInARowGiveUp() async {
-        let fixture = Fixture(levelReportInterval: 0.01)
+        let fixture = Fixture()
         fixture.start()
 
-        await speak(into: fixture, reports: WakeWordListener.firstRequestDeafReportLimit)
+        speak(into: fixture, reports: WakeWordListener.firstRequestDeafReportLimit)
         await fixture.listener.awaitPendingRestartForTesting()
         for _ in 1..<WakeWordListener.deafRestartLimit {
-            await speak(into: fixture, reports: WakeWordListener.deafReportLimit)
+            speak(into: fixture, reports: WakeWordListener.deafReportLimit)
             await fixture.listener.awaitPendingRestartForTesting()
         }
 
@@ -358,6 +420,30 @@ final class WakeWordListenerTests: XCTestCase {
         XCTAssertEqual(fixture.stopped.value, ["recognizer_deaf"])
         XCTAssertEqual(fixture.recognizer.requests.count, WakeWordListener.deafRestartLimit)
         XCTAssertEqual(fixture.sink.named("stopped").first?.fields["reason"], "recognizer_deaf")
+        XCTAssertFalse(fixture.reports.isScheduled, "giving up stops the reports too")
+    }
+
+    /// The reports run on the production interval, and a request's loop ends with the
+    /// request: a tick that lands after `stop()` reads nothing and logs nothing.
+    func testLevelReportsRunOnTheDefaultIntervalAndEndWithTheRequest() async {
+        let fixture = Fixture()
+        fixture.start()
+        XCTAssertEqual(fixture.reports.intervals,
+                       [WakeWordListener.defaultLevelReportInterval])
+        XCTAssertTrue(fixture.reports.isScheduled)
+
+        fixture.sources.value.last?.play(peak: 0.5)
+        fixture.reports.fire()
+        XCTAssertEqual(fixture.sink.named("audio.level").count, 1)
+        XCTAssertEqual(fixture.sink.named("audio.level").first?.fields["peak_db"], "-6.0")
+        XCTAssertEqual(fixture.sink.named("audio.level").first?.fields["buffers"], "1")
+
+        fixture.listener.stop()
+        XCTAssertFalse(fixture.reports.isScheduled)
+        fixture.reports.fire()
+        XCTAssertEqual(fixture.sink.named("audio.level").count, 1,
+                       "a stopped listener reports no level")
+        XCTAssertTrue(fixture.sink.named("recognizer.deaf").isEmpty)
     }
 
     func testBacksOffAndGivesUpAfterTenConsecutiveFailures() async {


### PR DESCRIPTION
## Why

Two tests in `Tests/TapQAppleAdaptersTests/WakeWordListenerTests.swift` failed intermittently on the macOS runner and passed locally:

- `testALaterRequestIsJudgedOnThreeReports` (`"2" is not equal to "3"`)
- `testThreeDeafRequestsInARowGiveUp` (`[] is not equal to ["recognizer_deaf"]`)

Seen on main's merge run for #47 (run 33975913911), on #48's README-only change (run 34172362033), and alternating across the wake-word branch. Same two tests every time, so timing, not a regression.

## Cause

`WakeWordListener.beginLevelReports` slept a real `Task.sleep` per report (10 ms in the tests), and the tests played one buffer then slept 30 ms of wall clock per report, assuming exactly one level report per window. The meter is peak-hold, so when a slow runner let two plays land inside one tick they folded into one loud report, and when a window got no tick at all the count fell short. The deaf watchdog counts reports, so the request was judged on two instead of three.

## Fix

The timer becomes a seam, in the shape `BackendAudioPlayback` already uses with `AudioPlaybackScheduling` / `FakeScheduler`:

- `LevelReportScheduling.schedule(every:report:)` returns a `LevelReportCancelling` handle.
- `SleepingLevelReportScheduler` is the production main-actor sleep loop (`Task` conforms to the handle protocol).
- The tests inject a `FakeLevelReportScheduler` and fire one report per buffer by hand. No sleeps, no 10 ms interval, no retries; every existing assertion is unchanged.
- Each report closure stays guarded by the generation it was armed for, and the handle is cancelled on `endRequest`, `teardown`, and now `deinit`.

Two small additions on the same seam: the deaf-reopen test checks the reopened request arms its own report loop, and a new test pins the production interval (5 s) and that a request's loop ends with the request.

## Verification

- Host `swift build`: clean.
- `scripts/slim-check.sh`: PASS (414 tests, boundary checks included).
- The suite itself is macOS-only and this host has no XCTest; the test file was type-checked against the built module in the package's Swift 5 language mode. CI's macOS job is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
