### PR TITLE
Realtime tests: settle on a quiet session, not a count of yields

### DIFF
--- a/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
+++ b/Sources/TapQVoiceBackends/OpenAIRealtimeVoiceBackend.swift
@@ -319,6 +319,19 @@ import TapQContracts
     var turnStateForTesting: VoiceTurnStateMachine.State { turns.state }
     var cancelledResponseIDsForTesting: [String] { cancelledResponseIDs }
 
+    /// Whether every frame TapQ has queued for the peer has been handed to the transport.
+    /// False from the moment `enqueue` runs until the pump finds the queue empty, so a test
+    /// reading it never catches a `response.create` still in the queue.
+    var isOutboundIdleForTesting: Bool { outbound.isEmpty && !pumpRunning }
+
+    /// Whether a receive loop's task is still alive: parked on the transport, handling a
+    /// frame, or exiting after the stream ended. Paired with the test peer's
+    /// `isReceiverParked`, this is what lets a test wait for inbound work to *finish*
+    /// instead of guessing at a number of scheduler turns — including the failure handling
+    /// a loop runs after the peer hangs up, which no count of yields can see.
+    var hasLiveReceiveLoopForTesting: Bool { liveReceiveLoops > 0 }
+    private var liveReceiveLoops = 0
+
     // MARK: - Session lifecycle
 
     public func open(onEvent: @escaping @MainActor (VoiceBackendEvent) -> Void) async throws {
@@ -743,7 +756,9 @@ import TapQContracts
 
     private func startReceiveLoop(generation: UInt64) {
         let frames = transport.receiveFrames()
+        liveReceiveLoops += 1
         Task { @MainActor [weak self] in
+            defer { self?.liveReceiveLoops -= 1 }
             do {
                 for try await frame in frames {
                     guard let self, self.sessionGeneration == generation else { return }

--- a/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
+++ b/Tests/TapQVoiceBackendsTests/OpenAIRealtimeVoiceBackendTests.swift
@@ -26,6 +26,9 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
     /// Fixed clock so audio timestamps are assertable.
     private nonisolated static let now: TimeInterval = 1_234.5
 
+    /// Every peer-and-adapter pair this test built, so `settle()` knows what to wait on.
+    private var sessions: [(server: ScriptedRealtimeServer, backend: OpenAIRealtimeVoiceBackend)] = []
+
     /// `turnEagerness` is stated rather than defaulted, deliberately: the shipped default
     /// reads `TAPQ_TURN_EAGERNESS` from the process environment, and a suite whose wire
     /// assertions depended on the machine running it would pass or fail for reasons that
@@ -35,17 +38,28 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
                              turnEagerness: RealtimeTurnEagerness = .low,
                              sink: RecordingSink = RecordingSink())
         -> OpenAIRealtimeVoiceBackend {
-        OpenAIRealtimeVoiceBackend(transport: server,
-                                   timeout: timeout,
-                                   turnEagerness: turnEagerness,
-                                   monotonicNow: { Self.now },
-                                   diagnosticSink: sink)
+        let backend = OpenAIRealtimeVoiceBackend(transport: server,
+                                                 timeout: timeout,
+                                                 turnEagerness: turnEagerness,
+                                                 monotonicNow: { Self.now },
+                                                 diagnosticSink: sink)
+        sessions.append((server, backend))
+        return backend
     }
 
-    /// Frames cross two task hops (the outbound pump and the receive loop), so tests hand
-    /// the main actor back before asserting.
-    private func settle() async {
-        for _ in 0..<8 { await Task.yield() }
+    /// Frames cross two task hops (the outbound pump and the receive loop), so tests wait
+    /// for both to go quiet before asserting: every client frame handed to the peer, every
+    /// server frame taken, and the receive loop parked for the next one or gone. A count of
+    /// `Task.yield()`s stood here until 2026-09-07, when eight were not enough on the macOS
+    /// CI runner for the six-frame tail in the suppressed-response tombstone test.
+    private func settle(file: StaticString = #filePath, line: UInt = #line) async {
+        guard !sessions.isEmpty else {
+            return XCTFail("settle() has nothing to wait on: build the adapter with makeBackend",
+                           file: file, line: line)
+        }
+        for session in sessions {
+            await session.server.settle(with: session.backend, file: file, line: line)
+        }
     }
 
     /// Opens a session with a live turn, which is where most of these tests start.
@@ -1251,7 +1265,7 @@ final class OpenAIRealtimeVoiceBackendTests: XCTestCase {
         let opening = Task { @MainActor in
             try await backend.open { _ in XCTFail("the window was abandoned") }
         }
-        await settle()
+        await waitUntil("connect parks on the gate") { gate.isHeld }
         backend.close()
         gate.open()
 

--- a/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
+++ b/Tests/TapQVoiceBackendsTests/ScriptedRealtimeServer.swift
@@ -55,10 +55,23 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
     private(set) var currentResponseID: String?
     private var responseCount = 0
 
-    private var continuation: AsyncThrowingStream<String, any Error>.Continuation?
     /// Rebuilt on every connect: a reconnect after a drop is a new stream, exactly as it
     /// would be against a real socket.
     private var frames: AsyncThrowingStream<String, any Error>?
+    /// Frames pushed but not yet taken by the client, oldest first.
+    ///
+    /// The stream's own buffer would hold these just as well, and hide the one fact the
+    /// adapter's tests need: whether the receive loop has taken everything pushed so far
+    /// and is parked waiting for more. So the buffer lives here, the stream is unfolded
+    /// from it one `take()` at a time, and `isReceiverParked` reads it. A yield count
+    /// stood in for that fact until 2026-09-07, when eight turns of the scheduler were not
+    /// enough on the macOS CI runner and a tombstone test failed on a `response.done` the
+    /// loop had not reached yet.
+    private var inbox: [String] = []
+    /// The client's receive loop, while it is parked on an empty inbox.
+    private var receiver: CheckedContinuation<String?, any Error>?
+    /// How this connection's stream ended, once it has. `nil` while the peer is still up.
+    private var ending: Result<Void, any Error>?
     private var uncommittedAudio = false
 
     // MARK: - RealtimeTransporting
@@ -68,9 +81,10 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
         if let connectGate { await connectGate() }
         if let connectFailure { throw connectFailure }
         isConnected = true
-        frames = AsyncThrowingStream { continuation in
-            self.continuation = continuation
-        }
+        XCTAssertNil(receiver, "a receive loop from the last connection is still parked")
+        inbox.removeAll()
+        ending = nil
+        frames = AsyncThrowingStream(unfolding: { try await self.take() })
     }
 
     func send(_ frame: String) async throws {
@@ -167,9 +181,31 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
     func close() {
         closeCount += 1
         isConnected = false
-        continuation?.finish()
-        continuation = nil
+        end(.success(()))
         frames = nil
+    }
+
+    /// Hands the client its next frame: the oldest one waiting, the stream's ending once
+    /// the inbox is empty, or — with neither — a parked wait for whichever comes first.
+    private func take() async throws -> String? {
+        if !inbox.isEmpty { return inbox.removeFirst() }
+        if let ending {
+            try ending.get()
+            return nil
+        }
+        return try await withCheckedThrowingContinuation { receiver = $0 }
+    }
+
+    /// Ends the current stream once, after whatever is still in the inbox: a parked client
+    /// is woken with the ending, a busy one finds it when it comes back for more. A second
+    /// ending, and any ending without a stream, changes nothing — the real socket's finish
+    /// is idempotent the same way.
+    private func end(_ ending: Result<Void, any Error>) {
+        guard frames != nil, self.ending == nil else { return }
+        self.ending = ending
+        guard let receiver else { return }
+        self.receiver = nil
+        receiver.resume(with: ending.map { _ -> String? in nil })
     }
 
     // MARK: - Scripting
@@ -178,9 +214,16 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
     /// window deliberately.
     var allowsEmptyCommit = true
 
-    /// Delivers a raw server frame.
+    /// Delivers a raw server frame. Dropped, like a frame on a closed socket, when there is
+    /// no live stream to carry it.
     func push(_ frame: String) {
-        continuation?.yield(frame)
+        guard frames != nil, ending == nil else { return }
+        if let receiver {
+            self.receiver = nil
+            receiver.resume(returning: frame)
+        } else {
+            inbox.append(frame)
+        }
     }
 
     /// Delivers a whole scripted sequence in order.
@@ -227,14 +270,46 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
 
     /// The peer drops the connection mid-stream.
     func disconnect(_ failure: RealtimeTransportFailure = .receiveFailed("socket dropped")) {
-        continuation?.finish(throwing: failure)
-        continuation = nil
+        end(.failure(failure))
     }
 
     /// The peer hangs up cleanly.
     func hangUp() {
-        continuation?.finish()
-        continuation = nil
+        end(.success(()))
+    }
+
+    // MARK: - Quiescence
+
+    /// Whether the client has taken every frame pushed on this connection and is parked
+    /// waiting for the next one. False between a `push` and the receive loop coming back
+    /// for more, and false for good once the stream has ended: an ended stream is never
+    /// waited on again, and what the loop does on its way out is the adapter's to report.
+    var isReceiverParked: Bool { receiver != nil }
+
+    /// Whether the adapter has nothing left to do with this peer: every client frame handed
+    /// over, every server frame taken, and the receive loop either parked for the next one
+    /// or gone. Read on the main actor, where every transition it depends on happens
+    /// synchronously, so it is never true of a session with a frame still in flight.
+    func isQuiet(with backend: OpenAIRealtimeVoiceBackend) -> Bool {
+        backend.isOutboundIdleForTesting
+            && (!backend.hasLiveReceiveLoopForTesting || isReceiverParked)
+    }
+
+    /// What is still in flight, for the failure message when a session never goes quiet.
+    func pendingWork(with backend: OpenAIRealtimeVoiceBackend) -> String {
+        var pending: [String] = []
+        if !backend.isOutboundIdleForTesting { pending.append("client frames queued") }
+        if backend.hasLiveReceiveLoopForTesting, !isReceiverParked {
+            pending.append("receive loop busy, \(inbox.count) server frame(s) untaken")
+        }
+        return pending.isEmpty ? "nothing" : pending.joined(separator: "; ")
+    }
+
+    /// Suspends until the adapter has nothing left to do with this peer — see `isQuiet`.
+    func settle(with backend: OpenAIRealtimeVoiceBackend,
+                file: StaticString = #filePath, line: UInt = #line) async {
+        await waitUntil("the session goes quiet (pending: \(pendingWork(with: backend)))",
+                        file: file, line: line) { isQuiet(with: backend) }
     }
 
     // MARK: - Assertions
@@ -282,12 +357,36 @@ final class ScriptedRealtimeServer: RealtimeTransporting {
 
 }
 
+/// Suspends until `condition` holds, handing the main actor back between checks so the
+/// adapter's own tasks can run, and fails the test — rather than hanging the container —
+/// if it never does. The bound is a diagnostic, not a schedule: nothing here waits a
+/// number of turns or a length of time, only for the condition, and a runner too slow to
+/// meet it within five seconds is a runner too slow to trust.
+///
+/// `describe` is evaluated at failure time, so it can read the state it names.
+@MainActor
+func waitUntil(_ describe: @autoclosure @MainActor () -> String,
+               file: StaticString = #filePath, line: UInt = #line,
+               _ condition: @MainActor () -> Bool) async {
+    let deadline = ContinuousClock.now + .seconds(5)
+    while !condition() {
+        if ContinuousClock.now > deadline {
+            return XCTFail("timed out waiting until \(describe())", file: file, line: line)
+        }
+        await Task.yield()
+    }
+}
+
 /// A one-shot latch, so a test can hold an async call open at a chosen suspension point
 /// and act while it is parked there.
 @MainActor
 final class AsyncGate {
     private var continuation: CheckedContinuation<Void, Never>?
     private var isOpen = false
+
+    /// Whether a caller is parked on the gate right now — the moment a test that wants to
+    /// act mid-call has been waiting for.
+    var isHeld: Bool { continuation != nil }
 
     func wait() async {
         guard !isOpen else { return }


### PR DESCRIPTION
## Why

`testASuppressedResponseCancelledOnFirstAudioIsTombstoned` failed on the macOS job of #49 (run 34173443220, first attempt) with `sink.names.contains("response.cancelled_done_drained")` false, unrelated to that PR's diff; the Linux job and a local slim-check passed. The suite's `settle()` was `for _ in 0..<8 { await Task.yield() }`, a guess at how many scheduler turns the adapter needs to push its outbound frames and take the peer's. That test pushes a six-frame cancelled-response tail and then the `response.done`; on a slow runner eight turns did not reach the done, so the tombstone was still unspent when the assertion ran.

## What

`settle()` now waits on the condition the yields were standing in for, and fails instead of hanging if it never holds.

- **Scripted peer is drain-aware.** `ScriptedRealtimeServer` keeps inbound frames in its own inbox and unfolds the transport stream from it one `take()` at a time, so it can say whether the receive loop has taken everything pushed and is parked for the next frame (`isReceiverParked`). Public behaviour is unchanged: pushes buffer, an ending lands after whatever is buffered, frames with no live stream are dropped.
- **Two test seams on the adapter.** `isOutboundIdleForTesting` (queue empty, pump idle) and `hasLiveReceiveLoopForTesting` (a receive-loop task is still alive). The second is what covers the failure handling a loop runs on its way out after a hang-up or disconnect, which no count of yields can observe.
- **`isQuiet(with:)` / `settle(with:)` / `waitUntil`** in ScriptedRealtimeServer.swift. Quiescence is read on the main actor, where every transition it depends on is synchronous, so it is never true of a session with a frame in flight. The five-second bound is a diagnostic (XCTFail with what is still pending), not a schedule. No assertion changed; no retries added.
- The one test that used `settle()` to let a Task reach a connect gate now waits on `AsyncGate.isHeld`, the condition it meant.

The sibling suites that still count yields (OpenAIRealtimeToolCallTests, RealtimeSelfAudioTests, VoiceBackendBreakWindowTests, StartTaskRealtimeRoundTripTests) can adopt the shared helpers; left as they are here.

## Verification

`scripts/slim-check.sh` with all six suites that use the scripted peer: 534 tests, 0 failed. OpenAIRealtimeVoiceBackendTests 76/76 on both scheduled passes (first pass hit the known container wedge twice and ran clean in 1s on retry). CI is the exhaustive gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
